### PR TITLE
test(e2e-prod): add the MCP tool coverage gate

### DIFF
--- a/tests/e2e-prod/harness/mcp-coverage.ts
+++ b/tests/e2e-prod/harness/mcp-coverage.ts
@@ -1,0 +1,61 @@
+import { writeFileSync, mkdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+// MCP tool-coverage recorder — the MCP analogue of coverage.ts, which does the
+// same job for the typed /v1 OpenAPI operations.
+//
+// The denominator is NOT derived from source. It is whatever the DEPLOYED server
+// advertises on `tools/list`, captured live during the run. Grepping
+// mcp/src/tools/*.ts for registerTool() would measure the repo instead of the
+// thing under test, and would silently drift the moment a tool is registered
+// conditionally, renamed, or gated behind a tier. The server's own advertisement
+// is the only honest catalog: whatever a real MCP client can see is exactly what
+// the suite is accountable for.
+//
+// A tool counts as covered only when a `tools/call` returned a result with
+// isError !== true. An error result means the tool's handler rejected — the same
+// reasoning as coverage.ts recording only 2xx: a rejected call proves the route
+// exists, not that the tool works.
+//
+// Shards live in reports/mcp-coverage/ — a separate subdir from the API
+// recorder's reports/coverage/ so the two gates can never read each other's
+// files, and neither collides with the per-suite {findings} JSONs in reports/.
+const MCP_COVERAGE_DIR = fileURLToPath(new URL("../reports/mcp-coverage/", import.meta.url));
+
+const covered = new Set<string>();
+const advertised = new Set<string>();
+let installed = false;
+
+function installFlush(): void {
+  if (installed) return;
+  installed = true;
+  // Sync flush on 'exit', matching coverage.ts. 'exit' does not fire on
+  // SIGKILL, so a force-killed suite contributes no shard and its tools read
+  // UNCOVERED — a safe false-FAIL, never a false-PASS, because `pretest` clears
+  // the directory so no stale shard can mask the loss.
+  process.on("exit", () => {
+    if (covered.size === 0 && advertised.size === 0) return;
+    try {
+      mkdirSync(MCP_COVERAGE_DIR, { recursive: true });
+      writeFileSync(
+        `${MCP_COVERAGE_DIR}${process.pid}.json`,
+        JSON.stringify({ advertised: [...advertised], covered: [...covered] }),
+      );
+    } catch {
+      /* best-effort: coverage is advisory and must never fail a suite */
+    }
+  });
+}
+
+/** Record the live tool catalog the server advertised on `tools/list`. */
+export function recordToolList(names: readonly string[]): void {
+  for (const n of names) advertised.add(n);
+  installFlush();
+}
+
+/** Record one `tools/call`. Only a non-error result counts as covered. */
+export function recordToolCall(name: string, isError: boolean | undefined): void {
+  if (isError === true) return;
+  covered.add(name);
+  installFlush();
+}

--- a/tests/e2e-prod/harness/mcp.ts
+++ b/tests/e2e-prod/harness/mcp.ts
@@ -1,8 +1,34 @@
+import { recordToolCall, recordToolList } from "./mcp-coverage.ts";
+
 interface JsonRpcRequest {
   jsonrpc: "2.0";
   id: number;
   method: string;
   params?: unknown;
+}
+
+// Feed the MCP tool-coverage recorder from the single JSON-RPC choke point, so
+// coverage is recorded whether a suite goes through callTool() or calls
+// `mcp.call("tools/call", …)` directly. Never throws: coverage is advisory and
+// must not be able to fail a suite.
+function recordMcpResult(method: string, params: unknown, result: unknown): void {
+  try {
+    if (method === "tools/list") {
+      const tools = (result as { tools?: Array<{ name?: string }> })?.tools;
+      if (Array.isArray(tools)) {
+        recordToolList(tools.map((t) => t?.name).filter((n): n is string => typeof n === "string"));
+      }
+      return;
+    }
+    if (method === "tools/call") {
+      const name = (params as { name?: string })?.name;
+      if (typeof name === "string") {
+        recordToolCall(name, (result as { isError?: boolean })?.isError);
+      }
+    }
+  } catch {
+    /* advisory only */
+  }
 }
 
 interface JsonRpcResponse<T = unknown> {
@@ -82,6 +108,7 @@ export class HttpMcpClient implements McpRpcClient {
     if (env.error) {
       throw new Error(`MCP ${method} error ${env.error.code}: ${env.error.message}`);
     }
+    recordMcpResult(method, params, env.result);
     return env.result as T;
   }
 

--- a/tests/e2e-prod/mcp_coverage_gate.py
+++ b/tests/e2e-prod/mcp_coverage_gate.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""MCP tool coverage gate.
+
+Every tool the deployed MCP server advertises must be exercised by the e2e-prod
+suite, or the gate fails — so a tool that ships without a test is caught the same
+way an unexercised /v1 operation is caught by coverage_gate.py.
+
+This is the MCP analogue of coverage_gate.py, with one deliberate difference:
+
+  coverage_gate.py takes its denominator from a REPO FILE (api/openapi.yaml,
+  which is itself drift-gated against the server).
+
+  This gate takes its denominator from the DEPLOYED SERVER — whatever it
+  advertised on `tools/list` during the run, captured by harness/mcp-coverage.ts.
+
+There is no drift-gated catalog file for MCP tools, so grepping
+mcp/src/tools/*.ts for registerTool() would measure the repo rather than the
+thing under test, and would go quietly wrong the moment a tool is registered
+conditionally or gated behind a tier. The server's own advertisement is the only
+honest catalog: what a real MCP client can see is exactly what we are
+accountable for testing.
+
+Inputs:
+  - reports/mcp-coverage/*.json : shards written by harness/mcp-coverage.ts, each
+    {"advertised": [...tool names...], "covered": [...tool names...]}.
+
+"Covered" means a `tools/call` returned a result with isError !== true, i.e. the
+tool actually ran — not merely that it was probed with a rejected request.
+
+Usage: python3 mcp_coverage_gate.py [--reports DIR]
+Exit 0 = every advertised tool covered (or allowlisted); 1 = coverage gap;
+2 = usage/IO error (including "no shards", which must never read as a pass).
+"""
+import argparse
+import glob
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+# Tools the black-box suite intentionally does NOT exercise, with the reason.
+# Keep this SHORT and justified — every entry is coverage we knowingly forgo.
+ALLOWLIST: dict[str, str] = {}
+
+
+def load_shards(reports_dir: str) -> tuple[set[str], set[str], int]:
+    advertised: set[str] = set()
+    covered: set[str] = set()
+    paths = sorted(glob.glob(os.path.join(reports_dir, "*.json")))
+    for path in paths:
+        with open(path, encoding="utf-8") as fh:
+            shard = json.load(fh)
+        # Tolerate a bare-list shard shape defensively, but the recorder always
+        # writes the object form.
+        if isinstance(shard, dict):
+            advertised.update(shard.get("advertised") or [])
+            covered.update(shard.get("covered") or [])
+    return advertised, covered, len(paths)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--reports", default=os.path.join(HERE, "reports", "mcp-coverage"))
+    args = ap.parse_args()
+
+    if not os.path.isdir(args.reports):
+        print(
+            f"mcp_coverage_gate: no shard directory at {args.reports}. "
+            "Run the suite first (`npm test`); an absent run is not a pass.",
+            file=sys.stderr,
+        )
+        return 2
+
+    advertised, covered, shard_count = load_shards(args.reports)
+
+    if shard_count == 0 or not advertised:
+        # Without a denominator there is nothing to verify. Failing loudly here is
+        # the whole point: a silent 0-of-0 "pass" would hide a broken harness.
+        print(
+            "mcp_coverage_gate: no tools/list denominator was recorded. "
+            "At least one suite must call tools/list against the deployed server.",
+            file=sys.stderr,
+        )
+        return 2
+
+    # An allowlist entry that no longer names an advertised tool is a silent hole
+    # (e.g. the tool was renamed) — fail loudly so the allowlist can't drift stale.
+    stale = set(ALLOWLIST) - advertised
+    if stale:
+        print(
+            f"mcp_coverage_gate: allowlist entries the server does not advertise "
+            f"(renamed/removed?): {sorted(stale)}",
+            file=sys.stderr,
+        )
+        return 2
+
+    # A covered tool the server never advertised means the recorder and the
+    # catalog disagree — report it, but it cannot mask a real gap.
+    unadvertised = sorted(covered - advertised)
+
+    missing = advertised - covered
+    allowlisted = missing & set(ALLOWLIST)
+    uncovered = sorted(missing - set(ALLOWLIST))
+
+    print(f"Shards             : {shard_count}")
+    print(f"Advertised tools   : {len(advertised)}")
+    print(f"Covered            : {len(covered & advertised)}")
+    print(f"Allowlisted        : {len(allowlisted)} " + (str(sorted(allowlisted)) if allowlisted else ""))
+    if unadvertised:
+        print(f"Called but not advertised: {unadvertised}")
+
+    if uncovered:
+        print(f"\nUNCOVERED ({len(uncovered)}):", file=sys.stderr)
+        for name in uncovered:
+            print(f"  {name}", file=sys.stderr)
+        print(
+            "\nEvery advertised MCP tool needs a suite that calls it successfully. "
+            "Add a test, or add an ALLOWLIST entry with a justification.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("\nPASS: every advertised MCP tool is exercised.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/e2e-prod/package.json
+++ b/tests/e2e-prod/package.json
@@ -4,10 +4,11 @@
   "type": "module",
   "scripts": {
     "smoke": "node smoke.ts",
-    "pretest": "rm -rf reports/coverage",
+    "pretest": "rm -rf reports/coverage reports/mcp-coverage",
     "test": "node --test --test-concurrency=1 --test-reporter=spec suites/*.test.ts",
     "test:unit": "node --test harness/*.test.ts",
     "coverage:gate": "python3 coverage_gate.py",
+    "coverage:gate:mcp": "python3 mcp_coverage_gate.py",
     "coverage": "npm test; npm run coverage:gate",
     "typecheck": "tsc --noEmit"
   },


### PR DESCRIPTION
Phase 1 of the comprehensive conformance work. This lands the **measurement**
only — the tool tests that close the gap follow in batched PRs.

## Why

The `/v1` surface has had a coverage gate since P4 (`coverage_gate.py`, 56/56).
MCP has had nothing. Querying the deployed staging server's `tools/list`:

> **60 tools advertised · 14 exercised · 46 never called by any test.**

## The denominator comes from the server, not the repo

`coverage_gate.py` takes its denominator from a repo file (`api/openapi.yaml`,
itself drift-gated against the server). There is no equivalent drift-gated
catalog for MCP tools, so this gate takes its denominator from whatever the
**deployed server advertises on `tools/list`** during the run, captured by
`harness/mcp-coverage.ts`.

This is not theoretical. Grepping `mcp/src/tools/*.ts` for `registerTool()`
finds **58** tools; the server advertises **60**. The grep misses
`reject_message` and `reject_pending_message`. Had the gate been built on the
source scan, those two would have been invisible to it permanently.

## Design

- `harness/mcp-coverage.ts` — records the advertised catalog and every
  successful `tools/call`. A tool counts as covered only when the result has
  `isError !== true`, mirroring `coverage.ts` recording only 2xx: a rejected
  call proves the route exists, not that the tool works.
- `harness/mcp.ts` — feeds the recorder from `HttpMcpClient.call`, the single
  JSON-RPC choke point, so coverage lands whether a suite uses `callTool()` or
  calls `mcp.call("tools/call", …)` directly. Never throws; coverage is
  advisory and must not be able to fail a suite.
- `mcp_coverage_gate.py` — unions the shards, fails on any advertised tool no
  suite exercised.
- Shards live in `reports/mcp-coverage/`, separate from the API recorder's
  `reports/coverage/`; `pretest` clears both so a prior run can't inflate
  coverage into a false PASS.

## Fails closed

| Situation | Exit | Rationale |
|---|---|---|
| No shards, or shards with no `tools/list` denominator | **2** | a vacuous 0-of-0 "pass" would hide a broken harness |
| Allowlist names a tool the server no longer advertises | **2** | the allowlist can't rot silently |
| Any advertised tool uncovered | **1** | names each one |
| All covered (across split shards) | 0 | |

Verified against synthetic shards for all four outcomes. `tsc --noEmit` clean,
harness unit tests pass.

## Not yet wired into CI

`mcp_coverage_gate.py` is **not** called by `release-pipeline.yml` yet, so this
PR is inert on merge — it cannot turn the staging gate red while the 46 tests
are still being written. Wiring it up is the last commit of the batch series,
once coverage is actually complete.

The `ALLOWLIST` is deliberately empty: every advertised tool should be exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)