### PR TITLE
test(e2e-prod): fail closed instead of defaulting to production

### DIFF
--- a/tests/e2e-prod/README.md
+++ b/tests/e2e-prod/README.md
@@ -1,12 +1,29 @@
 # Production E2E harness
 
+**This suite is destructive.** It creates and deletes agents, domains, webhooks
+and templates, and defaults to `E2E_CLEANUP=always`. Two guards make an
+accidental production run impossible:
+
+- **There is no default target.** `E2A_URL` (or `api_url` in
+  `~/.e2a/config.json`) must be set explicitly. An unconfigured run fails
+  closed. It previously defaulted to `https://e2a.dev` — combined with the
+  `~/.e2a/config.json` API-key fallback, an unconfigured `npm test` ran this
+  suite against **production using the operator's own credentials**.
+- **Production requires an explicit opt-in.** If the resolved target is a
+  hosted production origin (`e2a.dev`, `www.e2a.dev`, `api.e2a.dev`), the run
+  refuses unless `E2E_ALLOW_PROD=1` is set. Self-hosted and staging targets are
+  unaffected. When you do target production, use a **dedicated conformance
+  account**, never a real one.
+
 Run this harness only against the intended production-compatible deployment. Configure:
 
-- `E2A_URL`: API base URL.
+- `E2A_URL`: API base URL. **Required** — there is no default.
 - `E2A_API_KEY`: test-account API key.
 - `E2A_AGENT_EMAIL`: primary agent owned by that test account.
 - `E2E_SINK_EMAIL`: explicit safe test sink. This is required; never use a real agent or user mailbox. CI uses the Amazon SES mailbox simulator.
 - `E2A_SITE_URL`: optional site URL override when it cannot be derived from `E2A_URL`.
+
+- `E2E_ALLOW_PROD`: set to `1` to permit a run against a hosted production origin. Required there, ignored elsewhere.
 
 The registration rate-limit stress probe is disabled by default. Set `E2E_PROD_STRESS=1` only for an intentional stress run.
 

--- a/tests/e2e-prod/harness/env.test.ts
+++ b/tests/e2e-prod/harness/env.test.ts
@@ -1,6 +1,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
+  assertProductionOptIn,
+  isProductionTarget,
   resolveSinkEmail,
   resolveSiteUrl,
   type ProdEnv,
@@ -46,10 +48,75 @@ test("resolveSinkEmail rejects a missing or empty sink", () => {
   );
 });
 
