### PR TITLE
feat(telemetry): instrument the three adopted SLO targets

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -80,6 +80,7 @@ acceptance SLI below deliberately excludes them.
 | `e2a_outbound_attempts_total` | counter | `outcome` | Upstream submission attempts: `success`, `temporary_failure`, `permanent_failure`. |
 | `e2a_outbound_attempt_duration_seconds` | histogram | — | Upstream (SES/SMTP relay) submission duration. |
 | `e2a_outbound_terminal_total` | counter | `outcome` | Messages reaching a terminal submission outcome, **exactly once per message**: `sent`, `failed_suppressed`, `failed_provider`, `failed_local_retries`, `failed_cancelled` (policy cancel settled by the reconciler — kept out of `failed_local_retries` so cancellations can't mask a retries-exhausted regression). A deferred final attempt is counted when the terminal reconciler settles it — as `sent` when provider-accept evidence arrived (never a false failure), else as a failure. |
+| `e2a_outbound_terminal_latency_seconds` | histogram | — | Acceptance→terminal latency per message (the terminal write's occurred_at − `messages.created_at`), observed **exactly once per message**, co-located with the `e2a_outbound_terminal_total` emission so the two share their exactly-once contract (the SNS-feedback settle path is deliberately uninstrumented for both). Provider-evidence settles use the evidence's accept time as occurred_at, so they measure acceptance→provider-accept, not acceptance→sweep. Buckets span seconds→days (the 72h retry horizon is the tail). |
 
 ### Webhook delivery
 
@@ -87,6 +88,7 @@ acceptance SLI below deliberately excludes them.
 |---|---|---|---|
 | `e2a_webhook_attempts_total` | counter | `outcome`, `status_class` | Delivery attempts to subscriber endpoints: `delivered`, `retryable_failure`, `exhausted` (terminal after max attempts), `webhook_deleted`, `skipped_disabled`. `status_class` is the endpoint's response class, or `none` when no HTTP response was received (connect/DNS/SSRF-blocked). |
 | `e2a_webhook_attempt_duration_seconds` | histogram | — | HTTP POST duration per attempt. |
+| `e2a_webhook_first_attempt_latency_seconds` | histogram | — | Event→first-attempt latency per subscriber delivery (attempt start − the `webhook_events` row's `created_at`), observed **only on a first-delivery row's first HTTP attempt** (River attempt 1 with no recorded prior attempt). Retries, the no-POST outcomes (`webhook_deleted`, `skipped_disabled`), replay rows (their baseline would be the original event's age), and eventless `/test` deliveries never observe. |
 | `e2a_outbox_events_published_total` | counter | `type` | Events written to the outbox (fan-out input). |
 | `e2a_outbox_events_fanout_total` / `e2a_outbox_fanout_matched_total` | counter | `type` | Fan-out completions / subscriber delivery rows written. |
 | `e2a_outbox_events_nomatch_total` | counter | `type` | Events with zero matching subscribers. |
@@ -99,6 +101,7 @@ acceptance SLI below deliberately excludes them.
 |---|---|---|---|
 | `e2a_ws_connections_active` | gauge | — | Currently registered connections. |
 | `e2a_ws_connects_total` | counter | — | Accepted + registered connections. |
+| `e2a_ws_handshake_rejected_total` | counter | `reason` | Pre-upgrade handshake rejections: `unauthorized` (missing/invalid credential), `not_found` (unknown agent — including the deliberate cross-tenant 404 collapse), `forbidden` (agent-scoped credential pinned to a different agent), `upgrade_failed` (authenticated, but the WebSocket upgrade itself failed). Never labeled with emails or tokens. |
 | `e2a_ws_disconnects_total` | counter | `reason` | `replaced` (one-conn-per-agent takeover), `ping_timeout`, `client_close`, `error`, `shutdown`. |
 | `e2a_ws_drained_messages_total` | counter | — | Unread messages pushed during connect-drain. The prober's WS scenario trashes its own probe messages after each run so this stays customer signal, not prober noise. |
 | `e2a_ws_send_failures_total` | counter | — | Failed pushes to a registered connection. |
@@ -210,6 +213,20 @@ histogram_quantile(0.95, sum by (le) (rate(e2a_outbound_queue_wait_seconds_bucke
 max(e2a_queue_oldest_age_seconds{queue="outbound"})
 ```
 
+**Outbound acceptance→terminal** — fraction of messages reaching a terminal
+outcome within 5 minutes of acceptance (the `le="300"` bucket edge is the
+SLO threshold):
+
+```promql
+sum(rate(e2a_outbound_terminal_latency_seconds_bucket{le="300"}[1h]))
+/ sum(rate(e2a_outbound_terminal_latency_seconds_count[1h]))
+```
+
+The histogram's exactly-once contract (one sample per message, co-located
+with `e2a_outbound_terminal_total`) is what makes this ratio a per-message
+fraction; an outage-tail message can legitimately land in the day-scale
+buckets, so alert on the ratio, not the tail.
+
 **Webhook attempt health** — per-attempt success to responsive endpoints,
 across all attempt indexes (there is no attempt-number label; an unhealthy
 customer endpoint is not an e2a failure, but a rising `none` / `5xx` share
@@ -221,6 +238,29 @@ snooze, and no POST happens:
 sum(rate(e2a_webhook_attempts_total{outcome="delivered"}[5m]))
 / sum(rate(e2a_webhook_attempts_total{outcome=~"delivered|retryable_failure|exhausted"}[5m]))
 ```
+
+**Webhook event→first attempt** — p95 latency from event creation to the
+first HTTP attempt (covers fan-out, queue wait, and worker pickup):
+
+```promql
+histogram_quantile(0.95, sum by (le) (rate(e2a_webhook_first_attempt_latency_seconds_bucket[5m])))
+```
+
+**WebSocket handshake success (valid credentials)** — accepted handshakes
+over accepted plus e2a-attributable rejections:
+
+```promql
+sum(rate(e2a_ws_connects_total[5m]))
+/ (sum(rate(e2a_ws_connects_total[5m]))
+   + sum(rate(e2a_ws_handshake_rejected_total{reason=~"forbidden|upgrade_failed"}[5m])))
+```
+
+The split is deliberate: `unauthorized` (missing/invalid credential) and
+`not_found` (unknown agent — including the cross-tenant 404 collapse) are
+*client* faults and are excluded from the denominator, or scanner noise
+would burn the SLO. `forbidden` (a valid, authenticated credential pinned
+to a different agent) and `upgrade_failed` count against e2a — the
+credential was valid, so the rejection is ours to explain.
 
 **WebSocket health** — active connections, abnormal disconnect rate, and the
 black-box push path:
@@ -250,23 +290,13 @@ after M ≥ 2 consecutive failed probes).
 | HTTP API | p99 latency (`/v1`, excluding WS upgrades) | < 750 ms |
 | SMTP intake | acceptance (non-policy) | ≥ 99.9% |
 | SMTP intake | DATA processing p95 | < 2 s |
-| Outbound | terminal outcome within 5 min of acceptance ¹ | ≥ 99% |
+| Outbound | terminal outcome within 5 min of acceptance | ≥ 99% |
 | Outbound | queue wait p95 | < 30 s |
-| Webhooks | event → first delivery attempt ¹ | < 60 s (p95) |
+| Webhooks | event → first delivery attempt | < 60 s (p95) |
 | Webhooks | eventual delivery to responsive endpoints (≤ 8 attempts) | ≥ 99% |
-| WebSocket | handshake success (valid credentials) ¹ | ≥ 99.9% |
+| WebSocket | handshake success (valid credentials) | ≥ 99.9% |
 | WebSocket | prober round-trip (connect → live push) | ≥ 99.9% of probes |
 | MCP | prober connection + tool-call success | ≥ 99.9% of probes |
-
-¹ **Target adopted; instrument pending.** These three rows cannot yet be
-computed from shipped metrics: acceptance→terminal latency needs a per-
-message duration histogram (terminal counters and the queue-wait histogram
-don't compose into one), event→first-attempt needs the delivery row's age
-observed at attempt time, and handshake success needs a rejected-handshake
-counter (today only successful registrations increment `e2a_ws_connects_total`;
-rejections appear in the HTTP metrics as 4xx on the WS route). They are
-listed so the targets are on record; the instruments land in a follow-up,
-and until then these rows must not be reported as measured.
 
 ## Product SLOs vs. inbox placement
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -88,7 +88,7 @@ acceptance SLI below deliberately excludes them.
 |---|---|---|---|
 | `e2a_webhook_attempts_total` | counter | `outcome`, `status_class` | Delivery attempts to subscriber endpoints: `delivered`, `retryable_failure`, `exhausted` (terminal after max attempts), `webhook_deleted`, `skipped_disabled`. `status_class` is the endpoint's response class, or `none` when no HTTP response was received (connect/DNS/SSRF-blocked). |
 | `e2a_webhook_attempt_duration_seconds` | histogram | — | HTTP POST duration per attempt. |
-| `e2a_webhook_first_attempt_latency_seconds` | histogram | — | Event→first-attempt latency per subscriber delivery (attempt start − the `webhook_events` row's `created_at`), observed **only on a first-delivery row's first HTTP attempt** (River attempt 1 with no recorded prior attempt). Retries, the no-POST outcomes (`webhook_deleted`, `skipped_disabled`), replay rows (their baseline would be the original event's age), and eventless `/test` deliveries never observe. |
+| `e2a_webhook_first_attempt_latency_seconds` | histogram | — | Event→first-attempt latency per subscriber delivery (attempt start − the `webhook_events` row's `created_at`), observed **only on a first-delivery row's first HTTP attempt** (no recorded prior attempt — regardless of River attempt number, so a first POST delayed by pre-POST failures still observes). Retries, the no-POST outcomes (`webhook_deleted`, `skipped_disabled`), replay rows (their baseline would be the original event's age), eventless `/test` deliveries, and jobs that sat through a customer-disabled window (River snooze) never observe. |
 | `e2a_outbox_events_published_total` | counter | `type` | Events written to the outbox (fan-out input). |
 | `e2a_outbox_events_fanout_total` / `e2a_outbox_fanout_matched_total` | counter | `type` | Fan-out completions / subscriber delivery rows written. |
 | `e2a_outbox_events_nomatch_total` | counter | `type` | Events with zero matching subscribers. |
@@ -101,7 +101,7 @@ acceptance SLI below deliberately excludes them.
 |---|---|---|---|
 | `e2a_ws_connections_active` | gauge | — | Currently registered connections. |
 | `e2a_ws_connects_total` | counter | — | Accepted + registered connections. |
-| `e2a_ws_handshake_rejected_total` | counter | `reason` | Pre-upgrade handshake rejections: `unauthorized` (missing/invalid credential), `not_found` (unknown agent — including the deliberate cross-tenant 404 collapse), `forbidden` (agent-scoped credential pinned to a different agent), `upgrade_failed` (authenticated, but the WebSocket upgrade itself failed). Never labeled with emails or tokens. |
+| `e2a_ws_handshake_rejected_total` | counter | `reason` | Pre-upgrade handshake rejections: `unauthorized` (missing/invalid credential), `not_found` (unknown agent — including the deliberate cross-tenant 404 collapse), `forbidden` (agent-scoped credential pinned to a different agent), `upgrade_failed` (authenticated, but the WebSocket upgrade itself failed), `internal_error` (a store/infra error while authenticating or resolving the agent — the only e2a-attributable reason). Never labeled with emails or tokens. |
 | `e2a_ws_disconnects_total` | counter | `reason` | `replaced` (one-conn-per-agent takeover), `ping_timeout`, `client_close`, `error`, `shutdown`. |
 | `e2a_ws_drained_messages_total` | counter | — | Unread messages pushed during connect-drain. The prober's WS scenario trashes its own probe messages after each run so this stays customer signal, not prober noise. |
 | `e2a_ws_send_failures_total` | counter | — | Failed pushes to a registered connection. |
@@ -252,15 +252,23 @@ over accepted plus e2a-attributable rejections:
 ```promql
 sum(rate(e2a_ws_connects_total[5m]))
 / (sum(rate(e2a_ws_connects_total[5m]))
-   + sum(rate(e2a_ws_handshake_rejected_total{reason=~"forbidden|upgrade_failed"}[5m])))
+   + sum(rate(e2a_ws_handshake_rejected_total{reason="internal_error"}[5m])))
 ```
 
-The split is deliberate: `unauthorized` (missing/invalid credential) and
-`not_found` (unknown agent — including the cross-tenant 404 collapse) are
-*client* faults and are excluded from the denominator, or scanner noise
-would burn the SLO. `forbidden` (a valid, authenticated credential pinned
-to a different agent) and `upgrade_failed` count against e2a — the
-credential was valid, so the rejection is ours to explain.
+The split is deliberate, by who can act on the rejection. Client faults are
+excluded from the denominator, or scanner noise and customer
+misconfiguration would burn the SLO: `unauthorized` (missing/invalid
+credential), `not_found` (unknown agent — including the cross-tenant 404
+collapse), `forbidden` (an agent-scoped credential pinned to a different
+agent — deterministic scope enforcement, not e2a-actionable), and
+`upgrade_failed` (predominantly client protocol defects, e.g. a plain GET
+with a valid key; genuine server-side upgrade breakage — a proxy stripping
+Upgrade headers fleet-wide — is covered by the prober's
+`websocket_round_trip` SLI below). `internal_error` (a store/infra error
+while authenticating or resolving the agent, distinguished from a genuine
+miss by `pgx.ErrNoRows`) is the only e2a-attributable reason and the only
+one in the denominator — a Postgres outage burns this SLI rather than
+reading 0/0 behind the client-fault labels.
 
 **WebSocket health** — active connections, abnormal disconnect rate, and the
 black-box push path:

--- a/internal/agent/outbound_async.go
+++ b/internal/agent/outbound_async.go
@@ -227,11 +227,15 @@ func (a *outboundSendStore) meterSentTx(ctx context.Context, tx pgx.Tx, info *id
 // The returned delivery.Status tells the caller what actually happened so
 // metrics/logging report truth, not intent: StatusSent (evidence settle),
 // StatusFailed (failure recorded), or "" (no-op — row gone, already
-// terminal, or evidence raced the CAS; nothing was written).
-func (a *outboundSendStore) MarkFailed(ctx context.Context, messageID string, jobID int64, attempt int, occurredAt time.Time, detail string, source delivery.FailureSource, reason messagelifecycle.ReasonCode, blockedRecipients []string) (delivery.Status, error) {
+// terminal, or evidence raced the CAS; nothing was written). The returned
+// time is the occurred_at the write actually used: the provider-accept
+// evidence time on an evidence settle, the caller's occurredAt on a failure,
+// zero on a no-op.
+func (a *outboundSendStore) MarkFailed(ctx context.Context, messageID string, jobID int64, attempt int, occurredAt time.Time, detail string, source delivery.FailureSource, reason messagelifecycle.ReasonCode, blockedRecipients []string) (delivery.Status, time.Time, error) {
 	detail = messagelifecycle.SafeDiagnostic(detail)
 	blockedRecipients = normalizeBlockedRecipients(blockedRecipients)
 	var settled delivery.Status
+	var settledAt time.Time
 	var resolved *identity.OutboundSentInfo
 	var resolvedProviderID string
 	if err := a.store.WithTx(ctx, func(tx pgx.Tx) error {
@@ -244,6 +248,7 @@ func (a *outboundSendStore) MarkFailed(ctx context.Context, messageID string, jo
 			attempt = 0
 			occurredAt = info.ProviderAcceptedAt
 			settled = delivery.StatusSent
+			settledAt = occurredAt
 			return a.finalizeSentTx(ctx, tx, info, jobID, attempt, occurredAt, providerID)
 		}
 		finfo, err := a.store.MarkOutboundFailedTx(ctx, tx, messageID, detail, source)
@@ -255,6 +260,7 @@ func (a *outboundSendStore) MarkFailed(ctx context.Context, messageID string, jo
 			return nil
 		}
 		settled = delivery.StatusFailed
+		settledAt = occurredAt
 		if _, err := tx.Exec(ctx, `UPDATE messages SET delivery_failure_reason_code=$2 WHERE id=$1`, messageID, string(reason)); err != nil {
 			return err
 		}
@@ -273,12 +279,12 @@ func (a *outboundSendStore) MarkFailed(ctx context.Context, messageID string, jo
 		e.ID = webhookpub.DeterministicEventID(messageID, webhookpub.EventEmailFailed)
 		return a.outbox.PublishTx(ctx, tx, e)
 	}); err != nil {
-		return "", err
+		return "", time.Time{}, err
 	}
 	if resolved != nil {
 		log.Printf("[outbound-send] %s: terminal-failure guard settled as sent on provider evidence (provider id %q)", messageID, resolvedProviderID)
 	}
-	return settled, nil
+	return settled, settledAt, nil
 }
 
 func (a *outboundSendStore) PreserveTerminalFailure(ctx context.Context, messageID string, jobID int64, attempt int, occurredAt time.Time, detail string, source delivery.FailureSource, reason messagelifecycle.ReasonCode, blockedRecipients []string) error {

--- a/internal/agent/outbound_async_test.go
+++ b/internal/agent/outbound_async_test.go
@@ -1103,12 +1103,16 @@ func TestOutboundSendStore_MarkFailed(t *testing.T) {
 	}
 
 	adapter := agent.NewOutboundSendStore(store, outbox, usage.NewNoopUsageTracker())
-	settled, err := adapter.MarkFailed(ctx, res.MessageID, 999, 6, time.Now().UTC(), "550 mailbox unavailable", delivery.FailureSourceProvider, messagelifecycle.ReasonSubmissionProviderRejected, nil)
+	occurredAt := time.Now().UTC()
+	settled, settledAt, err := adapter.MarkFailed(ctx, res.MessageID, 999, 6, occurredAt, "550 mailbox unavailable", delivery.FailureSourceProvider, messagelifecycle.ReasonSubmissionProviderRejected, nil)
 	if err != nil {
 		t.Fatalf("MarkFailed: %v", err)
 	}
 	if settled != delivery.StatusFailed {
 		t.Fatalf("MarkFailed settled = %q, want %q (no provider evidence present)", settled, delivery.StatusFailed)
+	}
+	if !settledAt.Equal(occurredAt) {
+		t.Errorf("MarkFailed effective occurred_at = %s, want the caller's %s on the failure path", settledAt, occurredAt)
 	}
 
 	var deliveryStatus, detail string

--- a/internal/outboundsend/metrics.go
+++ b/internal/outboundsend/metrics.go
@@ -1,6 +1,8 @@
 package outboundsend
 
 import (
+	"time"
+
 	"github.com/tokencanopy/e2a/internal/delivery"
 	"github.com/tokencanopy/e2a/internal/messagelifecycle"
 )
@@ -18,6 +20,11 @@ type Metrics interface {
 	// outcome ∈ {sent, failed_suppressed, failed_provider,
 	// failed_local_retries, failed_cancelled}.
 	OutboundTerminal(outcome string)
+	// OutboundTerminalLatency records acceptance→terminal latency for one
+	// outbound message (the terminal write's occurred_at −
+	// messages.created_at). Observed exactly once per message, co-located
+	// with OutboundTerminal so the two share their exactly-once contract.
+	OutboundTerminalLatency(seconds float64)
 	// OutboundAttempt records one submission attempt to the upstream relay.
 	// outcome ∈ {success, temporary_failure, permanent_failure}.
 	OutboundAttempt(outcome string, seconds float64)
@@ -43,7 +50,24 @@ type noopMetrics struct{}
 
 func (noopMetrics) OutboundQueueWait(float64)       {}
 func (noopMetrics) OutboundTerminal(string)         {}
+func (noopMetrics) OutboundTerminalLatency(float64) {}
 func (noopMetrics) OutboundAttempt(string, float64) {}
+
+// observeTerminalLatency records the acceptance→terminal latency for one
+// settled message. Call it ONLY where OutboundTerminal is emitted, with the
+// same occurred_at the terminal write used — the two instruments share one
+// exactly-once contract. A zero accepted_at (hand-built row) or a
+// non-positive delta (clock skew) records no sample — the terminal is still
+// counted, but no honest duration exists (same discipline as the
+// queue-wait guard).
+func observeTerminalLatency(m Metrics, acceptedAt, occurredAt time.Time) {
+	if acceptedAt.IsZero() || occurredAt.IsZero() {
+		return
+	}
+	if d := occurredAt.Sub(acceptedAt); d > 0 {
+		m.OutboundTerminalLatency(d.Seconds())
+	}
+}
 
 // terminalOutcome maps a MarkFailed call's provenance to the OutboundTerminal
 // label: suppression holds blocked recipients; a policy cancel without them

--- a/internal/outboundsend/metrics.go
+++ b/internal/outboundsend/metrics.go
@@ -53,14 +53,16 @@ func (noopMetrics) OutboundTerminal(string)         {}
 func (noopMetrics) OutboundTerminalLatency(float64) {}
 func (noopMetrics) OutboundAttempt(string, float64) {}
 
-// observeTerminalLatency records the acceptance→terminal latency for one
-// settled message. Call it ONLY where OutboundTerminal is emitted, with the
-// same occurred_at the terminal write used — the two instruments share one
-// exactly-once contract. A zero accepted_at (hand-built row) or a
-// non-positive delta (clock skew) records no sample — the terminal is still
-// counted, but no honest duration exists (same discipline as the
-// queue-wait guard).
-func observeTerminalLatency(m Metrics, acceptedAt, occurredAt time.Time) {
+// emitTerminal records one terminal outcome count AND its co-located
+// acceptance→terminal latency — the two instruments' exactly-once contract
+// lives in this single helper so no call site can emit one without the
+// other. occurredAt is the terminal write's EFFECTIVE occurred_at (what the
+// write actually did: the provider-accept evidence time on an evidence
+// settle, the caller's observation time otherwise); acceptedAt is
+// messages.created_at. A zero timestamp or non-positive delta records the
+// count but no latency sample (same discipline as the queue-wait guard).
+func emitTerminal(m Metrics, outcome string, acceptedAt, occurredAt time.Time) {
+	m.OutboundTerminal(outcome)
 	if acceptedAt.IsZero() || occurredAt.IsZero() {
 		return
 	}

--- a/internal/outboundsend/metrics_test.go
+++ b/internal/outboundsend/metrics_test.go
@@ -15,6 +15,7 @@ import (
 type recordingMetrics struct {
 	queueWaits []float64
 	terminals  []string
+	latencies  []float64
 	attempts   []attemptSample
 }
 
@@ -28,6 +29,9 @@ func (r *recordingMetrics) OutboundQueueWait(seconds float64) {
 }
 func (r *recordingMetrics) OutboundTerminal(outcome string) {
 	r.terminals = append(r.terminals, outcome)
+}
+func (r *recordingMetrics) OutboundTerminalLatency(seconds float64) {
+	r.latencies = append(r.latencies, seconds)
 }
 func (r *recordingMetrics) OutboundAttempt(outcome string, seconds float64) {
 	r.attempts = append(r.attempts, attemptSample{outcome: outcome, seconds: seconds})
@@ -256,5 +260,107 @@ func TestSendWorker_MetricsDefaultIsNilSafe(t *testing.T) {
 	st2 := &fakeStore{job: acceptedJob("msg_2")}
 	if err := outboundsend.NewSendWorker(st2, dl).WithMetrics(nil).Work(context.Background(), timedJob("msg_2", 1, time.Second)); err != nil {
 		t.Fatalf("Work with nil metrics: %v", err)
+	}
+}
+
+// ── Acceptance→terminal latency SLI (docs/observability.md) ──────
+//
+// The latency histogram is observed EXACTLY ONCE per message, co-located
+// with the e2a_outbound_terminal_total emission so the two share their
+// exactly-once contract: a terminal that is not counted is not timed, and
+// vice versa. The value is the terminal write's occurred_at −
+// messages.created_at (SendJob.AcceptedAt), never a re-computed clock.
+
+func TestSendWorker_TerminalLatencySuccessPath(t *testing.T) {
+	j := acceptedJob("msg_1")
+	j.AcceptedAt = time.Now().Add(-90 * time.Second)
+	st := &fakeStore{job: j}
+	dl := &fakeDeliverer{out: outboundsend.DeliverOutcome{ProviderMessageID: "ses-1", SentAs: "relay"}}
+	rec := &recordingMetrics{}
+	if err := outboundsend.NewSendWorker(st, dl).WithMetrics(rec).Work(context.Background(), job("msg_1", 1)); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	if len(rec.latencies) != 1 {
+		t.Fatalf("latencies = %v, want exactly one sample (parity with the terminal count)", rec.latencies)
+	}
+	if got := rec.latencies[0]; got < 85 || got > 95 {
+		t.Errorf("terminal latency = %.1fs, want ~90s (occurred_at − accepted_at)", got)
+	}
+}
+
+func TestSendWorker_TerminalLatencyEvidenceSettleUsesProviderAcceptTime(t *testing.T) {
+	j := acceptedJob("msg_1")
+	j.AcceptedAt = time.Now().Add(-90 * time.Second)
+	providerAcceptedAt := time.Now().Add(-60 * time.Second).UTC()
+	j.ProviderAccepted = true
+	j.ProviderAcceptedAt = &providerAcceptedAt
+	j.ProviderMessageID = "ses-evidence-1"
+	st := &fakeStore{job: j}
+	rec := &recordingMetrics{}
+	if err := outboundsend.NewSendWorker(st, &fakeDeliverer{}).WithMetrics(rec).Work(context.Background(), job("msg_1", 2)); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	if len(rec.latencies) != 1 {
+		t.Fatalf("latencies = %v, want exactly one sample", rec.latencies)
+	}
+	// The settle's occurred_at is the provider-accept evidence time, so the
+	// latency measures acceptance→provider-accept (~30s), not
+	// acceptance→settle (~90s).
+	if got := rec.latencies[0]; got < 25 || got > 35 {
+		t.Errorf("terminal latency = %.1fs, want ~30s (provider-accept evidence time − accepted_at)", got)
+	}
+}
+
+func TestSendWorker_TerminalLatencyRecordedForFailureOutcomes(t *testing.T) {
+	j := acceptedJob("msg_1")
+	j.AcceptedAt = time.Now().Add(-2 * time.Minute)
+	st := &fakeStore{job: j, suppressed: []string{"blocked@example.net"}}
+	rec := &recordingMetrics{}
+	if err := outboundsend.NewSendWorker(st, &fakeDeliverer{}).WithMetrics(rec).Work(context.Background(), job("msg_1", 1)); err == nil {
+		t.Fatal("suppressed message must cancel")
+	}
+	if !stringsEqual(rec.terminals, []string{"failed_suppressed"}) {
+		t.Errorf("terminals = %v, want [failed_suppressed]", rec.terminals)
+	}
+	if len(rec.latencies) != 1 {
+		t.Fatalf("latencies = %v, want exactly one sample alongside the terminal count", rec.latencies)
+	}
+	if got := rec.latencies[0]; got < 110 || got > 130 {
+		t.Errorf("terminal latency = %.1fs, want ~120s", got)
+	}
+}
+
+func TestSendWorker_TerminalLatencyNotRecordedForDeferredFinalAttempt(t *testing.T) {
+	// Parity with e2a_outbound_terminal_total: a deferred final attempt is
+	// not terminal — the reconciler counts AND times the row when it
+	// settles. Observing here too would double-count the message.
+	j := acceptedJob("msg_1")
+	j.AcceptedAt = time.Now().Add(-10 * time.Minute)
+	st := &fakeStore{job: j}
+	dl := &fakeDeliverer{out: outboundsend.DeliverOutcome{Err: errors.New("boom 421")}}
+	rec := &recordingMetrics{}
+	if err := outboundsend.NewSendWorker(st, dl).WithMetrics(rec).Work(context.Background(), job("msg_1", outboundsend.MaxSendAttempts)); err == nil {
+		t.Fatal("final attempt failure should return an error so River discards")
+	}
+	if len(rec.terminals) != 0 || len(rec.latencies) != 0 {
+		t.Errorf("terminals=%v latencies=%v, want neither (reconciler settles the deferred row later)", rec.terminals, rec.latencies)
+	}
+}
+
+func TestSendWorker_TerminalLatencyGuardsZeroAcceptedAt(t *testing.T) {
+	// acceptedJob leaves AcceptedAt zero (hand-built row): a terminal must
+	// still be counted, but no latency sample can be computed — same
+	// discipline as the queue-wait guard against missing timestamps.
+	st := &fakeStore{job: acceptedJob("msg_1")}
+	dl := &fakeDeliverer{out: outboundsend.DeliverOutcome{ProviderMessageID: "ses-1", SentAs: "relay"}}
+	rec := &recordingMetrics{}
+	if err := outboundsend.NewSendWorker(st, dl).WithMetrics(rec).Work(context.Background(), job("msg_1", 1)); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	if !stringsEqual(rec.terminals, []string{"sent"}) {
+		t.Errorf("terminals = %v, want [sent]", rec.terminals)
+	}
+	if len(rec.latencies) != 0 {
+		t.Errorf("latencies = %v, want none with a zero accepted_at", rec.latencies)
 	}
 }

--- a/internal/outboundsend/metrics_test.go
+++ b/internal/outboundsend/metrics_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/riverqueue/river"
 
+	"github.com/tokencanopy/e2a/internal/delivery"
 	"github.com/tokencanopy/e2a/internal/outboundsend"
 )
 
@@ -362,5 +363,32 @@ func TestSendWorker_TerminalLatencyGuardsZeroAcceptedAt(t *testing.T) {
 	}
 	if len(rec.latencies) != 0 {
 		t.Errorf("latencies = %v, want none with a zero accepted_at", rec.latencies)
+	}
+}
+
+func TestSendWorker_TerminalLatencyMarkFailedSettlesSentUsesWriteTime(t *testing.T) {
+	// When the guarded MarkFailed settles the row as SENT on raced-in
+	// provider evidence, the store rewrites occurred_at to the provider-accept
+	// time for the durable write. The latency SLI must use the write's
+	// EFFECTIVE occurred_at (returned by MarkFailed), not the caller's
+	// observation time — that is what the write actually did.
+	j := acceptedJob("msg_1")
+	j.AcceptedAt = time.Now().Add(-90 * time.Second)
+	providerAcceptedAt := time.Now().Add(-30 * time.Second).UTC()
+	st := &fakeStore{job: j, settleStatus: delivery.StatusSent, settleAt: providerAcceptedAt}
+	dl := &fakeDeliverer{out: outboundsend.DeliverOutcome{Err: errors.New("rejected 550"), Permanent: true}}
+	rec := &recordingMetrics{}
+	if err := outboundsend.NewSendWorker(st, dl).WithMetrics(rec).Work(context.Background(), job("msg_1", 1)); err == nil {
+		t.Fatal("permanent failure should cancel")
+	}
+	if !stringsEqual(rec.terminals, []string{"sent"}) {
+		t.Fatalf("terminals = %v, want [sent] (evidence settle via the guarded write)", rec.terminals)
+	}
+	if len(rec.latencies) != 1 {
+		t.Fatalf("latencies = %v, want exactly one sample", rec.latencies)
+	}
+	// provider-accept time − accepted_at ≈ 60s, NOT now − accepted_at ≈ 90s.
+	if got := rec.latencies[0]; got < 55 || got > 65 {
+		t.Errorf("latency = %.1fs, want ~60s (the write's effective occurred_at − accepted_at)", got)
 	}
 }

--- a/internal/outboundsend/reconcile_test.go
+++ b/internal/outboundsend/reconcile_test.go
@@ -329,6 +329,56 @@ func (f *terminalFixture) assertEventCarriesOnly(t *testing.T, messageID, eventT
 	}
 }
 
+func TestTerminalReconcileWorker_RecordsTerminalLatencyPerSettledRow(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	adapter := agent.NewOutboundSendStore(store,
+		webhookpub.NewOutbox(pool, webhookpub.StaticFlag(true)), usage.NewNoopUsageTracker())
+
+	f := newTerminalFixture(t, pool, store, adapter)
+	discardedID := f.seed(t, "lat-discarded", "accepted", "discarded", false)
+	missingID := f.seed(t, "lat-missing", "accepted", "", true)
+	// Pin acceptance 20 minutes in the past so the latency values are
+	// deterministic: the discarded row settles at its finalized_at (16 min
+	// ago → ~4 min latency); the missing-job row settles at sweep time
+	// (~20 min latency).
+	for _, id := range []string{discardedID, missingID} {
+		if _, err := f.pool.Exec(context.Background(),
+			`UPDATE messages SET created_at = now() - interval '20 minutes' WHERE id=$1`, id); err != nil {
+			t.Fatalf("age acceptance for %s: %v", id, err)
+		}
+	}
+
+	rec := &recordingMetrics{}
+	worker := outboundsend.NewTerminalReconcileWorker(pool, adapter).WithMetrics(rec)
+	if err := worker.Work(context.Background(), &river.Job[outboundsend.TerminalReconcileArgs]{}); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	// Latency parity with the terminal counter: exactly one sample per
+	// settled row, co-located with the e2a_outbound_terminal_total emission.
+	if len(rec.terminals) != 2 {
+		t.Fatalf("terminals = %v, want two settled rows", rec.terminals)
+	}
+	if len(rec.latencies) != 2 {
+		t.Fatalf("latencies = %v, want one per settled row", rec.latencies)
+	}
+	for _, got := range rec.latencies {
+		// 4 min (discarded, settled at finalized_at) and 20 min (missing,
+		// settled at sweep time); generous band covers sweep scheduling.
+		if got < 3*time.Minute.Seconds() || got > 21*time.Minute.Seconds() {
+			t.Errorf("terminal latency = %.0fs outside the expected 3–21 min band", got)
+		}
+	}
+
+	// A second pass settles nothing — no terminal, no latency (exactly-once).
+	if err := worker.Work(context.Background(), &river.Job[outboundsend.TerminalReconcileArgs]{}); err != nil {
+		t.Fatalf("second Work: %v", err)
+	}
+	if len(rec.terminals) != 2 || len(rec.latencies) != 2 {
+		t.Errorf("after idempotent re-pass: terminals=%v latencies=%v, want no new samples", rec.terminals, rec.latencies)
+	}
+}
+
 func TestTerminalReconcileWorker_ReconcilesOnlyTerminalJobs(t *testing.T) {
 	pool := testutil.TestDB(t)
 	store := identity.NewStore(pool)

--- a/internal/outboundsend/reconcile_test.go
+++ b/internal/outboundsend/reconcile_test.go
@@ -329,6 +329,49 @@ func (f *terminalFixture) assertEventCarriesOnly(t *testing.T, messageID, eventT
 	}
 }
 
+func TestTerminalReconcileWorker_EvidenceSettleLatencyUsesProviderAcceptTime(t *testing.T) {
+	// The §3.1 evidence-settle path rewrites the terminal write's occurred_at
+	// to the provider-accept evidence time (the durable write records
+	// acceptance→provider-accept, not acceptance→sweep). The latency SLI must
+	// use that SAME effective occurred_at — the sweep runs a full grace
+	// window (15m+) after the job died, so measuring to sweep time would
+	// systematically burn the 5-minute SLO on the reconciler's priority
+	// population (submitted, crashed before MarkSent).
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	adapter := agent.NewOutboundSendStore(store,
+		webhookpub.NewOutbox(pool, webhookpub.StaticFlag(true)), usage.NewNoopUsageTracker())
+
+	f := newTerminalFixture(t, pool, store, adapter)
+	evidenceID := f.seed(t, "lat-evidence", "accepted", "discarded", false)
+	if err := store.RecordProviderAcceptEvidence(context.Background(), evidenceID, "ses-evidence-lat"); err != nil {
+		t.Fatalf("RecordProviderAcceptEvidence: %v", err)
+	}
+	// Acceptance 20 minutes ago; provider accepted 30 seconds after
+	// acceptance; the job was discarded 16 minutes ago.
+	if _, err := pool.Exec(context.Background(),
+		`UPDATE messages SET created_at = now() - interval '20 minutes',
+		                    provider_accepted_at = now() - interval '19 minutes 30 seconds'
+		  WHERE id=$1`, evidenceID); err != nil {
+		t.Fatalf("age acceptance/evidence: %v", err)
+	}
+
+	rec := &recordingMetrics{}
+	worker := outboundsend.NewTerminalReconcileWorker(pool, adapter).WithMetrics(rec)
+	if err := worker.Work(context.Background(), &river.Job[outboundsend.TerminalReconcileArgs]{}); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	if !stringsEqual(rec.terminals, []string{"sent"}) {
+		t.Fatalf("terminals = %v, want [sent] (evidence settle)", rec.terminals)
+	}
+	if len(rec.latencies) != 1 {
+		t.Fatalf("latencies = %v, want exactly one sample", rec.latencies)
+	}
+	if got := rec.latencies[0]; got < 25 || got > 35 {
+		t.Errorf("evidence-settle latency = %.0fs, want ~30s (provider-accept time − accepted_at), not acceptance→sweep (minutes)", got)
+	}
+}
+
 func TestTerminalReconcileWorker_RecordsTerminalLatencyPerSettledRow(t *testing.T) {
 	pool := testutil.TestDB(t)
 	store := identity.NewStore(pool)
@@ -1047,11 +1090,11 @@ func (s failingTerminalStore) ReleaseSend(context.Context, string, int64) error 
 func (s failingTerminalStore) MarkSent(context.Context, string, int64, int, time.Time, string, string) error {
 	return nil
 }
-func (s failingTerminalStore) MarkFailed(context.Context, string, int64, int, time.Time, string, delivery.FailureSource, messagelifecycle.ReasonCode, []string) (delivery.Status, error) {
+func (s failingTerminalStore) MarkFailed(_ context.Context, _ string, _ int64, _ int, occurredAt time.Time, _ string, _ delivery.FailureSource, _ messagelifecycle.ReasonCode, _ []string) (delivery.Status, time.Time, error) {
 	if s.err != nil {
-		return "", s.err
+		return "", time.Time{}, s.err
 	}
-	return delivery.StatusFailed, nil
+	return delivery.StatusFailed, occurredAt, nil
 }
 func (s failingTerminalStore) PreserveTerminalFailure(context.Context, string, int64, int, time.Time, string, delivery.FailureSource, messagelifecycle.ReasonCode, []string) error {
 	return nil

--- a/internal/outboundsend/terminal_reconcile.go
+++ b/internal/outboundsend/terminal_reconcile.go
@@ -77,6 +77,7 @@ type terminalCandidate struct {
 	attempt                  int
 	state                    string
 	finalizedAt              *time.Time
+	acceptedAt               time.Time // messages.created_at — the latency SLI baseline
 	failureSource            delivery.FailureSource
 	detail                   string
 	failureReason            string
@@ -97,6 +98,7 @@ func (w *TerminalReconcileWorker) Work(ctx context.Context, _ *river.Job[Termina
 		        COALESCE(r.attempt, 0),
 		        CASE WHEN r.id IS NULL THEN 'missing' ELSE r.state::text END,
 		        r.finalized_at,
+		        m.created_at,
 		        COALESCE(m.delivery_failure_source,''),COALESCE(m.delivery_detail,''),COALESCE(m.delivery_failure_reason_code,''),
 		        m.delivery_failure_occurred_at,m.delivery_failure_attempt,m.delivery_failure_blocked_recipients
 		   FROM messages m
@@ -120,7 +122,7 @@ func (w *TerminalReconcileWorker) Work(ctx context.Context, _ *river.Job[Termina
 	candidates := make([]terminalCandidate, 0)
 	for rows.Next() {
 		var candidate terminalCandidate
-		if err := rows.Scan(&candidate.messageID, &candidate.jobID, &candidate.attempt, &candidate.state, &candidate.finalizedAt, &candidate.failureSource, &candidate.detail, &candidate.failureReason, &candidate.failureOccurredAt, &candidate.failureAttempt, &candidate.failureBlockedRecipients); err != nil {
+		if err := rows.Scan(&candidate.messageID, &candidate.jobID, &candidate.attempt, &candidate.state, &candidate.finalizedAt, &candidate.acceptedAt, &candidate.failureSource, &candidate.detail, &candidate.failureReason, &candidate.failureOccurredAt, &candidate.failureAttempt, &candidate.failureBlockedRecipients); err != nil {
 			return err
 		}
 		candidates = append(candidates, candidate)
@@ -177,12 +179,18 @@ func (w *TerminalReconcileWorker) Work(ctx context.Context, _ *river.Job[Termina
 		// guarded write actually did. Evidence-settled rows (the reconciler's
 		// priority population: submitted, crashed before MarkSent) count as
 		// "sent", not as a false failure; a no-op (row already terminal)
-		// counts nothing.
+		// counts nothing. The latency observation is co-located with the
+		// terminal count and uses the same occurred_at the write used
+		// (finalized/failure time, else sweep time) against the row's
+		// acceptance time carried on the candidate.
 		switch settled {
 		case delivery.StatusFailed:
 			w.metrics.OutboundTerminal(terminalOutcome(source, reason, candidate.failureBlockedRecipients))
 		case delivery.StatusSent:
 			w.metrics.OutboundTerminal(terminalSent)
+		}
+		if settled == delivery.StatusFailed || settled == delivery.StatusSent {
+			observeTerminalLatency(w.metrics, candidate.acceptedAt, occurredAt)
 		}
 		if w.ramp != nil {
 			if err := w.ramp.Resolve(ctx, candidate.messageID); err != nil {

--- a/internal/outboundsend/terminal_reconcile.go
+++ b/internal/outboundsend/terminal_reconcile.go
@@ -168,7 +168,7 @@ func (w *TerminalReconcileWorker) Work(ctx context.Context, _ *river.Job[Termina
 		// fails it with provenance 'local' so later authoritative evidence can
 		// still correct it. The stored detail of a deferred final attempt is
 		// preferred over this generic sweep detail.
-		settled, err := w.store.MarkFailed(ctx, candidate.messageID, candidate.jobID, attempt, occurredAt, detail, source, reason, candidate.failureBlockedRecipients)
+		settled, settledAt, err := w.store.MarkFailed(ctx, candidate.messageID, candidate.jobID, attempt, occurredAt, detail, source, reason, candidate.failureBlockedRecipients)
 		if err != nil {
 			if processed > 0 {
 				log.Printf("[outbound-terminal-reconcile] processed %d candidates", processed)
@@ -179,18 +179,15 @@ func (w *TerminalReconcileWorker) Work(ctx context.Context, _ *river.Job[Termina
 		// guarded write actually did. Evidence-settled rows (the reconciler's
 		// priority population: submitted, crashed before MarkSent) count as
 		// "sent", not as a false failure; a no-op (row already terminal)
-		// counts nothing. The latency observation is co-located with the
-		// terminal count and uses the same occurred_at the write used
-		// (finalized/failure time, else sweep time) against the row's
-		// acceptance time carried on the candidate.
+		// counts nothing. emitTerminal uses the write's EFFECTIVE occurred_at
+		// (settledAt — the provider-accept evidence time on an evidence
+		// settle), so the latency measures acceptance→provider-accept, not
+		// acceptance→sweep.
 		switch settled {
 		case delivery.StatusFailed:
-			w.metrics.OutboundTerminal(terminalOutcome(source, reason, candidate.failureBlockedRecipients))
+			emitTerminal(w.metrics, terminalOutcome(source, reason, candidate.failureBlockedRecipients), candidate.acceptedAt, settledAt)
 		case delivery.StatusSent:
-			w.metrics.OutboundTerminal(terminalSent)
-		}
-		if settled == delivery.StatusFailed || settled == delivery.StatusSent {
-			observeTerminalLatency(w.metrics, candidate.acceptedAt, occurredAt)
+			emitTerminal(w.metrics, terminalSent, candidate.acceptedAt, settledAt)
 		}
 		if w.ramp != nil {
 			if err := w.ramp.Resolve(ctx, candidate.messageID); err != nil {

--- a/internal/outboundsend/worker.go
+++ b/internal/outboundsend/worker.go
@@ -288,8 +288,11 @@ func (w *SendWorker) Work(ctx context.Context, job *river.Job[OutboundSendArgs])
 			return err
 		}
 		// Terminal 'sent', but NOT an attempt — the submit happened on an
-		// earlier attempt; only the settle lands here.
+		// earlier attempt; only the settle lands here. occurredAt is the
+		// provider-accept evidence time, so the latency measures
+		// acceptance→provider-accept, not acceptance→settle.
 		w.metrics.OutboundTerminal(terminalSent)
+		observeTerminalLatency(w.metrics, j.AcceptedAt, observedAt)
 		if w.ramp != nil && j.rampEligible() {
 			return w.ramp.Confirm(ctx, j.MessageID)
 		}
@@ -313,13 +316,13 @@ func (w *SendWorker) Work(ctx context.Context, job *river.Job[OutboundSendArgs])
 		observedAt = time.Now().UTC()
 		if rerr != nil {
 			if isPermanentRampError(rerr) {
-				if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, observedAt, "sending_ramp_invalid: "+rerr.Error(), delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionCancelled, nil); err != nil {
+				if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, observedAt, j.AcceptedAt, "sending_ramp_invalid: "+rerr.Error(), delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionCancelled, nil); err != nil {
 					return err
 				}
 				return river.JobCancel(rerr)
 			}
 			if j.pastRetryHorizon() {
-				if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, observedAt, "ramp_capacity_timeout: "+rerr.Error(), delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionLocalRetriesExhausted, nil); err != nil {
+				if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, observedAt, j.AcceptedAt, "ramp_capacity_timeout: "+rerr.Error(), delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionLocalRetriesExhausted, nil); err != nil {
 					return err
 				}
 				_ = w.ramp.Release(ctx, j.MessageID)
@@ -333,7 +336,7 @@ func (w *SendWorker) Work(ctx context.Context, job *river.Job[OutboundSendArgs])
 		}
 		if !decision.Allowed {
 			if j.pastRetryHorizon() {
-				if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, observedAt, "ramp_capacity_timeout", delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionLocalRetriesExhausted, nil); err != nil {
+				if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, observedAt, j.AcceptedAt, "ramp_capacity_timeout", delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionLocalRetriesExhausted, nil); err != nil {
 					return err
 				}
 				if err := w.ramp.Release(ctx, j.MessageID); err != nil {
@@ -371,7 +374,7 @@ func (w *SendWorker) Work(ctx context.Context, job *river.Job[OutboundSendArgs])
 	}
 	if len(suppressed) > 0 {
 		supErr := fmt.Errorf("recipient_suppressed: %s%s", strings.Join(suppressed, ", "), outbound.SuppressionRemediation(j.AgentID))
-		if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, observedAt, supErr.Error(), delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionCancelled, suppressed); err != nil {
+		if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, observedAt, j.AcceptedAt, supErr.Error(), delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionCancelled, suppressed); err != nil {
 			return err
 		}
 		if w.ramp != nil && j.rampEligible() {
@@ -406,8 +409,12 @@ func (w *SendWorker) Work(ctx context.Context, job *river.Job[OutboundSendArgs])
 		// NOT instrumented, so this is still the message's ONLY sent count.
 		// If FinalizeProviderAcceptedTx is ever given its own emission, this
 		// site must become status-aware (like MarkFailed) or the race
-		// double-counts.
+		// double-counts. The latency observation below shares this
+		// exactly-once contract — it is co-located with the terminal count
+		// here and everywhere else, and the SNS-feedback path stays
+		// uninstrumented for both.
 		w.metrics.OutboundTerminal(terminalSent)
+		observeTerminalLatency(w.metrics, j.AcceptedAt, observedAt)
 		if w.ramp != nil && j.rampEligible() {
 			if err := w.ramp.Confirm(ctx, j.MessageID); err != nil {
 				return fmt.Errorf("confirm sending ramp: %w", err)
@@ -420,7 +427,7 @@ func (w *SendWorker) Work(ctx context.Context, job *river.Job[OutboundSendArgs])
 	// Provenance 'provider': SES itself refused this submission, so the §3.1
 	// correction never revives it.
 	if out.Permanent {
-		if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, observedAt, out.Err.Error(), delivery.FailureSourceProvider, messagelifecycle.ReasonSubmissionProviderRejected, nil); err != nil {
+		if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, observedAt, j.AcceptedAt, out.Err.Error(), delivery.FailureSourceProvider, messagelifecycle.ReasonSubmissionProviderRejected, nil); err != nil {
 			return err
 		}
 		if w.ramp != nil && j.rampEligible() {
@@ -437,7 +444,7 @@ func (w *SendWorker) Work(ctx context.Context, job *river.Job[OutboundSendArgs])
 	// (provenance 'local': the provider never confirmed a rejection).
 	if out.Outage {
 		if j.pastRetryHorizon() {
-			if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, observedAt, out.Err.Error(), delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionLocalRetriesExhausted, nil); err != nil {
+			if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, observedAt, j.AcceptedAt, out.Err.Error(), delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionLocalRetriesExhausted, nil); err != nil {
 				return err
 			}
 			if w.ramp != nil && j.rampEligible() {
@@ -504,7 +511,7 @@ const (
 	terminalWriteBackoff = 150 * time.Millisecond
 )
 
-func (w *SendWorker) markFailed(ctx context.Context, messageID string, jobID int64, attempt int, occurredAt time.Time, detail string, source delivery.FailureSource, reason messagelifecycle.ReasonCode, blockedRecipients []string) error {
+func (w *SendWorker) markFailed(ctx context.Context, messageID string, jobID int64, attempt int, occurredAt time.Time, acceptedAt time.Time, detail string, source delivery.FailureSource, reason messagelifecycle.ReasonCode, blockedRecipients []string) error {
 	var err error
 	for i := 0; i < terminalWriteRetries; i++ {
 		var settled delivery.Status
@@ -515,11 +522,16 @@ func (w *SendWorker) markFailed(ctx context.Context, messageID string, jobID int
 			// (row gone/already terminal) records nothing. The
 			// PreserveTerminalFailure fallback below deliberately does NOT
 			// emit — the reconciler declares (and counts) that row later.
+			// The latency observation is co-located with the terminal count
+			// and uses the same occurred_at the write used.
 			switch settled {
 			case delivery.StatusFailed:
 				w.metrics.OutboundTerminal(terminalOutcome(source, reason, blockedRecipients))
 			case delivery.StatusSent:
 				w.metrics.OutboundTerminal(terminalSent)
+			}
+			if settled == delivery.StatusFailed || settled == delivery.StatusSent {
+				observeTerminalLatency(w.metrics, acceptedAt, occurredAt)
 			}
 			return nil
 		}

--- a/internal/outboundsend/worker.go
+++ b/internal/outboundsend/worker.go
@@ -184,8 +184,12 @@ type Store interface {
 	// in one transaction. Callers therefore invoke it to "finalize a terminal
 	// state", not to unconditionally fail.
 	// The returned status reports what the guarded write actually did:
-	// StatusFailed, StatusSent (evidence settle), or "" (no-op).
-	MarkFailed(ctx context.Context, messageID string, jobID int64, attempt int, occurredAt time.Time, detail string, source delivery.FailureSource, reason messagelifecycle.ReasonCode, blockedRecipients []string) (delivery.Status, error)
+	// StatusFailed, StatusSent (evidence settle), or "" (no-op). The returned
+	// time is the occurred_at the write actually used — the provider-accept
+	// evidence time on an evidence settle, the passed occurredAt on a
+	// failure, zero on a no-op — so observability reports what the write
+	// did, not what the caller asked for.
+	MarkFailed(ctx context.Context, messageID string, jobID int64, attempt int, occurredAt time.Time, detail string, source delivery.FailureSource, reason messagelifecycle.ReasonCode, blockedRecipients []string) (delivery.Status, time.Time, error)
 	PreserveTerminalFailure(ctx context.Context, messageID string, jobID int64, attempt int, occurredAt time.Time, detail string, source delivery.FailureSource, reason messagelifecycle.ReasonCode, blockedRecipients []string) error
 	// DeferTerminalFailure records a final attempt's diagnostic + releases the
 	// I/O claim WITHOUT declaring failed: the terminal reconciler declares the
@@ -291,8 +295,7 @@ func (w *SendWorker) Work(ctx context.Context, job *river.Job[OutboundSendArgs])
 		// earlier attempt; only the settle lands here. occurredAt is the
 		// provider-accept evidence time, so the latency measures
 		// acceptance→provider-accept, not acceptance→settle.
-		w.metrics.OutboundTerminal(terminalSent)
-		observeTerminalLatency(w.metrics, j.AcceptedAt, observedAt)
+		emitTerminal(w.metrics, terminalSent, j.AcceptedAt, observedAt)
 		if w.ramp != nil && j.rampEligible() {
 			return w.ramp.Confirm(ctx, j.MessageID)
 		}
@@ -316,13 +319,13 @@ func (w *SendWorker) Work(ctx context.Context, job *river.Job[OutboundSendArgs])
 		observedAt = time.Now().UTC()
 		if rerr != nil {
 			if isPermanentRampError(rerr) {
-				if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, observedAt, j.AcceptedAt, "sending_ramp_invalid: "+rerr.Error(), delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionCancelled, nil); err != nil {
+				if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, j.AcceptedAt, observedAt, "sending_ramp_invalid: "+rerr.Error(), delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionCancelled, nil); err != nil {
 					return err
 				}
 				return river.JobCancel(rerr)
 			}
 			if j.pastRetryHorizon() {
-				if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, observedAt, j.AcceptedAt, "ramp_capacity_timeout: "+rerr.Error(), delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionLocalRetriesExhausted, nil); err != nil {
+				if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, j.AcceptedAt, observedAt, "ramp_capacity_timeout: "+rerr.Error(), delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionLocalRetriesExhausted, nil); err != nil {
 					return err
 				}
 				_ = w.ramp.Release(ctx, j.MessageID)
@@ -336,7 +339,7 @@ func (w *SendWorker) Work(ctx context.Context, job *river.Job[OutboundSendArgs])
 		}
 		if !decision.Allowed {
 			if j.pastRetryHorizon() {
-				if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, observedAt, j.AcceptedAt, "ramp_capacity_timeout", delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionLocalRetriesExhausted, nil); err != nil {
+				if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, j.AcceptedAt, observedAt, "ramp_capacity_timeout", delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionLocalRetriesExhausted, nil); err != nil {
 					return err
 				}
 				if err := w.ramp.Release(ctx, j.MessageID); err != nil {
@@ -374,7 +377,7 @@ func (w *SendWorker) Work(ctx context.Context, job *river.Job[OutboundSendArgs])
 	}
 	if len(suppressed) > 0 {
 		supErr := fmt.Errorf("recipient_suppressed: %s%s", strings.Join(suppressed, ", "), outbound.SuppressionRemediation(j.AgentID))
-		if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, observedAt, j.AcceptedAt, supErr.Error(), delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionCancelled, suppressed); err != nil {
+		if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, j.AcceptedAt, observedAt, supErr.Error(), delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionCancelled, suppressed); err != nil {
 			return err
 		}
 		if w.ramp != nil && j.rampEligible() {
@@ -409,12 +412,11 @@ func (w *SendWorker) Work(ctx context.Context, job *river.Job[OutboundSendArgs])
 		// NOT instrumented, so this is still the message's ONLY sent count.
 		// If FinalizeProviderAcceptedTx is ever given its own emission, this
 		// site must become status-aware (like MarkFailed) or the race
-		// double-counts. The latency observation below shares this
-		// exactly-once contract — it is co-located with the terminal count
-		// here and everywhere else, and the SNS-feedback path stays
-		// uninstrumented for both.
-		w.metrics.OutboundTerminal(terminalSent)
-		observeTerminalLatency(w.metrics, j.AcceptedAt, observedAt)
+		// double-counts. The latency observation shares this exactly-once
+		// contract — emitTerminal emits count and latency together, here and
+		// everywhere else, and the SNS-feedback path stays uninstrumented
+		// for both.
+		emitTerminal(w.metrics, terminalSent, j.AcceptedAt, observedAt)
 		if w.ramp != nil && j.rampEligible() {
 			if err := w.ramp.Confirm(ctx, j.MessageID); err != nil {
 				return fmt.Errorf("confirm sending ramp: %w", err)
@@ -427,7 +429,7 @@ func (w *SendWorker) Work(ctx context.Context, job *river.Job[OutboundSendArgs])
 	// Provenance 'provider': SES itself refused this submission, so the §3.1
 	// correction never revives it.
 	if out.Permanent {
-		if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, observedAt, j.AcceptedAt, out.Err.Error(), delivery.FailureSourceProvider, messagelifecycle.ReasonSubmissionProviderRejected, nil); err != nil {
+		if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, j.AcceptedAt, observedAt, out.Err.Error(), delivery.FailureSourceProvider, messagelifecycle.ReasonSubmissionProviderRejected, nil); err != nil {
 			return err
 		}
 		if w.ramp != nil && j.rampEligible() {
@@ -444,7 +446,7 @@ func (w *SendWorker) Work(ctx context.Context, job *river.Job[OutboundSendArgs])
 	// (provenance 'local': the provider never confirmed a rejection).
 	if out.Outage {
 		if j.pastRetryHorizon() {
-			if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, observedAt, j.AcceptedAt, out.Err.Error(), delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionLocalRetriesExhausted, nil); err != nil {
+			if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, j.AcceptedAt, observedAt, out.Err.Error(), delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionLocalRetriesExhausted, nil); err != nil {
 				return err
 			}
 			if w.ramp != nil && j.rampEligible() {
@@ -511,27 +513,26 @@ const (
 	terminalWriteBackoff = 150 * time.Millisecond
 )
 
-func (w *SendWorker) markFailed(ctx context.Context, messageID string, jobID int64, attempt int, occurredAt time.Time, acceptedAt time.Time, detail string, source delivery.FailureSource, reason messagelifecycle.ReasonCode, blockedRecipients []string) error {
+func (w *SendWorker) markFailed(ctx context.Context, messageID string, jobID int64, attempt int, acceptedAt, occurredAt time.Time, detail string, source delivery.FailureSource, reason messagelifecycle.ReasonCode, blockedRecipients []string) error {
 	var err error
 	for i := 0; i < terminalWriteRetries; i++ {
 		var settled delivery.Status
-		if settled, err = w.store.MarkFailed(ctx, messageID, jobID, attempt, occurredAt, detail, source, reason, blockedRecipients); err == nil {
+		var settledAt time.Time
+		if settled, settledAt, err = w.store.MarkFailed(ctx, messageID, jobID, attempt, occurredAt, detail, source, reason, blockedRecipients); err == nil {
 			// Emit what the guarded write actually did, exactly once, only
 			// after the durable write: a failure with the caller's provenance,
 			// or "sent" when provider evidence settled the row. A no-op write
 			// (row gone/already terminal) records nothing. The
 			// PreserveTerminalFailure fallback below deliberately does NOT
 			// emit — the reconciler declares (and counts) that row later.
-			// The latency observation is co-located with the terminal count
-			// and uses the same occurred_at the write used.
+			// emitTerminal uses the write's EFFECTIVE occurred_at (the
+			// provider-accept evidence time on an evidence settle), so the
+			// latency reports what the write did, not what the caller asked.
 			switch settled {
 			case delivery.StatusFailed:
-				w.metrics.OutboundTerminal(terminalOutcome(source, reason, blockedRecipients))
+				emitTerminal(w.metrics, terminalOutcome(source, reason, blockedRecipients), acceptedAt, settledAt)
 			case delivery.StatusSent:
-				w.metrics.OutboundTerminal(terminalSent)
-			}
-			if settled == delivery.StatusFailed || settled == delivery.StatusSent {
-				observeTerminalLatency(w.metrics, acceptedAt, occurredAt)
+				emitTerminal(w.metrics, terminalSent, acceptedAt, settledAt)
 			}
 			return nil
 		}

--- a/internal/outboundsend/worker_test.go
+++ b/internal/outboundsend/worker_test.go
@@ -19,6 +19,11 @@ type fakeStore struct {
 	loadErr     error
 	markSentErr error
 	releaseErr  error
+	// settleStatus/settleAt override MarkFailed's default StatusFailed return,
+	// mirroring the production store's evidence-settle branch, which rewrites
+	// occurred_at to the provider-accept evidence time for the durable write.
+	settleStatus delivery.Status
+	settleAt     time.Time
 	// terminalAfterFailure mirrors the production store: once MarkFailed commits,
 	// a retry can no longer claim the terminal message and ClaimSend returns nil.
 	terminalAfterFailure bool
@@ -57,9 +62,17 @@ func (f *fakeStore) MarkSent(_ context.Context, id string, _ int64, _ int, _ tim
 	f.sent = append(f.sent, sentCall{id, provider, sentAs})
 	return f.markSentErr
 }
-func (f *fakeStore) MarkFailed(_ context.Context, id string, _ int64, attempt int, occurredAt time.Time, detail string, source delivery.FailureSource, _ messagelifecycle.ReasonCode, blockedRecipients []string) (delivery.Status, error) {
+func (f *fakeStore) MarkFailed(_ context.Context, id string, _ int64, attempt int, occurredAt time.Time, detail string, source delivery.FailureSource, _ messagelifecycle.ReasonCode, blockedRecipients []string) (delivery.Status, time.Time, error) {
 	f.failed = append(f.failed, failedCall{id: id, attempt: attempt, occurredAt: occurredAt, detail: detail, source: source, blockedRecipients: blockedRecipients})
-	return delivery.StatusFailed, nil
+	status := f.settleStatus
+	if status == "" {
+		status = delivery.StatusFailed
+	}
+	at := f.settleAt
+	if at.IsZero() {
+		at = occurredAt
+	}
+	return status, at, nil
 }
 func (f *fakeStore) PreserveTerminalFailure(context.Context, string, int64, int, time.Time, string, delivery.FailureSource, messagelifecycle.ReasonCode, []string) error {
 	return nil

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -102,6 +102,15 @@ type Metrics interface {
 	// when it settles.
 	OutboundTerminal(outcome string)
 
+	// OutboundTerminalLatency records acceptance→terminal latency for
+	// one outbound message (the terminal write's occurred_at −
+	// messages.created_at). Observed exactly once per message,
+	// co-located with the OutboundTerminal emission so the two share
+	// their exactly-once contract (the SNS-feedback settle path stays
+	// uninstrumented for both — see the guard comment at the worker's
+	// MarkSent emit in internal/outboundsend).
+	OutboundTerminalLatency(seconds float64)
+
 	// OutboundAttempt records one submission attempt to the upstream
 	// relay. outcome ∈ {success, temporary_failure, permanent_failure}.
 	// seconds is the submission duration.
@@ -114,11 +123,23 @@ type Metrics interface {
 	// (connect/DNS/SSRF-blocked).
 	WebhookAttempt(outcome, statusClass string, seconds float64)
 
+	// WebhookFirstAttemptLatency records event→first-attempt latency
+	// for one subscriber delivery (attempt start − the webhook_events
+	// row's created_at). Observed only on a delivery's FIRST HTTP
+	// attempt — retries and the no-POST outcomes (webhook_deleted,
+	// skipped_disabled) never observe.
+	WebhookFirstAttemptLatency(seconds float64)
+
 	// WSConnected / WSDisconnected count WebSocket connection
 	// lifecycle events. reason ∈ {replaced, ping_timeout,
 	// client_close, error, shutdown}.
 	WSConnected()
 	WSDisconnected(reason string)
+
+	// WSHandshakeRejected counts pre-upgrade WebSocket handshake
+	// rejections. reason ∈ {unauthorized, not_found, forbidden,
+	// upgrade_failed}. Never label with emails or tokens.
+	WSHandshakeRejected(reason string)
 
 	// WSDrained counts unread messages pushed during connect-drain.
 	WSDrained(count int)
@@ -159,10 +180,13 @@ func (NoOp) HTTPRequest(string, string, string, float64) {}
 func (NoOp) SMTPInbound(string, float64)                 {}
 func (NoOp) OutboundQueueWait(float64)                   {}
 func (NoOp) OutboundTerminal(string)                     {}
+func (NoOp) OutboundTerminalLatency(float64)             {}
 func (NoOp) OutboundAttempt(string, float64)             {}
 func (NoOp) WebhookAttempt(string, string, float64)      {}
+func (NoOp) WebhookFirstAttemptLatency(float64)          {}
 func (NoOp) WSConnected()                                {}
 func (NoOp) WSDisconnected(string)                       {}
+func (NoOp) WSHandshakeRejected(string)                  {}
 func (NoOp) WSDrained(int)                               {}
 func (NoOp) WSSendFailure()                              {}
 func (NoOp) SetWSActive(int)                             {}
@@ -246,6 +270,10 @@ func (l *Log) OutboundTerminal(outcome string) {
 	log.Printf("[metrics] event=outbound.terminal outcome=%s", outcome)
 }
 
+func (l *Log) OutboundTerminalLatency(seconds float64) {
+	log.Printf("[metrics] event=outbound.terminal_latency duration=%.3f", seconds)
+}
+
 func (l *Log) OutboundAttempt(outcome string, seconds float64) {
 	log.Printf("[metrics] event=outbound.attempt outcome=%s duration=%.3f", outcome, seconds)
 }
@@ -254,8 +282,16 @@ func (l *Log) WebhookAttempt(outcome, statusClass string, seconds float64) {
 	log.Printf("[metrics] event=webhook.attempt outcome=%s status_class=%s duration=%.3f", outcome, statusClass, seconds)
 }
 
+func (l *Log) WebhookFirstAttemptLatency(seconds float64) {
+	log.Printf("[metrics] event=webhook.first_attempt_latency duration=%.3f", seconds)
+}
+
 func (l *Log) WSConnected() {
 	log.Printf("[metrics] event=ws.connected")
+}
+
+func (l *Log) WSHandshakeRejected(reason string) {
+	log.Printf("[metrics] event=ws.handshake_rejected reason=%s", reason)
 }
 
 func (l *Log) WSDisconnected(reason string) {

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -138,7 +138,7 @@ type Metrics interface {
 
 	// WSHandshakeRejected counts pre-upgrade WebSocket handshake
 	// rejections. reason ∈ {unauthorized, not_found, forbidden,
-	// upgrade_failed}. Never label with emails or tokens.
+	// upgrade_failed, internal_error}. Never label with emails or tokens.
 	WSHandshakeRejected(reason string)
 
 	// WSDrained counts unread messages pushed during connect-drain.

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -19,6 +19,9 @@ func TestNoOpSatisfiesInterface(t *testing.T) {
 	m.JanitorRowsDeleted("", 0)
 	m.NotifyMissed()
 	m.SetPublisherLag(0)
+	m.OutboundTerminalLatency(0)
+	m.WebhookFirstAttemptLatency(0)
+	m.WSHandshakeRejected("")
 }
 
 func TestLogSatisfiesInterface(t *testing.T) {
@@ -34,6 +37,9 @@ func TestLogSatisfiesInterface(t *testing.T) {
 	m.JanitorRowsDeleted("webhook_events", 5)
 	m.NotifyMissed()
 	m.SetPublisherLag(2.5)
+	m.OutboundTerminalLatency(240)
+	m.WebhookFirstAttemptLatency(12.5)
+	m.WSHandshakeRejected("unauthorized")
 }
 
 func TestLogJanitorSkipsZeroCount(t *testing.T) {

--- a/internal/telemetry/prom.go
+++ b/internal/telemetry/prom.go
@@ -25,12 +25,15 @@ type Prom struct {
 	smtpDuration    prometheus.Histogram
 	outQueueWait    prometheus.Histogram
 	outTerminal     *prometheus.CounterVec
+	outTerminalLat  prometheus.Histogram
 	outAttempts     *prometheus.CounterVec
 	outAttemptDur   prometheus.Histogram
 	whAttempts      *prometheus.CounterVec
 	whAttemptDur    prometheus.Histogram
+	whFirstTryLat   prometheus.Histogram
 	wsConnects      prometheus.Counter
 	wsDisconnects   *prometheus.CounterVec
+	wsRejected      *prometheus.CounterVec
 	wsDrained       prometheus.Counter
 	wsSendFailures  prometheus.Counter
 	wsActive        prometheus.Gauge
@@ -78,6 +81,7 @@ var (
 	whSet         = set("delivered", "retryable_failure", "exhausted",
 		"webhook_deleted", "skipped_disabled")
 	wsReasonSet = set("replaced", "ping_timeout", "client_close", "error", "shutdown")
+	wsRejectSet = set("unauthorized", "not_found", "forbidden", "upgrade_failed")
 	inboundSet  = set("processed", "noop", "failed_recipient_gone",
 		"failed_exhausted", "retryable")
 	queueSet = set("outbound", "inbound", "webhook", "maintenance", "notify", "default")
@@ -110,6 +114,11 @@ func enum(allowed map[string]struct{}, v string) string {
 var (
 	fastBuckets = []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 30}
 	waitBuckets = []float64{.05, .1, .25, .5, 1, 2.5, 5, 15, 30, 60, 120, 300, 900, 3600}
+	// longBuckets spans seconds-to-days: outbound acceptance→terminal can
+	// legitimately reach the 72h retry horizon under a provider outage,
+	// and webhook event→first-attempt includes fan-out + queue wait. The
+	// 60s and 300s edges are the SLO thresholds (docs/observability.md).
+	longBuckets = []float64{1, 5, 15, 30, 60, 120, 300, 600, 1800, 3600, 7200, 21600, 86400, 259200}
 )
 
 func NewProm() *Prom {
@@ -146,6 +155,11 @@ func NewProm() *Prom {
 			Name: "e2a_outbound_terminal_total",
 			Help: "Outbound messages reaching a terminal submission outcome.",
 		}, []string{"outcome"}),
+		outTerminalLat: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    "e2a_outbound_terminal_latency_seconds",
+			Help:    "Outbound acceptance→terminal latency per message (terminal occurred_at - messages.created_at), observed exactly once per message.",
+			Buckets: longBuckets,
+		}),
 		outAttempts: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "e2a_outbound_attempts_total",
 			Help: "Outbound submission attempts to the upstream relay, by outcome.",
@@ -164,10 +178,19 @@ func NewProm() *Prom {
 			Help:    "Webhook delivery attempt duration (HTTP POST to subscriber).",
 			Buckets: fastBuckets,
 		}),
+		whFirstTryLat: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    "e2a_webhook_first_attempt_latency_seconds",
+			Help:    "Webhook event→first-attempt latency per subscriber delivery (attempt start - webhook_events.created_at); first HTTP attempt only.",
+			Buckets: longBuckets,
+		}),
 		wsConnects: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "e2a_ws_connects_total",
 			Help: "WebSocket connections accepted and registered.",
 		}),
+		wsRejected: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "e2a_ws_handshake_rejected_total",
+			Help: "WebSocket handshakes rejected before upgrade, by reason.",
+		}, []string{"reason"}),
 		wsDisconnects: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "e2a_ws_disconnects_total",
 			Help: "WebSocket disconnects, by reason.",
@@ -243,9 +266,9 @@ func NewProm() *Prom {
 	reg.MustRegister(
 		p.httpRequests, p.httpDuration,
 		p.smtpInbound, p.smtpDuration,
-		p.outQueueWait, p.outTerminal, p.outAttempts, p.outAttemptDur,
-		p.whAttempts, p.whAttemptDur,
-		p.wsConnects, p.wsDisconnects, p.wsDrained, p.wsSendFailures, p.wsActive,
+		p.outQueueWait, p.outTerminal, p.outTerminalLat, p.outAttempts, p.outAttemptDur,
+		p.whAttempts, p.whAttemptDur, p.whFirstTryLat,
+		p.wsConnects, p.wsDisconnects, p.wsRejected, p.wsDrained, p.wsSendFailures, p.wsActive,
 		p.inboundProcess, p.inboundDuration,
 		p.queueDepth, p.queueOldestAge,
 		p.outboxPublished, p.outboxFanOut, p.outboxMatched, p.outboxNoMatch,
@@ -302,6 +325,8 @@ func (p *Prom) OutboundTerminal(outcome string) {
 	p.outTerminal.WithLabelValues(enum(outTermSet, outcome)).Inc()
 }
 
+func (p *Prom) OutboundTerminalLatency(seconds float64) { p.outTerminalLat.Observe(seconds) }
+
 func (p *Prom) OutboundAttempt(outcome string, seconds float64) {
 	p.outAttempts.WithLabelValues(enum(outAttemptSet, outcome)).Inc()
 	p.outAttemptDur.Observe(seconds)
@@ -319,6 +344,12 @@ func (p *Prom) WebhookAttempt(outcome, statusClass string, seconds float64) {
 func (p *Prom) WSConnected()      { p.wsConnects.Inc() }
 func (p *Prom) WSSendFailure()    { p.wsSendFailures.Inc() }
 func (p *Prom) SetWSActive(n int) { p.wsActive.Set(float64(n)) }
+
+func (p *Prom) WSHandshakeRejected(reason string) {
+	p.wsRejected.WithLabelValues(enum(wsRejectSet, reason)).Inc()
+}
+
+func (p *Prom) WebhookFirstAttemptLatency(seconds float64) { p.whFirstTryLat.Observe(seconds) }
 
 func (p *Prom) WSDisconnected(reason string) {
 	p.wsDisconnects.WithLabelValues(enum(wsReasonSet, reason)).Inc()

--- a/internal/telemetry/prom.go
+++ b/internal/telemetry/prom.go
@@ -81,7 +81,7 @@ var (
 	whSet         = set("delivered", "retryable_failure", "exhausted",
 		"webhook_deleted", "skipped_disabled")
 	wsReasonSet = set("replaced", "ping_timeout", "client_close", "error", "shutdown")
-	wsRejectSet = set("unauthorized", "not_found", "forbidden", "upgrade_failed")
+	wsRejectSet = set("unauthorized", "not_found", "forbidden", "upgrade_failed", "internal_error")
 	inboundSet  = set("processed", "noop", "failed_recipient_gone",
 		"failed_exhausted", "retryable")
 	queueSet = set("outbound", "inbound", "webhook", "maintenance", "notify", "default")

--- a/internal/telemetry/prom_test.go
+++ b/internal/telemetry/prom_test.go
@@ -52,10 +52,14 @@ func TestPromEmitsSMTPOutboundWebhookWSSeries(t *testing.T) {
 	p.OutboundTerminal("sent")
 	p.OutboundTerminal("failed_provider")
 	p.OutboundTerminal("failed_cancelled")
+	p.OutboundTerminalLatency(240)
 	p.OutboundAttempt("success", 0.8)
 	p.WebhookAttempt("delivered", "2xx", 0.3)
 	p.WebhookAttempt("retryable_failure", "5xx", 0.2)
+	p.WebhookFirstAttemptLatency(12.5)
 	p.WSConnected()
+	p.WSHandshakeRejected("unauthorized")
+	p.WSHandshakeRejected("forbidden")
 	p.WSDisconnected("ping_timeout")
 	p.WSDrained(7)
 	p.WSSendFailure()
@@ -72,10 +76,14 @@ func TestPromEmitsSMTPOutboundWebhookWSSeries(t *testing.T) {
 		`e2a_outbound_terminal_total{outcome="sent"} 1`,
 		`e2a_outbound_terminal_total{outcome="failed_provider"} 1`,
 		`e2a_outbound_terminal_total{outcome="failed_cancelled"} 1`,
+		`e2a_outbound_terminal_latency_seconds_count 1`,
 		`e2a_outbound_attempts_total{outcome="success"} 1`,
 		`e2a_webhook_attempts_total{outcome="delivered",status_class="2xx"} 1`,
 		`e2a_webhook_attempts_total{outcome="retryable_failure",status_class="5xx"} 1`,
+		`e2a_webhook_first_attempt_latency_seconds_count 1`,
 		`e2a_ws_connects_total 1`,
+		`e2a_ws_handshake_rejected_total{reason="unauthorized"} 1`,
+		`e2a_ws_handshake_rejected_total{reason="forbidden"} 1`,
 		`e2a_ws_disconnects_total{reason="ping_timeout"} 1`,
 		`e2a_ws_drained_messages_total 7`,
 		`e2a_ws_send_failures_total 1`,
@@ -137,6 +145,7 @@ func TestPromNormalizesUnknownLabelValues(t *testing.T) {
 	p.OutboundTerminal("weird_new_outcome") // unknown enum
 	p.WebhookAttempt(secret, "banana", 0.1) // junk outcome + junk status class
 	p.WSDisconnected("some very long free text reason with details")
+	p.WSHandshakeRejected(addr) // raw address must not become a rejection-reason label
 	p.InboundProcess(secret, 0)
 	p.SetQueueDepth("attacker_queue", "exploded", 1)
 	p.HTTPRequest("PROPFIND", "/v1/agents/{email}", "7xx", 0.1) // unknown method + class
@@ -150,6 +159,7 @@ func TestPromNormalizesUnknownLabelValues(t *testing.T) {
 		`e2a_outbound_terminal_total{outcome="other"} 1`,
 		`e2a_webhook_attempts_total{outcome="other",status_class="other"} 1`,
 		`e2a_ws_disconnects_total{reason="other"} 1`,
+		`e2a_ws_handshake_rejected_total{reason="other"} 1`,
 		`e2a_inbound_process_total{outcome="other"} 1`,
 		`e2a_queue_depth{queue="other",state="other"} 1`,
 		`e2a_http_requests_total{method="other",route="/v1/agents/{email}",status_class="other"} 1`,

--- a/internal/telemetry/prom_test.go
+++ b/internal/telemetry/prom_test.go
@@ -60,6 +60,7 @@ func TestPromEmitsSMTPOutboundWebhookWSSeries(t *testing.T) {
 	p.WSConnected()
 	p.WSHandshakeRejected("unauthorized")
 	p.WSHandshakeRejected("forbidden")
+	p.WSHandshakeRejected("internal_error")
 	p.WSDisconnected("ping_timeout")
 	p.WSDrained(7)
 	p.WSSendFailure()
@@ -84,6 +85,7 @@ func TestPromEmitsSMTPOutboundWebhookWSSeries(t *testing.T) {
 		`e2a_ws_connects_total 1`,
 		`e2a_ws_handshake_rejected_total{reason="unauthorized"} 1`,
 		`e2a_ws_handshake_rejected_total{reason="forbidden"} 1`,
+		`e2a_ws_handshake_rejected_total{reason="internal_error"} 1`,
 		`e2a_ws_disconnects_total{reason="ping_timeout"} 1`,
 		`e2a_ws_drained_messages_total 7`,
 		`e2a_ws_send_failures_total 1`,

--- a/internal/webhook/subscriber_store.go
+++ b/internal/webhook/subscriber_store.go
@@ -28,6 +28,16 @@ type SubscriberDelivery struct {
 	NextRetryAt    time.Time
 	CreatedAt      time.Time
 	ExpiresAt      time.Time
+	// ReplayID is non-nil for customer-initiated replay rows (a re-delivery
+	// of an old event), nil for first-delivery rows. The first-attempt
+	// latency SLI observes first-delivery rows only: a replay's baseline
+	// would be the ORIGINAL event's created_at, recording the replay lag
+	// as a false outlier.
+	ReplayID *string
+	// EventCreatedAt is the originating webhook_events row's created_at —
+	// the baseline of the event→first-attempt latency SLI. Nil for rows
+	// without an event link (the /test endpoint's deliveries).
+	EventCreatedAt *time.Time
 }
 
 // SubscriberStore manages webhook_subscriber_deliveries. Parallel to
@@ -75,17 +85,24 @@ func (s *SubscriberStore) MarkDelivered(ctx context.Context, deliveryID string, 
 // GetSubscriberDeliveryByID loads a single delivery row by id — the River
 // DeliverWorker's entry point (it holds only the delivery id and reads the
 // payload + webhook_id here). Returns pgx.ErrNoRows if the row is gone.
+// The replay_id + joined webhook_events.created_at feed the
+// event→first-attempt latency SLI (LEFT JOIN: rows without an event link,
+// e.g. /test deliveries, load a nil EventCreatedAt).
 func (s *SubscriberStore) GetSubscriberDeliveryByID(ctx context.Context, deliveryID string) (*SubscriberDelivery, error) {
 	var d SubscriberDelivery
 	err := s.pool.QueryRow(ctx,
-		`SELECT id, webhook_id, event_type, event_payload, message_id,
-		        status, attempts, max_attempts, COALESCE(last_error, ''),
-		        last_status_code, last_attempt_at, next_retry_at, created_at, expires_at
-		   FROM webhook_subscriber_deliveries WHERE id = $1`,
+		`SELECT d.id, d.webhook_id, d.event_type, d.event_payload, d.message_id,
+		        d.status, d.attempts, d.max_attempts, COALESCE(d.last_error, ''),
+		        d.last_status_code, d.last_attempt_at, d.next_retry_at, d.created_at, d.expires_at,
+		        d.replay_id, ev.created_at
+		   FROM webhook_subscriber_deliveries d
+		   LEFT JOIN webhook_events ev ON ev.id = d.event_id
+		  WHERE d.id = $1`,
 		deliveryID,
 	).Scan(&d.ID, &d.WebhookID, &d.EventType, &d.EventPayload, &d.MessageID,
 		&d.Status, &d.Attempts, &d.MaxAttempts, &d.LastError,
-		&d.LastStatusCode, &d.LastAttemptAt, &d.NextRetryAt, &d.CreatedAt, &d.ExpiresAt)
+		&d.LastStatusCode, &d.LastAttemptAt, &d.NextRetryAt, &d.CreatedAt, &d.ExpiresAt,
+		&d.ReplayID, &d.EventCreatedAt)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/webhookdelivery/worker.go
+++ b/internal/webhookdelivery/worker.go
@@ -62,6 +62,11 @@ type Metrics interface {
 	// skipped_disabled), which would otherwise drag the duration
 	// quantiles toward zero.
 	WebhookAttempt(outcome, statusClass string, seconds float64)
+	// WebhookFirstAttemptLatency records event→first-attempt latency for
+	// one subscriber delivery (attempt start − webhook_events.created_at).
+	// Observed only on a first-delivery row's FIRST HTTP attempt — retries,
+	// replays, and the no-POST outcomes never observe.
+	WebhookFirstAttemptLatency(seconds float64)
 }
 
 // statusClassOf maps an HTTP status code to its metrics label ("1xx".."5xx"),
@@ -114,6 +119,14 @@ func (w *DeliverWorker) WithMetrics(m Metrics) *DeliverWorker {
 func (w *DeliverWorker) emitAttempt(outcome, statusClass string, seconds float64) {
 	if w.metrics != nil {
 		w.metrics.WebhookAttempt(outcome, statusClass, seconds)
+	}
+}
+
+// emitFirstAttemptLatency records the event→first-attempt latency, tolerating
+// an unwired backend.
+func (w *DeliverWorker) emitFirstAttemptLatency(seconds float64) {
+	if w.metrics != nil {
+		w.metrics.WebhookFirstAttemptLatency(seconds)
 	}
 }
 
@@ -173,6 +186,21 @@ func (w *DeliverWorker) Work(ctx context.Context, job *river.Job[WebhookDeliverA
 	out := w.deliverer.Deliver(ctx, wh.URL, d.EventPayload, wh.SigningSecret, prevSecret,
 		d.EventType, strconv.Itoa(webhookpub.SchemaVersion))
 	dur := time.Since(start).Seconds()
+	// Event→first-attempt latency SLI: observed ONLY on this delivery row's
+	// first HTTP attempt — River job attempt 1 with no previously recorded
+	// attempt — and only for first-delivery rows. A replay row (replay_id
+	// set) is excluded: its baseline would be the ORIGINAL event's
+	// created_at, recording the customer's replay lag as a giant false
+	// outlier. The no-POST outcomes (webhook_deleted, skipped_disabled)
+	// returned above and never reach here; the SLO measures the first
+	// attempt regardless of its outcome. At-most-once: a crash between the
+	// POST and the attempt record means the sample is taken (below) but
+	// never re-taken — the retried job runs at attempt ≥ 2.
+	if job.Attempt == 1 && d.Attempts == 0 && d.ReplayID == nil && d.EventCreatedAt != nil {
+		if latency := start.Sub(*d.EventCreatedAt).Seconds(); latency > 0 {
+			w.emitFirstAttemptLatency(latency)
+		}
+	}
 	if out.Success {
 		w.emitAttempt("delivered", statusClassOf(out.StatusCode), dur)
 		return w.subStore.MarkDelivered(ctx, d.ID, out.StatusCode) // nil → River completes the job

--- a/internal/webhookdelivery/worker.go
+++ b/internal/webhookdelivery/worker.go
@@ -14,6 +14,7 @@ package webhookdelivery
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -130,6 +131,24 @@ func (w *DeliverWorker) emitFirstAttemptLatency(seconds float64) {
 	}
 }
 
+// snoozeCount reports how often River snoozed this job. The disabled-webhook
+// deferral is this worker's ONLY snooze source, so a non-zero count means
+// the job sat through a customer-disabled window. River's job executor
+// increments a "snoozes" counter in the job's metadata JSON on every snooze
+// (absent before the first); JobRow.Metadata is the public carrier.
+func snoozeCount(job *river.Job[WebhookDeliverArgs]) int {
+	if job == nil || len(job.Metadata) == 0 {
+		return 0
+	}
+	var md struct {
+		Snoozes int `json:"snoozes"`
+	}
+	if err := json.Unmarshal(job.Metadata, &md); err != nil {
+		return 0
+	}
+	return md.Snoozes
+}
+
 // NextRetry overrides River's client-wide policy for webhook jobs only, returning
 // the exact 29h21m envelope. job.Attempt is the just-failed attempt (1-based); River
 // discards at MaxAttempts so this is called for attempts 1..MaxDeliveryAttempts-1.
@@ -187,16 +206,30 @@ func (w *DeliverWorker) Work(ctx context.Context, job *river.Job[WebhookDeliverA
 		d.EventType, strconv.Itoa(webhookpub.SchemaVersion))
 	dur := time.Since(start).Seconds()
 	// Event→first-attempt latency SLI: observed ONLY on this delivery row's
-	// first HTTP attempt — River job attempt 1 with no previously recorded
-	// attempt — and only for first-delivery rows. A replay row (replay_id
+	// first HTTP attempt — the row shows no recorded prior attempt — and only
+	// for first-delivery rows. Not gated on River's attempt number: if
+	// transient pre-POST errors consume early attempts, the true first POST
+	// runs later and must still be observed, or the slowest first attempts
+	// (the incident population) never reach the SLI. A replay row (replay_id
 	// set) is excluded: its baseline would be the ORIGINAL event's
 	// created_at, recording the customer's replay lag as a giant false
-	// outlier. The no-POST outcomes (webhook_deleted, skipped_disabled)
-	// returned above and never reach here; the SLO measures the first
-	// attempt regardless of its outcome. At-most-once: a crash between the
-	// POST and the attempt record means the sample is taken (below) but
-	// never re-taken — the retried job runs at attempt ≥ 2.
-	if job.Attempt == 1 && d.Attempts == 0 && d.ReplayID == nil && d.EventCreatedAt != nil {
+	// outlier. The no-POST outcomes (webhook_deleted,
+	// skipped_disabled) returned above and never reach here; the SLO
+	// measures the first attempt regardless of its outcome. At-most-once:
+	// once any attempt is recorded the row never observes again.
+	//
+	// Disabled-window exclusion: the disabled path is this worker's ONLY
+	// snooze source, and River counts snoozes in job metadata — a snoozed
+	// job sat through a customer-disabled window (hour-scale, possibly
+	// days), which is not e2a's event→attempt latency, so it never observes.
+	// (River does not burn the attempt number on snooze, so job.Attempt
+	// cannot discriminate; a scheduled_at heuristic would false-skip jobs
+	// whose chained PRE-POST failures walked the retry envelope with zero
+	// recorded attempts — the exact incident population this SLI exists to
+	// catch.) The residual — a crash after the POST but before the attempt
+	// record — can double-observe on the retry; that is the same accepted
+	// residual as at-least-once delivery itself, and rare.
+	if d.Attempts == 0 && d.ReplayID == nil && d.EventCreatedAt != nil && snoozeCount(job) == 0 {
 		if latency := start.Sub(*d.EventCreatedAt).Seconds(); latency > 0 {
 			w.emitFirstAttemptLatency(latency)
 		}

--- a/internal/webhookdelivery/worker_test.go
+++ b/internal/webhookdelivery/worker_test.go
@@ -211,10 +211,17 @@ type attemptRec struct {
 }
 
 // fakeMetrics records WebhookAttempt calls for assertion.
-type fakeMetrics struct{ attempts []attemptRec }
+type fakeMetrics struct {
+	attempts []attemptRec
+	firstTry []float64
+}
 
 func (f *fakeMetrics) WebhookAttempt(outcome, statusClass string, seconds float64) {
 	f.attempts = append(f.attempts, attemptRec{outcome, statusClass, seconds})
+}
+
+func (f *fakeMetrics) WebhookFirstAttemptLatency(seconds float64) {
+	f.firstTry = append(f.firstTry, seconds)
 }
 
 // one asserts exactly one attempt was recorded and returns it.
@@ -315,6 +322,148 @@ func TestDeliverWorker_Metrics_StatusClassMapping(t *testing.T) {
 		if got := fm.one(t); got.statusClass != tc.want {
 			t.Errorf("code %d: statusClass = %q, want %q", tc.code, got.statusClass, tc.want)
 		}
+	}
+}
+
+// ── Event→first-attempt latency SLI (docs/observability.md) ──────
+
+// seedEventLinked creates a user + webhook, a webhook_events row aged
+// eventAge, and a pending delivery row linked to it (mirroring the fan-out
+// insert). replay=true marks the delivery as a customer-initiated replay
+// (replay_id set), which must never feed the first-attempt SLI.
+func seedEventLinked(t *testing.T, prefix string, eventAge time.Duration, replay bool) (string, *webhook.SubscriberStore, *identity.Store, *identity.Webhook) {
+	t.Helper()
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	store := identity.NewStore(pool)
+	user, err := store.CreateOrGetUser(ctx, "owner-"+prefix+"@example.com", "Owner", "google-"+prefix)
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	wh, err := store.CreateWebhook(ctx, user.ID, "https://example.com/hook", "", []string{"email.received"}, identity.WebhookFilters{})
+	if err != nil {
+		t.Fatalf("CreateWebhook: %v", err)
+	}
+	eventID := "evt_" + prefix
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO webhook_events (id, user_id, type, envelope, created_at)
+		 VALUES ($1, $2, 'email.received', '{}'::jsonb, now() - make_interval(secs => $3))`,
+		eventID, user.ID, eventAge.Seconds()); err != nil {
+		t.Fatalf("insert webhook_events row: %v", err)
+	}
+	deliveryID := "whd_" + prefix
+	var replayID *string
+	if replay {
+		replayID = &eventID // any non-null value marks a replay row
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO webhook_subscriber_deliveries
+		     (id, webhook_id, event_id, replay_id, event_type, event_payload, status)
+		 VALUES ($1, $2, $3, $4, 'email.received', '{}'::jsonb, 'pending')`,
+		deliveryID, wh.ID, eventID, replayID); err != nil {
+		t.Fatalf("insert delivery row: %v", err)
+	}
+	sub := webhook.NewSubscriberStore(pool)
+	return deliveryID, sub, store, wh
+}
+
+func TestDeliverWorker_Metrics_FirstAttemptLatencyObservedOnFirstAttempt(t *testing.T) {
+	id, sub, _, wh := seedEventLinked(t, "lat-first", 45*time.Second, false)
+	fm := &fakeMetrics{}
+	w := webhookdelivery.NewDeliverWorker(sub, fakeDeliverer{out: webhook.DeliveryOutcome{Success: true, StatusCode: 200}}, fakeWebhooks{wh: wh}).WithMetrics(fm)
+	if err := w.Work(context.Background(), job(id, 1)); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	if len(fm.firstTry) != 1 {
+		t.Fatalf("first-attempt latencies = %v, want exactly one sample", fm.firstTry)
+	}
+	if got := fm.firstTry[0]; got < 40 || got > 50 {
+		t.Errorf("first-attempt latency = %.1fs, want ~45s (attempt start − event created_at)", got)
+	}
+}
+
+func TestDeliverWorker_Metrics_FirstAttemptLatencyAlsoOnFailedFirstAttempt(t *testing.T) {
+	// The SLI measures event→first-attempt regardless of that attempt's
+	// outcome — a failed first POST is still the first attempt.
+	id, sub, _, wh := seedEventLinked(t, "lat-fail", 30*time.Second, false)
+	fm := &fakeMetrics{}
+	w := webhookdelivery.NewDeliverWorker(sub, fakeDeliverer{out: webhook.DeliveryOutcome{Success: false, StatusCode: 500, Error: "boom"}}, fakeWebhooks{wh: wh}).WithMetrics(fm)
+	if err := w.Work(context.Background(), job(id, 1)); err == nil {
+		t.Fatal("Work returned nil on a retryable failure")
+	}
+	if len(fm.firstTry) != 1 {
+		t.Fatalf("first-attempt latencies = %v, want one sample even for a failed first attempt", fm.firstTry)
+	}
+	if got := fm.firstTry[0]; got < 25 || got > 35 {
+		t.Errorf("first-attempt latency = %.1fs, want ~30s", got)
+	}
+}
+
+func TestDeliverWorker_Metrics_FirstAttemptLatencySkipsRetries(t *testing.T) {
+	id, sub, _, wh := seedEventLinked(t, "lat-retry", 45*time.Second, false)
+	fm := &fakeMetrics{}
+	w := webhookdelivery.NewDeliverWorker(sub, fakeDeliverer{out: webhook.DeliveryOutcome{Success: false, StatusCode: 500, Error: "boom"}}, fakeWebhooks{wh: wh}).WithMetrics(fm)
+	// First attempt fails and records the attempt; the retry (job attempt 2)
+	// must NOT observe — the SLO is event→FIRST attempt only.
+	if err := w.Work(context.Background(), job(id, 1)); err == nil {
+		t.Fatal("first attempt should fail (retryable)")
+	}
+	if err := w.Work(context.Background(), job(id, 2)); err == nil {
+		t.Fatal("second attempt should fail (retryable)")
+	}
+	if len(fm.firstTry) != 1 {
+		t.Errorf("first-attempt latencies = %v, want exactly one sample across two attempts", fm.firstTry)
+	}
+}
+
+func TestDeliverWorker_Metrics_FirstAttemptLatencySkipsNoPostOutcomes(t *testing.T) {
+	// skipped_disabled and webhook_deleted perform no HTTP POST, so there is
+	// no attempt to time — they must not observe even on job attempt 1.
+	idDisabled, sub, _, wh := seedEventLinked(t, "lat-disabled", 45*time.Second, false)
+	wh.Enabled = false
+	fm := &fakeMetrics{}
+	w := webhookdelivery.NewDeliverWorker(sub, fakeDeliverer{out: webhook.DeliveryOutcome{Success: true}}, fakeWebhooks{wh: wh}).WithMetrics(fm)
+	if err := w.Work(context.Background(), job(idDisabled, 1)); err == nil {
+		t.Fatal("disabled webhook should snooze")
+	}
+
+	idDeleted, _, _, _ := seedEventLinked(t, "lat-deleted", 45*time.Second, false)
+	wDeleted := webhookdelivery.NewDeliverWorker(sub, fakeDeliverer{out: webhook.DeliveryOutcome{Success: true}}, fakeWebhooks{err: errors.New("not found")}).WithMetrics(fm)
+	if err := wDeleted.Work(context.Background(), job(idDeleted, 1)); err == nil {
+		t.Fatal("deleted webhook should cancel")
+	}
+
+	if len(fm.firstTry) != 0 {
+		t.Errorf("first-attempt latencies = %v, want none for no-POST outcomes", fm.firstTry)
+	}
+}
+
+func TestDeliverWorker_Metrics_FirstAttemptLatencySkipsReplayRows(t *testing.T) {
+	// A replay row's baseline would be the ORIGINAL event's created_at —
+	// observing it would record the customer's replay lag (days) as a giant
+	// false outlier. Only first-delivery rows (replay_id NULL) feed the SLI.
+	id, sub, _, wh := seedEventLinked(t, "lat-replay", 72*time.Hour, true)
+	fm := &fakeMetrics{}
+	w := webhookdelivery.NewDeliverWorker(sub, fakeDeliverer{out: webhook.DeliveryOutcome{Success: true, StatusCode: 200}}, fakeWebhooks{wh: wh}).WithMetrics(fm)
+	if err := w.Work(context.Background(), job(id, 1)); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	if len(fm.firstTry) != 0 {
+		t.Errorf("first-attempt latencies = %v, want none for a replay row", fm.firstTry)
+	}
+}
+
+func TestDeliverWorker_Metrics_FirstAttemptLatencySkipsEventlessRows(t *testing.T) {
+	// Test-endpoint deliveries (InsertPendingForTest) carry no event link —
+	// there is no event created_at to measure against, so no sample.
+	id, sub, _, wh := seed(t, "wd-m-noevent")
+	fm := &fakeMetrics{}
+	w := webhookdelivery.NewDeliverWorker(sub, fakeDeliverer{out: webhook.DeliveryOutcome{Success: true, StatusCode: 200}}, fakeWebhooks{wh: wh}).WithMetrics(fm)
+	if err := w.Work(context.Background(), job(id, 1)); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	if len(fm.firstTry) != 0 {
+		t.Errorf("first-attempt latencies = %v, want none without an event link", fm.firstTry)
 	}
 }
 

--- a/internal/webhookdelivery/worker_test.go
+++ b/internal/webhookdelivery/worker_test.go
@@ -486,3 +486,65 @@ func TestDeliverWorker_NextRetryMatchesEnvelope(t *testing.T) {
 		t.Errorf("retry envelope spans %v, want 29h21m", total)
 	}
 }
+
+func TestDeliverWorker_Metrics_FirstAttemptLatencyObservedWhenFirstPostIsNotRiverAttemptOne(t *testing.T) {
+	// If a transient pre-POST error (e.g. a DB blip on the row load) consumes
+	// River attempt 1, the delivery's first HTTP attempt happens at job
+	// attempt 2 — it is STILL the first attempt and must be observed, or the
+	// slowest first attempts (the incident population) never reach the SLI.
+	id, sub, _, wh := seedEventLinked(t, "lat-att2", 45*time.Second, false)
+	fm := &fakeMetrics{}
+	w := webhookdelivery.NewDeliverWorker(sub, fakeDeliverer{out: webhook.DeliveryOutcome{Success: true, StatusCode: 200}}, fakeWebhooks{wh: wh}).WithMetrics(fm)
+	if err := w.Work(context.Background(), job(id, 2)); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	if len(fm.firstTry) != 1 {
+		t.Fatalf("first-attempt latencies = %v, want one sample for the true first POST", fm.firstTry)
+	}
+	if got := fm.firstTry[0]; got < 40 || got > 50 {
+		t.Errorf("first-attempt latency = %.1fs, want ~45s", got)
+	}
+}
+
+func TestDeliverWorker_Metrics_FirstAttemptLatencySkipsSnoozedJobs(t *testing.T) {
+	// A disabled webhook snoozes the River job WITHOUT burning an attempt
+	// (River counts snoozes in job metadata), so the eventual first POST
+	// still runs at job attempt 1 — but its latency would be the customer's
+	// entire disabled window (hours to days), not e2a's event→attempt
+	// latency. Snoozed jobs never observe.
+	id, sub, _, wh := seedEventLinked(t, "lat-snoozed", 26*time.Hour, false)
+	fm := &fakeMetrics{}
+	w := webhookdelivery.NewDeliverWorker(sub, fakeDeliverer{out: webhook.DeliveryOutcome{Success: true, StatusCode: 200}}, fakeWebhooks{wh: wh}).WithMetrics(fm)
+	snoozedJob := job(id, 1)
+	snoozedJob.Metadata = []byte(`{"snoozes":3}`)
+	if err := w.Work(context.Background(), snoozedJob); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	if len(fm.firstTry) != 0 {
+		t.Errorf("first-attempt latencies = %v, want none for a job that sat through a disabled window", fm.firstTry)
+	}
+}
+
+func TestDeliverWorker_Metrics_FirstAttemptLatencyObservedDespiteBackoffSchedule(t *testing.T) {
+	// Chained PRE-POST failures (e.g. a DB blip on the row load) record no
+	// attempt, so the row still shows attempts == 0 when the true first POST
+	// finally runs — deep into the retry envelope (scheduled_at far past
+	// created_at). That first POST MUST observe: a schedule-shift heuristic
+	// would false-skip exactly the outage population this SLI exists to
+	// catch. Only an actual snooze (metadata) excludes.
+	id, sub, _, wh := seedEventLinked(t, "lat-backoff", 90*time.Minute, false)
+	fm := &fakeMetrics{}
+	w := webhookdelivery.NewDeliverWorker(sub, fakeDeliverer{out: webhook.DeliveryOutcome{Success: true, StatusCode: 200}}, fakeWebhooks{wh: wh}).WithMetrics(fm)
+	lateJob := job(id, 4)
+	lateJob.CreatedAt = time.Now().Add(-90 * time.Minute).UTC()
+	lateJob.ScheduledAt = time.Now().Add(-time.Minute).UTC() // deep in the backoff envelope, never snoozed
+	if err := w.Work(context.Background(), lateJob); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	if len(fm.firstTry) != 1 {
+		t.Fatalf("first-attempt latencies = %v, want one sample for the true first POST after chained pre-POST failures", fm.firstTry)
+	}
+	if got := fm.firstTry[0]; got < 89*time.Minute.Seconds() || got > 91*time.Minute.Seconds() {
+		t.Errorf("first-attempt latency = %.0fs, want ~90min (the honest outage signal)", got)
+	}
+}

--- a/internal/ws/handler.go
+++ b/internal/ws/handler.go
@@ -82,6 +82,7 @@ func (h *Handler) serve(w http.ResponseWriter, r *http.Request, rawEmail string)
 	// prod stack the authChallenge middleware also (re)asserts it on any 401.
 	token := bearerToken(r)
 	if token == "" {
+		h.metrics.WSHandshakeRejected("unauthorized")
 		w.Header().Set("WWW-Authenticate", `Bearer realm="e2a"`)
 		httpapi.WriteError(w, r, http.StatusUnauthorized, "unauthorized",
 			"missing credential — send Authorization: Bearer <api_key>")
@@ -90,6 +91,7 @@ func (h *Handler) serve(w http.ResponseWriter, r *http.Request, rawEmail string)
 
 	principal, err := h.store.GetPrincipalByAPIKey(r.Context(), token)
 	if err != nil || principal == nil || principal.User == nil {
+		h.metrics.WSHandshakeRejected("unauthorized")
 		w.Header().Set("WWW-Authenticate", `Bearer realm="e2a"`)
 		httpapi.WriteError(w, r, http.StatusUnauthorized, "unauthorized", "invalid token")
 		return
@@ -101,6 +103,7 @@ func (h *Handler) serve(w http.ResponseWriter, r *http.Request, rawEmail string)
 	email := identity.NormalizeEmail(rawEmail)
 	agent, err := h.store.GetAgentByEmail(r.Context(), email)
 	if err != nil {
+		h.metrics.WSHandshakeRejected("not_found")
 		httpapi.WriteError(w, r, http.StatusNotFound, "not_found", "agent not found")
 		return
 	}
@@ -112,6 +115,7 @@ func (h *Handler) serve(w http.ResponseWriter, r *http.Request, rawEmail string)
 	// across tenants; collapsing both into 404 closes it (mirrors the REST
 	// resolveOwnedAgent, which likewise refuses to distinguish the two).
 	if agent.UserID != principal.User.ID {
+		h.metrics.WSHandshakeRejected("not_found")
 		httpapi.WriteError(w, r, http.StatusNotFound, "not_found", "agent not found")
 		return
 	}
@@ -119,6 +123,7 @@ func (h *Handler) serve(w http.ResponseWriter, r *http.Request, rawEmail string)
 	// its one bound agent — it may not open a different agent's stream even
 	// within the same account. Mirrors the REST resolveOwnedAgent pin.
 	if principal.Scope == identity.ScopeAgent && principal.AgentID != agent.ID {
+		h.metrics.WSHandshakeRejected("forbidden")
 		httpapi.WriteError(w, r, http.StatusForbidden, "forbidden", "not authorized for this agent")
 		return
 	}
@@ -134,6 +139,7 @@ func (h *Handler) serve(w http.ResponseWriter, r *http.Request, rawEmail string)
 		InsecureSkipVerify: true,
 	})
 	if err != nil {
+		h.metrics.WSHandshakeRejected("upgrade_failed")
 		log.Printf("[ws] upgrade failed for %s: %v", email, err)
 		return
 	}

--- a/internal/ws/handler.go
+++ b/internal/ws/handler.go
@@ -3,11 +3,14 @@ package ws
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log"
 	"net/http"
 	"strings"
 	"sync/atomic"
 	"time"
+
+	"github.com/jackc/pgx/v5"
 
 	"github.com/tokencanopy/e2a/internal/eventpayload"
 	"github.com/tokencanopy/e2a/internal/httpapi"
@@ -61,6 +64,20 @@ func (h *Handler) ServeWithEmail(w http.ResponseWriter, r *http.Request, rawEmai
 	h.serve(w, r, rawEmail)
 }
 
+// reject counts the handshake rejection and writes the canonical error
+// envelope — the two always happen together, so a future early return can't
+// skip the counter. reason ∈ the WSHandshakeRejected enum; status/code/msg
+// shape the (unchanged) client-facing response.
+func (h *Handler) reject(w http.ResponseWriter, r *http.Request, reason string, status int, code, msg string) {
+	h.metrics.WSHandshakeRejected(reason)
+	if status == http.StatusUnauthorized {
+		// RFC 6750 §3 — set before WriteError writes the status line, since
+		// headers can't be added once the status is flushed.
+		w.Header().Set("WWW-Authenticate", `Bearer realm="e2a"`)
+	}
+	httpapi.WriteError(w, r, status, code, msg)
+}
+
 func (h *Handler) serve(w http.ResponseWriter, r *http.Request, rawEmail string) {
 	// Authenticate via the `Authorization: Bearer <api_key>` handshake header —
 	// the standard shape for non-browser WebSocket clients (matches OpenAI
@@ -82,18 +99,24 @@ func (h *Handler) serve(w http.ResponseWriter, r *http.Request, rawEmail string)
 	// prod stack the authChallenge middleware also (re)asserts it on any 401.
 	token := bearerToken(r)
 	if token == "" {
-		h.metrics.WSHandshakeRejected("unauthorized")
-		w.Header().Set("WWW-Authenticate", `Bearer realm="e2a"`)
-		httpapi.WriteError(w, r, http.StatusUnauthorized, "unauthorized",
+		h.reject(w, r, "unauthorized", http.StatusUnauthorized, "unauthorized",
 			"missing credential — send Authorization: Bearer <api_key>")
 		return
 	}
 
 	principal, err := h.store.GetPrincipalByAPIKey(r.Context(), token)
 	if err != nil || principal == nil || principal.User == nil {
-		h.metrics.WSHandshakeRejected("unauthorized")
-		w.Header().Set("WWW-Authenticate", `Bearer realm="e2a"`)
-		httpapi.WriteError(w, r, http.StatusUnauthorized, "unauthorized", "invalid token")
+		// A genuinely unknown/revoked/expired key surfaces as pgx.ErrNoRows
+		// (or a nil principal) — a client fault. Any OTHER store error is an
+		// e2a-side failure to serve the handshake and is counted
+		// internal_error so a DB outage burns the handshake SLI instead of
+		// hiding inside the client-fault bucket. The 401 response is
+		// unchanged either way.
+		reason := "unauthorized"
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			reason = "internal_error"
+		}
+		h.reject(w, r, reason, http.StatusUnauthorized, "unauthorized", "invalid token")
 		return
 	}
 
@@ -103,8 +126,14 @@ func (h *Handler) serve(w http.ResponseWriter, r *http.Request, rawEmail string)
 	email := identity.NormalizeEmail(rawEmail)
 	agent, err := h.store.GetAgentByEmail(r.Context(), email)
 	if err != nil {
-		h.metrics.WSHandshakeRejected("not_found")
-		httpapi.WriteError(w, r, http.StatusNotFound, "not_found", "agent not found")
+		// Same split as the credential check: pgx.ErrNoRows is a genuinely
+		// unknown address (client fault); any other store error is e2a-side
+		// (internal_error). The 404 response is unchanged either way.
+		reason := "not_found"
+		if !errors.Is(err, pgx.ErrNoRows) {
+			reason = "internal_error"
+		}
+		h.reject(w, r, reason, http.StatusNotFound, "not_found", "agent not found")
 		return
 	}
 	// Tenant ownership: the agent must belong to the credential's user. A
@@ -115,16 +144,14 @@ func (h *Handler) serve(w http.ResponseWriter, r *http.Request, rawEmail string)
 	// across tenants; collapsing both into 404 closes it (mirrors the REST
 	// resolveOwnedAgent, which likewise refuses to distinguish the two).
 	if agent.UserID != principal.User.ID {
-		h.metrics.WSHandshakeRejected("not_found")
-		httpapi.WriteError(w, r, http.StatusNotFound, "not_found", "agent not found")
+		h.reject(w, r, "not_found", http.StatusNotFound, "not_found", "agent not found")
 		return
 	}
 	// Agent-scope confinement (HIGH-1): an agent-scoped credential is pinned to
 	// its one bound agent — it may not open a different agent's stream even
 	// within the same account. Mirrors the REST resolveOwnedAgent pin.
 	if principal.Scope == identity.ScopeAgent && principal.AgentID != agent.ID {
-		h.metrics.WSHandshakeRejected("forbidden")
-		httpapi.WriteError(w, r, http.StatusForbidden, "forbidden", "not authorized for this agent")
+		h.reject(w, r, "forbidden", http.StatusForbidden, "forbidden", "not authorized for this agent")
 		return
 	}
 

--- a/internal/ws/hub.go
+++ b/internal/ws/hub.go
@@ -12,11 +12,15 @@ import (
 // (same pattern as internal/janitor.Metrics). Each event has exactly ONE
 // owner so nothing double-counts: the Hub owns connects, the active gauge,
 // send failures, and shutdown disconnects (it drops every conn at Close);
-// the Handler owns per-connection disconnect reasons and drain counts (it
-// is the only place the reason is known).
+// the Handler owns handshake rejections, per-connection disconnect reasons,
+// and drain counts (it is the only place the reason is known).
 type Metrics interface {
 	WSConnected()
 	WSDisconnected(reason string) // reason ∈ {replaced, ping_timeout, client_close, error, shutdown}
+	// WSHandshakeRejected counts pre-upgrade handshake rejections.
+	// reason ∈ {unauthorized, not_found, forbidden, upgrade_failed}.
+	// Never pass emails or tokens.
+	WSHandshakeRejected(reason string)
 	WSDrained(count int)
 	WSSendFailure()
 	SetWSActive(n int)
@@ -26,11 +30,12 @@ type Metrics interface {
 // never guard and tests don't have to wire anything.
 type noopMetrics struct{}
 
-func (noopMetrics) WSConnected()          {}
-func (noopMetrics) WSDisconnected(string) {}
-func (noopMetrics) WSDrained(int)         {}
-func (noopMetrics) WSSendFailure()        {}
-func (noopMetrics) SetWSActive(int)       {}
+func (noopMetrics) WSConnected()               {}
+func (noopMetrics) WSDisconnected(string)      {}
+func (noopMetrics) WSHandshakeRejected(string) {}
+func (noopMetrics) WSDrained(int)              {}
+func (noopMetrics) WSSendFailure()             {}
+func (noopMetrics) SetWSActive(int)            {}
 
 // Hub manages WebSocket connections for agents that live-tail inbound
 // mail. Any agent may connect — WS is an opportunistic push on top of

--- a/internal/ws/hub.go
+++ b/internal/ws/hub.go
@@ -18,8 +18,8 @@ type Metrics interface {
 	WSConnected()
 	WSDisconnected(reason string) // reason ∈ {replaced, ping_timeout, client_close, error, shutdown}
 	// WSHandshakeRejected counts pre-upgrade handshake rejections.
-	// reason ∈ {unauthorized, not_found, forbidden, upgrade_failed}.
-	// Never pass emails or tokens.
+	// reason ∈ {unauthorized, not_found, forbidden, upgrade_failed,
+	// internal_error}. Never pass emails or tokens.
 	WSHandshakeRejected(reason string)
 	WSDrained(count int)
 	WSSendFailure()

--- a/internal/ws/metrics_test.go
+++ b/internal/ws/metrics_test.go
@@ -7,6 +7,7 @@ package ws
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -21,6 +22,7 @@ type fakeWSMetrics struct {
 	mu          sync.Mutex
 	connected   int
 	disconnects []string
+	rejections  []string
 	drained     []int
 	sendFails   int
 	active      []int // every SetWSActive value, in order
@@ -36,6 +38,12 @@ func (f *fakeWSMetrics) WSDisconnected(reason string) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.disconnects = append(f.disconnects, reason)
+}
+
+func (f *fakeWSMetrics) WSHandshakeRejected(reason string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.rejections = append(f.rejections, reason)
 }
 
 func (f *fakeWSMetrics) WSDrained(count int) {
@@ -71,6 +79,13 @@ func (f *fakeWSMetrics) snapshotDisconnects() []string {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return append([]string(nil), f.disconnects...)
+}
+
+// snapshotRejections copies the recorded handshake-rejection reasons.
+func (f *fakeWSMetrics) snapshotRejections() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.rejections...)
 }
 
 // waitDisconnect polls until a disconnect with the given reason is recorded.
@@ -296,5 +311,78 @@ func TestHandlerMetrics_Replaced(t *testing.T) {
 	}
 	if fm.connected != 2 {
 		t.Fatalf("connected = %d, want 2", fm.connected)
+	}
+}
+
+// ── Handshake-rejection SLI (docs/observability.md) ─────────────
+//
+// Every pre-upgrade rejection branch in serve() records exactly one
+// e2a_ws_handshake_rejected_total with an enum reason; a successful
+// handshake records none (the success side is e2a_ws_connects_total).
+
+func TestHandlerMetrics_HandshakeRejections(t *testing.T) {
+	cases := []struct {
+		name       string
+		store      *mockStore
+		token      string
+		plainHTTP  bool // plain GET (no upgrade) instead of a WS dial
+		wantReason string
+	}{
+		{"missing credential", &mockStore{}, "", true, "unauthorized"},
+		{"invalid token", &mockStore{user: nil}, "bad_key", false, "unauthorized"},
+		{"agent not found", &mockStore{user: newTestUser(), agentErr: errors.New("no rows")}, "valid_key", false, "not_found"},
+		{"cross-tenant agent", &mockStore{user: newTestUser(), agent: newTestAgent("user_other")}, "valid_key", false, "not_found"},
+		{"agent-scope pin", &mockStore{user: newTestUser(), scope: identity.ScopeAgent, agentID: "agent_other", agent: newTestAgent("user_1")}, "valid_key", false, "forbidden"},
+		{"upgrade failure", &mockStore{user: newTestUser(), agent: newTestAgent("user_1")}, "valid_key", true, "upgrade_failed"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hub := NewHub()
+			defer hub.Close()
+			fm := &fakeWSMetrics{}
+			handler := NewHandler(hub, tc.store)
+			handler.SetMetrics(fm)
+			srv := startServer(t, handler)
+
+			if tc.plainHTTP {
+				resp := doHTTP(t, srv, "bot@agents.e2a.dev", tc.token)
+				resp.Body.Close()
+			} else {
+				conn, _ := dialWS(t, srv, "bot@agents.e2a.dev", tc.token)
+				if conn != nil {
+					t.Fatal("expected the handshake to be rejected")
+				}
+			}
+			got := fm.snapshotRejections()
+			if len(got) != 1 || got[0] != tc.wantReason {
+				t.Fatalf("rejections = %v, want exactly [%s]", got, tc.wantReason)
+			}
+			fm.mu.Lock()
+			connected := fm.connected
+			fm.mu.Unlock()
+			if connected != 0 {
+				t.Errorf("connected = %d, want 0 — a rejected handshake never registers", connected)
+			}
+		})
+	}
+}
+
+func TestHandlerMetrics_SuccessfulHandshakeRecordsNoRejection(t *testing.T) {
+	hub := NewHub()
+	defer hub.Close()
+	fm := &fakeWSMetrics{}
+	handler := NewHandler(hub, &mockStore{user: newTestUser(), agent: newTestAgent("user_1")})
+	handler.SetMetrics(fm)
+	srv := startServer(t, handler)
+
+	conn, _ := dialWS(t, srv, "bot@agents.e2a.dev", "valid_key")
+	if conn == nil {
+		t.Fatal("expected successful WS connection")
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	waitConnected(t, hub, "agent_test")
+
+	if got := fm.snapshotRejections(); len(got) != 0 {
+		t.Errorf("rejections = %v, want none for a successful handshake", got)
 	}
 }

--- a/internal/ws/metrics_test.go
+++ b/internal/ws/metrics_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
+
 	"github.com/tokencanopy/e2a/internal/identity"
 	"nhooyr.io/websocket"
 )
@@ -330,7 +332,10 @@ func TestHandlerMetrics_HandshakeRejections(t *testing.T) {
 	}{
 		{"missing credential", &mockStore{}, "", true, "unauthorized"},
 		{"invalid token", &mockStore{user: nil}, "bad_key", false, "unauthorized"},
-		{"agent not found", &mockStore{user: newTestUser(), agentErr: errors.New("no rows")}, "valid_key", false, "not_found"},
+		{"unknown key from store", &mockStore{userErr: pgx.ErrNoRows}, "bad_key", false, "unauthorized"},
+		{"auth store outage", &mockStore{userErr: errors.New("connection reset")}, "valid_key", false, "internal_error"},
+		{"agent not found", &mockStore{user: newTestUser(), agentErr: pgx.ErrNoRows}, "valid_key", false, "not_found"},
+		{"agent store outage", &mockStore{user: newTestUser(), agentErr: errors.New("connection reset")}, "valid_key", false, "internal_error"},
 		{"cross-tenant agent", &mockStore{user: newTestUser(), agent: newTestAgent("user_other")}, "valid_key", false, "not_found"},
 		{"agent-scope pin", &mockStore{user: newTestUser(), scope: identity.ScopeAgent, agentID: "agent_other", agent: newTestAgent("user_1")}, "valid_key", false, "forbidden"},
 		{"upgrade failure", &mockStore{user: newTestUser(), agent: newTestAgent("user_1")}, "valid_key", true, "upgrade_failed"},


### PR DESCRIPTION
## Summary

Ships the three instruments that docs/observability.md's footnote ¹ marked **"target adopted; instrument pending"** (PR #671), and removes the footnote. All three SLO rows are now computable from shipped metrics.

- **`e2a_outbound_terminal_latency_seconds`** (histogram) — acceptance→terminal latency, observed **exactly once per message**, co-located with every `e2a_outbound_terminal_total` emission (worker `MarkSent` success + evidence-settle paths, `markFailed`'s settled-switch, and the terminal reconciler's settled-switch) via a shared `emitTerminal` helper so count and latency can't drift apart. The value is the terminal write's **effective** `occurred_at` − `messages.created_at`: `Store.MarkFailed` now returns the occurred_at the write actually used (the provider-accept evidence time on an evidence settle — previously the reconciler would have recorded acceptance→sweep, falsely burning the 5-minute SLO on its priority population). The reconciler candidate query carries `m.created_at` (no migration; the column exists). The `FinalizeProviderAcceptedTx` (SNS-feedback) and `PreserveTerminalFailure`/`DeferTerminalFailure` paths stay uninstrumented for both instruments, preserving the guard comment's contract. Buckets span seconds→days (72h retry-horizon tail; `le="300"` is the SLO edge).
- **`e2a_webhook_first_attempt_latency_seconds`** (histogram) — event→first-attempt latency in `webhookdelivery.DeliverWorker`, observed only on a first-delivery row's **first HTTP attempt**: no recorded prior attempt (any River attempt number — a first POST delayed by transient pre-POST failures still observes, so the incident population can't silently drop out), `replay_id IS NULL` (a replay's baseline would be the original event's age), event `created_at` LEFT-JOINed from `webhook_events`, and never snoozed (the disabled path is the worker's only snooze source; a job that sat through a customer-disabled window is excluded via River's `snoozes` metadata counter — `job.Attempt` can't discriminate since snooze doesn't burn attempts). Retries, `skipped_disabled`/`webhook_deleted` (no POST), and eventless `/test` deliveries never observe. `le="60"` is the SLO edge.
- **`e2a_ws_handshake_rejected_total{reason}`** (counter) — emitted at every pre-upgrade rejection branch in `ws/handler.go` via a `reject` helper that pairs the count with the error write: `unauthorized`, `not_found` (including the deliberate cross-tenant 404 collapse), `forbidden`, `upgrade_failed`, `internal_error`. Never labeled with emails/tokens; the Prom backend enum-allowlists the label (unknown → `"other"`). Store errors are distinguished from genuine misses by `pgx.ErrNoRows`: a DB outage during auth/agent lookup counts as `internal_error` (e2a-attributable) instead of hiding in the client-fault buckets. Documented SLI split: the denominator is `connects + internal_error` only — `unauthorized`/`not_found` (credential/address errors), `forbidden` (deterministic scope enforcement, not e2a-actionable), and `upgrade_failed` (predominantly client protocol defects; genuine server-side upgrade breakage is covered by the prober `websocket_round_trip` SLI) are client faults. HTTP responses are byte-unchanged.

Conventions follow PR #671 exactly: `telemetry.Metrics` extended additively (NoOp/Log/Prom all implement; Log keeps the new moderate-rate events), consumers keep narrow package-local `Metrics` interfaces (nil-safe defaults), wiring unchanged in `cmd/e2a/main.go`.

## Review history

Two adversarial review rounds, all actionable findings applied:

- **Round 1** (pre-push): cleared the PR #671 bug class ("emit caller intent, not what the write did") at every emit site; three low notes (all since addressed or documented).
- **Round 2** (external review): found the evidence-settle latency used caller-side sweep time instead of the write's provider-accept time (fixed — `MarkFailed` returns the effective occurred_at); survivorship bias when transient errors consume River attempt 1 (fixed — gate on recorded attempts, not attempt number); disabled-window poisoning of the first-attempt histogram (fixed — snooze-aware exclusion); WS handshake SLI reading 0/0 during a DB outage (fixed — `internal_error` reason); `upgrade_failed`/`forbidden` mis-attributed to e2a (fixed — client-fault split, prober backstop documented); the terminal count+latency contract being comment-only (fixed — shared `emitTerminal`); hand-placed WS rejection calls (fixed — `reject` helper).
- **Round 3** (re-review of the fix delta): found my scheduled_at heuristic could false-skip chained pre-POST failures (the exact outage population) — replaced with River's exact `snoozes` metadata discriminator; fixed a stale docs row.
- **Known pre-existing issue, NOT fixed here (out of scope, one-PR-per-feature):** any `GetWebhookByIDInternal` error — including a transient DB blip — is treated as `webhook_deleted` and terminally cancels the delivery row (`webhookdelivery/worker.go`). Real delivery-loss bug on a path this PR touches; deserves its own fix PR with `pgx.ErrNoRows` discrimination like the WS handler now has.

## Test plan

- TDD throughout (failing tests first): telemetry Prom series + label-cardinality normalization; latency value bands tied to seeded timestamps incl. the provider-accept-time cases (worker + reconciler); exactly-one-sample parity with the terminal count (incl. deferred-final-attempt and idempotent reconciler re-pass negative cases); webhook retry/replay/no-POST/eventless/snoozed/backoff-schedule exclusions and the not-attempt-1 observation case; all WS rejection branches incl. the `pgx.ErrNoRows` vs store-error split + success-records-none.
- `E2A_TEST_DATABASE_URL=postgres://e2a:e2a@localhost:5433/e2a_test_sloinst?sslmode=disable go test -tags integration -p 1 ./...` — **green** (private test DB, `-p 1` per AGENTS.md).
- `make spec-check` — green (no `/v1` API change).
- Coverage gate (`vladopajic/go-test-coverage`, `.testcoverage.yml`) — **exit 0**; floors hold (outboundsend 75, webhookdelivery 88, jobs 82). New tests add ~15s to the affected packages; negligible against the 18m CI cap.

🤖 Generated with [Kimi Code](https://www.kimi.com/code)
