### PR TITLE
fix(logging): redact PII from process logs before centralized log shipping

### DIFF
--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -30,6 +30,7 @@ import (
 	"github.com/tokencanopy/e2a/internal/identity"
 	"github.com/tokencanopy/e2a/internal/inboundscreen"
 	"github.com/tokencanopy/e2a/internal/limits"
+	"github.com/tokencanopy/e2a/internal/logredact"
 	"github.com/tokencanopy/e2a/internal/oauth"
 	"github.com/tokencanopy/e2a/internal/outbound"
 	"github.com/tokencanopy/e2a/internal/piguard"
@@ -1120,8 +1121,8 @@ func (a *API) HoldForApprovalCore(ctx context.Context, agent *identity.AgentIden
 	}
 
 	slug, _, _ := strings.Cut(agent.EmailAddress(), "@")
-	log.Printf("[mail:%s] dir=outbound type=%s status=%s from=%s to=%v slug=%s conv_id=%s subject=%q approval_expires_at=%s",
-		msg.ID, msgType, msg.Status, agent.EmailAddress(), req.To, slug, req.ConversationID, req.Subject, msg.ApprovalExpiresAt.Format(time.RFC3339))
+	log.Printf("[mail:%s] dir=outbound type=%s status=%s from=%s to_count=%d to_domains=%v slug=%s conv_id=%s subject_len=%d approval_expires_at=%s",
+		msg.ID, msgType, msg.Status, agent.EmailAddress(), len(req.To), logredact.AddressDomains(req.To), slug, req.ConversationID, utf8.RuneCountInString(req.Subject), msg.ApprovalExpiresAt.Format(time.RFC3339))
 
 	a.publishPendingApproval(ctx, a.buildPendingApprovalEvent(agent, msg, req, msgType), msg.ID)
 	return msg, nil
@@ -1310,7 +1311,7 @@ func (a *API) DeliverOutbound(ctx context.Context, user *identity.User, agent *i
 		// on metering; the pre-check remains the quota gate.
 		a.recordLoopbackUsage(ctx, user.ID, agent)
 		slug, _, _ := strings.Cut(agent.EmailAddress(), "@")
-		log.Printf("[mail:%s] dir=outbound type=%s method=loopback status=sent from=%s to=%s slug=%s conv_id=%s subject=%q", outMsg.ID, msgType, agent.EmailAddress(), agent.EmailAddress(), slug, req.ConversationID, req.Subject)
+		log.Printf("[mail:%s] dir=outbound type=%s method=loopback status=sent from=%s to=%s slug=%s conv_id=%s subject_len=%d", outMsg.ID, msgType, agent.EmailAddress(), agent.EmailAddress(), slug, req.ConversationID, utf8.RuneCountInString(req.Subject))
 		return &OutboundResult{MessageID: outMsg.ID, SentAs: "own_address", Method: "loopback"}, nil
 	}
 
@@ -1324,7 +1325,7 @@ func (a *API) DeliverOutbound(ctx context.Context, user *identity.User, agent *i
 	// (email.sent / email.failed + metering). Missing queue wiring is a startup bug;
 	// fail closed here as defense in depth and never submit inline.
 	if a.outboundEnq == nil {
-		log.Printf("[api] outbound queue unavailable: agent=%s to=%v", agent.Domain, req.To)
+		log.Printf("[api] outbound queue unavailable: agent=%s to_count=%d to_domains=%v", agent.Domain, len(req.To), logredact.AddressDomains(req.To))
 		return nil, &OutboundError{Status: http.StatusInternalServerError, Code: "internal_error", Msg: "outbound delivery queue unavailable"}
 	}
 	comp, cerr := a.sender.ComposeForAccept(agent, req)
@@ -1335,7 +1336,7 @@ func (a *API) DeliverOutbound(ctx context.Context, user *identity.User, agent *i
 		if outbound.IsValidationError(cerr) {
 			return nil, &OutboundError{Status: http.StatusBadRequest, Code: "invalid_request", Msg: cerr.Error()}
 		}
-		log.Printf("[api] async compose failed: agent=%s to=%v error=%v", agent.Domain, req.To, cerr)
+		log.Printf("[api] async compose failed: agent=%s to_count=%d to_domains=%v error=%v", agent.Domain, len(req.To), logredact.AddressDomains(req.To), cerr)
 		return nil, &OutboundError{Status: http.StatusInternalServerError, Code: "internal_error", Msg: fmt.Sprintf("compose failed: %v", cerr)}
 	}
 	var accepted *identity.Message
@@ -1367,14 +1368,14 @@ func (a *API) DeliverOutbound(ctx context.Context, user *identity.User, agent *i
 		accepted = msg
 		return nil
 	}); txErr != nil {
-		log.Printf("[api] async accept tx failed: agent=%s to=%v error=%v", agent.Domain, req.To, txErr)
+		log.Printf("[api] async accept tx failed: agent=%s to_count=%d to_domains=%v error=%v", agent.Domain, len(req.To), logredact.AddressDomains(req.To), txErr)
 		return nil, &OutboundError{Status: http.StatusInternalServerError, Code: "internal_error", Msg: "failed to accept message for send"}
 	}
 	if verdict.Annotate() {
 		a.annotateAndAudit(ctx, agent, accepted.ID, req, verdict)
 	}
 	slug, _, _ := strings.Cut(agent.EmailAddress(), "@")
-	log.Printf("[mail:%s] dir=outbound type=%s status=accepted from=%s to=%v slug=%s conv_id=%s subject=%q", accepted.ID, msgType, agent.EmailAddress(), comp.To, slug, req.ConversationID, req.Subject)
+	log.Printf("[mail:%s] dir=outbound type=%s status=accepted from=%s to_count=%d to_domains=%v slug=%s conv_id=%s subject_len=%d", accepted.ID, msgType, agent.EmailAddress(), len(comp.To), logredact.AddressDomains(comp.To), slug, req.ConversationID, utf8.RuneCountInString(req.Subject))
 	return &OutboundResult{MessageID: accepted.ID, Status: "accepted", SentAs: comp.SentAs, Method: comp.Method}, nil
 }
 
@@ -1454,7 +1455,7 @@ func (a *API) acceptPlatformSend(ctx context.Context, agent *identity.AgentIdent
 	// Missing queue wiring is a startup bug; fail closed before provider I/O
 	// and never submit inline (same contract as DeliverOutbound).
 	if a.outboundEnq == nil {
-		log.Printf("[api] outbound queue unavailable: agent=%s to=%v (platform %s)", agent.Domain, req.To, msgType)
+		log.Printf("[api] outbound queue unavailable: agent=%s to_count=%d to_domains=%v (platform %s)", agent.Domain, len(req.To), logredact.AddressDomains(req.To), msgType)
 		return nil, &OutboundError{Status: http.StatusInternalServerError, Code: "internal_error", Msg: "outbound delivery queue unavailable"}
 	}
 	comp, cerr := a.sender.ComposePlatformForAccept(req)
@@ -1465,7 +1466,7 @@ func (a *API) acceptPlatformSend(ctx context.Context, agent *identity.AgentIdent
 		if outbound.IsValidationError(cerr) {
 			return nil, &OutboundError{Status: http.StatusBadRequest, Code: "invalid_request", Msg: cerr.Error()}
 		}
-		log.Printf("[api] platform compose failed: agent=%s to=%v error=%v", agent.Domain, req.To, cerr)
+		log.Printf("[api] platform compose failed: agent=%s to_count=%d to_domains=%v error=%v", agent.Domain, len(req.To), logredact.AddressDomains(req.To), cerr)
 		return nil, &OutboundError{Status: http.StatusInternalServerError, Code: "internal_error", Msg: fmt.Sprintf("compose failed: %v", cerr)}
 	}
 	var accepted *identity.Message
@@ -1484,12 +1485,12 @@ func (a *API) acceptPlatformSend(ctx context.Context, agent *identity.AgentIdent
 		accepted = msg
 		return nil
 	}); txErr != nil {
-		log.Printf("[api] platform accept tx failed: agent=%s to=%v error=%v", agent.Domain, req.To, txErr)
+		log.Printf("[api] platform accept tx failed: agent=%s to_count=%d to_domains=%v error=%v", agent.Domain, len(req.To), logredact.AddressDomains(req.To), txErr)
 		return nil, &OutboundError{Status: http.StatusInternalServerError, Code: "internal_error", Msg: "failed to accept message for send"}
 	}
 	slug, _, _ := strings.Cut(agent.EmailAddress(), "@")
-	log.Printf("[mail:%s] dir=outbound type=%s status=accepted from=%s to=%v slug=%s conv_id=%s subject=%q platform_originated=true",
-		accepted.ID, msgType, comp.EnvelopeFrom, comp.To, slug, req.ConversationID, req.Subject)
+	log.Printf("[mail:%s] dir=outbound type=%s status=accepted from=%s to_count=%d to_domains=%v slug=%s conv_id=%s subject_len=%d platform_originated=true",
+		accepted.ID, msgType, comp.EnvelopeFrom, len(comp.To), logredact.AddressDomains(comp.To), slug, req.ConversationID, utf8.RuneCountInString(req.Subject))
 	return &OutboundResult{MessageID: accepted.ID, Status: "accepted", SentAs: comp.SentAs, Method: comp.Method}, nil
 }
 
