### PR TITLE
fix(webhookdelivery): retry transient webhook-lookup errors, never mislabel them deleted

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -86,7 +86,7 @@ acceptance SLI below deliberately excludes them.
 
 | Metric | Type | Labels | Meaning |
 |---|---|---|---|
-| `e2a_webhook_attempts_total` | counter | `outcome`, `status_class` | Delivery attempts to subscriber endpoints: `delivered`, `retryable_failure`, `exhausted` (terminal after max attempts), `webhook_deleted`, `skipped_disabled`. `status_class` is the endpoint's response class, or `none` when no HTTP response was received (connect/DNS/SSRF-blocked). |
+| `e2a_webhook_attempts_total` | counter | `outcome`, `status_class` | Delivery attempts to subscriber endpoints: `delivered`, `retryable_failure`, `exhausted` (terminal after max attempts — including a delivery that exhausted its retries on a pre-POST infrastructure error, e.g. a sustained webhook-lookup outage), `webhook_deleted`, `skipped_disabled`. `status_class` is the endpoint's response class, or `none` when no HTTP response was received — connect/DNS/SSRF-blocked, or no POST was ever made. |
 | `e2a_webhook_attempt_duration_seconds` | histogram | — | HTTP POST duration per attempt. |
 | `e2a_webhook_first_attempt_latency_seconds` | histogram | — | Event→first-attempt latency per subscriber delivery (attempt start − the `webhook_events` row's `created_at`), observed **only on a first-delivery row's first HTTP attempt** (no recorded prior attempt — regardless of River attempt number, so a first POST delayed by pre-POST failures still observes). Retries, the no-POST outcomes (`webhook_deleted`, `skipped_disabled`), replay rows (their baseline would be the original event's age), eventless `/test` deliveries, and jobs that sat through a customer-disabled window (River snooze) never observe. |
 | `e2a_outbox_events_published_total` | counter | `type` | Events written to the outbox (fan-out input). |
@@ -238,6 +238,13 @@ snooze, and no POST happens:
 sum(rate(e2a_webhook_attempts_total{outcome="delivered"}[5m]))
 / sum(rate(e2a_webhook_attempts_total{outcome=~"delivered|retryable_failure|exhausted"}[5m]))
 ```
+
+One deliberate gap: a delivery retrying a *pre-POST* infrastructure error
+(e.g. a webhook-lookup DB outage) emits nothing until it exhausts — up to
+the 29h21m retry envelope — because no attempt happens to count. River's
+job-error logs and `e2a_queue_oldest_age_seconds{queue="webhook"}` cover
+the window; the first `exhausted` sample lands the SLI impact when the
+envelope runs out.
 
 **Webhook event→first attempt** — p95 latency from event creation to the
 first HTTP attempt (covers fan-out, queue wait, and worker pickup):

--- a/internal/webhookdelivery/worker.go
+++ b/internal/webhookdelivery/worker.go
@@ -175,8 +175,30 @@ func (w *DeliverWorker) Work(ctx context.Context, job *river.Job[WebhookDeliverA
 	}
 
 	wh, err := w.webhooks.GetWebhookByIDInternal(ctx, d.WebhookID)
+	if err != nil && !errors.Is(err, identity.ErrWebhookNotFound) {
+		// Anything but a genuine miss is an infrastructure error (Postgres
+		// blip, pool exhaustion, network reset) — retryable. Terminally
+		// cancelling here would permanently fail a deliverable row, mislabel
+		// it "webhook not found", and hide the loss behind the
+		// customer-fault webhook_deleted metric.
+		if job.Attempt >= MaxDeliveryAttempts {
+			// Final attempt — River discards after this regardless, so the
+			// terminal 'failed' write is the row's last chance (mirrors the
+			// POST-failure path below): without it the row would sit
+			// 'pending' with a dead job_id the reconciler can't see. The
+			// delivery exhausted its attempts without a POST — count it as
+			// exhausted (e2a-side, in the attempt-health denominator), never
+			// webhook_deleted.
+			w.emitAttempt("exhausted", "none", -1)
+			if merr := w.markFailedReliably(ctx, d.ID, job.Attempt, "webhook lookup error: "+err.Error(), 0); merr != nil {
+				log.Printf("[webhook-deliver] CRITICAL: terminal 'failed' write for delivery %s failed after retries (row stays pending, needs manual reconcile): %v", d.ID, merr)
+			}
+		}
+		return err
+	}
 	if err != nil {
-		// Webhook deleted — terminal. Write the terminal status; if that write
+		// Webhook deleted (the store's ErrWebhookNotFound sentinel — a real
+		// miss) — terminal. Write the terminal status; if that write
 		// fails, return the error (retryable) rather than cancelling with an
 		// unmarked row — a JobCancel here would strand the row 'pending' with a
 		// dead job that the reconciler (keyed on job_id IS NULL) can't recover.

--- a/internal/webhookdelivery/worker.go
+++ b/internal/webhookdelivery/worker.go
@@ -188,9 +188,12 @@ func (w *DeliverWorker) Work(ctx context.Context, job *river.Job[WebhookDeliverA
 			// 'pending' with a dead job_id the reconciler can't see. The
 			// delivery exhausted its attempts without a POST — count it as
 			// exhausted (e2a-side, in the attempt-health denominator), never
-			// webhook_deleted.
+			// webhook_deleted. last_error is a CONSTANT: it is returned
+			// verbatim by GET /v1/webhooks/{id}/deliveries, and a raw pgx
+			// error would leak internal hosts/IPs and DB identifiers. The
+			// returned err carries the real detail to River's job-error log.
 			w.emitAttempt("exhausted", "none", -1)
-			if merr := w.markFailedReliably(ctx, d.ID, job.Attempt, "webhook lookup error: "+err.Error(), 0); merr != nil {
+			if merr := w.markFailedReliably(ctx, d.ID, job.Attempt, "internal error resolving webhook", 0); merr != nil {
 				log.Printf("[webhook-deliver] CRITICAL: terminal 'failed' write for delivery %s failed after retries (row stays pending, needs manual reconcile): %v", d.ID, merr)
 			}
 		}

--- a/internal/webhookdelivery/worker_extra_test.go
+++ b/internal/webhookdelivery/worker_extra_test.go
@@ -147,7 +147,7 @@ func TestDeliverWorker_PrevSigningSecretWithinGraceIsHonored(t *testing.T) {
 func TestDeliverWorker_TerminalWriteFailureIsReturned(t *testing.T) {
 	id, sub, _, _ := seed(t, "wd-markfail")
 	w := webhookdelivery.NewDeliverWorker(sub, fakeDeliverer{out: webhook.DeliveryOutcome{Success: true}},
-		fakeWebhooks{err: errors.New("webhook gone")})
+		fakeWebhooks{err: identity.ErrWebhookNotFound})
 	err := w.Work(context.Background(), job(id, -1))
 	if err == nil {
 		t.Fatal("Work returned nil even though the terminal 'failed' write never succeeded")
@@ -197,7 +197,7 @@ func TestDeliverWorker_TerminalWriteHonorsContextCancel(t *testing.T) {
 	workCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	w := webhookdelivery.NewDeliverWorker(sub, fakeDeliverer{out: webhook.DeliveryOutcome{Success: true}},
-		fakeWebhooks{err: errors.New("webhook gone")})
+		fakeWebhooks{err: identity.ErrWebhookNotFound})
 	err = w.Work(workCtx, job(id, 1))
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Errorf("Work error = %v, want context.DeadlineExceeded (cancel must abort the retry backoff)", err)

--- a/internal/webhookdelivery/worker_test.go
+++ b/internal/webhookdelivery/worker_test.go
@@ -126,7 +126,7 @@ func TestDeliverWorker_DisabledSnoozes(t *testing.T) {
 
 func TestDeliverWorker_DeletedWebhookCancels(t *testing.T) {
 	id, sub, _, _ := seed(t, "wd-deleted")
-	w := webhookdelivery.NewDeliverWorker(sub, fakeDeliverer{out: webhook.DeliveryOutcome{Success: true}}, fakeWebhooks{err: errors.New("not found")})
+	w := webhookdelivery.NewDeliverWorker(sub, fakeDeliverer{out: webhook.DeliveryOutcome{Success: true}}, fakeWebhooks{err: identity.ErrWebhookNotFound})
 	if err := w.Work(context.Background(), job(id, 1)); err == nil {
 		t.Fatal("deleted webhook should return a cancel error")
 	}
@@ -289,7 +289,7 @@ func TestDeliverWorker_Metrics_DisabledSkip(t *testing.T) {
 func TestDeliverWorker_Metrics_DeletedWebhook(t *testing.T) {
 	id, sub, _, _ := seed(t, "wd-m-deleted")
 	fm := &fakeMetrics{}
-	w := webhookdelivery.NewDeliverWorker(sub, fakeDeliverer{out: webhook.DeliveryOutcome{Success: true}}, fakeWebhooks{err: errors.New("not found")}).WithMetrics(fm)
+	w := webhookdelivery.NewDeliverWorker(sub, fakeDeliverer{out: webhook.DeliveryOutcome{Success: true}}, fakeWebhooks{err: identity.ErrWebhookNotFound}).WithMetrics(fm)
 	if err := w.Work(context.Background(), job(id, 1)); err == nil {
 		t.Fatal("deleted webhook should return a cancel error")
 	}
@@ -428,7 +428,7 @@ func TestDeliverWorker_Metrics_FirstAttemptLatencySkipsNoPostOutcomes(t *testing
 	}
 
 	idDeleted, _, _, _ := seedEventLinked(t, "lat-deleted", 45*time.Second, false)
-	wDeleted := webhookdelivery.NewDeliverWorker(sub, fakeDeliverer{out: webhook.DeliveryOutcome{Success: true}}, fakeWebhooks{err: errors.New("not found")}).WithMetrics(fm)
+	wDeleted := webhookdelivery.NewDeliverWorker(sub, fakeDeliverer{out: webhook.DeliveryOutcome{Success: true}}, fakeWebhooks{err: identity.ErrWebhookNotFound}).WithMetrics(fm)
 	if err := wDeleted.Work(context.Background(), job(idDeleted, 1)); err == nil {
 		t.Fatal("deleted webhook should cancel")
 	}
@@ -544,7 +544,91 @@ func TestDeliverWorker_Metrics_FirstAttemptLatencyObservedDespiteBackoffSchedule
 	if len(fm.firstTry) != 1 {
 		t.Fatalf("first-attempt latencies = %v, want one sample for the true first POST after chained pre-POST failures", fm.firstTry)
 	}
-	if got := fm.firstTry[0]; got < 89*time.Minute.Seconds() || got > 91*time.Minute.Seconds() {
+	// Wide band: suite-load overhead between seeding and Work adds to the
+	// 90-minute seeded age (observed 91+ min under full-suite load).
+	if got := fm.firstTry[0]; got < 88*time.Minute.Seconds() || got > 95*time.Minute.Seconds() {
 		t.Errorf("first-attempt latency = %.0fs, want ~90min (the honest outage signal)", got)
+	}
+}
+
+// TestDeliverWorker_TransientWebhookLookupErrorRetries pins the guard
+// against misclassifying infrastructure errors: a webhook lookup that fails
+// with anything OTHER than "webhook gone" (a Postgres blip, pool
+// exhaustion, network reset) must NOT terminally fail the delivery — the
+// row stays pending and River retries. Only identity.ErrWebhookNotFound is
+// terminal; everything else is a retryable worker error, and no
+// webhook_deleted attempt is emitted (no POST happened, no deletion
+// occurred).
+func TestDeliverWorker_TransientWebhookLookupErrorRetries(t *testing.T) {
+	id, sub, _, _ := seed(t, "wd-transient-lookup")
+	fm := &fakeMetrics{}
+	w := webhookdelivery.NewDeliverWorker(sub, fakeDeliverer{out: webhook.DeliveryOutcome{Success: true}}, fakeWebhooks{err: errors.New("connection reset by peer")}).WithMetrics(fm)
+	err := w.Work(context.Background(), job(id, 1))
+	if err == nil {
+		t.Fatal("transient lookup error must return an error so River retries")
+	}
+	var cancelErr *river.JobCancelError
+	if errors.As(err, &cancelErr) {
+		t.Fatalf("transient lookup error must NOT cancel the job (that would strand the row pending): %v", err)
+	}
+	d := statusOf(t, sub, id)
+	if d.Status != "pending" {
+		t.Errorf("status = %q, want pending — a transient error must not fail the delivery", d.Status)
+	}
+	if len(fm.attempts) != 0 {
+		t.Errorf("attempts = %+v, want none — nothing was attempted and the webhook was not deleted", fm.attempts)
+	}
+}
+
+func TestDeliverWorker_WebhookNotFoundIsTerminal(t *testing.T) {
+	// The genuine-delete case keeps its terminal behavior: only the
+	// store's ErrWebhookNotFound sentinel (a real miss) cancels.
+	id, sub, _, _ := seed(t, "wd-genuine-delete")
+	fm := &fakeMetrics{}
+	w := webhookdelivery.NewDeliverWorker(sub, fakeDeliverer{out: webhook.DeliveryOutcome{Success: true}}, fakeWebhooks{err: identity.ErrWebhookNotFound}).WithMetrics(fm)
+	if err := w.Work(context.Background(), job(id, 1)); err == nil {
+		t.Fatal("deleted webhook should return a cancel error")
+	}
+	if d := statusOf(t, sub, id); d.Status != "failed" {
+		t.Errorf("status = %q, want failed (genuine delete is terminal)", d.Status)
+	}
+	got := fm.one(t)
+	if got.outcome != "webhook_deleted" {
+		t.Errorf("attempt = %+v, want webhook_deleted for a genuine delete", got)
+	}
+}
+
+func TestDeliverWorker_TransientLookupErrorOnFinalAttemptTerminatesHonestly(t *testing.T) {
+	// A transient lookup error persisting through the LAST attempt: River
+	// discards after this, so the worker must not strand the row 'pending'
+	// with a dead job. Mirror the POST-failure final-attempt path: terminal
+	// 'failed' write + an exhausted (never webhook_deleted) metric — the
+	// delivery used up its attempts without a POST, and a sustained e2a-side
+	// outage must burn the attempt-health SLI, not hide.
+	id, sub, _, _ := seed(t, "wd-transient-final")
+	fm := &fakeMetrics{}
+	w := webhookdelivery.NewDeliverWorker(sub, fakeDeliverer{out: webhook.DeliveryOutcome{Success: true}}, fakeWebhooks{err: errors.New("connection reset by peer")}).WithMetrics(fm)
+	if err := w.Work(context.Background(), job(id, webhookdelivery.MaxDeliveryAttempts)); err == nil {
+		t.Fatal("final-attempt lookup error must still return the error (River discards)")
+	}
+	if d := statusOf(t, sub, id); d.Status != "failed" {
+		t.Errorf("status = %q, want failed (terminal write is the row's last chance)", d.Status)
+	}
+	got := fm.one(t)
+	if got.outcome != "exhausted" || got.statusClass != "none" || got.seconds >= 0 {
+		t.Errorf("attempt = %+v, want exhausted/none/negative — attempts exhausted with no POST, never webhook_deleted", got)
+	}
+}
+
+func TestDeliverWorker_WrappedWebhookNotFoundIsStillTerminal(t *testing.T) {
+	// Pin the errors.Is traversal: a future store-side wrap of the sentinel
+	// must keep the terminal delete semantics.
+	id, sub, _, _ := seed(t, "wd-wrapped-delete")
+	w := webhookdelivery.NewDeliverWorker(sub, fakeDeliverer{out: webhook.DeliveryOutcome{Success: true}}, fakeWebhooks{err: fmt.Errorf("lookup webhook: %w", identity.ErrWebhookNotFound)})
+	if err := w.Work(context.Background(), job(id, 1)); err == nil {
+		t.Fatal("wrapped sentinel should still cancel")
+	}
+	if d := statusOf(t, sub, id); d.Status != "failed" {
+		t.Errorf("status = %q, want failed", d.Status)
 	}
 }

--- a/internal/webhookdelivery/worker_test.go
+++ b/internal/webhookdelivery/worker_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -544,10 +545,12 @@ func TestDeliverWorker_Metrics_FirstAttemptLatencyObservedDespiteBackoffSchedule
 	if len(fm.firstTry) != 1 {
 		t.Fatalf("first-attempt latencies = %v, want one sample for the true first POST after chained pre-POST failures", fm.firstTry)
 	}
-	// Wide band: suite-load overhead between seeding and Work adds to the
-	// 90-minute seeded age (observed 91+ min under full-suite load).
-	if got := fm.firstTry[0]; got < 88*time.Minute.Seconds() || got > 95*time.Minute.Seconds() {
-		t.Errorf("first-attempt latency = %.0fs, want ~90min (the honest outage signal)", got)
+	// Lower bound only: the seeded age compares Postgres now() against the
+	// host's time.Now(), and Docker VM clock drift makes any tight upper
+	// bound flaky. The assertion that matters: the outage-scale sample is
+	// recorded, not skipped or clamped.
+	if got := fm.firstTry[0]; got < time.Hour.Seconds() {
+		t.Errorf("first-attempt latency = %.0fs, want the honest outage-scale signal (>1h), got a small value", got)
 	}
 }
 
@@ -611,8 +614,18 @@ func TestDeliverWorker_TransientLookupErrorOnFinalAttemptTerminatesHonestly(t *t
 	if err := w.Work(context.Background(), job(id, webhookdelivery.MaxDeliveryAttempts)); err == nil {
 		t.Fatal("final-attempt lookup error must still return the error (River discards)")
 	}
-	if d := statusOf(t, sub, id); d.Status != "failed" {
+	d := statusOf(t, sub, id)
+	if d.Status != "failed" {
 		t.Errorf("status = %q, want failed (terminal write is the row's last chance)", d.Status)
+	}
+	// last_error is customer-facing (GET /v1/webhooks/{id}/deliveries): it
+	// must be a constant, never the raw pgx error (which leaks internal
+	// hosts/IPs and DB identifiers).
+	if d.LastError != "internal error resolving webhook" {
+		t.Errorf("last_error = %q, want the constant %q", d.LastError, "internal error resolving webhook")
+	}
+	if strings.Contains(d.LastError, "connection reset") {
+		t.Errorf("last_error leaks the raw infrastructure error: %q", d.LastError)
 	}
 	got := fm.one(t)
 	if got.outcome != "exhausted" || got.statusClass != "none" || got.seconds >= 0 {


### PR DESCRIPTION
## Summary

Fixes a pre-existing delivery-loss bug in `webhookdelivery.DeliverWorker.Work` (surfaced during PR #676's review): **any** error from `GetWebhookByIDInternal` — including a transient Postgres blip, pool exhaustion, or network reset — was treated as "webhook deleted", terminally failing the delivery row (`markFailedReliably` + `webhook_deleted` metric + `river.JobCancel`). A one-second DB blip could permanently kill deliverable webhook deliveries, mislabeled "webhook not found" and hidden behind the customer-fault `webhook_deleted` metric (excluded from the attempt-health SLI denominator, so even a batch loss during a failover wouldn't burn any SLO).

The fix branches on the store's sentinel: `GetWebhookByIDInternal` returns `identity.ErrWebhookNotFound` only for a genuine miss (`pgx.ErrNoRows`) and propagates every other error raw.

- **Genuine miss (`errors.Is(err, identity.ErrWebhookNotFound)`)** → terminal path unchanged (terminal write + `webhook_deleted` + cancel).
- **Anything else** → returned as a retryable worker error; the row stays pending and River retries. No metric — nothing was attempted and no deletion occurred.
- **Transient error on the final attempt** → mirrors the POST-failure final-attempt path: the terminal `failed` write is the row's last chance (a discarded job would otherwise strand the row `pending` with a dead `job_id` the reconciler can't see), counted as `exhausted`/`none` — never `webhook_deleted` — so a sustained e2a-side outage burns the attempt-health SLI instead of hiding.

Also rides along: a timing-flake fix in `TestDeliverWorker_Metrics_FirstAttemptLatencyObservedDespiteBackoffSchedule` (merged in #676; the assertion now checks only a lower bound — the seeded age compares Postgres `now()` against host `time.Now()`, and Docker VM clock drift made any tight upper bound flaky).

## Review history

- **Round 1** (adversarial subagent): **SHIP**; the one medium finding (final-attempt stranding residual) is addressed here by the `exhausted` terminal treatment. Verified the sentinel contract is airtight (only `pgx.ErrNoRows` maps to it; the filters-JSON unmarshal error does not) and that no metric can fire for something that didn't happen.
- **Round 2** (external review, "approve with one requested fix"): the final-attempt terminal write stored the raw pgx error into `last_error`, which `GET /v1/webhooks/{id}/deliveries` returns **verbatim** — leaking internal hosts/IPs and DB identifiers. Fixed: `last_error` is now the constant `"internal error resolving webhook"` (the existing convention; the real error still reaches River's job-error log via the returned `err`), pinned by test. Docs nits applied: `status_class=none` now covers "no POST was ever made", and the pre-POST retry window's observability gap is documented in the attempt-health SLI section.
- **Accepted trade, surfaced by review:** a permanently-broken filters-JSON row (unmarshal error in the store) now retries 8× over the 29h21m envelope before terminating instead of failing fast. Better classified than before, slightly more wasteful — accepted.
- **Known residual, noted not fixed:** the `GetSubscriberDeliveryByID` row-load error path has the same discard-after-final-attempt stranding gap (pre-existing, separate from the misclassification this PR fixes).

## Test plan

- TDD: `TestDeliverWorker_TransientWebhookLookupErrorRetries` failed pre-fix exactly as predicted (`JobCancelError: webhook ... not found: connection reset by peer`); green after.
- New tests: transient error → non-cancel error + row pending + no metric; genuine sentinel → terminal + `webhook_deleted`; wrapped sentinel (`fmt.Errorf` %w) still terminal; transient error on final attempt → row failed + `exhausted`/`none`/no-duration + constant non-leaking `last_error`.
- Three pre-existing tests that exercised the terminal path via a generic error (i.e., via the bug itself) now use the sentinel; `worker_extra_test.go`'s unreachable-lookup case deliberately keeps a generic error.
- `make spec-check` — green (no `/v1` change).
- `E2A_TEST_DATABASE_URL=postgres://e2a:e2a@localhost:5433/e2a_test_whtrans?sslmode=disable go test -tags integration -p 1 ./...` (private DB) — green, gated on `go test`'s own exit code.
- Coverage gate (`vladopajic/go-test-coverage`, `.testcoverage.yml`) — exit 0; webhookdelivery sits at 90.9% vs the 88 floor.

🤖 Generated with [Kimi Code](https://www.kimi.com/code)
