### PR TITLE
fix(web): default feedback email to signed-in user, drop the field

### DIFF
--- a/web/src/app/(app)/feedback/page.test.tsx
+++ b/web/src/app/(app)/feedback/page.test.tsx
@@ -2,23 +2,61 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import FeedbackPage from "./page";
 
+let mockAuth: {
+  user: { id: string; email: string; name: string; created_at: string } | null;
+  loading: boolean;
+  signOut: jest.Mock;
+  setUser: jest.Mock;
+};
+
+jest.mock("../../components/AuthProvider", () => ({
+  useAuth: () => mockAuth,
+}));
+
 const mockFetch = jest.fn();
 global.fetch = mockFetch;
 
 beforeEach(() => {
   mockFetch.mockReset();
+  mockAuth = {
+    user: {
+      id: "usr_abc123",
+      email: "alice@example.com",
+      name: "Alice",
+      created_at: "2026-04-01T10:00:00Z",
+    },
+    loading: false,
+    signOut: jest.fn(),
+    setUser: jest.fn(),
+  };
 });
 
 describe("Feedback page", () => {
   it("renders form with all elements", () => {
     render(<FeedbackPage />);
     expect(screen.getByText("Send us feedback")).toBeInTheDocument();
-    expect(screen.getByPlaceholderText("you@example.com")).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("you@example.com")).not.toBeInTheDocument();
     expect(screen.getByPlaceholderText("What's on your mind?")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Bug report" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Feature request" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "General" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Submit feedback" })).toBeDisabled();
+  });
+
+  it("submits with the signed-in user's email, no email field shown", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ status: "ok" }) });
+    const user = userEvent.setup();
+    render(<FeedbackPage />);
+    await user.type(screen.getByPlaceholderText("What's on your mind?"), "Great product!");
+    await user.click(screen.getByRole("button", { name: "Submit feedback" }));
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/feedback",
+        expect.objectContaining({
+          body: JSON.stringify({ email: "alice@example.com", category: "general", message: "Great product!" }),
+        }),
+      );
+    });
   });
 
   it("enables submit when message is entered", async () => {

--- a/web/src/app/(app)/feedback/page.tsx
+++ b/web/src/app/(app)/feedback/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { FEEDBACK_EMAIL } from "../../../lib/site";
 import { PageShell } from "../../components/loft/PageShell";
+import { useAuth } from "../../components/AuthProvider";
 
 // Restyled to match the rest of the app — PageShell wrapping, accent
 // selected category, canopy submit CTA, the Loft input + button rhythm
@@ -12,7 +13,7 @@ import { PageShell } from "../../components/loft/PageShell";
 // passing across visual tweaks.
 
 export default function FeedbackPage() {
-  const [email, setEmail] = useState("");
+  const { user } = useAuth();
   const [category, setCategory] = useState<"bug" | "feature" | "general">("general");
   const [message, setMessage] = useState("");
   const [status, setStatus] = useState<"idle" | "sending" | "sent" | "error" | "rate-limited">("idle");
@@ -27,12 +28,11 @@ export default function FeedbackPage() {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         credentials: "include",
-        body: JSON.stringify({ email: email || undefined, category, message }),
+        body: JSON.stringify({ email: user?.email || undefined, category, message }),
       });
       if (res.ok) {
         setStatus("sent");
         setMessage("");
-        setEmail("");
       } else if (res.status === 429) {
         setStatus("rate-limited");
       } else {
@@ -125,36 +125,6 @@ export default function FeedbackPage() {
       maxWidth={640}
     >
       <form onSubmit={handleSubmit} className="space-y-5">
-        <div>
-          <label
-            htmlFor="feedback-email"
-            className="block text-[13px] font-medium mb-1.5"
-            style={{ color: "var(--fg)" }}
-          >
-            Email{" "}
-            <span
-              className="font-normal"
-              style={{ color: "var(--fg-muted)" }}
-            >
-              (optional, if you want a reply)
-            </span>
-          </label>
-          <input
-            id="feedback-email"
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            placeholder="you@example.com"
-            className="w-full text-[13px] px-3 py-2"
-            style={{
-              background: "var(--bg-panel)",
-              border: "1px solid var(--border)",
-              borderRadius: "var(--r-md)",
-              color: "var(--fg)",
-            }}
-          />
-        </div>
-
         <div>
           <label
             className="block text-[13px] font-medium mb-1.5"


### PR DESCRIPTION
## Summary
- The web feedback form asked users to type their email even though they're already signed in. It now uses the authenticated user's email automatically and drops the manual input.

## Operational risk
None — UI-only change, no API/data model impact. Falls back to omitting the email if the auth session hasn't loaded yet (same behavior as leaving the old field blank).

## Test plan
- [x] `npx jest feedback` (web) — updated to mock `AuthProvider` and assert the submitted payload carries the signed-in user's email with no email input rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)