@@ -1646,11 +1647,8 @@ func (a *API) handleFeedback(w http.ResponseWriter, r *http.Request) {
 
 	if attempted == 0 {
 		// No delivery channel configured — log-only graceful fallback.
-		safeMsg := strings.ReplaceAll(req.Message, "\n", " ")
-		if len([]rune(safeMsg)) > 200 {
-			safeMsg = string([]rune(safeMsg)[:200])
-		}
-		log.Printf("feedback: no delivery channel configured, logging only: [%s] %s", req.Category, safeMsg)
+		safeMsg := logredact.Truncate(strings.ReplaceAll(req.Message, "\n", " "), 60)
+		log.Printf("feedback: no delivery channel configured, logging only: [%s] message_len=%d preview=%q", req.Category, utf8.RuneCountInString(req.Message), safeMsg)
 	} else if delivered == 0 {
 		http.Error(w, "failed to submit feedback", http.StatusInternalServerError)
 		return

--- a/internal/agent/hitl_api.go
+++ b/internal/agent/hitl_api.go
@@ -8,8 +8,10 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/tokencanopy/e2a/internal/identity"
+	"github.com/tokencanopy/e2a/internal/logredact"
 	"github.com/tokencanopy/e2a/internal/outbound"
 )
 
@@ -149,8 +151,8 @@ func (a *API) ApprovePendingCore(ctx context.Context, userID, messageID, expecte
 	}
 	if handled {
 		slug, _, _ := strings.Cut(agent.EmailAddress(), "@")
-		log.Printf("[mail:%s] dir=outbound type=%s status=%s from=%s to=%v slug=%s subject=%q edited=%v approved=user:%s delivery=async",
-			sent.ID, sent.Type, sent.Status, agent.EmailAddress(), sent.ToRecipients, slug, sent.Subject, sent.Edited, userID)
+		log.Printf("[mail:%s] dir=outbound type=%s status=%s from=%s to_count=%d to_domains=%v slug=%s subject_len=%d edited=%v approved=user:%s delivery=async",
+			sent.ID, sent.Type, sent.Status, agent.EmailAddress(), len(sent.ToRecipients), logredact.AddressDomains(sent.ToRecipients), slug, utf8.RuneCountInString(sent.Subject), sent.Edited, userID)
 		a.publishApproved(ctx, a.buildApprovedEvent(agent, sent, userID), sent)
 		// No metering here — the SendWorker meters on MarkSent.
 		return sent, nil
@@ -175,8 +177,8 @@ func (a *API) ApprovePendingCore(ctx context.Context, userID, messageID, expecte
 
 	a.recordLoopbackUsage(ctx, userID, agent)
 	slug, _, _ := strings.Cut(agent.EmailAddress(), "@")
-	log.Printf("[mail:%s] dir=outbound type=%s status=%s from=%s to=%v slug=%s subject=%q edited=%v approved=user:%s",
-		sent.ID, sent.Type, sent.Status, agent.EmailAddress(), sent.ToRecipients, slug, sent.Subject, sent.Edited, userID)
+	log.Printf("[mail:%s] dir=outbound type=%s status=%s from=%s to_count=%d to_domains=%v slug=%s subject_len=%d edited=%v approved=user:%s",
+		sent.ID, sent.Type, sent.Status, agent.EmailAddress(), len(sent.ToRecipients), logredact.AddressDomains(sent.ToRecipients), slug, utf8.RuneCountInString(sent.Subject), sent.Edited, userID)
 	a.publishApproved(ctx, a.buildApprovedEvent(agent, sent, userID), sent)
 	return sent, nil
 }
@@ -369,8 +371,8 @@ func (a *API) RejectPendingCore(ctx context.Context, userID, messageID, expected
 			return nil, &OutboundError{Status: http.StatusInternalServerError, Code: "internal_error", Msg: "failed to reject message"}
 		}
 	}
-	log.Printf("[mail:%s] dir=outbound type=%s status=%s agent=%s rejected_by=user:%s reason=%q",
-		rejected.ID, rejected.Type, rejected.Status, rejected.AgentID, userID, reason)
+	log.Printf("[mail:%s] dir=outbound type=%s status=%s agent=%s rejected_by=user:%s reason_len=%d",
+		rejected.ID, rejected.Type, rejected.Status, rejected.AgentID, userID, utf8.RuneCountInString(reason))
 	a.publishRejected(ctx, a.buildRejectedEvent(userID, rejected, reason), rejected.ID)
 	return rejected, nil
 }
@@ -429,8 +431,8 @@ func (a *API) RejectInboundReviewCore(ctx context.Context, userID, reason string
 		log.Printf("[api] reject inbound review %s: %v", msg.ID, err)
 		return &OutboundError{Status: http.StatusInternalServerError, Code: "internal_error", Msg: "failed to reject message"}
 	}
-	log.Printf("[mail:%s] dir=inbound type=%s status=%s agent=%s rejected_by=user:%s reason=%q",
-		msg.ID, msg.Type, identity.MessageStatusReviewRejected, msg.AgentID, userID, reason)
+	log.Printf("[mail:%s] dir=inbound type=%s status=%s agent=%s rejected_by=user:%s reason_len=%d",
+		msg.ID, msg.Type, identity.MessageStatusReviewRejected, msg.AgentID, userID, utf8.RuneCountInString(reason))
 	a.publishRejected(ctx, a.buildInboundRejectedEvent(msg, a.reviewOwnerID(ctx, msg.AgentID, userID), userID, reason, transition), msg.ID)
 	return nil
 }

--- a/internal/agent/hitl_magic_api.go
+++ b/internal/agent/hitl_magic_api.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/tokencanopy/e2a/internal/approvaltoken"
 	"github.com/tokencanopy/e2a/internal/identity"
+	"github.com/tokencanopy/e2a/internal/logredact"
 	"github.com/tokencanopy/e2a/internal/outbound"
 )
 
@@ -270,8 +271,8 @@ func (a *API) magicApprove(w http.ResponseWriter, r *http.Request, messageID, us
 		return
 	}
 	if handled {
-		log.Printf("[mail:%s] dir=outbound type=%s status=%s agent=%s to=%v approved=magic-link:user:%s delivery=async",
-			sent.ID, sent.Type, sent.Status, agent.EmailAddress(), sent.ToRecipients, userID)
+		log.Printf("[mail:%s] dir=outbound type=%s status=%s agent=%s to_count=%d to_domains=%v approved=magic-link:user:%s delivery=async",
+			sent.ID, sent.Type, sent.Status, agent.EmailAddress(), len(sent.ToRecipients), logredact.AddressDomains(sent.ToRecipients), userID)
 		writeMagicMessage(w, http.StatusOK, "Approved",
 			fmt.Sprintf("Your message to %s has been queued for delivery.", html.EscapeString(firstRecipient(sent.ToRecipients))))
 		return
@@ -304,8 +305,8 @@ func (a *API) magicApprove(w http.ResponseWriter, r *http.Request, messageID, us
 	}
 
 	a.recordLoopbackUsage(r.Context(), userID, agent)
-	log.Printf("[mail:%s] dir=outbound type=%s status=%s agent=%s to=%v approved=magic-link:user:%s",
-		sent.ID, sent.Type, sent.Status, agent.EmailAddress(), sent.ToRecipients, userID)
+	log.Printf("[mail:%s] dir=outbound type=%s status=%s agent=%s to_count=%d to_domains=%v approved=magic-link:user:%s",
+		sent.ID, sent.Type, sent.Status, agent.EmailAddress(), len(sent.ToRecipients), logredact.AddressDomains(sent.ToRecipients), userID)
 
 	writeMagicMessage(w, http.StatusOK,
 		"Approved",
@@ -353,8 +354,8 @@ func (a *API) magicReject(w http.ResponseWriter, r *http.Request, messageID, use
 		}
 		return
 	}
-	log.Printf("[mail:%s] dir=outbound type=%s status=%s rejected_by=magic-link:user:%s reason=%q",
-		rejected.ID, rejected.Type, rejected.Status, userID, reason)
+	log.Printf("[mail:%s] dir=outbound type=%s status=%s rejected_by=magic-link:user:%s reason_len=%d",
+		rejected.ID, rejected.Type, rejected.Status, userID, utf8.RuneCountInString(reason))
 
 	writeMagicMessage(w, http.StatusOK, "Rejected",
 		"The message has been discarded and will not be sent.")

--- a/internal/agent/user_data_rights_api.go
+++ b/internal/agent/user_data_rights_api.go
@@ -8,7 +8,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"time"
@@ -91,7 +90,7 @@ func (a *API) DeleteUserDataCore(ctx context.Context, user *identity.User) (*ide
 	res.OAuthAuthCodesDeleted = oauthCounts.AuthCodes
 	res.OAuthAccessTokensDeleted = oauthCounts.AccessTokens
 	res.OAuthRefreshTokensDeleted = oauthCounts.RefreshTokens
-	log.Printf("[api] user deleted: id=%s email=%s removed=%+v", user.ID, user.Email, res)
+	log.Printf("[api] user deleted: id=%s removed=%+v", user.ID, res)
 	return res, nil
 }
 
@@ -127,8 +126,9 @@ func (a *API) notifyBillingUserDeleted(ctx context.Context, userID string) error
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusNoContent {
-		b, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		return fmt.Errorf("billing hook returned %d: %s", resp.StatusCode, string(b))
+		// Status code only: the sidecar's response body is third-party text that
+		// would flow into logs via callers' err=%v. The sidecar logs its own errors.
+		return fmt.Errorf("billing hook returned status %d", resp.StatusCode)
 	}
 	return nil
 }

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/subtle"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/tokencanopy/e2a/internal/config"
 	"github.com/tokencanopy/e2a/internal/identity"
