### PR TITLE
test(e2e-prod): MCP conformance for webhooks + events (11 tools)

### DIFF
--- a/tests/e2e-prod/harness/mcp-coverage.ts
+++ b/tests/e2e-prod/harness/mcp-coverage.ts
@@ -1,0 +1,61 @@
+import { writeFileSync, mkdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+// MCP tool-coverage recorder — the MCP analogue of coverage.ts, which does the
+// same job for the typed /v1 OpenAPI operations.
+//
+// The denominator is NOT derived from source. It is whatever the DEPLOYED server
+// advertises on `tools/list`, captured live during the run. Grepping
+// mcp/src/tools/*.ts for registerTool() would measure the repo instead of the
+// thing under test, and would silently drift the moment a tool is registered
+// conditionally, renamed, or gated behind a tier. The server's own advertisement
+// is the only honest catalog: whatever a real MCP client can see is exactly what
+// the suite is accountable for.
+//
+// A tool counts as covered only when a `tools/call` returned a result with
+// isError !== true. An error result means the tool's handler rejected — the same
+// reasoning as coverage.ts recording only 2xx: a rejected call proves the route
+// exists, not that the tool works.
+//
+// Shards live in reports/mcp-coverage/ — a separate subdir from the API
+// recorder's reports/coverage/ so the two gates can never read each other's
+// files, and neither collides with the per-suite {findings} JSONs in reports/.
+const MCP_COVERAGE_DIR = fileURLToPath(new URL("../reports/mcp-coverage/", import.meta.url));
+
+const covered = new Set<string>();
+const advertised = new Set<string>();
+let installed = false;
+
+function installFlush(): void {
+  if (installed) return;
+  installed = true;
+  // Sync flush on 'exit', matching coverage.ts. 'exit' does not fire on
+  // SIGKILL, so a force-killed suite contributes no shard and its tools read
+  // UNCOVERED — a safe false-FAIL, never a false-PASS, because `pretest` clears
+  // the directory so no stale shard can mask the loss.
+  process.on("exit", () => {
+    if (covered.size === 0 && advertised.size === 0) return;
+    try {
+      mkdirSync(MCP_COVERAGE_DIR, { recursive: true });
+      writeFileSync(
+        `${MCP_COVERAGE_DIR}${process.pid}.json`,
+        JSON.stringify({ advertised: [...advertised], covered: [...covered] }),
+      );
+    } catch {
+      /* best-effort: coverage is advisory and must never fail a suite */
+    }
+  });
+}
+
+/** Record the live tool catalog the server advertised on `tools/list`. */
+export function recordToolList(names: readonly string[]): void {
+  for (const n of names) advertised.add(n);
+  installFlush();
+}
+
+/** Record one `tools/call`. Only a non-error result counts as covered. */
+export function recordToolCall(name: string, isError: boolean | undefined): void {
+  if (isError === true) return;
+  covered.add(name);
+  installFlush();
+}

--- a/tests/e2e-prod/harness/mcp.ts
+++ b/tests/e2e-prod/harness/mcp.ts
@@ -1,8 +1,34 @@
+import { recordToolCall, recordToolList } from "./mcp-coverage.ts";
+
 interface JsonRpcRequest {
   jsonrpc: "2.0";
   id: number;
   method: string;
   params?: unknown;
+}
+
+// Feed the MCP tool-coverage recorder from the single JSON-RPC choke point, so
+// coverage is recorded whether a suite goes through callTool() or calls
+// `mcp.call("tools/call", …)` directly. Never throws: coverage is advisory and
+// must not be able to fail a suite.
+function recordMcpResult(method: string, params: unknown, result: unknown): void {
+  try {
+    if (method === "tools/list") {
+      const tools = (result as { tools?: Array<{ name?: string }> })?.tools;
+      if (Array.isArray(tools)) {
+        recordToolList(tools.map((t) => t?.name).filter((n): n is string => typeof n === "string"));
+      }
+      return;
+    }
+    if (method === "tools/call") {
+      const name = (params as { name?: string })?.name;
+      if (typeof name === "string") {
+        recordToolCall(name, (result as { isError?: boolean })?.isError);
+      }
+    }
+  } catch {
+    /* advisory only */
+  }
 }
 
 interface JsonRpcResponse<T = unknown> {
@@ -82,6 +108,7 @@ export class HttpMcpClient implements McpRpcClient {
     if (env.error) {
       throw new Error(`MCP ${method} error ${env.error.code}: ${env.error.message}`);
     }
+    recordMcpResult(method, params, env.result);
     return env.result as T;
   }
 

--- a/tests/e2e-prod/mcp_coverage_gate.py
+++ b/tests/e2e-prod/mcp_coverage_gate.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""MCP tool coverage gate.
+
+Every tool the deployed MCP server advertises must be exercised by the e2e-prod
+suite, or the gate fails — so a tool that ships without a test is caught the same
+way an unexercised /v1 operation is caught by coverage_gate.py.
+
+This is the MCP analogue of coverage_gate.py, with one deliberate difference:
+
+  coverage_gate.py takes its denominator from a REPO FILE (api/openapi.yaml,
+  which is itself drift-gated against the server).
+
+  This gate takes its denominator from the DEPLOYED SERVER — whatever it
+  advertised on `tools/list` during the run, captured by harness/mcp-coverage.ts.
+
+There is no drift-gated catalog file for MCP tools, so grepping
+mcp/src/tools/*.ts for registerTool() would measure the repo rather than the
+thing under test, and would go quietly wrong the moment a tool is registered
+conditionally or gated behind a tier. The server's own advertisement is the only
+honest catalog: what a real MCP client can see is exactly what we are
+accountable for testing.
+
+Inputs:
+  - reports/mcp-coverage/*.json : shards written by harness/mcp-coverage.ts, each
+    {"advertised": [...tool names...], "covered": [...tool names...]}.
+
+"Covered" means a `tools/call` returned a result with isError !== true, i.e. the
+tool actually ran — not merely that it was probed with a rejected request.
+
+Usage: python3 mcp_coverage_gate.py [--reports DIR]
+Exit 0 = every advertised tool covered (or allowlisted); 1 = coverage gap;
+2 = usage/IO error (including "no shards", which must never read as a pass).
+"""
+import argparse
+import glob
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+# Tools the black-box suite intentionally does NOT exercise, with the reason.
+# Keep this SHORT and justified — every entry is coverage we knowingly forgo.
+ALLOWLIST: dict[str, str] = {}
+
+
+def load_shards(reports_dir: str) -> tuple[set[str], set[str], int]:
+    advertised: set[str] = set()
+    covered: set[str] = set()
+    paths = sorted(glob.glob(os.path.join(reports_dir, "*.json")))
+    for path in paths:
+        with open(path, encoding="utf-8") as fh:
+            shard = json.load(fh)
+        # Tolerate a bare-list shard shape defensively, but the recorder always
+        # writes the object form.
+        if isinstance(shard, dict):
+            advertised.update(shard.get("advertised") or [])
+            covered.update(shard.get("covered") or [])
+    return advertised, covered, len(paths)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--reports", default=os.path.join(HERE, "reports", "mcp-coverage"))
+    args = ap.parse_args()
+
+    if not os.path.isdir(args.reports):
+        print(
+            f"mcp_coverage_gate: no shard directory at {args.reports}. "
+            "Run the suite first (`npm test`); an absent run is not a pass.",
+            file=sys.stderr,
+        )
+        return 2
+
+    advertised, covered, shard_count = load_shards(args.reports)
+
+    if shard_count == 0 or not advertised:
+        # Without a denominator there is nothing to verify. Failing loudly here is
+        # the whole point: a silent 0-of-0 "pass" would hide a broken harness.
+        print(
+            "mcp_coverage_gate: no tools/list denominator was recorded. "
+            "At least one suite must call tools/list against the deployed server.",
+            file=sys.stderr,
+        )
+        return 2
+
+    # An allowlist entry that no longer names an advertised tool is a silent hole
+    # (e.g. the tool was renamed) — fail loudly so the allowlist can't drift stale.
+    stale = set(ALLOWLIST) - advertised
+    if stale:
+        print(
+            f"mcp_coverage_gate: allowlist entries the server does not advertise "
+            f"(renamed/removed?): {sorted(stale)}",
+            file=sys.stderr,
+        )
+        return 2
+
+    # A covered tool the server never advertised means the recorder and the
+    # catalog disagree — report it, but it cannot mask a real gap.
+    unadvertised = sorted(covered - advertised)
+
+    missing = advertised - covered
+    allowlisted = missing & set(ALLOWLIST)
+    uncovered = sorted(missing - set(ALLOWLIST))
+
+    print(f"Shards             : {shard_count}")
+    print(f"Advertised tools   : {len(advertised)}")
+    print(f"Covered            : {len(covered & advertised)}")
+    print(f"Allowlisted        : {len(allowlisted)} " + (str(sorted(allowlisted)) if allowlisted else ""))
+    if unadvertised:
+        print(f"Called but not advertised: {unadvertised}")
+
+    if uncovered:
+        print(f"\nUNCOVERED ({len(uncovered)}):", file=sys.stderr)
+        for name in uncovered:
+            print(f"  {name}", file=sys.stderr)
+        print(
+            "\nEvery advertised MCP tool needs a suite that calls it successfully. "
+            "Add a test, or add an ALLOWLIST entry with a justification.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("\nPASS: every advertised MCP tool is exercised.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/e2e-prod/package.json
+++ b/tests/e2e-prod/package.json
@@ -4,10 +4,11 @@
   "type": "module",
   "scripts": {
     "smoke": "node smoke.ts",
-    "pretest": "rm -rf reports/coverage",
+    "pretest": "rm -rf reports/coverage reports/mcp-coverage",
     "test": "node --test --test-concurrency=1 --test-reporter=spec suites/*.test.ts",
     "test:unit": "node --test harness/*.test.ts",
     "coverage:gate": "python3 coverage_gate.py",
+    "coverage:gate:mcp": "python3 mcp_coverage_gate.py",
     "coverage": "npm test; npm run coverage:gate",
     "typecheck": "tsc --noEmit"
   },

--- a/tests/e2e-prod/suites/26-mcp-webhooks.test.ts
+++ b/tests/e2e-prod/suites/26-mcp-webhooks.test.ts
@@ -1,0 +1,451 @@
+import { test, before, after, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient } from "../harness/client.ts";
+import { cleanup, track } from "../harness/cleanup.ts";
+import { HttpMcpClient, callTool, type McpToolResult } from "../harness/mcp.ts";
+import { isEventsLogDisabled } from "../harness/event-capability.ts";
+import { uniqueSlug, uniqueSubject } from "../harness/fixtures.ts";
+import { fail, info, writeReport } from "../harness/report.ts";
+
+// Black-box MCP conformance for the webhooks + events tool surface (11 tools)
+// against the DEPLOYED streamable-HTTP /mcp server. This is the MCP analogue
+// of suites 16-webhooks.test.ts (REST webhook CRUD) and 21-webhook-events.test.ts
+// (REST event emission) — same domain, same server-side semantics, but every
+// call here goes through tools/call so the mcp_coverage_gate.py recorder
+// credits the tool.
+//
+// Tools exercised (exactly 11, per the coverage batch):
+//   create_webhook, get_webhook, list_webhooks, update_webhook, delete_webhook,
+//   rotate_webhook_secret, test_webhook, list_webhook_deliveries,
+//   list_events, get_event, redeliver_event
+//
+// Shapes verified against mcp/src/tools/webhooks.ts + events.ts (the MCP tool
+// registrations) and cross-checked against the REST WebhookView/EventView
+// shapes in 16-webhooks.test.ts / 21-webhook-events.test.ts — the MCP layer's
+// toMcpOutput() snake-cases the SDK's camelCase fields back to the same REST
+// vocabulary, so the JSON text content matches those interfaces field-for-field.
+//
+// Coverage note: `test_webhook` delivers a REAL synthetic event to the
+// configured URL (bypassing filter matching); we do not depend on an external
+// request-bin sink — the dummy https://example.com target 404/405s the POST,
+// which still proves the delivery ATTEMPT ran (asserted via
+// list_webhook_deliveries), matching the "assert the API's own response plus
+// the resulting delivery record" guidance rather than requiring a 2xx from a
+// sink we don't control.
+//
+// `redeliver_event` needs a prior delivered event to replay honestly, so this
+// suite drives one real email.sent emission (no HITL hold, real send to the
+// SES simulator) exactly like 21-webhook-events.test.ts, then replays THAT
+// event. The event-log capability probe + skip semantics are copied verbatim
+// from harness/event-capability.ts (501 + events_log_disabled ONLY) — no
+// looser skip is invented, and a capability-disabled target legitimately
+// leaves list_events/get_event/redeliver_event uncovered rather than faking it.
+const SUITE = "26-mcp-webhooks";
+const apiClient = new ApiClient();
+const mcp = new HttpMcpClient(apiClient.env.mcpUrl, apiClient.env.apiKey);
+
+const SIMULATOR = "success@simulator.amazonses.com";
+
+interface WebhookView {
+  id: string;
+  url: string;
+  description?: string;
+  events: string[];
+  filters?: Record<string, unknown>;
+  enabled: boolean;
+  created_at: string;
+  last_delivered_at?: string;
+  auto_disabled_at?: string;
+  signing_secret?: string;
+}
+interface ListWebhooksResult {
+  webhooks: WebhookView[];
+  next_cursor?: string;
+}
+interface DeleteWebhookResult {
+  deleted: boolean;
+  id: string;
+}
+interface RotateSecretResult {
+  signing_secret: string;
+  previous_secret_expires_at: string;
+}
+interface TestWebhookResult {
+  delivery_id: string;
+}
+interface WebhookDeliveryView {
+  id: string;
+  type: string;
+  status: string;
+  attempts: number;
+  next_retry_at?: string;
+  created_at: string;
+  last_status_code?: number;
+  last_error?: string;
+}
+interface ListWebhookDeliveriesResult {
+  deliveries: WebhookDeliveryView[];
+  next_cursor?: string;
+}
+interface EventView {
+  id: string;
+  type: string;
+  schema_version: string;
+  created_at: string;
+  status: string;
+  data: Record<string, unknown>;
+  agent_email?: string;
+  message_id?: string;
+  delivery_status?: { matched_webhooks?: number };
+}
+interface ListEventsResult {
+  events: EventView[];
+  next_cursor?: string;
+}
+interface RedeliverResult {
+  event_id: string;
+  status: string;
+  delivery_id?: string;
+  webhook_id?: string;
+  deliveries?: Array<{ webhook_id?: string; delivery_id?: string; status?: string }>;
+}
+interface SendResult {
+  status?: string;
+  message_id?: string;
+}
+
+const REQUIRED_TOOLS = [
+  "create_webhook",
+  "get_webhook",
+  "list_webhooks",
+  "update_webhook",
+  "delete_webhook",
+  "rotate_webhook_secret",
+  "test_webhook",
+  "list_webhook_deliveries",
+  "list_events",
+  "get_event",
+  "redeliver_event",
+];
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function extractText(r: McpToolResult): string {
+  return r.content?.find((c) => c.type === "text")?.text ?? "";
+}
+
+function parseOk<T>(r: McpToolResult, label: string): T {
+  assert.equal(r.isError, undefined, `${label} isError: ${extractText(r).slice(0, 300)}`);
+  const text = extractText(r);
+  assert.ok(text, `${label} returned text content`);
+  return JSON.parse(text) as T;
+}
+
+async function deleteHook(id: string): Promise<void> {
+  // Best-effort: the delete_webhook happy path is asserted explicitly in the
+  // CRUD test, which already deletes the hook — this is only a cleanup net
+  // for tests that create a hook and exit early on assertion failure.
+  await callTool(mcp, "delete_webhook", { id, confirm: true }).catch(() => {});
+}
+
+async function createAgent(label: string): Promise<string> {
+  const slug = uniqueSlug(label);
+  const c = await apiClient.post<{ email: string }>("/v1/agents", {
+    body: { email: `${slug}@${apiClient.env.sharedDomain}`, name: `mcp webhooks ${label}` },
+  });
+  if (c.status !== 201 || !c.body?.email) {
+    throw new Error(`create agent failed: ${c.status} ${c.raw.slice(0, 200)}`);
+  }
+  track("agent", c.body.email);
+  return c.body.email;
+}
+
+// pollWebhookDelivery: poll list_webhook_deliveries (via MCP) until a
+// delivery matching `match` appears, or the bounded window elapses.
+async function pollWebhookDelivery(
+  hookId: string,
+  match: (d: WebhookDeliveryView) => boolean,
+  timeoutMs = 15000,
+): Promise<WebhookDeliveryView | null> {
+  const deadline = Date.now() + timeoutMs;
+  let delay = 500;
+  while (Date.now() < deadline) {
+    const r = await callTool(mcp, "list_webhook_deliveries", { id: hookId, limit: 50 });
+    if (!r.isError) {
+      const parsed = JSON.parse(extractText(r)) as ListWebhookDeliveriesResult;
+      const found = parsed.deliveries?.find(match);
+      if (found) return found;
+    }
+    await sleep(delay);
+    delay = Math.min(Math.floor(delay * 1.5), 3000);
+  }
+  return null;
+}
+
+// pollEvent: poll list_events (via MCP) until an event matching `match`
+// appears, or the bounded window elapses. Mirrors 21-webhook-events.test.ts's
+// REST pollEvent, but driven through the MCP tool so this suite's own
+// tools/call traffic is what the coverage recorder sees.
+async function pollEvent(
+  params: { type: string; agentEmail: string; since: string },
+  match: (e: EventView) => boolean,
+  timeoutMs = 15000,
+): Promise<EventView | null> {
+  const deadline = Date.now() + timeoutMs;
+  let delay = 500;
+  while (Date.now() < deadline) {
+    const r = await callTool(mcp, "list_events", {
+      type: params.type,
+      agent_email: params.agentEmail,
+      since: params.since,
+      limit: 50,
+    });
+    if (!r.isError) {
+      const parsed = JSON.parse(extractText(r)) as ListEventsResult;
+      const found = parsed.events?.find(match);
+      if (found) return found;
+    }
+    await sleep(delay);
+    delay = Math.min(Math.floor(delay * 1.5), 3000);
+  }
+  return null;
+}
+
+before(async () => {
+  info(SUITE, "transport", `MCP over HTTP -> ${apiClient.env.mcpUrl}`);
+});
+
+afterEach(async () => {
+  await cleanup(apiClient);
+});
+
+after(async () => {
+  await mcp.stop();
+  await cleanup(apiClient);
+  writeReport(`./reports/${SUITE}.json`);
+});
+
+test("mcp-webhooks: tools/list advertises all 11 target tools", async () => {
+  const list = await mcp.call<{ tools: Array<{ name: string }> }>("tools/list");
+  const names = new Set(list.tools.map((t) => t.name));
+  const missing = REQUIRED_TOOLS.filter((n) => !names.has(n));
+  assert.deepEqual(missing, [], `deployed MCP server must advertise every target tool; missing: ${missing.join(", ")}`);
+});
+
+// create_webhook + get_webhook + list_webhooks + update_webhook +
+// rotate_webhook_secret + test_webhook + list_webhook_deliveries +
+// delete_webhook — the full webhook-subscriber CRUD round-trip over MCP.
+test("mcp-webhooks: full webhook CRUD round-trip via MCP", async () => {
+  const url = `https://example.com/e2e-mcp-webhook-${uniqueSlug("wh")}`;
+
+  // create_webhook
+  const created = await parseOk<WebhookView>(
+    await callTool(mcp, "create_webhook", {
+      url,
+      events: ["email.received", "email.sent"],
+      description: `e2e mcp ${uniqueSlug("wh")}`,
+    }),
+    "create_webhook",
+  );
+  assert.ok(created.id?.startsWith("wh_"), `create_webhook id has wh_ prefix: ${created.id}`);
+  assert.equal(created.url, url);
+  assert.deepEqual(created.events, ["email.received", "email.sent"]);
+  assert.equal(created.enabled, true, "new webhook defaults to enabled");
+  assert.ok(
+    created.signing_secret?.startsWith("whsec_"),
+    `create_webhook returns a whsec_ signing_secret: ${created.signing_secret}`,
+  );
+  const id = created.id;
+
+  try {
+    // get_webhook
+    const got = await parseOk<WebhookView>(await callTool(mcp, "get_webhook", { id }), "get_webhook");
+    assert.equal(got.id, id);
+    assert.equal(got.url, url);
+    assert.equal(got.enabled, true);
+    assert.equal(got.signing_secret, undefined, "get_webhook must NOT return signing_secret");
+
+    // list_webhooks
+    const listed = await parseOk<ListWebhooksResult>(await callTool(mcp, "list_webhooks", {}), "list_webhooks");
+    assert.ok(Array.isArray(listed.webhooks), "list_webhooks.webhooks is an array");
+    const inList = listed.webhooks.find((w) => w.id === id);
+    assert.ok(inList, `created webhook ${id} is present in list_webhooks`);
+    assert.equal(inList!.signing_secret, undefined, "list_webhooks items must NOT carry signing_secret");
+
+    // update_webhook — partial update; events is a full replace when present.
+    const updated = await parseOk<WebhookView>(
+      await callTool(mcp, "update_webhook", {
+        id,
+        description: "e2e mcp updated",
+        events: ["email.received", "email.sent", "email.failed"],
+      }),
+      "update_webhook",
+    );
+    assert.equal(updated.description, "e2e mcp updated");
+    assert.deepEqual(updated.events, ["email.received", "email.sent", "email.failed"]);
+    assert.equal(updated.enabled, true, "update_webhook left enabled untouched (not passed)");
+
+    // rotate_webhook_secret — new secret, distinct from the created one.
+    const rotated = await parseOk<RotateSecretResult>(
+      await callTool(mcp, "rotate_webhook_secret", { id }),
+      "rotate_webhook_secret",
+    );
+    assert.ok(
+      rotated.signing_secret?.startsWith("whsec_"),
+      `rotate_webhook_secret returns a whsec_ secret: ${rotated.signing_secret}`,
+    );
+    assert.notEqual(rotated.signing_secret, created.signing_secret, "rotated secret differs from the original");
+    assert.ok(
+      typeof rotated.previous_secret_expires_at === "string" && rotated.previous_secret_expires_at.length > 0,
+      "rotate_webhook_secret returns previous_secret_expires_at (grace window)",
+    );
+
+    // test_webhook — fires a synthetic event at the (unreachable, but valid
+    // HTTPS/public) target. Does not depend on the sink responding 2xx.
+    const tested = await parseOk<TestWebhookResult>(
+      await callTool(mcp, "test_webhook", { id, type: "email.received" }),
+      "test_webhook",
+    );
+    assert.ok(
+      typeof tested.delivery_id === "string" && tested.delivery_id.length > 0,
+      `test_webhook returns a delivery_id: ${tested.delivery_id}`,
+    );
+
+    // list_webhook_deliveries — the delivery test_webhook scheduled must
+    // surface here (proves the tool + the resulting delivery record, per the
+    // "don't depend on an external sink" guidance).
+    const delivery = await pollWebhookDelivery(id, (d) => d.id === tested.delivery_id);
+    assert.ok(delivery, `test_webhook's delivery ${tested.delivery_id} must appear in list_webhook_deliveries`);
+    assert.equal(delivery!.type, "email.received");
+    info(SUITE, "test_webhook", `delivery=${delivery!.id} status=${delivery!.status} attempts=${delivery!.attempts} last_status=${delivery!.last_status_code}`);
+  } finally {
+    // delete_webhook — DESTRUCTIVE; requires confirm:true.
+    const deleted = await parseOk<DeleteWebhookResult>(
+      await callTool(mcp, "delete_webhook", { id, confirm: true }),
+      "delete_webhook",
+    );
+    assert.equal(deleted.deleted, true, "delete_webhook returns deleted:true");
+    assert.equal(deleted.id, id, "delete_webhook echoes the webhook id");
+
+    // Confirm it is actually gone.
+    const gone = await callTool(mcp, "get_webhook", { id });
+    if (!gone.isError) {
+      fail(SUITE, "delete-webhook-not-gone", `get_webhook still succeeds for deleted ${id}`);
+    }
+  }
+});
+
+// delete_webhook without confirm:true must be rejected by the tool's own
+// guard (never reaches the API) — a cheap extra proof the destructive guard
+// works, using a throwaway hook so the CRUD test above stays the sole owner
+// of the "real" delete path.
+test("mcp-webhooks: delete_webhook without confirm:true is rejected", async () => {
+  const url = `https://example.com/e2e-mcp-webhook-${uniqueSlug("whguard")}`;
+  const created = await parseOk<WebhookView>(
+    await callTool(mcp, "create_webhook", { url, events: ["email.received"] }),
+    "create_webhook (guard fixture)",
+  );
+  try {
+    const r = await callTool(mcp, "delete_webhook", { id: created.id, confirm: false });
+    assert.equal(r.isError, true, "delete_webhook must reject confirm:false");
+  } finally {
+    await deleteHook(created.id);
+  }
+});
+
+// list_events + get_event + redeliver_event — driven by one real email.sent
+// emission (no HITL hold, real send to the SES simulator), exactly the
+// trigger 21-webhook-events.test.ts uses on the REST side. The event-log
+// capability probe below is copied verbatim from that suite: skip ONLY on
+// the exact 501 events_log_disabled signal, never on a looser heuristic, and
+// never treat a connectivity failure as a skip.
+let eventsSkip: string | false = false;
+try {
+  const probe = await apiClient.get("/v1/events", { query: { limit: 1 } });
+  if (isEventsLogDisabled(probe.status, probe.body)) {
+    eventsSkip = "event-log capability disabled on this target (events_log_disabled)";
+  }
+} catch {
+  // Probe couldn't reach the target — do NOT skip; let the tests run and
+  // surface the real connectivity error instead of masking an outage.
+}
+
+test(
+  "mcp-webhooks: list_events / get_event / redeliver_event round-trip via a real send",
+  { skip: eventsSkip },
+  async () => {
+    const email = await createAgent("mcpev");
+    const url = `https://example.com/e2e-mcp-webhook-events-${uniqueSlug("wh")}`;
+    const hook = await parseOk<WebhookView>(
+      await callTool(mcp, "create_webhook", { url, events: ["email.sent"] }),
+      "create_webhook (events fixture)",
+    );
+    const since = new Date(Date.now() - 5000).toISOString();
+    try {
+      // Real (no-hold) send to the SES simulator, exactly like
+      // 21-webhook-events.test.ts's email.sent emission test.
+      const send = await apiClient.post<SendResult>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
+        body: { to: [SIMULATOR], subject: uniqueSubject("mcp emit sent"), text: "real send via MCP events suite" },
+      });
+      assert.equal(send.status, 202, `real send expected 202 accepted, got ${send.status}: ${send.raw.slice(0, 200)}`);
+      assert.equal(send.body?.status, "accepted", "no-hold agent send is accepted for async delivery");
+      const messageId = send.body!.message_id!;
+      assert.ok(messageId?.startsWith("msg_"), "send returns a msg_ id");
+
+      // list_events (via MCP), filtered — polled until the emitted event lands.
+      const ev = await pollEvent({ type: "email.sent", agentEmail: email, since }, (e) =>
+        e.message_id === messageId || e.data.message_id === messageId,
+      );
+      assert.ok(ev, `email.sent event for ${messageId} must appear via list_events within 15s`);
+      assert.ok(ev!.id?.startsWith("evt_"), `event id has evt_ prefix: ${ev!.id}`);
+      assert.equal(ev!.type, "email.sent");
+      assert.equal(ev!.agent_email, email, "event.agent_email is the sending agent");
+
+      // get_event — single-event fetch by id.
+      const got = await parseOk<EventView>(await callTool(mcp, "get_event", { event_id: ev!.id }), "get_event");
+      assert.equal(got.id, ev!.id, "get_event echoes the requested id");
+      assert.equal(got.type, "email.sent");
+
+      // Nonexistent event id -> isError.
+      const missGet = await callTool(mcp, "get_event", { event_id: `evt_nonexistent_${Date.now()}` });
+      if (!missGet.isError) {
+        fail(SUITE, "get-event-bogus-not-error", "get_event with a nonexistent id did not surface as error");
+      }
+
+      // redeliver_event — replay to our fresh webhook by id. Uses the SAME
+      // envelope id as the original (documented, non-dedup-safe replay
+      // semantics); we only assert the tool's own response shape plus the
+      // resulting delivery record, not a receiver-side outcome.
+      const redelivered = await parseOk<RedeliverResult>(
+        await callTool(mcp, "redeliver_event", { event_id: ev!.id, webhook_id: hook.id }),
+        "redeliver_event",
+      );
+      assert.equal(redelivered.event_id, ev!.id, "redeliver_event echoes the event id");
+      assert.ok(
+        typeof redelivered.status === "string" && redelivered.status.length > 0,
+        "redeliver_event returns a status",
+      );
+      const newDeliveryIds = [
+        redelivered.delivery_id,
+        ...(redelivered.deliveries ?? []).map((d) => d.delivery_id),
+      ].filter((x): x is string => typeof x === "string" && x.length > 0);
+      assert.ok(newDeliveryIds.length >= 1, `redeliver_event returns at least one delivery id: ${JSON.stringify(redelivered)}`);
+
+      const requeued = await pollWebhookDelivery(hook.id, (d) => newDeliveryIds.includes(d.id));
+      assert.ok(requeued, `redelivered delivery ${newDeliveryIds[0]} must appear in list_webhook_deliveries`);
+      info(
+        SUITE,
+        "redeliver_event",
+        `event=${ev!.id} webhook=${hook.id} -> delivery=${requeued!.id} status=${requeued!.status} attempts=${requeued!.attempts}`,
+      );
+
+      // Nonexistent event id -> isError.
+      const missRedeliver = await callTool(mcp, "redeliver_event", { event_id: `evt_nonexistent_${Date.now()}` });
+      if (!missRedeliver.isError) {
+        fail(SUITE, "redeliver-event-bogus-not-error", "redeliver_event with a nonexistent id did not surface as error");
+      }
+    } finally {
+      await deleteHook(hook.id);
+    }
+  },
+);


### PR DESCRIPTION
## Summary
- Adds `tests/e2e-prod/suites/26-mcp-webhooks.test.ts`, one of four parallel batches closing the MCP tool coverage gap measured by `mcp_coverage_gate.py` / `harness/mcp-coverage.ts` (introduced in #main via the `test/mcp-coverage-gate` branch this PR is stacked on).
- Exercises exactly 11 tools through the deployed streamable-HTTP `/mcp` server: `create_webhook`, `get_webhook`, `list_webhooks`, `update_webhook`, `delete_webhook`, `rotate_webhook_secret`, `test_webhook`, `list_webhook_deliveries`, `list_events`, `get_event`, `redeliver_event`.
- `test_webhook` is proven via its own response plus the resulting `list_webhook_deliveries` record — no external request-bin sink required (uses `https://example.com/...` as a dummy-but-valid HTTPS target).
- `redeliver_event` replays a real `email.sent` emission, triggered the same way `suites/21-webhook-events.test.ts` does on the REST side (no HITL hold, real send to the SES simulator).
- The `events_log_disabled` skip check for `list_events`/`get_event`/`redeliver_event` is reused verbatim from `harness/event-capability.ts` — no looser skip invented.

## Test plan
- [x] `npm run typecheck` in `tests/e2e-prod` — clean.
- [x] `node --test --test-concurrency=1 --test-reporter=spec suites/26-mcp-webhooks.test.ts` against staging — 4/4 pass, 0 skipped.
- [x] `python3 mcp_coverage_gate.py` — Covered=11, Advertised=60; none of the 11 target tools appear in the UNCOVERED list (gate still exits 1 overall since the other 3 parallel batches aren't merged yet — expected).
- [x] Verified no leftover agents/webhooks on the staging account after the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)