### PR TITLE
test(web): add coverage gate to the web CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -180,7 +180,7 @@ jobs:
           cache: "npm"
       - run: npm ci
       - run: npm run lint
-      - run: npm test
+      - run: npm run test:coverage
       - run: npm run build
 
   ts-sdk:

--- a/web/jest.config.ts
+++ b/web/jest.config.ts
@@ -24,6 +24,18 @@ const config: Config = {
       },
     ],
   },
+  // Coverage gate (applies only when jest runs with --coverage, i.e.
+  // `npm run test:coverage` in CI). Floors sit ~2 points under current
+  // coverage (statements 87.5, branches 80.2, functions 85.3, lines 89.7).
+  // Ratchet up, never down.
+  coverageThreshold: {
+    global: {
+      statements: 85,
+      branches: 78,
+      functions: 83,
+      lines: 87,
+    },
+  },
 };
 
 export default config;

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "jest"
+    "test": "jest",
+    "test:coverage": "jest --coverage"
   },
   "dependencies": {
     "@e2a/ui": "file:../design-system",


### PR DESCRIPTION
## Summary

Adds a coverage gate to the web dashboard — the last CI-tested surface without one.

- `web/jest.config.ts`: `coverageThreshold` set ~2 points under measured coverage (statements 87.5 → **85**, branches 80.2 → **78**, functions 85.3 → **83**, lines 89.7 → **87**), with the measured values and the ratchet-up-never-down policy recorded in a comment — same convention as `.testcoverage.yml` and the SDK vitest configs
- `web/package.json`: `test:coverage` script (`jest --coverage`); plain `npm test` stays uninstrumented locally since thresholds only apply with `--coverage`
- `.github/workflows/test.yml`: the web job now runs `npm run test:coverage`

### Verification

- `npm run test:coverage` passes: 592 tests, all floors met
- Negative experiment: temporarily raising the statements floor to 99 fails with `Coverage for statements (87.53%) does not meet "global" threshold (99%)` — restored after

Every CI-tested surface now has a coverage gate: Go (11 package floors), TS SDK / CLI / MCP (vitest thresholds), Python (`--cov-fail-under=90`), and web (this PR).

🤖 Generated with [Kimi Code](https://www.kimi.com/code)