+	"github.com/tokencanopy/e2a/internal/logredact"
 )
 
 const (
@@ -301,7 +303,20 @@ func (oa *OIDCAuth) HandleCallback(w http.ResponseWriter, r *http.Request) {
 
 	token, err := rs.oauthConfig.Exchange(r.Context(), code, oauth2.VerifierOption(verifierCookie.Value))
 	if err != nil {
-		log.Printf("[auth] OIDC code exchange failed: %v", err)
+		// A *oauth2.RetrieveError formats the provider's FULL raw HTTP response
+		// body into its Error() string — third-party text of unbounded size that
+		// must not land in logs verbatim. Log the status + RFC 6749 error code
+		// only; anything else is hard-truncated.
+		var retrieveErr *oauth2.RetrieveError
+		if errors.As(err, &retrieveErr) {
+			status := 0
+			if retrieveErr.Response != nil {
+				status = retrieveErr.Response.StatusCode
+			}
+			log.Printf("[auth] OIDC code exchange failed: provider returned HTTP %d (oauth error=%q)", status, retrieveErr.ErrorCode)
+		} else {
+			log.Printf("[auth] OIDC code exchange failed: %s", logredact.Truncate(err.Error(), 200))
+		}
 		http.Error(w, "login verification failed", http.StatusUnauthorized)
 		return
 	}

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -306,14 +306,16 @@ func (oa *OIDCAuth) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		// A *oauth2.RetrieveError formats the provider's FULL raw HTTP response
 		// body into its Error() string — third-party text of unbounded size that
 		// must not land in logs verbatim. Log the status + RFC 6749 error code
-		// only; anything else is hard-truncated.
+		// only, and truncate that too: ErrorCode is parsed straight out of the
+		// provider's response body, so it is provider-controlled and unbounded
+		// just like the Error() string in the sibling branch.
 		var retrieveErr *oauth2.RetrieveError
 		if errors.As(err, &retrieveErr) {
 			status := 0
 			if retrieveErr.Response != nil {
 				status = retrieveErr.Response.StatusCode
 			}
-			log.Printf("[auth] OIDC code exchange failed: provider returned HTTP %d (oauth error=%q)", status, retrieveErr.ErrorCode)
+			log.Printf("[auth] OIDC code exchange failed: provider returned HTTP %d (oauth error=%q)", status, logredact.Truncate(retrieveErr.ErrorCode, 200))
 		} else {
 			log.Printf("[auth] OIDC code exchange failed: %s", logredact.Truncate(err.Error(), 200))
 		}

--- a/internal/emailauth/checker.go
+++ b/internal/emailauth/checker.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
 	"net"
 	"net/mail"
 	"strings"
@@ -102,7 +101,9 @@ func checkWithEvaluatorForAuthor(ctx context.Context, evaluator *dmarcEvaluator,
 		DKIM: checkDKIM(rawMessage),
 	}
 	evaluator.evaluateAuthentication(ctx, author.Domain, authentication)
-	log.Printf("Email auth for %s from %s: SPF=%s DKIM=%d DMARC=%s", envelopeFrom, remoteIP, authentication.SPF.Status, len(authentication.DKIM), authentication.DMARC.Status)
+	// No log line here: the relay (the only production caller, via
+	// srv.authenticate) logs the same evidence with the message trace ID and
+	// redacted sender/IP — a second copy here would just duplicate PII handling.
 	return authentication
 
 }

--- a/internal/hitlnotify/notifier.go
+++ b/internal/hitlnotify/notifier.go
@@ -160,7 +160,7 @@ func (n *Notifier) NotifyPendingApproval(ctx context.Context, msg *identity.Mess
 	}
 
 	log.Printf("[hitl-notify] sent approval email: msg=%s owner=%s agent=%s",
-		msg.ID, owner.Email, agent.ID)
+		msg.ID, owner.ID, agent.ID)
 	return nil
 }
 

--- a/internal/hitlworker/suppression_test.go
+++ b/internal/hitlworker/suppression_test.go
@@ -61,14 +61,12 @@ func TestWorkerAutoApproveAsync_SuppressedRecipientAutoRejected(t *testing.T) {
 		t.Errorf("status = %q, want %q (resolved via the existing rejected/expired lifecycle)",
 			status, identity.MessageStatusReviewExpiredRejected)
 	}
-	// Domains only: autoReject logs this string verbatim (reason=%q), so the
-	// reason must identify the suppressed recipient by domain, never by full
-	// external address (internal/logredact policy).
-	if !strings.Contains(reason, "suppression") || !strings.Contains(reason, "external.test") {
-		t.Errorf("rejection_reason = %q, want an explicit suppression reason naming the recipient domain", reason)
-	}
-	if strings.Contains(reason, "bob@") {
-		t.Errorf("rejection_reason = %q must not carry the full external address — it flows into shipped logs", reason)
+	// The reason is customer-facing (stored on the message row, returned by the
+	// HITL API, emitted in email.review_rejected), so it must name the exact
+	// suppressed recipient — the owner's own recipient, and ambiguous by domain
+	// alone. Log-side redaction lives in autoReject (reason_len only), not here.
+	if !strings.Contains(reason, "suppression") || !strings.Contains(reason, "bob@external.test") {
+		t.Errorf("rejection_reason = %q, want an explicit suppression reason naming the address", reason)
 	}
 }
 

--- a/internal/hitlworker/suppression_test.go
+++ b/internal/hitlworker/suppression_test.go
@@ -61,8 +61,14 @@ func TestWorkerAutoApproveAsync_SuppressedRecipientAutoRejected(t *testing.T) {
 		t.Errorf("status = %q, want %q (resolved via the existing rejected/expired lifecycle)",
 			status, identity.MessageStatusReviewExpiredRejected)
 	}
-	if !strings.Contains(reason, "suppression") || !strings.Contains(reason, "bob@external.test") {
-		t.Errorf("rejection_reason = %q, want an explicit suppression reason naming the address", reason)
+	// Domains only: autoReject logs this string verbatim (reason=%q), so the
+	// reason must identify the suppressed recipient by domain, never by full
+	// external address (internal/logredact policy).
+	if !strings.Contains(reason, "suppression") || !strings.Contains(reason, "external.test") {
+		t.Errorf("rejection_reason = %q, want an explicit suppression reason naming the recipient domain", reason)
+	}
+	if strings.Contains(reason, "bob@") {
+		t.Errorf("rejection_reason = %q must not carry the full external address — it flows into shipped logs", reason)
 	}
 }
 

