### PR TITLE
fix(webhookdelivery): terminal-write rows whose load fails on the final attempt

### DIFF
--- a/internal/webhook/subscriber_store.go
+++ b/internal/webhook/subscriber_store.go
@@ -147,6 +147,23 @@ func (s *SubscriberStore) MarkSubscriberFailed(ctx context.Context, deliveryID s
 	return err
 }
 
+// MarkSubscriberFailedIfPending is MarkSubscriberFailed conditional on the row
+// still being 'pending' — the BLIND terminal write for the final-attempt
+// row-load failure, where the read error means the row's true state is
+// unknown. It must never clobber a row that already reached a terminal state
+// (e.g. delivered by a path the failed read couldn't see). A missing row is
+// a no-op, not an error.
+func (s *SubscriberStore) MarkSubscriberFailedIfPending(ctx context.Context, deliveryID string, attemptN int, errMsg string, statusCode int) error {
+	_, err := s.pool.Exec(ctx,
+		`UPDATE webhook_subscriber_deliveries
+		    SET status = 'failed', attempts = $2, last_attempt_at = now(),
+		        last_error = $3, last_status_code = $4
+		  WHERE id = $1 AND status = 'pending'`,
+		deliveryID, attemptN, errMsg, statusCode,
+	)
+	return err
+}
+
 // generateDeliveryID returns a prefixed id of the form whd_<32-hex>.
 // 16 bytes of entropy is more than enough — the row is short-lived
 // (30-day expiry), and the prefix follows the rest of the e2a id

--- a/internal/webhook/subscriber_store_test.go
+++ b/internal/webhook/subscriber_store_test.go
@@ -251,3 +251,66 @@ func TestSubscriberStore_MarkDeliveredBumpsLastDeliveredAt(t *testing.T) {
 		t.Error("last_delivered_at not bumped on the webhook row after MarkDelivered")
 	}
 }
+
+// TestMarkSubscriberFailedIfPending pins the blind terminal write used when
+// the worker cannot read the row (a final-attempt row-load failure): it must
+// fail a PENDING row but never clobber a row that already reached a terminal
+// state (the read failing means the row's true state is unknown).
+func TestMarkSubscriberFailedIfPending(t *testing.T) {
+	pool := testutil.TestDB(t)
+	istore := identity.NewStore(pool)
+	ss := webhook.NewSubscriberStore(pool)
+	ctx := context.Background()
+	user, _ := istore.CreateOrGetUser(ctx, "wsd-cond@example.com", "Owner", "google-wsd-cond")
+	wh, _ := istore.CreateWebhook(ctx, user.ID, "https://example.com/hook", "", []string{"email.received"}, identity.WebhookFilters{})
+	env := []byte(`{"type":"email.received"}`)
+
+	// Pending row → failed, with the constant customer-safe last_error.
+	pendingID, err := ss.InsertPendingForTest(ctx, wh.ID, "email.received", env)
+	if err != nil {
+		t.Fatalf("InsertPendingForTest: %v", err)
+	}
+	if err := ss.MarkSubscriberFailedIfPending(ctx, pendingID, 8, "internal error loading delivery", 0); err != nil {
+		t.Fatalf("MarkSubscriberFailedIfPending on pending row: %v", err)
+	}
+	d, _ := ss.GetSubscriberDeliveryByID(ctx, pendingID)
+	if d.Status != "failed" || d.Attempts != 8 || d.LastError != "internal error loading delivery" {
+		t.Errorf("pending row: status=%q attempts=%d last_error=%q, want failed/8/constant", d.Status, d.Attempts, d.LastError)
+	}
+
+	// Already-failed row → untouched (the original, more informative
+	// last_error must survive).
+	failedID, err := ss.InsertPendingForTest(ctx, wh.ID, "email.received", env)
+	if err != nil {
+		t.Fatalf("InsertPendingForTest (failed): %v", err)
+	}
+	if err := ss.MarkSubscriberFailed(ctx, failedID, 8, "smtp 550 rejected", 550); err != nil {
+		t.Fatalf("MarkSubscriberFailed: %v", err)
+	}
+	if err := ss.MarkSubscriberFailedIfPending(ctx, failedID, 8, "internal error loading delivery", 0); err != nil {
+		t.Fatalf("MarkSubscriberFailedIfPending on failed row: %v", err)
+	}
+	if d, _ := ss.GetSubscriberDeliveryByID(ctx, failedID); d.Status != "failed" || d.LastError != "smtp 550 rejected" {
+		t.Errorf("failed row: status=%q last_error=%q, want failed with the ORIGINAL last_error", d.Status, d.LastError)
+	}
+
+	// Delivered row → untouched (never clobbered).
+	deliveredID, err := ss.InsertPendingForTest(ctx, wh.ID, "email.received", env)
+	if err != nil {
+		t.Fatalf("InsertPendingForTest 2: %v", err)
+	}
+	if err := ss.MarkDelivered(ctx, deliveredID, 200); err != nil {
+		t.Fatalf("MarkDelivered: %v", err)
+	}
+	if err := ss.MarkSubscriberFailedIfPending(ctx, deliveredID, 8, "internal error loading delivery", 0); err != nil {
+		t.Fatalf("MarkSubscriberFailedIfPending on delivered row: %v", err)
+	}
+	if d, _ := ss.GetSubscriberDeliveryByID(ctx, deliveredID); d.Status != "delivered" {
+		t.Errorf("delivered row: status=%q, want delivered (must not be clobbered)", d.Status)
+	}
+
+	// Missing row → no error, no panic (the blind write tolerates a gone row).
+	if err := ss.MarkSubscriberFailedIfPending(ctx, "whd_does_not_exist", 8, "internal error loading delivery", 0); err != nil {
+		t.Errorf("MarkSubscriberFailedIfPending on missing row: %v, want nil", err)
+	}
+}

