### PR TITLE
test(e2e-prod): MCP coverage for domains + pending-review-queue tools

### DIFF
--- a/tests/e2e-prod/harness/mcp-coverage.ts
+++ b/tests/e2e-prod/harness/mcp-coverage.ts
@@ -1,0 +1,61 @@
+import { writeFileSync, mkdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+// MCP tool-coverage recorder — the MCP analogue of coverage.ts, which does the
+// same job for the typed /v1 OpenAPI operations.
+//
+// The denominator is NOT derived from source. It is whatever the DEPLOYED server
+// advertises on `tools/list`, captured live during the run. Grepping
+// mcp/src/tools/*.ts for registerTool() would measure the repo instead of the
+// thing under test, and would silently drift the moment a tool is registered
+// conditionally, renamed, or gated behind a tier. The server's own advertisement
+// is the only honest catalog: whatever a real MCP client can see is exactly what
+// the suite is accountable for.
+//
+// A tool counts as covered only when a `tools/call` returned a result with
+// isError !== true. An error result means the tool's handler rejected — the same
+// reasoning as coverage.ts recording only 2xx: a rejected call proves the route
+// exists, not that the tool works.
+//
+// Shards live in reports/mcp-coverage/ — a separate subdir from the API
+// recorder's reports/coverage/ so the two gates can never read each other's
+// files, and neither collides with the per-suite {findings} JSONs in reports/.
+const MCP_COVERAGE_DIR = fileURLToPath(new URL("../reports/mcp-coverage/", import.meta.url));
+
+const covered = new Set<string>();
+const advertised = new Set<string>();
+let installed = false;
+
+function installFlush(): void {
+  if (installed) return;
+  installed = true;
+  // Sync flush on 'exit', matching coverage.ts. 'exit' does not fire on
+  // SIGKILL, so a force-killed suite contributes no shard and its tools read
+  // UNCOVERED — a safe false-FAIL, never a false-PASS, because `pretest` clears
+  // the directory so no stale shard can mask the loss.
+  process.on("exit", () => {
+    if (covered.size === 0 && advertised.size === 0) return;
+    try {
+      mkdirSync(MCP_COVERAGE_DIR, { recursive: true });
+      writeFileSync(
+        `${MCP_COVERAGE_DIR}${process.pid}.json`,
+        JSON.stringify({ advertised: [...advertised], covered: [...covered] }),
+      );
+    } catch {
+      /* best-effort: coverage is advisory and must never fail a suite */
+    }
+  });
+}
+
+/** Record the live tool catalog the server advertised on `tools/list`. */
+export function recordToolList(names: readonly string[]): void {
+  for (const n of names) advertised.add(n);
+  installFlush();
+}
+
+/** Record one `tools/call`. Only a non-error result counts as covered. */
+export function recordToolCall(name: string, isError: boolean | undefined): void {
+  if (isError === true) return;
+  covered.add(name);
+  installFlush();
+}

--- a/tests/e2e-prod/harness/mcp.ts
+++ b/tests/e2e-prod/harness/mcp.ts
@@ -1,8 +1,34 @@
+import { recordToolCall, recordToolList } from "./mcp-coverage.ts";
+
 interface JsonRpcRequest {
   jsonrpc: "2.0";
   id: number;
   method: string;
   params?: unknown;
+}
+
+// Feed the MCP tool-coverage recorder from the single JSON-RPC choke point, so
+// coverage is recorded whether a suite goes through callTool() or calls
+// `mcp.call("tools/call", …)` directly. Never throws: coverage is advisory and
+// must not be able to fail a suite.
+function recordMcpResult(method: string, params: unknown, result: unknown): void {
+  try {
+    if (method === "tools/list") {
+      const tools = (result as { tools?: Array<{ name?: string }> })?.tools;
+      if (Array.isArray(tools)) {
+        recordToolList(tools.map((t) => t?.name).filter((n): n is string => typeof n === "string"));
+      }
+      return;
+    }
+    if (method === "tools/call") {
+      const name = (params as { name?: string })?.name;
+      if (typeof name === "string") {
+        recordToolCall(name, (result as { isError?: boolean })?.isError);
+      }
+    }
+  } catch {
+    /* advisory only */
+  }
 }
 
 interface JsonRpcResponse<T = unknown> {
@@ -82,6 +108,7 @@ export class HttpMcpClient implements McpRpcClient {
     if (env.error) {
       throw new Error(`MCP ${method} error ${env.error.code}: ${env.error.message}`);
     }
+    recordMcpResult(method, params, env.result);
     return env.result as T;
   }
 

--- a/tests/e2e-prod/mcp_coverage_gate.py
+++ b/tests/e2e-prod/mcp_coverage_gate.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""MCP tool coverage gate.
+
+Every tool the deployed MCP server advertises must be exercised by the e2e-prod
+suite, or the gate fails — so a tool that ships without a test is caught the same
+way an unexercised /v1 operation is caught by coverage_gate.py.
+
+This is the MCP analogue of coverage_gate.py, with one deliberate difference:
+
+  coverage_gate.py takes its denominator from a REPO FILE (api/openapi.yaml,
+  which is itself drift-gated against the server).
+
+  This gate takes its denominator from the DEPLOYED SERVER — whatever it
+  advertised on `tools/list` during the run, captured by harness/mcp-coverage.ts.
+
+There is no drift-gated catalog file for MCP tools, so grepping
+mcp/src/tools/*.ts for registerTool() would measure the repo rather than the
+thing under test, and would go quietly wrong the moment a tool is registered
+conditionally or gated behind a tier. The server's own advertisement is the only
+honest catalog: what a real MCP client can see is exactly what we are
+accountable for testing.
+
+Inputs:
+  - reports/mcp-coverage/*.json : shards written by harness/mcp-coverage.ts, each
+    {"advertised": [...tool names...], "covered": [...tool names...]}.
+
+"Covered" means a `tools/call` returned a result with isError !== true, i.e. the
+tool actually ran — not merely that it was probed with a rejected request.
+
+Usage: python3 mcp_coverage_gate.py [--reports DIR]
+Exit 0 = every advertised tool covered (or allowlisted); 1 = coverage gap;
+2 = usage/IO error (including "no shards", which must never read as a pass).
+"""
+import argparse
+import glob
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+# Tools the black-box suite intentionally does NOT exercise, with the reason.
+# Keep this SHORT and justified — every entry is coverage we knowingly forgo.
+ALLOWLIST: dict[str, str] = {}
+
+
+def load_shards(reports_dir: str) -> tuple[set[str], set[str], int]:
+    advertised: set[str] = set()
+    covered: set[str] = set()
+    paths = sorted(glob.glob(os.path.join(reports_dir, "*.json")))
+    for path in paths:
+        with open(path, encoding="utf-8") as fh:
+            shard = json.load(fh)
+        # Tolerate a bare-list shard shape defensively, but the recorder always
+        # writes the object form.
+        if isinstance(shard, dict):
+            advertised.update(shard.get("advertised") or [])
+            covered.update(shard.get("covered") or [])
+    return advertised, covered, len(paths)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--reports", default=os.path.join(HERE, "reports", "mcp-coverage"))
+    args = ap.parse_args()
+
+    if not os.path.isdir(args.reports):
+        print(
+            f"mcp_coverage_gate: no shard directory at {args.reports}. "
+            "Run the suite first (`npm test`); an absent run is not a pass.",
+            file=sys.stderr,
+        )
+        return 2
+
+    advertised, covered, shard_count = load_shards(args.reports)
+
+    if shard_count == 0 or not advertised:
+        # Without a denominator there is nothing to verify. Failing loudly here is
+        # the whole point: a silent 0-of-0 "pass" would hide a broken harness.
+        print(
+            "mcp_coverage_gate: no tools/list denominator was recorded. "
+            "At least one suite must call tools/list against the deployed server.",
+            file=sys.stderr,
+        )
+        return 2
+
+    # An allowlist entry that no longer names an advertised tool is a silent hole
+    # (e.g. the tool was renamed) — fail loudly so the allowlist can't drift stale.
+    stale = set(ALLOWLIST) - advertised
+    if stale:
+        print(
+            f"mcp_coverage_gate: allowlist entries the server does not advertise "
+            f"(renamed/removed?): {sorted(stale)}",
+            file=sys.stderr,
+        )
+        return 2
+
+    # A covered tool the server never advertised means the recorder and the
+    # catalog disagree — report it, but it cannot mask a real gap.
+    unadvertised = sorted(covered - advertised)
+
+    missing = advertised - covered
+    allowlisted = missing & set(ALLOWLIST)
+    uncovered = sorted(missing - set(ALLOWLIST))
+
+    print(f"Shards             : {shard_count}")
+    print(f"Advertised tools   : {len(advertised)}")
+    print(f"Covered            : {len(covered & advertised)}")
+    print(f"Allowlisted        : {len(allowlisted)} " + (str(sorted(allowlisted)) if allowlisted else ""))
+    if unadvertised:
+        print(f"Called but not advertised: {unadvertised}")
+
+    if uncovered:
+        print(f"\nUNCOVERED ({len(uncovered)}):", file=sys.stderr)
+        for name in uncovered:
+            print(f"  {name}", file=sys.stderr)
+        print(
+            "\nEvery advertised MCP tool needs a suite that calls it successfully. "
+            "Add a test, or add an ALLOWLIST entry with a justification.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("\nPASS: every advertised MCP tool is exercised.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/e2e-prod/package.json
+++ b/tests/e2e-prod/package.json
@@ -4,10 +4,11 @@
   "type": "module",
   "scripts": {
     "smoke": "node smoke.ts",
-    "pretest": "rm -rf reports/coverage",
+    "pretest": "rm -rf reports/coverage reports/mcp-coverage",
     "test": "node --test --test-concurrency=1 --test-reporter=spec suites/*.test.ts",
     "test:unit": "node --test harness/*.test.ts",
     "coverage:gate": "python3 coverage_gate.py",
+    "coverage:gate:mcp": "python3 mcp_coverage_gate.py",
     "coverage": "npm test; npm run coverage:gate",
     "typecheck": "tsc --noEmit"
   },

--- a/tests/e2e-prod/suites/28-mcp-domains-reviews.test.ts
+++ b/tests/e2e-prod/suites/28-mcp-domains-reviews.test.ts
@@ -1,0 +1,219 @@
+import { test, before, after, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient } from "../harness/client.ts";
+import { cleanup, track, untrack } from "../harness/cleanup.ts";
+import { HttpMcpClient, callTool } from "../harness/mcp.ts";
+import { uniqueSlug, uniqueSubject, runId, SINK_EMAIL, holdAllOutbound } from "../harness/fixtures.ts";
+import { fail, info, warn, writeReport } from "../harness/report.ts";
+
+// MCP coverage for the domains tool family (register_domain, get_domain,
+// list_domains, verify_domain, delete_domain) and the pending-review-queue
+// legacy alias family (approve_message, reject_message, get_pending_message,
+// list_pending_messages — deprecated aliases that all route through the same
+// unified review queue as approve_review/reject_review/get_review/list_reviews,
+// see mcp/src/tools/legacy.ts). Both families are exercised over the deployed
+// streamable-HTTP /mcp server, mirroring suites/12-mcp-extended.test.ts style.
+const apiClient = new ApiClient();
+const SUITE = "28-mcp-domains-reviews";
+const mcp = new HttpMcpClient(apiClient.env.mcpUrl, apiClient.env.apiKey);
+
+// .example.com is reserved by RFC 2606 for documentation/testing — safe to
+// register-then-never-publish-DNS without colliding with anything real. Same
+// convention as suites/10-domains.test.ts.
+function fakeDomain(label: string): string {
+  return `e2e-${runId()}-${label}-${Math.random().toString(36).slice(2, 8)}.example.com`;
+}
+
+function extractText(r: { content?: Array<{ type: string; text?: string }> }): string {
+  return r.content?.find((c) => c.type === "text")?.text ?? "";
+}
+
+before(async () => {
+  info(SUITE, "transport", `MCP over HTTP → ${apiClient.env.mcpUrl}`);
+});
+
+afterEach(async () => {
+  const r = await cleanup(apiClient);
+  if (r.failed.length) warn(SUITE, "cleanup-after-each", `failed ${r.failed.length}`, r.failed);
+});
+
+after(async () => {
+  await mcp.stop();
+  const r = await cleanup(apiClient);
+  if (r.failed.length) warn(SUITE, "cleanup", `failed ${r.failed.length}`, r.failed);
+  writeReport(`./reports/28-mcp-domains-reviews.json`);
+});
+
+// createHeldReview: throwaway shared-domain agent -> hold-all-outbound ->
+// send. Returns the agent email + the held message id. Mirrors
+// suites/18-reviews.test.ts's createHeldReview / suites/12-mcp-extended.test.ts's
+// ensureHitlAgent — the proven mechanism for landing a message in
+// pending_review that the review/pending-message MCP tools can then act on.
+// Caller MUST delete the agent (via track("agent", email) + cleanup, or
+// explicitly) once done.
+async function createHeldReview(label: string): Promise<{ email: string; id: string; subject: string }> {
+  const slug = uniqueSlug(label);
+  const c = await apiClient.post<{ email: string }>("/v1/agents", {
+    body: { email: `${slug}@${apiClient.env.sharedDomain}`, name: `mcp-dr ${label}` },
+  });
+  if (c.status !== 201) throw new Error(`create agent failed: ${c.status} ${c.raw.slice(0, 200)}`);
+  const email = c.body!.email;
+  track("agent", email);
+  const u = await holdAllOutbound(apiClient, email);
+  if (u.status !== 200) throw new Error(`hold-all-outbound failed: ${u.status} ${u.raw.slice(0, 200)}`);
+  const subject = uniqueSubject(`mcp-dr ${label}`);
+  const s = await apiClient.post<{ message_id: string; status: string }>(
+    `/v1/agents/${encodeURIComponent(email)}/messages`,
+    { body: { to: [SINK_EMAIL], subject, text: "held for review via MCP — must never actually go out" } },
+  );
+  if (s.status !== 202 || !s.body?.message_id) {
+    throw new Error(`held send expected 202 pending_review, got ${s.status}: ${s.raw.slice(0, 200)}`);
+  }
+  assert.equal(s.body.status, "pending_review", "held send status is pending_review");
+  return { email, id: s.body.message_id, subject };
+}
+
+test("mcp-domains: register_domain / get_domain / list_domains / verify_domain (negative control) / delete_domain", async () => {
+  // Call tools/list once so the coverage gate records the live denominator
+  // (harness/mcp.ts feeds mcp-coverage.ts from this same JSON-RPC call).
+  const list = await mcp.call<{ tools: Array<{ name: string }> }>("tools/list");
+  for (const name of [
+    "register_domain",
+    "get_domain",
+    "list_domains",
+    "verify_domain",
+    "delete_domain",
+    "approve_message",
+    "reject_message",
+    "get_pending_message",
+    "list_pending_messages",
+  ]) {
+    assert.ok(list.tools.some((t) => t.name === name), `deployed server must advertise ${name}`);
+  }
+
+  const domain = fakeDomain("mcpdom");
+
+  // register_domain — step 1 of the custom-domain flow. Track immediately so
+  // the afterEach/after cleanup net catches it even if a later assertion in
+  // this test throws (free-plan account: 1 domain total, must not leak it).
+  const reg = await callTool(mcp, "register_domain", { domain });
+  if (reg.isError) {
+    fail(SUITE, "register-domain-error", `register_domain isError: ${extractText(reg).slice(0, 200)}`);
+    return;
+  }
+  track("domain", domain);
+  const regParsed = JSON.parse(extractText(reg)) as {
+    domain?: string;
+    dns_records?: Array<{ type: string; purpose: string }>;
+    verified?: boolean;
+  };
+  assert.equal(regParsed.domain, domain, "register_domain echoes the requested domain");
+  assert.ok(Array.isArray(regParsed.dns_records) && regParsed.dns_records.length > 0, "register_domain returns dns_records to publish");
+  assert.equal(regParsed.verified, false, "a freshly-registered domain starts unverified");
+
+  // get_domain — poll target, single-domain read.
+  const got = await callTool(mcp, "get_domain", { domain });
+  assert.equal(got.isError, undefined, `get_domain isError: ${extractText(got).slice(0, 200)}`);
+  const gotParsed = JSON.parse(extractText(got)) as { domain?: string; verified?: boolean };
+  assert.equal(gotParsed.domain, domain, "get_domain returns the same domain we registered");
+
+  // list_domains — assert OUR domain is present by name. No account-global
+  // count assertion: other suites/agents may share this account.
+  const listed = await callTool(mcp, "list_domains", {});
+  assert.equal(listed.isError, undefined, `list_domains isError: ${extractText(listed).slice(0, 200)}`);
+  const listedParsed = JSON.parse(extractText(listed)) as { domains?: Array<{ domain: string }> };
+  assert.ok(
+    listedParsed.domains?.some((d) => d.domain === domain),
+    `list_domains must include our freshly-registered ${domain}`,
+  );
+
+  // verify_domain — NEGATIVE CONTROL. We deliberately never publish the DNS
+  // records for this .example.com domain, so this must report verified:false
+  // as a NORMAL 200-equivalent success (not isError) — the honest way to
+  // cover verify_domain here per the task brief: calling it on a domain
+  // whose DNS IS published would either hang forever or (if it isn't yet
+  // propagated) negative-cache the miss for up to the zone's SOA minimum
+  // (~30min), which no in-test poll can outlast. This also guards against a
+  // dev-mode DNS short-circuit tautology (suites/22-domain-lifecycle.test.ts
+  // runs the equivalent REST-side negative control).
+  const verify = await callTool(mcp, "verify_domain", { domain });
+  assert.equal(verify.isError, undefined, `verify_domain (negative control) must be a normal success, not isError: ${extractText(verify).slice(0, 200)}`);
+  const verifyParsed = JSON.parse(extractText(verify)) as { domain?: string; verified?: boolean };
+  assert.equal(verifyParsed.domain, domain, "verify_domain echoes the domain");
+  assert.equal(verifyParsed.verified, false, "unpublished-DNS domain must report verified:false, not a DNS/dev-mode short-circuit");
+
+  // delete_domain — DESTRUCTIVE, requires confirm:true (schema-level literal
+  // guard against an LLM hallucinating a delete). No agents were ever
+  // created on this domain (it never verified), so no domain_has_agents risk.
+  const del = await callTool(mcp, "delete_domain", { domain, confirm: true });
+  assert.equal(del.isError, undefined, `delete_domain isError: ${extractText(del).slice(0, 200)}`);
+  const delParsed = JSON.parse(extractText(del)) as { deleted?: boolean; domain?: string };
+  assert.equal(delParsed.deleted, true, "delete_domain result has deleted:true");
+  assert.equal(delParsed.domain, domain, "delete_domain result echoes the domain");
+  // Already deleted via the tool call above — untrack so the redundant
+  // afterEach cleanup DELETE (which would 404, itself harmless) is skipped.
+  untrack("domain", domain);
+});
+
+test("mcp-domains-reviews: list_pending_messages + get_pending_message + approve_message round-trip", async () => {
+  const { email, id, subject } = await createHeldReview("approve");
+  try {
+    // list_pending_messages — deprecated alias for list_reviews; walks every
+    // page of the unified account-level review queue and returns the
+    // historical {messages: [...]} envelope. Assert OUR held message is
+    // present by id, not an account-global count.
+    const listed = await callTool(mcp, "list_pending_messages", {});
+    assert.equal(listed.isError, undefined, `list_pending_messages isError: ${extractText(listed).slice(0, 200)}`);
+    const listedParsed = JSON.parse(extractText(listed)) as { messages?: Array<{ id?: string }> };
+    assert.ok(
+      listedParsed.messages?.some((m) => m.id === id),
+      `list_pending_messages must include our held message ${id}`,
+    );
+
+    // get_pending_message — deprecated alias for get_review; full detail.
+    const got = await callTool(mcp, "get_pending_message", { message_id: id });
+    assert.equal(got.isError, undefined, `get_pending_message isError: ${extractText(got).slice(0, 200)}`);
+    const gotParsed = JSON.parse(extractText(got)) as { id?: string; review_status?: string; subject?: string };
+    assert.equal(gotParsed.id, id, "get_pending_message returns the same message id");
+    assert.equal(gotParsed.review_status, "pending_review", "held message is still pending_review before approval");
+    assert.equal(gotParsed.subject, subject, "get_pending_message echoes the held subject");
+
+    // approve_message — deprecated alias for approve_review; releases the
+    // outbound hold for async send (queued, not necessarily synchronous).
+    const approved = await callTool(mcp, "approve_message", { message_id: id });
+    assert.equal(approved.isError, undefined, `approve_message isError: ${extractText(approved).slice(0, 200)}`);
+    const approvedParsed = JSON.parse(extractText(approved)) as { message_id?: string; status?: string };
+    assert.equal(approvedParsed.message_id, id, "approve_message result echoes the approved message id");
+    assert.ok(
+      approvedParsed.status === "accepted" || approvedParsed.status === "sent",
+      `approve_message must transition to accepted/sent, got "${approvedParsed.status}"`,
+    );
+
+    // Re-approve a resolved hold must surface as a terminal-state tool error.
+    const reapproved = await callTool(mcp, "approve_message", { message_id: id });
+    assert.equal(reapproved.isError, true, "re-approve of an already-resolved message must isError");
+  } finally {
+    // Agent delete cascades to its held/sent messages; explicit and tracked
+    // regardless so a mid-test throw still gets cleaned up.
+    await apiClient.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE`);
+    untrack("agent", email);
+  }
+});
+
+test("mcp-domains-reviews: reject_message discards the held draft", async () => {
+  const { email, id } = await createHeldReview("reject");
+  try {
+    const rejected = await callTool(mcp, "reject_message", { message_id: id, reason: "e2e mcp-domains-reviews reject" });
+    assert.equal(rejected.isError, undefined, `reject_message isError: ${extractText(rejected).slice(0, 200)}`);
+    const rejectedParsed = JSON.parse(extractText(rejected)) as { message_id?: string; status?: string };
+    assert.equal(rejectedParsed.message_id, id, "reject_message result echoes the rejected message id");
+    assert.equal(rejectedParsed.status, "review_rejected", "reject_message transitions the hold to review_rejected");
+
+    // Re-reject a resolved hold must surface as a terminal-state tool error.
+    const rereject = await callTool(mcp, "reject_message", { message_id: id, reason: "should fail" });
+    assert.equal(rereject.isError, true, "re-reject of an already-resolved message must isError");
+  } finally {
+    await apiClient.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE`);
+    untrack("agent", email);
+  }
+});


### PR DESCRIPTION
## Summary
- Adds `tests/e2e-prod/suites/28-mcp-domains-reviews.test.ts`, closing MCP coverage-gate gaps for the domains tool family and the pending-review-queue legacy alias family: `register_domain`, `get_domain`, `list_domains`, `verify_domain`, `delete_domain`, `approve_message`, `reject_message`, `get_pending_message`, `list_pending_messages`.
- Domain flow uses one `.example.com` fixture (free-plan 1-domain budget): register → get → list (presence check, not count) → `verify_domain` **negative control** (DNS deliberately never published — `verified:false` asserted as a normal success, not a live-DNS poll that risks the ~30min SOA negative-cache) → `delete_domain` (schema `confirm:true` guard).
- The pending-message tools are deprecated aliases that route through the same unified review queue as `approve_review`/`reject_review` (`mcp/src/tools/legacy.ts`). Reuses the hold-all-outbound + send mechanism from `suites/18-reviews.test.ts` to produce a real `pending_review` hold, then exercises list/get/approve in one round trip and reject in a second.
- Agents are always deleted before their domain (explicit delete + `untrack`, with `cleanup.ts`'s reversed-order tracking as a backup net).

Branches off `test/mcp-tools-domains-reviews`'s base, `test/mcp-coverage-gate` (adds `mcp_coverage_gate.py` + `harness/mcp-coverage.ts`), which is not yet merged — this PR's diff includes both commits until that lands.

## Test plan
- [x] `npm run typecheck` in `tests/e2e-prod` — clean
- [x] `node --test --test-concurrency=1 --test-reporter=spec suites/28-mcp-domains-reviews.test.ts` against staging — 3/3 pass
- [x] `python3 mcp_coverage_gate.py` — confirmed all 9 target tools appear in `covered`, none in `UNCOVERED` (gate still exits 1 overall: the other 3 parallel coverage batches — messaging/templates/webhooks/etc. — aren't merged yet, which is expected per the task)
- [x] Post-run account check: 0 leaked domains, 0 leaked agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)