### PR TITLE
test(harness): per-package test databases; parallelize DB-backed runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,10 +60,8 @@ jobs:
   go-coverage:
     name: Go coverage gate
     runs-on: ubuntu-latest
-    # 18, not 12: `make cover` runs every DB-backed package serialized (-p 1)
-    # and sits at ~12m after the SLO-instrumentation suites landed — the old
-    # cap canceled a fully-passing run 16s over budget, after the last
-    # package but before floor enforcement. Keep ~50% headroom over observed.
+    # Headroom over observed: the parallel (-p 4, per-package DBs) cover run
+    # is well under this; the cap exists so a hung suite can't burn an hour.
     timeout-minutes: 18
     services:
       postgres:
@@ -85,15 +83,16 @@ jobs:
         with:
           go-version: "1.26"
           cache: true
-      # Generate the coverage profile with the test DB available (the webhook
-      # delivery/publish + httpapi suites are DB-backed; -p 1 avoids cross-
-      # package test-DB contention). Floors live in .testcoverage.yml.
+      # Generate the coverage profile with the test DB available. Packages
+      # run in parallel (-p 4): the testutil harness gives each package its
+      # own database, self-provisioned from the service's e2a_test base.
+      # Floors live in .testcoverage.yml.
       - name: Generate coverage profile
         run: make cover
       - name: Race-check ramp and outbound worker
         env:
           E2A_TEST_DATABASE_URL: postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable
-        run: go test -race -p 1 ./internal/sendramp ./internal/outboundsend
+        run: go test -race -p 2 ./internal/sendramp ./internal/outboundsend
       - name: Enforce per-package coverage floors
         uses: vladopajic/go-test-coverage@v2
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,9 @@ A fresh base database needs no manual setup — the harness creates the
 per-package databases and applies all `migrations/*.sql` on connect (the
 BASE database itself must exist). Per-package databases accumulate on the
 local server; they are disposable — drop any `*_pkg_*` database at will,
-the next run recreates it. `-p 1` is no longer required for
+the next run recreates it. Note that dropping a BASE database does not drop
+its `_pkg_` siblings (harmless — migrate+truncate on connect — but a "reset"
+that only recreates the base leaves them behind). `-p 1` is no longer required for
 cross-package isolation; it remains useful only when reproducing ordering-
 sensitive failures.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ with Go 1.26. Node: engines `>=18`, CI runs on 22. Python: `requires-python
 ```bash
 make build              # go build -o bin/e2a ./cmd/e2a
 make run                # build + run with config.yaml (copy from config.example.yaml first)
-make test               # ALL Go tests, -tags integration -p 1 (needs Postgres on :5433)
+make test               # ALL Go tests, -tags integration, -p 4 parallel (needs Postgres on :5433)
 make test-unit          # unit tests only, no DB needed — fast
 make test-integration   # integration tests (needs Postgres on :5433)
 make test-e2e           # discovers every package with //go:build integration tests
@@ -91,19 +91,25 @@ make openapi-compat-test   # runs the compat-gate's own test harness (scripts/te
 DB-backed tests need
 `E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable"`.
 The test harness (`internal/testutil/db.go`) truncates tables between tests
-and auto-applies all migrations on connect. **Never share one test database
-between concurrent sessions/agents/worktrees** — the shared truncate-between-
-tests behavior means two concurrent runs wipe each other's rows (a known
-local flake source). Give each runner its own database:
+and auto-applies all migrations on connect. Each test binary automatically
+derives a **per-package database** (`<base>_pkg_<package>`, self-provisioned
+on first run) from the configured base URL, so parallel packages (`-p 4` in
+the Make targets) cannot truncate each other; `E2A_TEST_DB_SHARED=1` forces
+the old single-DB behavior. **Concurrent sessions/agents/worktrees running
+the SAME package still contend** — give each runner its own base database:
 
 ```bash
 psql "postgres://e2a:e2a@localhost:5433/e2a" -c 'CREATE DATABASE e2a_test_<name>'
 export E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test_<name>?sslmode=disable"
 ```
 
-A fresh database needs no manual setup — the harness applies all
-`migrations/*.sql` on connect. Always run DB-backed packages with `-p 1`
-(even within one database, parallel packages contend).
+A fresh base database needs no manual setup — the harness creates the
+per-package databases and applies all `migrations/*.sql` on connect (the
+BASE database itself must exist). Per-package databases accumulate on the
+local server; they are disposable — drop any `*_pkg_*` database at will,
+the next run recreates it. `-p 1` is no longer required for
+cross-package isolation; it remains useful only when reproducing ordering-
+sensitive failures.
 
 ### TypeScript (npm workspaces — always use `--workspace` and `npm ci`)
 
