### PR TITLE
fix(testutil): bound cleanup's lock wait, not its duration

### DIFF
--- a/internal/testutil/db.go
+++ b/internal/testutil/db.go
@@ -230,8 +230,24 @@ func runMigrations(ctx context.Context, pool *pgxpool.Pool) error {
 // calls this helper hundreds of times; repeatedly truncating inbound_intake also
 // recreates and fsyncs its three indexes and requires an ACCESS EXCLUSIVE lock.
 // Any future FK-less table MUST be added to the DELETE section here.
+// truncateAllLockTimeout bounds how long cleanup will WAIT ON A LOCK — not how
+// long it may take. Cleanup is expected to be lock-free (inbound_intake is
+// DELETEd precisely so a concurrent reader's ACCESS SHARE cannot block it), so a
+// wait this long means something genuinely holds a conflicting lock. Failing
+// fast with SQLSTATE 55P03 (lock_not_available) makes that case
+// self-identifying, instead of hanging until the caller's context expires and
+// reporting an indistinguishable deadline error.
+//
+// Deliberately NOT a statement timeout: cleanup is legitimately slow under a
+// loaded parallel run (`-p 4` across every package), and slowness must not be
+// conflated with a lock conflict — that conflation is what made
+// TestTruncateAll_CleansInboundIntakeWithoutExclusiveTableLock flaky in CI.
+const truncateAllLockTimeout = "5s"
+
 func truncateAll(ctx context.Context, pool *pgxpool.Pool) error {
 	_, err := pool.Exec(ctx, `
+		SET LOCAL lock_timeout = '`+truncateAllLockTimeout+`';
+
 		DELETE FROM inbound_intake;
 
 		TRUNCATE oauth_pkce_requests, oauth_refresh_tokens, oauth_access_tokens,

--- a/internal/testutil/db_test.go
+++ b/internal/testutil/db_test.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"context"
+	"errors"
 	"net/url"
 	"os"
 	"os/exec"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -41,10 +43,27 @@ func TestTruncateAll_CleansInboundIntakeWithoutExclusiveTableLock(t *testing.T) 
 		t.Fatalf("inbound_intake rows before cleanup = %d, want 1", before)
 	}
 
-	cleanupCtx, cancel := context.WithTimeout(ctx, time.Second)
+	// The budget here is a safety net against a genuine hang, NOT the assertion.
+	// What proves the invariant is the SQLSTATE below: truncateAll sets
+	// lock_timeout, so a conflicting lock surfaces as 55P03 (lock_not_available)
+	// within seconds rather than blocking until this context expires.
+	//
+	// It must stay generous. An earlier version budgeted one second and treated
+	// ANY error as proof of a lock conflict, which made this test flaky in CI:
+	// under `make cover` (-p 4, every package provisioning a database and
+	// applying all migrations against one Postgres) cleanup legitimately exceeds
+	// a second, and the deadline error was reported as a lock problem that did
+	// not exist. Slowness and lock contention are different failures and this
+	// test must only fail for the second one.
+	cleanupCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
 	defer cancel()
 	if err := truncateAll(cleanupCtx, pool); err != nil {
-		t.Fatalf("cleanup should not require exclusive access to inbound_intake: %v", err)
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "55P03" {
+			t.Fatalf("cleanup blocked on a conflicting lock while a reader held ACCESS SHARE on "+
+				"inbound_intake — it must be cleaned with DELETE, not TRUNCATE: %v", err)
+		}
+		t.Fatalf("cleanup failed for a non-lock reason: %v", err)
 	}
 
 	if err := reader.Rollback(ctx); err != nil {


### PR DESCRIPTION
## Summary

Fixes the flaky `TestTruncateAll_CleansInboundIntakeWithoutExclusiveTableLock`, which has been failing the **Go coverage gate on `main`** (e.g. `f0978b3e`) and on PRs.

**Root cause: the test used a 1-second wall-clock budget as a lock detector.** It gave `truncateAll` a 1s context and attributed *any* error to a lock conflict. Under `make cover` — `-p 4`, every package provisioning a database and applying all migrations against one Postgres — cleanup legitimately exceeds a second, so the deadline fired and the test reported a lock problem that did not exist.

## Confirmed by measurement, not inference

With the budget set below the measured duration and `pg_locks` sampled throughout, the failure reproduces with **zero ungranted locks** and an error byte-identical to CI's:

```
budget=20ms  duration=20.3ms  ungranted_lock_samples=0  err=timeout: context deadline exceeded
→ "cleanup should not require exclusive access to inbound_intake: timeout: context deadline exceeded"
```

Baselines: `truncateAll` takes **126ms** idle, worst **308ms** under six concurrent provision-and-migrate loaders.

Falsified alternatives:

| Hypothesis | Verdict | Evidence |
|---|---|---|
| Go data race | falsified | `-race -count=3` clean |
| Lock wait vs the reader txn | falsified | 0 ungranted locks; `inbound_intake` has **no FK in either direction**, so `TRUNCATE…CASCADE` cannot reach it |
| pgxpool starvation | falsified | `pgxpool.New` grants `max(4,numCPU)`; the reader holds one |

## The fix

Separates the two failure modes the test conflated:

- `truncateAll` sets **`lock_timeout`** — bounding how long cleanup will *wait on a lock* without bounding how long it may *take*. Deliberately **not** a statement timeout: slowness under a loaded parallel run is expected and must not fail anything.
- The test's context becomes generous (a hang guard, no longer the assertion) and it branches on **SQLSTATE 55P03**, so it fails only for a real lock conflict — and reports it accurately.

Bonus: any cleanup genuinely stuck behind a lock now fails in seconds with a named cause, instead of hanging until its caller's context expires.

## Regression evidence (red → green)

Reintroducing the bug this test guards (`TRUNCATE` instead of `DELETE` for `inbound_intake`) fails in 5.5s:

```
cleanup blocked on a conflicting lock while a reader held ACCESS SHARE on
inbound_intake — it must be cleaned with DELETE, not TRUNCATE:
ERROR: canceling statement due to lock timeout (SQLSTATE 55P03)
```

Restoring `DELETE` makes it green. The old test caught this same bug but described it as a deadline error; the new one names the lock, the SQLSTATE, and the fix.

## Verification

`truncateAll` runs in **every** DB-backed test, so verification is the full suite, not just this package: `go test -p 4 -covermode=atomic ./internal/...` on a **clean isolated base database** — 2/2 green on `main` and 2/2 green with this change, zero deadlocks, zero lock timeouts. `internal/testutil` alone: `-count=3` green.

## Follow-up worth its own issue: `make cover` and `make test` hardcode the shared base database

AGENTS.md instructs each agent/session to use its **own** base database, but both recipes pin `E2A_TEST_DATABASE_URL=…/e2a_test` inline, which overrides any env the caller sets — so the guidance cannot actually be followed through the Makefile.

This bit me while investigating: my local `e2a_test*` databases had `079_contacts.sql` recorded in `schema_migrations` from an unmerged branch, and the resulting schema drift produced ~40 spurious failures plus `40P01 deadlock detected` in `truncate tables`. All of it vanished on a clean isolated base. Worth making these targets honor a caller-supplied `E2A_TEST_DATABASE_URL` so concurrent sessions stop corrupting each other.

Note this is a *local* hazard only — CI provisions a fresh Postgres per run, so it is not the cause of the CI flake this PR fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