--- a/internal/webhookdelivery/worker.go
+++ b/internal/webhookdelivery/worker.go
@@ -173,7 +173,24 @@ func (w *DeliverWorker) Work(ctx context.Context, job *river.Job[WebhookDeliverA
 		return nil // delivery row gone (webhook deleted, cascaded) — nothing to do
 	}
 	if err != nil {
-		return err // DB error — retryable
+		// DB error — retryable. On the FINAL attempt, River discards after
+		// this: give the row its terminal write NOW, or it becomes a poison
+		// row — every dead-job rescue (ReconcilePending rescues discarded
+		// jobs) re-drives it with a fresh 29h21m envelope that fails at
+		// row-load again, leaving it customer-visibly 'pending' forever. The
+		// write is conditional on still-pending — the read failed, so the
+		// row's true state is unknown and a delivered row must never be
+		// clobbered — and last_error is a constant (customer-facing; a raw
+		// pgx error would leak internal hosts/IPs and DB identifiers).
+		// Counted exhausted (attempts consumed without a POST), never
+		// webhook_deleted.
+		if job.Attempt >= MaxDeliveryAttempts {
+			w.emitAttempt("exhausted", "none", -1)
+			if merr := w.subStore.MarkSubscriberFailedIfPending(ctx, job.Args.DeliveryID, job.Attempt, "internal error loading delivery", 0); merr != nil {
+				log.Printf("[webhook-deliver] CRITICAL: terminal 'failed' write for delivery %s failed after row-load error (row stays pending; the reconciler will re-drive it once this job is discarded): %v", job.Args.DeliveryID, merr)
+			}
+		}
+		return err
 	}
 	if d.Status != "pending" {
 		// Terminal row — idempotent no-op. Covers a re-drive after a crash
@@ -204,7 +221,7 @@ func (w *DeliverWorker) Work(ctx context.Context, job *river.Job[WebhookDeliverA
 			// returned err carries the real detail to River's job-error log.
 			w.emitAttempt("exhausted", "none", -1)
 			if merr := w.markFailedReliably(ctx, d.ID, job.Attempt, "internal error resolving webhook", 0); merr != nil {
-				log.Printf("[webhook-deliver] CRITICAL: terminal 'failed' write for delivery %s failed after retries (row stays pending, needs manual reconcile): %v", d.ID, merr)
+				log.Printf("[webhook-deliver] CRITICAL: terminal 'failed' write for delivery %s failed after retries (row stays pending; the reconciler will re-drive it once this job is discarded): %v", d.ID, merr)
 			}
 		}
 		return err

--- a/internal/webhookdelivery/worker_test.go
+++ b/internal/webhookdelivery/worker_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/rivertype"
 
@@ -655,5 +656,53 @@ func TestDeliverWorker_WrappedWebhookNotFoundIsStillTerminal(t *testing.T) {
 	}
 	if d := statusOf(t, sub, id); d.Status != "failed" {
 		t.Errorf("status = %q, want failed", d.Status)
+	}
+}
+
+// closedPoolSubStore returns a SubscriberStore whose every query fails —
+// the row's true state is unreachable, which is exactly the blind-spot the
+// final-attempt guard exists for. Plain pgxpool.New + Close (the readyz
+// precedent): no ping, no migrations, no live DB needed.
+func closedPoolSubStore(t *testing.T) *webhook.SubscriberStore {
+	t.Helper()
+	pool, err := pgxpool.New(context.Background(), testutil.TestDBURL())
+	if err != nil {
+		t.Fatalf("pgxpool.New: %v", err)
+	}
+	pool.Close()
+	return webhook.NewSubscriberStore(pool)
+}
+
+func TestDeliverWorker_RowLoadErrorBeforeFinalAttemptEmitsNothing(t *testing.T) {
+	sub := closedPoolSubStore(t)
+	fm := &fakeMetrics{}
+	w := webhookdelivery.NewDeliverWorker(sub, fakeDeliverer{out: webhook.DeliveryOutcome{Success: true}}, fakeWebhooks{}).WithMetrics(fm)
+	err := w.Work(context.Background(), job("whd_unreachable", 1))
+	if err == nil {
+		t.Fatal("row-load error must return an error so River retries")
+	}
+	if len(fm.attempts) != 0 {
+		t.Errorf("attempts = %+v, want none — nothing was attempted", fm.attempts)
+	}
+}
+
+func TestDeliverWorker_RowLoadErrorOnFinalAttemptIsExhausted(t *testing.T) {
+	// River discards after the final attempt, so a row whose load kept
+	// failing must be terminally written (conditional on still-pending — the
+	// read failing means the row's true state is unknown) and counted
+	// exhausted — otherwise it strands 'pending' with a dead job_id the
+	// reconciler can't see. (The terminal write itself also fails here —
+	// the pool is closed — so the CRITICAL log path runs; what we pin is
+	// the exhausted classification + the returned error.)
+	sub := closedPoolSubStore(t)
+	fm := &fakeMetrics{}
+	w := webhookdelivery.NewDeliverWorker(sub, fakeDeliverer{out: webhook.DeliveryOutcome{Success: true}}, fakeWebhooks{}).WithMetrics(fm)
+	err := w.Work(context.Background(), job("whd_unreachable", webhookdelivery.MaxDeliveryAttempts))
+	if err == nil {
+		t.Fatal("final-attempt row-load error must still return the error (River discards)")
+	}
+	got := fm.one(t)
+	if got.outcome != "exhausted" || got.statusClass != "none" || got.seconds >= 0 {
+		t.Errorf("attempt = %+v, want exhausted/none/negative", got)
 	}
 }


### PR DESCRIPTION
## Summary

Closes the last terminality gap flagged in PR #682's review: the `GetSubscriberDeliveryByID` (row-load) error path in `DeliverWorker.Work` was purely retryable, so a row whose load failed on **all 8 River attempts** (the full 29h21m envelope) would be discarded without a terminal write — becoming a **poison row**: every dead-job rescue (`ReconcilePending` rescues `discarded` jobs) re-drives it with a fresh envelope that fails at row-load again, leaving it customer-visibly `pending` forever and never counted anywhere.

On the final attempt, the row-load error branch now:

- emits `exhausted`/`none`/no-duration (attempts consumed without a POST — never `webhook_deleted`), matching the lookup and POST final-attempt paths;
- writes the terminal `failed` status via a new **`MarkSubscriberFailedIfPending`** (`UPDATE ... WHERE id=$1 AND status='pending'`) — the read failed, so the row's true state is unknown and an already-terminal row (delivered/failed, with its more informative `last_error`) must never be clobbered; a missing row is a no-op;
- writes a **constant** `last_error` (`"internal error loading delivery"`) — customer-facing via `GET /v1/webhooks/{id}/deliveries`; a raw pgx error would leak internal hosts/IPs and DB identifiers (the #682 review finding);
- CRITICAL-logs if even that write fails, with the correct operator framing (the reconciler's dead-job rescue will re-drive it — it self-heals once the DB recovers), also fixing the same stale advice in the #682 lookup-path log.

## Review history

- Adversarial review: **SHIP**, two lows applied — (1) the original framing ("reconciler can't see the row") was wrong: `jobs.deadJobStates` includes `discarded`, so the real pre-fix failure mode is the poison-row *loop*, and comments/logs now say so; (2) the closed-pool test helper is now hermetic (`pgxpool.New` + `Close`, the readyz precedent — no live DB, no migrations). Store test additionally pins the already-failed case (original `last_error` survives) and the written values.

## Test plan

- TDD: `TestDeliverWorker_RowLoadErrorOnFinalAttemptIsExhausted` failed pre-fix (`recorded 0 attempts, want 1`); green after. Removal-tested by review: deleting the branch makes it fail again.
- New tests: store-level `TestMarkSubscriberFailedIfPending` (pending→failed with constant `last_error`; delivered→untouched; already-failed→original `last_error` survives; missing→nil); worker-level final-attempt `exhausted` classification and pre-final no-metric, using a closed pool (no live DB needed).
- `make spec-check` — green (no `/v1` change).
- `E2A_TEST_DATABASE_URL=postgres://e2a:e2a@localhost:5433/e2a_test_whrow?sslmode=disable go test -tags integration -p 1 ./...` (private DB) — exit 0, zero failures.
- Coverage gate (`vladopajic/go-test-coverage`, `.testcoverage.yml`) — exit 0; floors hold.

🤖 Generated with [Kimi Code](https://www.kimi.com/code)