@@ -268,7 +274,7 @@ manually on every API change even though the template won't remind you.
 
 - **Go tiers**: `test-unit` (no DB), `test-integration` (Postgres),
   `test-e2e` (auto-discovers `//go:build integration` packages); `make test`
-  runs everything with `-tags integration -p 1`. CI additionally race-checks
+  runs everything with `-tags integration -p 4` (safe: per-package test DBs). CI additionally race-checks
   `./internal/sendramp` and `./internal/outboundsend` with `-race`.
 - **Coverage ratchet**: `.testcoverage.yml` sets per-package floors (currently
   webhook, webhookpub, webhookdelivery, httpapi, outboundsend, sendramp,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,7 +201,7 @@ slow and need a database.
 make test-unit          # no DB needed — fast
 make test-integration   # needs Postgres on :5433 (make docker-up)
 make test-e2e           # discovers and runs every package with integration-tagged tests
-make test               # all three, with -p 1 to avoid DB-state races
+make test               # all three, -p 4 parallel (per-package test DBs)
 make cover-check        # tests + per-package coverage floors (.testcoverage.yml)
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -11,27 +11,32 @@ build:
 run: build
 	./bin/e2a -config config.yaml
 
+# -p 4 everywhere a DB is involved: the testutil harness gives each package
+# its own database (<base>_pkg_<package>, self-provisioned on first run), so
+# packages can run in parallel without truncating each other. Capped at 4 —
+# not the core count — so N × pgxpool connections stay under Postgres's
+# default max_connections=100 on many-core dev machines.
 test:
-	E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable" go test -tags integration -p 1 ./...
+	E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable" go test -tags integration -p 4 ./...
 
 test-unit:
 	go test -short ./internal/outbound/ ./internal/relay/ ./internal/config/ ./internal/webhook/ ./internal/approvaltoken/ ./internal/unsubscribe/ ./internal/limits/ ./internal/httpapi/ ./internal/ratelimit/
 
 test-integration:
-	E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable" go test -p 1 ./internal/identity/ ./internal/agent/ ./internal/hitlworker/ ./internal/hitlnotify/ ./internal/limits/ ./internal/relay/ ./internal/sendramp/
+	E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable" go test -p 4 ./internal/identity/ ./internal/agent/ ./internal/hitlworker/ ./internal/hitlnotify/ ./internal/limits/ ./internal/relay/ ./internal/sendramp/
 
 test-e2e:
 	@packages="$$(find ./cmd ./internal ./tests -name '*_test.go' -exec grep -l '^//go:build integration$$' {} + | xargs -n 1 dirname | sort -u)"; \
 	test -n "$$packages"; \
-	E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable" go test -tags integration -p 1 $$packages
+	E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable" go test -tags integration -p 4 $$packages
 
 # cover writes a coverage profile across the internal packages (needs Postgres
-# on :5433, like `make test`; -p 1 avoids cross-package test-DB contention).
+# on :5433, like `make test`; per-package DBs make the -p 4 parallel run safe).
 # cover-check enforces the per-package floors in .testcoverage.yml. CI runs the
 # same gate via the vladopajic/go-test-coverage action.
 GO_TEST_COVERAGE_VERSION ?= v2.14.3
 cover:
-	E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable" go test -p 1 -covermode=atomic -coverprofile=cover.out ./internal/...
+	E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable" go test -p 4 -covermode=atomic -coverprofile=cover.out ./internal/...
 
 cover-check: cover
 	go run github.com/vladopajic/go-test-coverage/v2@$(GO_TEST_COVERAGE_VERSION) --config=.testcoverage.yml

--- a/internal/testutil/contract_server_river_test.go
+++ b/internal/testutil/contract_server_river_test.go
@@ -2,10 +2,9 @@ package testutil
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
-
-	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 func TestContractServerRepeatedStartClearsRiverStateAndPreservesMigrations(t *testing.T) {
@@ -50,26 +49,28 @@ func TestContractServerRepeatedStartClearsRiverStateAndPreservesMigrations(t *te
 	}
 }
 
-// requireReachableContractTestDB is the test's only skip gate. Once this ping
-// succeeds, migration, River reset, and server startup errors are regressions
-// and the caller must fail rather than classifying them as DB unavailability.
+// requireReachableContractTestDB is the test's only skip gate. Once this
+// check succeeds, migration, River reset, and server startup errors are
+// regressions and the caller must fail rather than classifying them as DB
+// unavailability. It must go through OpenPreparedTestDB — a raw ping of the
+// derived per-package URL fails with 3D000 on every cold database (CI's
+// service container is always cold), which would silently skip this
+// regression gate forever instead of self-provisioning like every other
+// harness consumer.
 func requireReachableContractTestDB(t *testing.T) string {
 	t.Helper()
 	dbURL := TestDBURL()
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	config, err := pgxpool.ParseConfig(dbURL)
+	pool, err := OpenPreparedTestDB(ctx, dbURL)
 	if err != nil {
-		t.Fatalf("parse E2A_TEST_DATABASE_URL: %v", err)
-	}
-	pool, err := pgxpool.NewWithConfig(ctx, config)
-	if err != nil {
-		t.Fatalf("open E2A_TEST_DATABASE_URL pool: %v", err)
-	}
-	defer pool.Close()
-	if err := pool.Ping(ctx); err != nil {
+		var prepErr *testDBPreparationError
+		if errors.As(err, &prepErr) {
+			t.Fatalf("prepare contract test database: %v", err)
+		}
 		t.Skipf("private test database unavailable: %v", err)
 	}
+	pool.Close()
 	return dbURL
 }

--- a/internal/testutil/db.go
+++ b/internal/testutil/db.go
@@ -61,8 +61,17 @@ func TestDBURL() string {
 		return base
 	}
 	u, err := url.Parse(base)
-	if err != nil || strings.TrimPrefix(u.Path, "/") == "" {
-		return base // unparseable/unnamed base: leave it alone
+	// Only derive on genuine postgres:// URLs. DSN keyword/value form
+	// ("host=… dbname=…") "parses" into u.Path and would be mangled into
+	// garbage; pass anything unrecognizable through verbatim.
+	if err != nil || (u.Scheme != "postgres" && u.Scheme != "postgresql") ||
+		strings.TrimPrefix(u.Path, "/") == "" {
+		return base
+	}
+	// Idempotent: a child .test process handed an already-derived URL (the
+	// harness's own re-exec tests do this) must not double-suffix it.
+	if strings.HasSuffix(strings.TrimSuffix(u.Path, "/"), suffix) {
+		return base
 	}
 	u.Path = u.Path + suffix
 	return u.String()
@@ -71,7 +80,8 @@ func TestDBURL() string {
 // packageDBSuffix derives the per-package database suffix, or "" when the
 // process is not a test binary or sharing is forced.
 func packageDBSuffix() string {
-	if os.Getenv("E2A_TEST_DB_SHARED") != "" {
+	switch strings.ToLower(os.Getenv("E2A_TEST_DB_SHARED")) {
+	case "1", "true", "yes":
 		return ""
 	}
 	bin := filepath.Base(os.Args[0])
@@ -167,16 +177,25 @@ func TruncateAll(t *testing.T, pool *pgxpool.Pool) {
 }
 
 // createTestDatabase creates dbURL's database via the base URL's server.
-// A concurrent creator racing us (SQLSTATE 42P04 duplicate_database) is
-// success — the database exists either way.
+// A concurrent creator racing us is success — the database exists either
+// way. Postgres reports that race two ways: 42P04 (duplicate_database, the
+// already-committed case) and 23505 (unique violation on
+// pg_database_datname_index, the losing side of a true concurrent race —
+// empirically what 8 parallel same-name creates produce on PG16).
+//
+// Error classification is load-bearing for skip-vs-fail: a failure to
+// CONNECT to the base URL keeps the caller's "DB unavailable → skip"
+// semantics, but a failure to CREATE on a reachable server (e.g. a role
+// without CREATEDB) is a preparation error — TestDB must FAIL loudly, not
+// silently skip the entire DB tier green.
 func createTestDatabase(ctx context.Context, dbURL string) error {
 	target, err := url.Parse(dbURL)
 	if err != nil {
-		return fmt.Errorf("parse target db url: %w", err)
+		return &testDBPreparationError{stage: "parse target db url", err: err}
 	}
 	name := strings.TrimPrefix(target.Path, "/")
 	if name == "" {
-		return fmt.Errorf("target db url has no database name: %s", dbURL)
+		return &testDBPreparationError{stage: "derive database name", err: fmt.Errorf("no database name in %s", dbURL)}
 	}
 	conn, err := pgx.Connect(ctx, baseTestDBURL())
 	if err != nil {
@@ -185,10 +204,10 @@ func createTestDatabase(ctx context.Context, dbURL string) error {
 	defer conn.Close(ctx)
 	if _, err := conn.Exec(ctx, "CREATE DATABASE "+pgx.Identifier{name}.Sanitize()); err != nil {
 		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == "42P04" {
+		if errors.As(err, &pgErr) && (pgErr.Code == "42P04" || pgErr.Code == "23505") {
 			return nil
 		}
-		return fmt.Errorf("create database %s: %w", name, err)
+		return &testDBPreparationError{stage: "create database " + name, err: err}
 	}
 	return nil
 }

--- a/internal/testutil/db.go
+++ b/internal/testutil/db.go
@@ -4,9 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/tokencanopy/e2a/internal/identity"
 	"github.com/tokencanopy/e2a/migrations"
@@ -27,12 +32,63 @@ func (e *testDBPreparationError) Unwrap() error {
 	return e.err
 }
 
-func TestDBURL() string {
-	dbURL := os.Getenv("E2A_TEST_DATABASE_URL")
-	if dbURL == "" {
-		dbURL = defaultTestDBURL
+// baseTestDBURL is the configured URL before per-package derivation: the
+// E2A_TEST_DATABASE_URL override or the local-dev default. Also the admin
+// connection target for creating missing package databases.
+func baseTestDBURL() string {
+	if dbURL := os.Getenv("E2A_TEST_DATABASE_URL"); dbURL != "" {
+		return dbURL
 	}
-	return dbURL
+	return defaultTestDBURL
+}
+
+// TestDBURL returns the database URL tests should use. Inside a `go test`
+// binary it derives a PER-PACKAGE database name (<base>_pkg_<package>) so
+// packages can run in parallel: the harness truncates tables between tests,
+// which made one shared database the documented cross-package flake source
+// and forced -p 1 on every DB-backed run. The suffix comes from the test
+// binary's name (os.Args[0] = <package>.test — unique per package in this
+// repo), so every URL consumer in one test binary — TestDB, hand-built
+// pools, the in-process contract server — lands on the same database.
+// Non-test binaries (cmd/e2a-contract-server) and E2A_TEST_DB_SHARED=1 get
+// the base URL verbatim. Missing databases self-provision on first open
+// (see OpenPreparedTestDB); concurrent SESSIONS running the SAME package
+// still contend, so per-session base URLs remain the guidance in AGENTS.md.
+func TestDBURL() string {
+	base := baseTestDBURL()
+	suffix := packageDBSuffix()
+	if suffix == "" {
+		return base
+	}
+	u, err := url.Parse(base)
+	if err != nil || strings.TrimPrefix(u.Path, "/") == "" {
+		return base // unparseable/unnamed base: leave it alone
+	}
+	u.Path = u.Path + suffix
+	return u.String()
+}
+
+// packageDBSuffix derives the per-package database suffix, or "" when the
+// process is not a test binary or sharing is forced.
+func packageDBSuffix() string {
+	if os.Getenv("E2A_TEST_DB_SHARED") != "" {
+		return ""
+	}
+	bin := filepath.Base(os.Args[0])
+	if !strings.HasSuffix(bin, ".test") {
+		return ""
+	}
+	name := strings.ToLower(strings.TrimSuffix(bin, ".test"))
+	sanitized := make([]rune, 0, len(name))
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			sanitized = append(sanitized, r)
+		default:
+			sanitized = append(sanitized, '_')
+		}
+	}
+	return "_pkg_" + string(sanitized)
 }
 
 func OpenPreparedTestDB(ctx context.Context, dbURL string) (*pgxpool.Pool, error) {
@@ -47,7 +103,25 @@ func OpenPreparedTestDB(ctx context.Context, dbURL string) (*pgxpool.Pool, error
 
 	if err := pool.Ping(ctx); err != nil {
 		pool.Close()
-		return nil, err
+		// SQLSTATE 3D000 (invalid_catalog_name): the server is up but this
+		// per-package database doesn't exist yet — self-provision it from
+		// the base URL's server and retry once. Any other error (server
+		// down, bad credentials) keeps the caller's skip-vs-fail semantics.
+		var pgErr *pgconn.PgError
+		if !errors.As(err, &pgErr) || pgErr.Code != "3D000" {
+			return nil, err
+		}
+		if cerr := createTestDatabase(ctx, dbURL); cerr != nil {
+			return nil, cerr
+		}
+		pool, err = pgxpool.New(ctx, dbURL)
+		if err != nil {
+			return nil, err
+		}
+		if err := pool.Ping(ctx); err != nil {
+			pool.Close()
+			return nil, err
+		}
 	}
 
 	if err := runMigrations(ctx, pool); err != nil {
@@ -90,6 +164,33 @@ func TruncateAll(t *testing.T, pool *pgxpool.Pool) {
 	if err != nil {
 		t.Fatalf("failed to truncate tables: %v", err)
 	}
+}
+
+// createTestDatabase creates dbURL's database via the base URL's server.
+// A concurrent creator racing us (SQLSTATE 42P04 duplicate_database) is
+// success — the database exists either way.
+func createTestDatabase(ctx context.Context, dbURL string) error {
+	target, err := url.Parse(dbURL)
+	if err != nil {
+		return fmt.Errorf("parse target db url: %w", err)
+	}
+	name := strings.TrimPrefix(target.Path, "/")
+	if name == "" {
+		return fmt.Errorf("target db url has no database name: %s", dbURL)
+	}
+	conn, err := pgx.Connect(ctx, baseTestDBURL())
+	if err != nil {
+		return fmt.Errorf("connect base db to create %s: %w", name, err)
+	}
+	defer conn.Close(ctx)
+	if _, err := conn.Exec(ctx, "CREATE DATABASE "+pgx.Identifier{name}.Sanitize()); err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "42P04" {
+			return nil
+		}
+		return fmt.Errorf("create database %s: %w", name, err)
+	}
+	return nil
 }
 
 func runMigrations(ctx context.Context, pool *pgxpool.Pool) error {

--- a/internal/testutil/db_test.go
+++ b/internal/testutil/db_test.go
@@ -250,3 +250,25 @@ func TestOpenPreparedTestDBCreatesMissingDatabase(t *testing.T) {
 	}
 	pool2.Close()
 }
+
+func TestTestDBURLDerivationIsIdempotentAndURLOnly(t *testing.T) {
+	// Re-deriving an already-derived URL must be a no-op — the harness's
+	// child-exec tests hand TestDBURL() to a spawned .test process, which
+	// re-derives; double-suffixing would self-provision junk databases.
+	t.Setenv("E2A_TEST_DATABASE_URL", TestDBURL())
+	u, err := url.Parse(TestDBURL())
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := strings.TrimPrefix(u.Path, "/"); strings.Contains(got, "_pkg_testutil_pkg_") {
+		t.Errorf("double-derived dbname %q", got)
+	}
+
+	// DSN keyword/value form must pass through verbatim: url.Parse "accepts"
+	// it into u.Path, and appending a suffix there produces garbage.
+	dsn := "host=localhost port=5433 user=e2a dbname=e2a_test sslmode=disable"
+	t.Setenv("E2A_TEST_DATABASE_URL", dsn)
+	if got := TestDBURL(); got != dsn {
+		t.Errorf("DSN-form base mangled: %q", got)
+	}
+}

--- a/internal/testutil/db_test.go
+++ b/internal/testutil/db_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -179,4 +180,73 @@ func testDBChildEnv(testName, dbURL string) []string {
 		env = append(env, item)
 	}
 	return append(env, testDBErrorChildEnv+"="+testName, "E2A_TEST_DATABASE_URL="+dbURL)
+}
+
+func TestTestDBURLDerivesPerPackageDatabase(t *testing.T) {
+	// Inside a `go test` binary (os.Args[0] ends in ".test"), TestDBURL
+	// appends a per-package suffix to the base database name so packages
+	// running in parallel (-p N) cannot truncate each other's rows — the
+	// harness truncates between tests, which made a shared DB the
+	// documented cross-package flake source. This binary is testutil.test,
+	// so the derived name is <base>_pkg_testutil.
+	u, err := url.Parse(TestDBURL())
+	if err != nil {
+		t.Fatalf("parse TestDBURL: %v", err)
+	}
+	if got := strings.TrimPrefix(u.Path, "/"); !strings.HasSuffix(got, "_pkg_testutil") {
+		t.Errorf("TestDBURL dbname = %q, want *_pkg_testutil suffix", got)
+	}
+
+	// E2A_TEST_DB_SHARED=1 restores the verbatim single-DB behavior (escape
+	// hatch for tooling that must target one known database).
+	t.Setenv("E2A_TEST_DB_SHARED", "1")
+	u2, err := url.Parse(TestDBURL())
+	if err != nil {
+		t.Fatalf("parse shared TestDBURL: %v", err)
+	}
+	if got := strings.TrimPrefix(u2.Path, "/"); strings.Contains(got, "_pkg_") {
+		t.Errorf("shared-mode dbname = %q, want no _pkg_ suffix", got)
+	}
+}
+
+func TestOpenPreparedTestDBCreatesMissingDatabase(t *testing.T) {
+	// First use of a package database must self-provision: connect failure
+	// with SQLSTATE 3D000 creates the database from the base URL's server
+	// and retries. Drop the derived DB first so this exercises creation.
+	ctx := context.Background()
+	base, err := url.Parse(TestDBURL())
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	scratch := *base
+	scratch.Path = "/" + strings.TrimPrefix(base.Path, "/") + "_selfprov"
+
+	admin, err := pgxpool.New(ctx, TestDBURL())
+	if err != nil {
+		t.Fatalf("admin pool: %v", err)
+	}
+	defer admin.Close()
+	if err := admin.Ping(ctx); err != nil {
+		t.Skipf("test database not available: %v", err)
+	}
+	name := strings.TrimPrefix(scratch.Path, "/")
+	if _, err := admin.Exec(ctx, `DROP DATABASE IF EXISTS `+pgx.Identifier{name}.Sanitize()); err != nil {
+		t.Fatalf("drop scratch db: %v", err)
+	}
+	t.Cleanup(func() {
+		admin.Exec(context.Background(), `DROP DATABASE IF EXISTS `+pgx.Identifier{name}.Sanitize())
+	})
+
+	pool, err := OpenPreparedTestDB(ctx, scratch.String())
+	if err != nil {
+		t.Fatalf("OpenPreparedTestDB should create the missing database, got: %v", err)
+	}
+	pool.Close()
+
+	// Idempotent on the second open (database now exists and is migrated).
+	pool2, err := OpenPreparedTestDB(ctx, scratch.String())
+	if err != nil {
+		t.Fatalf("second OpenPreparedTestDB: %v", err)
+	}
+	pool2.Close()
 }


### PR DESCRIPTION
## Summary

Follow-up to #671's review discussion: DB-backed test runs no longer serialize.

The `testutil` harness truncates tables between tests, so one shared database forced `-p 1` on every DB-backed run — the documented cross-package flake source (AGENTS.md), and a ~12-minute wall for the coverage job that recently started brushing its CI timeout.

**Mechanism** (`internal/testutil/db.go`):
- `TestDBURL()` derives a **per-package database** inside test binaries: `<base>_pkg_<package>`, from the test binary's name (`relay.test` → `…_pkg_relay`; base names are unique across the repo). Every URL consumer in one test binary — `TestDB`, hand-built pools, the in-process contract server — lands on the same database, so intra-package behavior is unchanged.
- `OpenPreparedTestDB` **self-provisions** a missing database: SQLSTATE 3D000 → `CREATE DATABASE` via the base URL's server (42P04 duplicate-race tolerated) → retry, then the existing migrate+truncate path. First run per package pays one migration pass; after that it's a no-op check.
- Non-test binaries (`cmd/e2a-contract-server`) and `E2A_TEST_DB_SHARED=1` get the base URL verbatim. Concurrent sessions running the *same* package still follow the per-session base-URL guidance (updated in AGENTS.md, including that `*_pkg_*` databases are disposable).

**Parallelism**: Make targets (`test`, `test-integration`, `test-e2e`, `cover`) and the CI coverage/e2e jobs move from `-p 1` to `-p 4` — capped below core count so N × pgxpool connections stay under Postgres's default `max_connections=100`. The coverage job's race step goes to `-p 2`.

## Impact

- Local full cover run: ~12m serialized → **4m14s** at `-p 4` (44 packages).
- Full `-tags integration` suite: 49 packages, 0 failures, 6m33s uncached.
- Coverage floors verified on the parallel profile (`go-test-coverage` PASS, total 77.7%).
- `make test-unit`'s intermittent shared-DB failures (relay/webhook packages truncating each other) are structurally fixed — it runs default-parallel and now each package is isolated.

No API changes, no migrations, no production code paths touched (test harness + Make/CI/docs only).

## Tests

```
go test ./internal/testutil/                                  new: suffix derivation, shared-mode escape, self-provision + idempotent reopen
go test -p 4 -covermode=atomic ./internal/...                 44 ok, floors PASS   (4m14s)
make test-e2e (parallel)                                      5 ok, 0 FAIL         (1m42s)
go test -tags integration -p 4 -count=1 ./...                 49 ok, 0 FAIL        (6m33s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