+test("isProductionTarget recognizes the hosted production origins", () => {
+  for (const url of [
+    "https://e2a.dev",
+    "https://e2a.dev/",
+    "https://api.e2a.dev",
+    "https://API.E2A.DEV/v1",
+    "https://www.e2a.dev",
+  ]) {
+    assert.equal(isProductionTarget(url), true, `${url} should be production`);
+  }
+});
+
+test("isProductionTarget does not flag staging, localhost, or self-hosted targets", () => {
+  for (const url of [
+    "https://api-staging.e2a.dev",
+    "https://staging.e2a.dev",
+    "http://localhost:8080",
+    "https://self-hosted.example.test",
+    // A lookalike host must not be treated as production, but equally must not
+    // be mistaken for one — it is simply somebody else's deployment.
+    "https://e2a.dev.evil.example",
+    "not a url",
+  ]) {
+    assert.equal(isProductionTarget(url), false, `${url} should not be production`);
+  }
+});
+
+test("assertProductionOptIn refuses a production target without the explicit opt-in", () => {
+  assert.throws(
+    () => assertProductionOptIn("https://e2a.dev", undefined),
+    /Refusing to run the destructive e2e-prod suite against production/,
+  );
+  // Anything other than the exact opt-in value is still a refusal.
+  assert.throws(() => assertProductionOptIn("https://api.e2a.dev", "true"), /E2E_ALLOW_PROD=1/);
+  assert.throws(() => assertProductionOptIn("https://api.e2a.dev", "0"), /E2E_ALLOW_PROD=1/);
+});
+
+test("assertProductionOptIn allows production with the explicit opt-in, and non-production always", () => {
+  assert.doesNotThrow(() => assertProductionOptIn("https://e2a.dev", "1"));
+  assert.doesNotThrow(() => assertProductionOptIn("https://api-staging.e2a.dev", undefined));
+  assert.doesNotThrow(() => assertProductionOptIn("http://localhost:8080", undefined));
+});
+
+test("loadEnv fails closed when no target deployment is configured", async () => {
+  const saved = { ...process.env };
+  for (const k of ["E2A_URL", "E2A_API_URL", "E2A_API_KEY", "E2A_AGENT_EMAIL", "E2A_PRIMARY_AGENT"]) {
+    delete process.env[k];
+  }
+  process.env.E2E_SINK_EMAIL = "sink@example.test";
+  // HOME is redirected so a real ~/.e2a/config.json on the developer's machine
+  // cannot supply api_url and mask the failure this test is asserting.
+  process.env.HOME = "/nonexistent-home-for-e2e-prod-env-test";
+  try {
+    const { loadEnv } = await import(`./env.ts?no-target=${Date.now()}`);
+    assert.throws(() => loadEnv(), /No target deployment/);
+  } finally {
+    process.env = saved;
+  }
+});
+
 test("ApiClient can override its base URL without changing existing constructor arguments", async () => {
+  const originalApiUrl = process.env.E2A_URL;
   const originalApiKey = process.env.E2A_API_KEY;
   const originalAgentEmail = process.env.E2A_AGENT_EMAIL;
   const originalSinkEmail = process.env.E2E_SINK_EMAIL;
+  // client.ts calls loadEnv() at module scope, so the target must be explicit.
+  // This test previously set no E2A_URL and silently inherited the old
+  // https://e2a.dev default — exactly the footgun the guard removes.
+  process.env.E2A_URL = "https://api.example.test";
   process.env.E2A_API_KEY = "test-key";
   process.env.E2A_AGENT_EMAIL = "primary@agents.example.test";
   process.env.E2E_SINK_EMAIL = "sink@example.test";
@@ -78,6 +145,8 @@ test("ApiClient can override its base URL without changing existing constructor 
     await client.get("/pricing", { apiKey: null });
   } finally {
     globalThis.fetch = originalFetch;
+    if (originalApiUrl === undefined) delete process.env.E2A_URL;
+    else process.env.E2A_URL = originalApiUrl;
     if (originalApiKey === undefined) delete process.env.E2A_API_KEY;
     else process.env.E2A_API_KEY = originalApiKey;
     if (originalAgentEmail === undefined) delete process.env.E2A_AGENT_EMAIL;

--- a/tests/e2e-prod/harness/env.ts
+++ b/tests/e2e-prod/harness/env.ts
@@ -37,6 +37,38 @@ export function resolveSiteUrl(apiUrl: string, explicitSiteUrl?: string): string
   return normalizedApiUrl;
 }
 
+// The hosted PRODUCTION origins. This suite is destructive by construction — it
+// creates and deletes agents, domains, webhooks and templates, and defaults to
+// `E2E_CLEANUP=always` — so running it against these hosts must be a deliberate,
+// explicit act, never something an unconfigured `npm test` can stumble into.
+// Self-hosted deployments are deliberately NOT listed: their operators are the
+// intended audience for an unguarded run against their own instance.
+const PRODUCTION_HOSTS = new Set(["e2a.dev", "www.e2a.dev", "api.e2a.dev"]);
+
+export function isProductionTarget(apiUrl: string): boolean {
+  try {
+    return PRODUCTION_HOSTS.has(new URL(normalizeBaseUrl(apiUrl)).hostname.toLowerCase());
+  } catch {
+    // An unparseable URL is not a production URL; loadEnv surfaces the real
+    // error when it tries to use it.
+    return false;
+  }
+}
+
+// assertProductionOptIn fails closed when the resolved target is a hosted
+// production origin and the operator has not explicitly opted in. Named and
+// exported so the check is unit-testable without mutating process.env.
+export function assertProductionOptIn(apiUrl: string, allowProd = process.env.E2E_ALLOW_PROD): void {
+  if (!isProductionTarget(apiUrl)) return;
+  if (allowProd === "1") return;
+  throw new Error(
+    `Refusing to run the destructive e2e-prod suite against production (${apiUrl}).\n` +
+      `This suite creates and deletes agents, domains, webhooks and templates, and cleans up with E2E_CLEANUP=always.\n` +
+      `If you really mean to target production, set E2E_ALLOW_PROD=1 — and use a dedicated conformance account, never a real one.\n` +
+      `To target staging instead: E2A_URL=https://api-staging.e2a.dev`,
+  );
+}
+
 export function resolveSinkEmail(explicitSinkEmail?: string): string {
   const sinkEmail = explicitSinkEmail?.trim();
   if (!sinkEmail) {
@@ -79,7 +111,17 @@ function pickEnv(canonical: string, ...legacy: string[]): string | undefined {
 
 export function loadEnv(): ProdEnv {
   const local = readLocalConfig();
-  const apiUrl = pickEnv("E2A_URL", "E2A_API_URL") ?? local.api_url ?? "https://e2a.dev";
+  // No default target. This used to fall back to https://e2a.dev, which — combined
+  // with the ~/.e2a/config.json api_key fallback below — meant an unconfigured
+  // `npm test` ran the destructive suite against PRODUCTION using the operator's
+  // own CLI credentials. The target is now always explicit.
+  const apiUrl = pickEnv("E2A_URL", "E2A_API_URL") ?? local.api_url;
+  if (!apiUrl) {
+    throw new Error(
+      "No target deployment. Set E2A_URL (e.g. https://api-staging.e2a.dev) or configure api_url in ~/.e2a/config.json.",
+    );
+  }
+  assertProductionOptIn(apiUrl);
   const primaryAgentEmail = pickEnv("E2A_AGENT_EMAIL", "E2A_PRIMARY_AGENT") ?? local.agent_email ?? "";
   const env: ProdEnv = {
     apiUrl,


### PR DESCRIPTION
Phase 0 of the comprehensive production conformance work. This one is a safety
fix and stands alone — it's worth landing regardless of the rest.

## The problem

`tests/e2e-prod` is a **destructive** suite: it creates and deletes agents,
domains, webhooks and templates, and defaults to `E2E_CLEANUP=always`.

`loadEnv()` defaulted its target to `https://e2a.dev` and fell back to the
`api_key` in `~/.e2a/config.json`. So an unconfigured `npm test` in that
directory ran the destructive suite **against production, using the operator's
own CLI credentials**, with the production shared domain (`agents.e2a.dev`) as
its default. Nothing warned.

The proof is in this diff: the pre-existing `ApiClient can override its base URL`
test never set `E2A_URL` and had been silently inheriting the production
default. Removing the default is what surfaced it.

## The fix

Two guards, both following the precedent already set by `resolveSinkEmail()` in
the same file — fail closed rather than guess a safe-looking default.

1. **No default target.** `E2A_URL` (or `api_url` in `~/.e2a/config.json`) must
   be explicit; otherwise `loadEnv()` throws.
2. **`assertProductionOptIn()`** — when the resolved host is a hosted production
   origin (`e2a.dev`, `www.e2a.dev`, `api.e2a.dev`), refuse unless
   `E2E_ALLOW_PROD=1`.

`isProductionTarget` / `assertProductionOptIn` are exported and take their input
as arguments, so they're unit-testable without mutating `process.env`.

**Staging, localhost and self-hosted targets are deliberately unaffected.** A
self-hoster running this against their own deployment is the intended unguarded
case; only the hosted production origins are gated.

## Behavior

| Target | Before | After |
|---|---|---|
| _(unconfigured)_ | silently hit **production** with your real key | `No target deployment` |
| `https://api.e2a.dev`, no opt-in | ran | `Refusing to run the destructive e2e-prod suite against production` |
| `https://api.e2a.dev` + `E2E_ALLOW_PROD=1` | ran | runs |
| `https://api-staging.e2a.dev` | ran | runs, unchanged |
| self-hosted / localhost | ran | runs, unchanged |

## No pipeline impact

`release-pipeline.yml` already sets `E2A_URL=https://api-staging.e2a.dev` at
both call sites, so the staging conformance gate is unaffected.

## Verification

- 18/18 harness unit tests pass (5 new), `tsc --noEmit` clean
- New tests cover host classification (including that `e2a.dev.evil.example` is
  **not** treated as production), the exact-value opt-in (`"true"` and `"0"` are
  still refusals), and that `loadEnv` fails closed with `HOME` redirected so a
  real `~/.e2a/config.json` can't mask it
- Exercised all four paths live: unconfigured → blocked, prod without opt-in →
  blocked, prod with opt-in → allowed, staging → allowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)