### PR TITLE
chore(sdk-monitor): pin the 1.3.0 release packages

### DIFF
--- a/tests/sdk-monitor/README.md
+++ b/tests/sdk-monitor/README.md
@@ -30,8 +30,8 @@ of five interfaces:
 | `api` | raw HTTP against the server's `/v1/agents/{email}/messages` (and `.../reply`) endpoints — no SDK. Catches a server-contract break distinct from an SDK break. | python (stdlib `urllib`) |
 | `python_sdk` | the published `e2a` PyPI package | python |
 | `mcp` | the deployed MCP streamable-HTTP server's `send_message` / `reply_to_message` tools | python (hand-rolled JSON-RPC over `urllib`) |
-| `ts_sdk` | the published `@e2a/sdk` npm package (v5.3.0) | node, shelled out from python |
-| `cli` | the published `@e2a/cli` npm package (v2.0.0, bin `e2a`) | node, shelled out from python |
+| `ts_sdk` | the published `@e2a/sdk` npm package (v5.4.0) | node, shelled out from python |
+| `cli` | the published `@e2a/cli` npm package (v2.1.0, bin `e2a`) | node, shelled out from python |
 
 Anything that breaks any of those — a bad publish, a wire-contract drift, a
 packaging regression, an MCP transport change — stops that interface's
@@ -274,8 +274,8 @@ signal, not something to work around.
 ## SDK / package version bump policy
 
 `requirements.txt` pins an exact published Python SDK version (currently
-**5.3.0**); `package.json` pins exact published `@e2a/sdk` (**5.3.0**) and
-`@e2a/cli` (**2.0.0**) versions. None of these is ever a path or workspace
+**5.4.0**); `package.json` pins exact published `@e2a/sdk` (**5.4.0**) and
+`@e2a/cli` (**2.1.0**) versions. None of these is ever a path or workspace
 dependency on the corresponding source directory — installing from local
 source would defeat the entire purpose by hiding a broken publish.
 

--- a/tests/sdk-monitor/package.json
+++ b/tests/sdk-monitor/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "description": "Node-runtime dependencies for tests/sdk-monitor's ts_sdk and cli interfaces — pinned to the exact PUBLISHED npm packages so a broken publish surfaces here, never workspace source. Never add a path/workspace dependency on ../../sdks/typescript or ../../cli.",
   "dependencies": {
-    "@e2a/sdk": "5.3.0",
-    "@e2a/cli": "2.0.0"
+    "@e2a/sdk": "5.4.0",
+    "@e2a/cli": "2.1.0"
   }
 }

--- a/tests/sdk-monitor/requirements.txt
+++ b/tests/sdk-monitor/requirements.txt
@@ -2,4 +2,4 @@
 # this MUST stay a pinned PyPI release — never a path/editable dep on
 # ../../sdks/python. A broken publish has to surface here, not be papered over
 # by local source. Bump this on every Python SDK release (see README.md).
-e2a==5.3.0
+e2a==5.4.0


### PR DESCRIPTION
Bumps the synthetic monitor's registry pins to the versions published with
[v1.3.0](https://github.com/tokencanopy/e2a/releases/tag/v1.3.0).

| Pin | Before | After |
|---|---|---|
| `requirements.txt` → `e2a` (PyPI) | 5.3.0 | **5.4.0** |
| `package.json` → `@e2a/sdk` (npm) | 5.3.0 | **5.4.0** |
| `package.json` → `@e2a/cli` (npm) | 2.0.0 | **2.1.0** |

Plus the two README spots that restate those versions.

## Why this is a separate PR

`tests/sdk-monitor/README.md` is explicit that these pins move only *after* the
new versions are live on PyPI/npm:

> Bump each pin as a step of its package's release, *after* the new version is
> live on PyPI/npm. Rebuilding the image then proves the release is installable
> and works end to end against production.

The monitor installs from real registries by design — no path or workspace
dependency on `sdks/` or `cli/`, and the Dockerfile verifies this at build time
(`pip show e2a`, `npm ls @e2a/sdk @e2a/cli`). Bumping these in the release PR
itself would have failed the image build against versions that didn't exist yet.
All three are now published, so this is safe.

## Verification

- `npm install --dry-run` resolves `@e2a/sdk 5.4.0` and `@e2a/cli 2.1.0`
- `pip download -r requirements.txt` pulls `e2a-5.4.0-py3-none-any.whl` from PyPI
- A fresh venv built from `requirements.txt` runs `test_monitor.py` → `all checks passed`

That last one is the real signal: the offline suite exercises the monitor
against the **newly published** SDK, not local source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)