--- a/internal/hitlworker/worker.go
+++ b/internal/hitlworker/worker.go
@@ -13,6 +13,7 @@ import (
 	"log"
 	"net/mail"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/jackc/pgx/v5"
 
@@ -277,12 +278,14 @@ func (w *Worker) autoApproveAsync(ctx context.Context, agent *identity.AgentIden
 		return true
 	}
 	if len(suppressed) > 0 {
-		// Domains only: this reason string is logged verbatim by autoReject
-		// (reason=%q), so full external recipient addresses must not ride in it.
-		// The owner can identify the exact suppressed recipient from the
-		// message's stored recipient list.
-		w.autoReject(ctx, c.MessageID, fmt.Sprintf("auto-approve blocked: %d recipient(s) on the suppression list (domains: %s)",
-			len(suppressed), strings.Join(logredact.AddressDomains(suppressed), ", ")))
+		// Precise addresses on purpose: this reason string is CUSTOMER-FACING
+		// output, not a log line — it is persisted to messages.rejection_reason,
+		// returned by the HITL REST API, and carried in the
+		// email.review_rejected webhook payload. The owner is entitled to know
+		// exactly which of THEIR OWN recipients is suppressed (two suppressed
+		// recipients can share a domain). Log-side redaction happens in
+		// autoReject, which is where the log copy is produced.
+		w.autoReject(ctx, c.MessageID, "auto-approve blocked: recipient(s) on the suppression list: "+strings.Join(suppressed, ", "))
 		return true
 	}
 	w.attachReferencesChain(ctx, agent.ID, &req)
@@ -562,7 +565,17 @@ func (w *Worker) pushLoopbackReceived(ctx context.Context, agentID, messageID st
 	w.wsHub.Send(agentID, payload)
 }
 
+// autoReject resolves a stuck/blocked hold to rejected. `reason` is customer-
+// facing and must stay precise: it is written to messages.rejection_reason,
+// surfaced by the HITL REST API, and emitted in email.review_rejected. It is
+// therefore NOT log-safe — callers build it from suppressed recipient lists and
+// from %v of arbitrary compose/validation errors, which routinely embed a
+// recipient address (see internal/outbound.platform "invalid To address: %v").
+// The redaction belongs here, at the log sink, not at the source: the two
+// log.Printf calls below carry reason_len only. Operators recover the exact
+// reason from the message row keyed by the message id already on the line.
 func (w *Worker) autoReject(ctx context.Context, messageID, reason string) {
+	reasonLen := utf8.RuneCountInString(reason)
 	rejected, err := w.store.ExpireReject(ctx, messageID, reason)
 	if err != nil {
 		if err == identity.ErrNotPendingApproval {
@@ -574,12 +587,12 @@ func (w *Worker) autoReject(ctx context.Context, messageID, reason string) {
 		// intervenes. Tag the log line so monitors / alerting can match
 		// on it specifically — distinct from routine "[hitl-worker]"
 		// noise.
-		log.Printf("[hitl-stuck] message=%s reason=%q reject_error=%v ACTION=needs_manual_intervention",
-			messageID, reason, err)
+		log.Printf("[hitl-stuck] message=%s reason_len=%d reject_error=%v ACTION=needs_manual_intervention",
+			messageID, reasonLen, err)
 		return
 	}
-	log.Printf("[mail:%s] dir=outbound type=%s status=%s agent=%s reason=%q auto_rejected=true",
-		rejected.ID, rejected.Type, rejected.Status, rejected.AgentID, reason)
+	log.Printf("[mail:%s] dir=outbound type=%s status=%s agent=%s reason_len=%d auto_rejected=true",
+		rejected.ID, rejected.Type, rejected.Status, rejected.AgentID, reasonLen)
 	w.emitOutboundRejected(ctx, rejected, reason)
 }
 

--- a/internal/hitlworker/worker.go
+++ b/internal/hitlworker/worker.go
@@ -20,6 +20,7 @@ import (
 	"github.com/tokencanopy/e2a/internal/identity"
 	"github.com/tokencanopy/e2a/internal/inboundpolicy"
 	"github.com/tokencanopy/e2a/internal/inboundscreen"
+	"github.com/tokencanopy/e2a/internal/logredact"
 	"github.com/tokencanopy/e2a/internal/loopback"
 	"github.com/tokencanopy/e2a/internal/messagelifecycle"
 	"github.com/tokencanopy/e2a/internal/outbound"
@@ -276,7 +277,12 @@ func (w *Worker) autoApproveAsync(ctx context.Context, agent *identity.AgentIden
 		return true
 	}
 	if len(suppressed) > 0 {
-		w.autoReject(ctx, c.MessageID, "auto-approve blocked: recipient(s) on the suppression list: "+strings.Join(suppressed, ", "))
+		// Domains only: this reason string is logged verbatim by autoReject
+		// (reason=%q), so full external recipient addresses must not ride in it.
+		// The owner can identify the exact suppressed recipient from the
+		// message's stored recipient list.
+		w.autoReject(ctx, c.MessageID, fmt.Sprintf("auto-approve blocked: %d recipient(s) on the suppression list (domains: %s)",
+			len(suppressed), strings.Join(logredact.AddressDomains(suppressed), ", ")))
 		return true
 	}
 	w.attachReferencesChain(ctx, agent.ID, &req)
@@ -333,8 +339,8 @@ func (w *Worker) autoApproveAsync(ctx context.Context, agent *identity.AgentIden
 		log.Printf("[hitl-worker] auto-approve %s: accept+enqueue: %v", c.MessageID, err)
 		return true
 	}
-	log.Printf("[mail:%s] dir=outbound type=%s status=%s agent=%s to=%v auto_approved=true delivery=async",
-		sent.ID, sent.Type, sent.Status, agent.ID, sent.ToRecipients)
+	log.Printf("[mail:%s] dir=outbound type=%s status=%s agent=%s to_count=%d to_domains=%v auto_approved=true delivery=async",
+		sent.ID, sent.Type, sent.Status, agent.ID, len(sent.ToRecipients), logredact.AddressDomains(sent.ToRecipients))
 	// review_approved fires now (hold resolved to approved); the delivery outcome
 	// arrives later via email.sent/email.failed from the SendWorker. No metering
 	// here — the SendWorker meters on MarkSent.
@@ -446,8 +452,8 @@ func (w *Worker) autoApproveLoopback(ctx context.Context, agent *identity.AgentI
 		}
 	}
 
-	log.Printf("[mail:%s] dir=outbound type=%s status=%s agent=%s to=%v auto_sent=true",
-		sent.ID, sent.Type, sent.Status, agent.ID, sent.ToRecipients)
+	log.Printf("[mail:%s] dir=outbound type=%s status=%s agent=%s to_count=%d to_domains=%v auto_sent=true",
+		sent.ID, sent.Type, sent.Status, agent.ID, len(sent.ToRecipients), logredact.AddressDomains(sent.ToRecipients))
 	// Mirror the user-driven approve: fire email.review_approved (the send
 	// already happened; this is the post-side-effect notification).
 	w.emitOutboundApproved(agent, sent)

--- a/internal/logredact/logguard_test.go
+++ b/internal/logredact/logguard_test.go
@@ -1,0 +1,126 @@
+package logredact
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// subjectLogPatternAllowlist is the complete set of non-test source files
+// that are DELIBERATELY allowed to carry a subject-content log verb,
+// keyed by module-relative path, with the reason.
+//
+// The governing rule (see the package comment on logredact): container
+// stdout ships to centralized log storage with long retention and broad
+// queryability, so message subject lines — customer content — must never
+// be logged. Log `subject_len=%d` instead; the full subject stays on the
+// message row in Postgres.
+//
+// Adding an entry here is a privacy decision, not a formality: be able to
+// state why the value formatted at that site can never contain a real
+// message subject.
+var subjectLogPatternAllowlist = map[string]string{
+	// (empty — no exceptions today)
+}
+
+// subjectContentPattern matches format verbs that would render subject
+// CONTENT into a log or error string: subject=%q / subject=%s / subject=%v
+// and the quoted form subject="%s". subject_len=%d and other derived,
+// content-free fields do not match.
+var subjectContentPattern = regexp.MustCompile(`subject=(%[qsv]|\\?"%[qsv])`)
+
+// TestNoSubjectContentInLogFormats is the stance gate for the log-redaction
+// rule on email subject lines. It scans every non-test Go source file in the
+// module and fails when a format string renders subject content — the exact
+// pattern this package's introduction removed (e.g. `subject=%q` in the
+// [mail:...] lines).
+//
+// If this test failed because you added a subject to a log line: log
+// `subject_len=%d` (utf8.RuneCountInString) instead — operators get a
+// non-empty/anomaly signal, and the full subject is durably stored on the
+// message row. If the site genuinely cannot log subject content (e.g. the
+// value is a system constant), allowlist the file above WITH the reason.
+func TestNoSubjectContentInLogFormats(t *testing.T) {
+	root := moduleRoot(t)
+
+	checked := 0
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			// Only Go source can call log; skip trees that never hold it.
+			switch d.Name() {
+			case ".git", "node_modules", "vendor", "web", "sdks", "docs":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		raw, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		checked++
+		if !subjectContentPattern.Match(raw) {
+			return nil
+		}
+		if _, ok := subjectLogPatternAllowlist[filepath.ToSlash(rel)]; ok {
+			return nil
+		}
+		for i, line := range strings.Split(string(raw), "\n") {
+			if subjectContentPattern.MatchString(line) {
+				t.Errorf("%s:%d formats subject CONTENT (%s).\n"+
+					"Email subjects are customer content and logs are shipped to long-retention,\n"+
+					"widely queryable storage: log subject_len=%%d instead (the full subject lives\n"+
+					"on the message row in Postgres), or allowlist the file in\n"+
+					"subjectLogPatternAllowlist with the reason it can never carry a real subject.",
+					rel, i+1, strings.TrimSpace(line))
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk module source: %v", err)
+	}
+	if checked == 0 {
+		t.Fatal("scanned no Go source files — the module-root discovery or the walk is wrong")
+	}
+
+	// Prune the allowlist when a file stops carrying the pattern, so it stays
+	// the exact inventory of deliberate exceptions.
+	for rel := range subjectLogPatternAllowlist {
+		raw, readErr := os.ReadFile(filepath.Join(root, filepath.FromSlash(rel)))
+		if readErr != nil || !subjectContentPattern.Match(raw) {
+			t.Errorf("subjectLogPatternAllowlist entry %q matched no subject-content pattern — remove the stale entry", rel)
+		}
+	}
+}
+
+// moduleRoot walks up from the test's working directory to the directory
+// holding go.mod.
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found above the test directory")
+		}
+		dir = parent
+	}
+}

--- a/internal/logredact/logguard_test.go
+++ b/internal/logredact/logguard_test.go
@@ -26,16 +26,36 @@ var subjectLogPatternAllowlist = map[string]string{
 }
 
 // subjectContentPattern matches format verbs that would render subject
-// CONTENT into a log or error string: subject=%q / subject=%s / subject=%v
-// and the quoted form subject="%s". subject_len=%d and other derived,
-// content-free fields do not match.
-var subjectContentPattern = regexp.MustCompile(`subject=(%[qsv]|\\?"%[qsv])`)
+// CONTENT: the `subject<sep><verb>` family in the shapes that actually occur —
+// either separator (`subject=%q`, `subject: %q`), any case (`Subject=%v`), and
+// the quoted / escaped-quoted forms (`"subject": %s`, `subject=\"%s\"`).
+// subject_len=%d and other derived, content-free fields do not match.
+var subjectContentPattern = regexp.MustCompile(`(?i)subject(\\?")?\s*[:=]\s*(\\?")?%[qsv]`)
 
-// TestNoSubjectContentInLogFormats is the stance gate for the log-redaction
-// rule on email subject lines. It scans every non-test Go source file in the
-// module and fails when a format string renders subject content — the exact
-// pattern this package's introduction removed (e.g. `subject=%q` in the
-// [mail:...] lines).
+// logSitePattern narrows subjectContentPattern to lines that actually emit a
+// log or error string. Without it the case-insensitive `[:=]` form above also
+// flags legitimate `"Subject: %s\n"` MIME-header composition (the HITL
+// notification email body) and prompt building (the piguard LLM prompt) —
+// sites that handle the subject on purpose and never reach stdout. Keeping the
+// two checks separate is what lets the content pattern stay broad without
+// generating false positives that would get the whole guard allowlisted away.
+var logSitePattern = regexp.MustCompile(`\b(log|logger|slog)\.|fmt\.Errorf|errors\.Errorf`)
+
+// TestNoSubjectContentInLogFormats is a TRIPWIRE for one rule only: email
+// subject CONTENT must not appear in a log or error format string. It scans
+// every non-test Go source file in the module and fails on the `subject=%q`
+// family — the exact pattern this package's introduction removed from the
+// [mail:...] lines.
+//
+// What it does NOT do, so nobody mistakes a green run for compliance:
+//   - It enforces the SUBJECT rule only. The rest of the logredact policy
+//     (external addresses, IPs, free text, third-party error bodies) is not
+//     machine-checked — that stays a code-review responsibility.
+//   - It is a textual, line-at-a-time scan, not analysis. A subject reached
+//     through a variable (`log.Printf("%s", subj)`), a differently named
+//     field, a positional form like `log.Println("subject", s)`, a format
+//     string built on a different line from its logging call, or a logger
+//     reached through some other name all pass right through it.
 //
 // If this test failed because you added a subject to a log line: log
 // `subject_len=%d` (utf8.RuneCountInString) instead — operators get a
@@ -77,8 +97,8 @@ func TestNoSubjectContentInLogFormats(t *testing.T) {
 			return nil
 		}
 		for i, line := range strings.Split(string(raw), "\n") {
-			if subjectContentPattern.MatchString(line) {
-				t.Errorf("%s:%d formats subject CONTENT (%s).\n"+
+			if subjectLogViolation(line) {
+				t.Errorf("%s:%d logs subject CONTENT (%s).\n"+
 					"Email subjects are customer content and logs are shipped to long-retention,\n"+
 					"widely queryable storage: log subject_len=%%d instead (the full subject lives\n"+
 					"on the message row in Postgres), or allowlist the file in\n"+
@@ -99,8 +119,60 @@ func TestNoSubjectContentInLogFormats(t *testing.T) {
 	// the exact inventory of deliberate exceptions.
 	for rel := range subjectLogPatternAllowlist {
 		raw, readErr := os.ReadFile(filepath.Join(root, filepath.FromSlash(rel)))
-		if readErr != nil || !subjectContentPattern.Match(raw) {
+		if readErr != nil || !anyLineViolates(string(raw)) {
 			t.Errorf("subjectLogPatternAllowlist entry %q matched no subject-content pattern — remove the stale entry", rel)
+		}
+	}
+}
+
+// subjectLogViolation reports whether one source line both formats subject
+// content AND is a log/error emission site.
+func subjectLogViolation(line string) bool {
+	return subjectContentPattern.MatchString(line) && logSitePattern.MatchString(line)
+}
+
+func anyLineViolates(src string) bool {
+	for _, line := range strings.Split(src, "\n") {
+		if subjectLogViolation(line) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSubjectLogViolationDiscrimination pins the guard's own behaviour: the
+// shapes it must catch (the reason it exists) and the shapes it must not flag
+// (the reason it stays useful rather than being allowlisted into silence).
+func TestSubjectLogViolationDiscrimination(t *testing.T) {
+	violations := []string{
+		`log.Printf("[mail:%s] subject=%q", id, subject)`,
+		`log.Printf("subject: %q", subject)`,
+		`log.Printf("Subject=%v", subject)`,
+		`log.Printf("SUBJECT = %s", subject)`,
+		`log.Printf("{\"subject\": %q}", subject)`,
+		`log.Printf("subject=\"%s\"", subject)`,
+		`return fmt.Errorf("bad subject: %q", subject)`,
+		`slog.Info(fmt.Sprintf("subject=%s", subject))`,
+	}
+	for _, line := range violations {
+		if !subjectLogViolation(line) {
+			t.Errorf("guard missed a subject-content log line: %s", line)
+		}
+	}
+
+	clean := []string{
+		`log.Printf("[mail:%s] subject_len=%d", id, utf8.RuneCountInString(subject))`,
+		`log.Printf("subject_len=%d", n)`,
+		// MIME header composition into an email body, not a log.
+		`fmt.Fprintf(&b, "Subject: %s\n", msg.Subject)`,
+		// LLM prompt construction, not a log.
+		`return fmt.Sprintf("Subject: %s\nFrom: %s\n\n%s", subject, req.Sender, body)`,
+		`h.Set("Subject", subject)`,
+		`var subject = "%s"`,
+	}
+	for _, line := range clean {
+		if subjectLogViolation(line) {
+			t.Errorf("guard false-positived on a non-log line: %s", line)
 		}
 	}
 }

--- a/internal/logredact/logredact.go
+++ b/internal/logredact/logredact.go
@@ -4,16 +4,25 @@
 // and broad queryability, so log lines are NOT a private scratchpad: an email
 // subject, an external human's address, or a free-text rejection reason in a
 // log line is personal data replicated outside the database's access controls.
-// The policy (enforced by logguard_test.go):
+// The policy:
 //
 //   - Never log message subject lines — log subject_len instead.
 //   - Never log an EXTERNAL human's full email address — log only its domain
 //     (AddressDomain) or, for recipient lists, the count plus the distinct
 //     domain set (AddressDomains). e2a AGENT addresses are our own namespace
-//     and the primary tracing key, so they stay in full.
+//     and the primary tracing key, so they stay in full — but only once the
+//     address has RESOLVED to an agent row. An unresolved recipient is just an
+//     attacker-supplied string (SMTP RCPT runs before any authentication) and
+//     is redacted like any external address.
 //   - Truncate connecting IPs to a network prefix (IPNetwork): /24 for IPv4,
 //     /48 for IPv6 — enough for abuse/rate-limit debugging, less identifying.
 //   - Cap free-text human input and third-party error bodies (Truncate).
+//   - Redact at the LOG SINK, not at the source. A value that is also stored,
+//     served by the API, or emitted in a webhook (e.g. a HITL rejection
+//     reason) must stay precise there; only its log copy is reduced.
+//
+// Only the subject rule is machine-checked, by the tripwire scan in
+// logguard_test.go; the rest is a code-review responsibility.
 //
 // Every helper here runs on hostile external input on the SMTP hot path and
 // must never panic; malformed input degrades to a safe placeholder.
@@ -24,6 +33,7 @@ import (
 	"net"
 	"sort"
 	"strings"
+	"unicode"
 )
 
 // invalidPlaceholder is returned when the input cannot be interpreted at all.
@@ -41,9 +51,10 @@ const (
 
 // AddressDomain reduces an email address to only its domain, e.g.
 // "alice@example.com" -> "example.com". It tolerates display-name forms
-// ("Alice <alice@example.com>") and angle brackets, lowercases the result,
-// and returns "invalid" for anything without a parsable domain. It never
-// returns the local part.
+// ("Alice <alice@example.com>"), angle brackets, and the RFC 5322 comment
+// form ("alice@example.com (Alice Smith)"), lowercases the result, and
+// returns "invalid" for anything whose domain part is not hostname-shaped.
+// It never returns the local part, a display name, or a comment.
 func AddressDomain(addr string) string {
 	addr = strings.TrimSpace(addr)
 	// Tolerate "Display Name <local@domain>" and bare "<local@domain>".
@@ -56,10 +67,44 @@ func AddressDomain(addr string) string {
 		return invalidPlaceholder
 	}
 	domain := strings.ToLower(strings.TrimSpace(addr[at+1:]))
-	if domain == "" {
+	// Cut at the first character that cannot occur inside a hostname. Without
+	// this, the RFC 5322 comment form leaks a PERSON'S NAME as the "domain"
+	// ("alice@example.com (Alice Smith)" -> "example.com (alice smith)"), and
+	// a stray unmatched bracket rides along ("example.com>").
+	if i := strings.IndexFunc(domain, notHostnameRune); i >= 0 {
+		domain = domain[:i]
+	}
+	if !hostnameShaped(domain) {
 		return invalidPlaceholder
 	}
 	return Truncate(domain, maxDomainRunes)
+}
+
+// notHostnameRune reports whether r cannot appear inside a hostname, and so
+// terminates the domain. Kept as a denylist of the structural/quoting runes
+// RFC 5322 puts around an address, plus all whitespace.
+func notHostnameRune(r rune) bool {
+	return unicode.IsSpace(r) || strings.ContainsRune("()<>[]{},;:\"'\\@", r)
+}
+
+// hostnameShaped reports whether s looks like a domain name: non-empty, no
+// leading or trailing dot, and built only from letters, digits, dots, hyphens
+// and underscores. Unicode letters count, so IDN labels ("bücher.example")
+// pass through unchanged; anything else degrades to the invalid placeholder
+// rather than being logged.
+func hostnameShaped(s string) bool {
+	if s == "" || strings.HasPrefix(s, ".") || strings.HasSuffix(s, ".") {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case unicode.IsLetter(r), unicode.IsDigit(r):
+		case r == '.', r == '-', r == '_':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // AddressDomains reduces a recipient list to its distinct, sorted domain set,

--- a/internal/logredact/logredact.go
+++ b/internal/logredact/logredact.go
@@ -1,0 +1,121 @@
+// Package logredact keeps personal data out of process logs.
+//
+// Container stdout is shipped to centralized log storage with long retention
+// and broad queryability, so log lines are NOT a private scratchpad: an email
+// subject, an external human's address, or a free-text rejection reason in a
+// log line is personal data replicated outside the database's access controls.
+// The policy (enforced by logguard_test.go):
+//
+//   - Never log message subject lines — log subject_len instead.
+//   - Never log an EXTERNAL human's full email address — log only its domain
+//     (AddressDomain) or, for recipient lists, the count plus the distinct
+//     domain set (AddressDomains). e2a AGENT addresses are our own namespace
+//     and the primary tracing key, so they stay in full.
+//   - Truncate connecting IPs to a network prefix (IPNetwork): /24 for IPv4,
+//     /48 for IPv6 — enough for abuse/rate-limit debugging, less identifying.
+//   - Cap free-text human input and third-party error bodies (Truncate).
+//
+// Every helper here runs on hostile external input on the SMTP hot path and
+// must never panic; malformed input degrades to a safe placeholder.
+package logredact
+
+import (
+	"fmt"
+	"net"
+	"sort"
+	"strings"
+)
+
+// invalidPlaceholder is returned when the input cannot be interpreted at all.
+// It deliberately carries no part of the original value.
+const invalidPlaceholder = "invalid"
+
+const (
+	// maxDomainRunes bounds a single logged domain (RFC 1035 caps real domain
+	// names at 253 octets; anything longer is hostile input).
+	maxDomainRunes = 253
+	// maxDomains bounds the distinct-domain set for recipient lists so a
+	// hostile 1000-recipient submit cannot bloat a log line.
+	maxDomains = 10
+)
+
+// AddressDomain reduces an email address to only its domain, e.g.
+// "alice@example.com" -> "example.com". It tolerates display-name forms
+// ("Alice <alice@example.com>") and angle brackets, lowercases the result,
+// and returns "invalid" for anything without a parsable domain. It never
+// returns the local part.
+func AddressDomain(addr string) string {
+	addr = strings.TrimSpace(addr)
+	// Tolerate "Display Name <local@domain>" and bare "<local@domain>".
+	if i := strings.LastIndexByte(addr, '<'); i >= 0 {
+		addr = strings.TrimSpace(addr[i+1:])
+		addr = strings.TrimSuffix(addr, ">")
+	}
+	at := strings.LastIndexByte(addr, '@')
+	if at < 0 {
+		return invalidPlaceholder
+	}
+	domain := strings.ToLower(strings.TrimSpace(addr[at+1:]))
+	if domain == "" {
+		return invalidPlaceholder
+	}
+	return Truncate(domain, maxDomainRunes)
+}
+
+// AddressDomains reduces a recipient list to its distinct, sorted domain set,
+// bounded at maxDomains entries (a "+N more" marker replaces the overflow).
+// Use together with the list's length, e.g.:
+//
+//	log.Printf("... to_count=%d to_domains=%v", len(to), logredact.AddressDomains(to))
+func AddressDomains(addrs []string) []string {
+	seen := make(map[string]struct{}, len(addrs))
+	domains := make([]string, 0, len(addrs))
+	for _, a := range addrs {
+		d := AddressDomain(a)
+		if _, dup := seen[d]; dup {
+			continue
+		}
+		seen[d] = struct{}{}
+		domains = append(domains, d)
+	}
+	sort.Strings(domains)
+	if len(domains) > maxDomains {
+		overflow := len(domains) - maxDomains
+		domains = append(domains[:maxDomains:maxDomains], fmt.Sprintf("+%d more", overflow))
+	}
+	return domains
+}
+
+// IPNetwork truncates an IP address to its network prefix: /24 for IPv4,
+// /48 for IPv6. It accepts bare addresses, "host:port" forms, and bracketed
+// IPv6 literals; anything unparsable (including a non-IP transport address)
+// returns "invalid".
+func IPNetwork(ip string) string {
+	s := strings.TrimSpace(ip)
+	if host, _, err := net.SplitHostPort(s); err == nil {
+		s = host
+	}
+	s = strings.TrimPrefix(s, "[")
+	s = strings.TrimSuffix(s, "]")
+	parsed := net.ParseIP(s)
+	if parsed == nil {
+		return invalidPlaceholder
+	}
+	if v4 := parsed.To4(); v4 != nil {
+		return v4.Mask(net.CIDRMask(24, 32)).String() + "/24"
+	}
+	return parsed.Mask(net.CIDRMask(48, 128)).String() + "/48"
+}
+
+// Truncate caps s at max runes, appending "…" when anything was cut. It is
+// rune-safe (never splits a UTF-8 sequence) and returns "" for max <= 0.
+func Truncate(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	return string(runes[:max]) + "…"
+}

--- a/internal/logredact/logredact_test.go
+++ b/internal/logredact/logredact_test.go
@@ -1,0 +1,176 @@
+package logredact
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestAddressDomain(t *testing.T) {
+	tests := []struct {
+		name, in, want string
+	}{
+		{"plain address", "alice@example.com", "example.com"},
+		{"uppercase is normalized", "Alice@EXAMPLE.COM", "example.com"},
+		{"display-name form", "Alice Example <alice@example.com>", "example.com"},
+		{"bare angle brackets", "<alice@example.com>", "example.com"},
+		{"surrounding whitespace", "  alice@example.com  ", "example.com"},
+		{"plus tag stripped with local part", "alice+tag@example.com", "example.com"},
+		{"quoted local part with @", `"a@b"@example.com`, "example.com"},
+		{"subdomain", "bob@mail.corp.example.co.uk", "mail.corp.example.co.uk"},
+		{"unicode domain", "user@bücher.example", "bücher.example"},
+		{"no at sign", "not-an-address", "invalid"},
+		{"empty string", "", "invalid"},
+		{"only at sign", "@", "invalid"},
+		{"trailing at sign", "alice@", "invalid"},
+		{"whitespace only", "   ", "invalid"},
+		{"null bytes", "a\x00b", "invalid"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AddressDomain(tt.in); got != tt.want {
+				t.Errorf("AddressDomain(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestAddressDomainNeverReturnsLocalPart is the property the whole package
+// exists for: whatever the input shape, the local part must not leak.
+func TestAddressDomainNeverReturnsLocalPart(t *testing.T) {
+	for _, in := range []string{
+		"secret-local@example.com",
+		"Secret Local <secret-local@example.com>",
+		"<secret-local@example.com>",
+		"secret-local@",
+		"secret-local",
+	} {
+		if got := AddressDomain(in); strings.Contains(got, "secret-local") {
+			t.Errorf("AddressDomain(%q) = %q leaks the local part", in, got)
+		}
+	}
+}
+
+func TestAddressDomainBoundsHostileLength(t *testing.T) {
+	hostile := "a@" + strings.Repeat("x", 100_000)
+	got := AddressDomain(hostile)
+	if n := len([]rune(got)); n > maxDomainRunes+1 { // +1 for the ellipsis
+		t.Errorf("AddressDomain on hostile input returned %d runes, want <= %d", n, maxDomainRunes+1)
+	}
+}
+
+func TestAddressDomains(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"nil list", nil, []string{}},
+		{"empty list", []string{}, []string{}},
+		{"distinct and sorted", []string{"z@zeta.com", "a@acme.com", "b@zeta.com"}, []string{"acme.com", "zeta.com"}},
+		{"malformed entries collapse to invalid", []string{"nope", "also-nope", "ok@acme.com"}, []string{"acme.com", "invalid"}},
+		{"case-insensitive dedupe", []string{"a@Acme.COM", "b@acme.com"}, []string{"acme.com"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AddressDomains(tt.in)
+			if len(got) == 0 && len(tt.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("AddressDomains(%v) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAddressDomainsBoundsListLength(t *testing.T) {
+	var addrs []string
+	for i := 0; i < 100; i++ {
+		addrs = append(addrs, fmt.Sprintf("user@domain-%03d.example", i))
+	}
+	got := AddressDomains(addrs)
+	if len(got) != maxDomains+1 {
+		t.Fatalf("len(AddressDomains(100 distinct)) = %d, want %d (cap + overflow marker)", len(got), maxDomains+1)
+	}
+	if got[maxDomains] != "+90 more" {
+		t.Errorf("overflow marker = %q, want %q", got[maxDomains], "+90 more")
+	}
+}
+
+func TestIPNetwork(t *testing.T) {
+	tests := []struct {
+		name, in, want string
+	}{
+		{"ipv4", "203.0.113.99", "203.0.113.0/24"},
+		{"ipv4 with port", "203.0.113.99:52731", "203.0.113.0/24"},
+		{"ipv6", "2001:db8:85a3:8d3:1319:8a2e:370:7348", "2001:db8:85a3::/48"},
+		{"ipv6 bracketed with port", "[2001:db8:85a3:8d3::1]:25", "2001:db8:85a3::/48"},
+		{"ipv4-mapped ipv6", "::ffff:203.0.113.99", "203.0.113.0/24"},
+		{"loopback", "127.0.0.1", "127.0.0.0/24"},
+		{"nil net.IP String()", "<nil>", "invalid"},
+		{"empty", "", "invalid"},
+		{"hostname", "mail.example.com", "invalid"},
+		{"unix socket path", "/var/run/proxy.sock", "invalid"},
+		{"garbage", "999.999.999.999", "invalid"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IPNetwork(tt.in); got != tt.want {
+				t.Errorf("IPNetwork(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		max  int
+		want string
+	}{
+		{"shorter than max", "hello", 10, "hello"},
+		{"exactly max", "hello", 5, "hello"},
+		{"truncated", "hello world", 5, "hello…"},
+		{"zero max", "hello", 0, ""},
+		{"negative max", "hello", -1, ""},
+		{"empty input", "", 5, ""},
+		{"multibyte runes not split", "héllo wörld", 6, "héllo …"},
+		{"emoji not split", "🙂🙂🙂🙂", 2, "🙂🙂…"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Truncate(tt.in, tt.max); got != tt.want {
+				t.Errorf("Truncate(%q, %d) = %q, want %q", tt.in, tt.max, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHelpersNeverPanic fuzzes the helpers with adversarial shapes by hand:
+// they all run on hostile external input inside the SMTP receive path, where
+// a panic would take down mail acceptance.
+func TestHelpersNeverPanic(t *testing.T) {
+	inputs := []string{
+		"", " ", "@", "@@", "<", ">", "<>", "<@>", "a@", "@b",
+		"\x00", "\xff\xfe", strings.Repeat("@", 10_000),
+		strings.Repeat("<", 10_000), "a@b@c@d", "[::1]", "[",
+		"名前 <ユーザー@例え.テスト>", string(rune(0xD800)), // lone surrogate
+	}
+	for _, in := range inputs {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("panic on input %q: %v", in, r)
+				}
+			}()
+			_ = AddressDomain(in)
+			_ = AddressDomains([]string{in, in})
+			_ = IPNetwork(in)
+			_ = Truncate(in, 3)
+			_ = Truncate(in, len(in)+1)
+		}()
+	}
+}

--- a/internal/logredact/logredact_test.go
+++ b/internal/logredact/logredact_test.go
@@ -26,6 +26,22 @@ func TestAddressDomain(t *testing.T) {
 		{"trailing at sign", "alice@", "invalid"},
 		{"whitespace only", "   ", "invalid"},
 		{"null bytes", "a\x00b", "invalid"},
+		// RFC 5322 comment form: the parenthesised display name is a PERSON'S
+		// NAME and must never come back as part of the "domain".
+		{"comment form", "alice@example.com (Alice Smith)", "example.com"},
+		{"comment form no space", "alice@example.com(Alice Smith)", "example.com"},
+		{"display name plus comment", "Alice Smith <alice@example.com> (work)", "example.com"},
+		{"stray closing bracket", "alice@example.com>", "example.com"},
+		{"stray opening bracket", "alice@<example.com", "invalid"},
+		{"trailing semicolon", "alice@example.com;", "example.com"},
+		{"trailing comma in a header list", "alice@example.com, bob@other.test", "other.test"},
+		{"address literal", "alice@[192.168.0.1]", "invalid"},
+		{"leading dot", "alice@.example.com", "invalid"},
+		{"trailing dot", "alice@example.com.", "invalid"},
+		{"domain is only punctuation", "alice@---", "---"},
+		{"control characters in domain", "alice@exa\x01mple.com", "invalid"},
+		{"quoted domain", `alice@"example.com"`, "invalid"},
+		{"tab separated comment", "alice@example.com\t(Alice)", "example.com"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -48,6 +64,25 @@ func TestAddressDomainNeverReturnsLocalPart(t *testing.T) {
 	} {
 		if got := AddressDomain(in); strings.Contains(got, "secret-local") {
 			t.Errorf("AddressDomain(%q) = %q leaks the local part", in, got)
+		}
+	}
+}
+
+// TestAddressDomainNeverReturnsDisplayName covers the other half of the
+// property: a human's NAME is personal data too, and RFC 5322 lets it sit on
+// either side of the address (angle-bracket form before it, comment form
+// after it). Neither may survive into a log line.
+func TestAddressDomainNeverReturnsDisplayName(t *testing.T) {
+	for _, in := range []string{
+		"alice@example.com (Secret Name)",
+		"alice@example.com(Secret Name)",
+		"Secret Name <alice@example.com>",
+		"Secret Name <alice@example.com> (Secret Name)",
+		"alice@example.com (Secret Name) <alice@example.com>",
+		"alice@example.com \"Secret Name\"",
+	} {
+		if got := AddressDomain(in); strings.Contains(strings.ToLower(got), "secret") {
+			t.Errorf("AddressDomain(%q) = %q leaks the display name", in, got)
 		}
 	}
 }
@@ -157,6 +192,7 @@ func TestHelpersNeverPanic(t *testing.T) {
 		"", " ", "@", "@@", "<", ">", "<>", "<@>", "a@", "@b",
 		"\x00", "\xff\xfe", strings.Repeat("@", 10_000),
 		strings.Repeat("<", 10_000), "a@b@c@d", "[::1]", "[",
+		"a@b (", "a@b )", "a@(((", strings.Repeat("a@b (c) ", 1_000),
 		"名前 <ユーザー@例え.テスト>", string(rune(0xD800)), // lone surrogate
 	}
 	for _, in := range inputs {

--- a/internal/outbound/smtp_relay.go
+++ b/internal/outbound/smtp_relay.go
@@ -72,8 +72,14 @@ func (r *SMTPRelay) SendWithEnvelopeContext(ctx context.Context, envelopeFrom st
 			return "", lastErr
 		}
 		if attempt < len(smtpRetryBackoffs) {
-			log.Printf("[smtp-relay] transient error sending to recipient_count=%d recipient_domains=%v (attempt %d/%d), retrying in %s: %v",
-				len(recipients), logredact.AddressDomains(recipients), attempt+1, len(smtpRetryBackoffs)+1, smtpRetryBackoffs[attempt], lastErr)
+			// lastErr is an upstream MTA response and cannot be perfectly
+			// sanitized: rejections routinely quote the recipient back at us
+			// ("550 5.1.1 <bob@example.com>: user unknown"), which would
+			// otherwise defeat the recipient redaction on this same line. Cap
+			// it so at most a bounded slice of provider text is retained; the
+			// full error still reaches the caller and the message row.
+			log.Printf("[smtp-relay] transient error sending to recipient_count=%d recipient_domains=%v (attempt %d/%d), retrying in %s: %s",
+				len(recipients), logredact.AddressDomains(recipients), attempt+1, len(smtpRetryBackoffs)+1, smtpRetryBackoffs[attempt], logredact.Truncate(lastErr.Error(), 200))
 			select {
 			case <-time.After(smtpRetryBackoffs[attempt]):
 			case <-ctx.Done():

--- a/internal/outbound/smtp_relay.go
+++ b/internal/outbound/smtp_relay.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/tokencanopy/e2a/internal/config"
+	"github.com/tokencanopy/e2a/internal/logredact"
 )
 
 var smtpRetryBackoffs = []time.Duration{1 * time.Second, 5 * time.Second, 15 * time.Second}
@@ -71,8 +72,8 @@ func (r *SMTPRelay) SendWithEnvelopeContext(ctx context.Context, envelopeFrom st
 			return "", lastErr
 		}
 		if attempt < len(smtpRetryBackoffs) {
-			log.Printf("[smtp-relay] transient error sending to %v (attempt %d/%d), retrying in %s: %v",
-				recipients, attempt+1, len(smtpRetryBackoffs)+1, smtpRetryBackoffs[attempt], lastErr)
+			log.Printf("[smtp-relay] transient error sending to recipient_count=%d recipient_domains=%v (attempt %d/%d), retrying in %s: %v",
+				len(recipients), logredact.AddressDomains(recipients), attempt+1, len(smtpRetryBackoffs)+1, smtpRetryBackoffs[attempt], lastErr)
 			select {
 			case <-time.After(smtpRetryBackoffs[attempt]):
 			case <-ctx.Done():

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/emersion/go-smtp"
 	"github.com/jackc/pgx/v5"
@@ -26,6 +27,7 @@ import (
 	"github.com/tokencanopy/e2a/internal/inboundpolicy"
 	"github.com/tokencanopy/e2a/internal/inboundscreen"
 	"github.com/tokencanopy/e2a/internal/limits"
+	"github.com/tokencanopy/e2a/internal/logredact"
 	"github.com/tokencanopy/e2a/internal/messagelifecycle"
 	"github.com/tokencanopy/e2a/internal/piguard"
 	"github.com/tokencanopy/e2a/internal/usage"
@@ -216,10 +218,10 @@ func (b *backend) NewSession(c *smtp.Conn) (smtp.Session, error) {
 		// Reachable only via a trusted proxy peer presenting a non-TCP-family
 		// PROXY header; the session degrades to SPF=none, so make the
 		// misbehaving front-end visible.
-		log.Printf("relay: non-TCP remote address %v (%T); SPF will be skipped for this session", c.Conn().RemoteAddr(), c.Conn().RemoteAddr())
+		log.Printf("relay: non-TCP remote address %s (%T); SPF will be skipped for this session", logredact.IPNetwork(c.Conn().RemoteAddr().String()), c.Conn().RemoteAddr())
 	}
 	sid := newSessionID()
-	log.Printf("[%s] new session from %s", sid, remoteIP)
+	log.Printf("[%s] new session from %s", sid, logredact.IPNetwork(remoteIP.String()))
 	return &session{relay: b.relay, id: sid, remoteIP: remoteIP, heloDomain: c.Hostname()}, nil
 }
 
@@ -244,24 +246,28 @@ func (s *session) AuthPlain(username, password string) error {
 
 func (s *session) Mail(from string, opts *smtp.MailOptions) error {
 	s.from = from
-	log.Printf("[%s] [%s] MAIL FROM", s.id, from)
+	// External human sender: log only the domain (the full address is retained
+	// on the persisted message row, not in the shipped logs).
+	log.Printf("[%s] [%s] MAIL FROM", s.id, logredact.AddressDomain(from))
 	return nil
 }
 
 func (s *session) Rcpt(to string, opts *smtp.RcptOptions) error {
-	log.Printf("[%s] [%s] RCPT TO: %s", s.id, s.from, to)
+	// `to` is an address in OUR agent namespace (the tracing key) — keep it in
+	// full; the external sender is reduced to its domain.
+	log.Printf("[%s] [%s] RCPT TO: %s", s.id, logredact.AddressDomain(s.from), to)
 
 	// Reject unknown or unverified recipients at SMTP level.
 	// The sender's mail server will generate a bounce notification.
 	ctx := context.Background()
 	agent, err := s.relay.resolveAgent(ctx, to)
 	if err != nil {
-		log.Printf("[%s] [%s] rejecting %s: no agent found", s.id, s.from, to)
+		log.Printf("[%s] [%s] rejecting %s: no agent found", s.id, logredact.AddressDomain(s.from), to)
 		s.relay.recordSMTPInbound("rejected_unknown_recipient", 0)
 		return &smtp.SMTPError{Code: 550, EnhancedCode: smtp.EnhancedCode{5, 1, 1}, Message: "recipient not found"}
 	}
 	if !agent.DomainVerified {
-		log.Printf("[%s] [%s] rejecting %s: domain not verified", s.id, s.from, to)
+		log.Printf("[%s] [%s] rejecting %s: domain not verified", s.id, logredact.AddressDomain(s.from), to)
 		s.relay.recordSMTPInbound("rejected_unverified_domain", 0)
 		return &smtp.SMTPError{Code: 550, EnhancedCode: smtp.EnhancedCode{5, 1, 1}, Message: "recipient not found"}
 	}
@@ -275,11 +281,11 @@ func (s *session) Rcpt(to string, opts *smtp.RcptOptions) error {
 	if s.relay.enforcer != nil && agent.UserID != "" {
 		if err := s.relay.enforcer.CheckMessageSend(ctx, agent.UserID); err != nil {
 			if le, ok := limits.IsLimitExceeded(err); ok {
-				log.Printf("[%s] [%s] rejecting %s: limit exceeded (%s)", s.id, s.from, to, le.Resource)
+				log.Printf("[%s] [%s] rejecting %s: limit exceeded (%s)", s.id, logredact.AddressDomain(s.from), to, le.Resource)
 				s.relay.recordSMTPInbound("rejected_quota", 0)
 				return &smtp.SMTPError{Code: 552, EnhancedCode: smtp.EnhancedCode{5, 2, 2}, Message: "mailbox quota exceeded"}
 			}
-			log.Printf("[%s] [%s] limits check error (failing open): %v", s.id, s.from, err)
+			log.Printf("[%s] [%s] limits check error (failing open): %v", s.id, logredact.AddressDomain(s.from), err)
 		}
 	}
 
@@ -304,7 +310,7 @@ func (s *session) Data(r io.Reader) error {
 	if threadInfo.From != "" {
 		senderEmail = threadInfo.From
 	}
-	log.Printf("[%s] [%s] DATA recipients=%v size=%d bytes", s.id, senderEmail, s.recipients, len(body))
+	log.Printf("[%s] [%s] DATA recipients=%v size=%d bytes", s.id, logredact.AddressDomain(senderEmail), s.recipients, len(body))
 
 	// Queue-first async path (E2A_INBOUND_MODE=async): durably accept the raw MIME to
 	// inbound_intake + enqueue a River processing job, all before 250 — processing
@@ -390,7 +396,7 @@ func (srv *Server) processInbound(ctx context.Context, in inboundInput, hook pos
 	// SPF/DKIM/DMARC against the TRUE envelope MAIL FROM (RFC 7208), not the From
 	// header — else SPF-alignment is a tautology (adversarial review F5).
 	authentication := srv.authenticate(ctx, in.RemoteIP, envelopeFrom, in.HELODomain, in.Body, author)
-	log.Printf("[%s] [%s] email auth from %s (envelope %s): SPF=%s DKIM=%d DMARC=%s", in.TraceID, headerFrom, in.RemoteIP, envelopeFrom, authentication.SPF.Status, len(authentication.DKIM), authentication.DMARC.Status)
+	log.Printf("[%s] [%s] email auth from %s (envelope %s): SPF=%s DKIM=%d DMARC=%s", in.TraceID, logredact.AddressDomain(headerFrom), logredact.IPNetwork(in.RemoteIP.String()), logredact.AddressDomain(envelopeFrom), authentication.SPF.Status, len(authentication.DKIM), authentication.DMARC.Status)
 
 	agent, err := srv.resolveAgent(ctx, in.Recipient)
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
@@ -658,7 +664,7 @@ func (srv *Server) processInbound(ctx context.Context, in inboundInput, hook pos
 		}
 		// Do NOT swallow — surface to deliverMessages so the SMTP session returns a
 		// 451 and the sender retries, instead of a 250 that silently drops the mail.
-		log.Printf("[%s] [%s] failed to record inbound message: %v", in.TraceID, headerFrom, err)
+		log.Printf("[%s] [%s] failed to record inbound message: %v", in.TraceID, logredact.AddressDomain(headerFrom), err)
 		return err
 	}
 	_ = inboundMsg
@@ -679,8 +685,8 @@ func (srv *Server) processInbound(ctx context.Context, in inboundInput, hook pos
 
 	slug, _, _ := strings.Cut(rcpt, "@")
 
-	log.Printf("[mail:%s] dir=inbound from=%s to=%s slug=%s conv_id=%s subject=%q verified=%t",
-		messageID, headerFrom, rcpt, slug, conversationID, threadInfo.Subject, authentication.Passed())
+	log.Printf("[mail:%s] dir=inbound from_domain=%s to=%s slug=%s conv_id=%s subject_len=%d verified=%t",
+		messageID, logredact.AddressDomain(headerFrom), rcpt, slug, conversationID, utf8.RuneCountInString(threadInfo.Subject), authentication.Passed())
 
 	// Inbound events (email.received + flagged/blocked/review_requested variants)
 	// are written to the outbox (webhook_events) above, in the message tx; the

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -253,19 +253,27 @@ func (s *session) Mail(from string, opts *smtp.MailOptions) error {
 }
 
 func (s *session) Rcpt(to string, opts *smtp.RcptOptions) error {
-	// `to` is an address in OUR agent namespace (the tracing key) — keep it in
-	// full; the external sender is reduced to its domain.
-	log.Printf("[%s] [%s] RCPT TO: %s", s.id, logredact.AddressDomain(s.from), to)
+	// INVARIANT: an UNRESOLVED `to` is never logged in full. This listener is
+	// open to the internet and RCPT runs before any authentication, so `to` is
+	// at this point an arbitrary attacker-chosen string — anyone can
+	// `RCPT TO:<victim@gmail.com>` and inject a third party's address into the
+	// shipped logs. Only after resolveAgent succeeds is `to` known to be an
+	// address in OUR agent namespace, and only then is it logged in full as the
+	// tracing key. Until then: domain only.
+	log.Printf("[%s] [%s] RCPT TO: %s", s.id, logredact.AddressDomain(s.from), logredact.AddressDomain(to))
 
 	// Reject unknown or unverified recipients at SMTP level.
 	// The sender's mail server will generate a bounce notification.
 	ctx := context.Background()
 	agent, err := s.relay.resolveAgent(ctx, to)
 	if err != nil {
-		log.Printf("[%s] [%s] rejecting %s: no agent found", s.id, logredact.AddressDomain(s.from), to)
+		// Still unresolved — an arbitrary probe address, so still domain only.
+		log.Printf("[%s] [%s] rejecting %s: no agent found", s.id, logredact.AddressDomain(s.from), logredact.AddressDomain(to))
 		s.relay.recordSMTPInbound("rejected_unknown_recipient", 0)
 		return &smtp.SMTPError{Code: 550, EnhancedCode: smtp.EnhancedCode{5, 1, 1}, Message: "recipient not found"}
 	}
+	// Past this point `to` resolved to a real agent row: it is ours, and the
+	// full address is the tracing key operators need.
 	if !agent.DomainVerified {
 		log.Printf("[%s] [%s] rejecting %s: domain not verified", s.id, logredact.AddressDomain(s.from), to)
 		s.relay.recordSMTPInbound("rejected_unverified_domain", 0)


### PR DESCRIPTION
## Why

Container stdout is about to ship to Google Cloud Logging (30-day retention, org-queryable). Today the server logs email **subject lines** and **external human email addresses** in plaintext, plus a few adjacent leaks (account-owner emails, free-text HITL reasons, unbounded third-party error bodies, full connecting IPs). Once logs are centralized, every one of those lines becomes replicated personal data outside the database's access controls. This PR removes/reduces them while keeping the operational signal. It is standalone — no structured-logging conversion, only value redaction in the existing `log.Printf` lines.

**Direction rule applied per-site:** on inbound, the sender is an external human (redact to domain) and the recipient is an e2a agent address (kept in full — our namespace, the tracing key). On outbound it flips: agent `from` kept, external recipients reduced to count + distinct domain set.

## New package

`internal/logredact` — `AddressDomain`, `AddressDomains` (distinct, sorted, capped at 10 + overflow marker), `IPNetwork` (/24 v4, /48 v6), `Truncate` (rune-safe). All panic-safe on hostile input (they run in the SMTP receive path); unit-tested including malformed/unicode/no-panic cases. `logguard_test.go` is a source-scan regression guard (house style of `internal/httpapi/response_enum_stance_test.go`): it fails if `subject=%q`/`%s`/`%v` logging reappears anywhere in non-test Go source, with an allowlist-with-reason escape hatch.

## Redactions, and what an operator loses at each

(line numbers are post-change)

**Subject lines → `subject_len=%d`** (full subject stays on the message row in Postgres). Lost: grepping logs by subject; you now pivot via `msg_` id → DB.
- `internal/relay/server.go:688` (every inbound message)
- `internal/agent/api.go:1124, 1314, 1378, 1492` — `internal/agent/hitl_api.go:154, 180`

**External addresses → domain only** (full addresses on the message/intake rows in Postgres). Lost: correlating one specific human sender across sessions from logs alone; domain + trace/session id remains.
- Inbound sender: `internal/relay/server.go:251, 258, 265, 270, 284, 288, 313` (MAIL FROM / RCPT / rejections / DATA), `:399` (auth line), `:667` (persist failure), `:688` (`from_domain=`). Recipient/agent addresses on these lines kept in full.
- Outbound recipients → `to_count` + `to_domains`: `internal/agent/api.go:1124, 1328, 1339, 1371, 1378, 1458, 1469, 1488, 1492`, `internal/agent/hitl_api.go:154, 180`, `internal/agent/hitl_magic_api.go:274, 308`, `internal/hitlworker/worker.go:342, 455`, `internal/outbound/smtp_relay.go:75` (retry line).

**Account-owner (login) emails → user id only** (email on the users row; for the deletion line, in the export the user could take before deleting).
- `internal/agent/user_data_rights_api.go:93` — the GDPR/CCPA deletion audit line no longer logs the deleted person's address.
- `internal/hitlnotify/notifier.go:162` — `owner=` is now the user id.

**Free-text human input → length (or 60-rune preview)**
- HITL/review reject reasons → `reason_len`: `internal/agent/hitl_api.go:374, 434`, `internal/agent/hitl_magic_api.go:357`. Full reason is stored (`rejection_reason` column) and delivered in the `email.review_rejected` event. Lost: reading the reason in the log stream.
- Feedback fallback `internal/agent/api.go:1651`: now `message_len` + 60-rune preview (was 200-rune dump). Honest caveat: when no delivery channel is configured (self-host dev), the log **was the only sink**, so content beyond 60 runes is genuinely lost there. Hosted prod configures a delivery channel, so nothing is lost in our deployment.

**Third-party error bodies → status code only**
- `internal/auth/oidc.go:305-319` — `*oauth2.RetrieveError` formats the provider's FULL raw HTTP response body; now logs HTTP status + RFC 6749 error code, other errors hard-truncated to 200 runes. Lost: the provider's freeform error prose; usually reproducible.
- `internal/agent/user_data_rights_api.go:131` — billing-hook error keeps the status, drops the sidecar body. The sidecar logs its own errors, so the detail still exists on the billing container.

**Connecting IPs → network prefix** (/24 / /48)
- `internal/relay/server.go:221, 224` (session open) and `:399` (auth line). Lost: exact-IP correlation from logs; prefix-level abuse/rate-limit debugging preserved. Exact IP is still used (not logged) by SPF evaluation.

**Duplicate removed instead of redacted twice**
- `internal/emailauth/checker.go:104`: the library-level "Email auth for X from Y" line duplicated relay `server.go:399` byte-for-byte in production (the relay is the only production caller via `srv.authenticate`) but without the trace id. Removing it beats maintaining redaction in two places; a comment marks the decision. Non-relay/library consumers of `CheckAuthentication*` lose that implicit log line — none exist in this repo.

## Judgment calls / found-in-flight

- **Extra leak found and fixed** (not on the audit list): `internal/hitlworker/worker.go:280` built an auto-reject reason containing the full suppressed recipient addresses, which flowed verbatim into the `reason=%q` auto-reject logs. Reason now carries count + domains. This also changes the *stored/emitted* rejection reason — the owner identifies the exact address via the message's stored recipient list or the suppression API. `suppression_test.go` updated to assert the new contract (and that the local part does NOT appear).
- **Deliberately NOT redacted:** agent addresses everywhere (our namespace, primary tracing key), including the loopback self-send line `api.go:1314` where `from`/`to` are both the agent itself; `comp.EnvelopeFrom` on the platform-send line `api.go:1492` (platform address at our domain); rejected-RCPT target addresses in `relay/server.go` (addresses in our MX namespace — the typo'd local part is the debugging signal); worker auto-reject `reason=%q` at `worker.go:577/581` (system-generated strings, now address-free after the suppression fix — though embedded `%v` compose/send errors are a residual theoretical path); the magic-link HTML responses showing the recipient (user-facing HTTP to the owner, not logs).
- **Ambiguity flagged:** `relay/server.go:399` also logs the connecting IP; the task listed that line for address redaction only, but with the checker.go duplicate removed this became the sole copy, so I applied the same /24 truncation there for consistency.

## Tests

- `internal/logredact`: full unit coverage incl. malformed/empty/unicode/no-panic; `TestNoSubjectContentInLogFormats` regression guard.
- Changed test: `internal/hitlworker/suppression_test.go` (asserted the old full-address reason).
- `go build ./...` clean; `go test ./...` green for every touched package.
- **Pre-existing, unrelated:** `internal/identity` DB-backed tests fail flakily (random FK-violation subsets, e.g. `domains_user_id_fkey`) on my local test DB — reproduced identically on a clean `origin/main` checkout, so not introduced here. Also pre-existing: `go vet` nits in agent test files and gofmt drift in ~20 untouched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)