### PR TITLE
test(logredact): scope the subject-log guard to the repo's own files

### DIFF
--- a/internal/logredact/logguard_test.go
+++ b/internal/logredact/logguard_test.go
@@ -2,6 +2,7 @@ package logredact
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -66,35 +67,17 @@ func TestNoSubjectContentInLogFormats(t *testing.T) {
 	root := moduleRoot(t)
 
 	checked := 0
-	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
-			// Only Go source can call log; skip trees that never hold it.
-			switch d.Name() {
-			case ".git", "node_modules", "vendor", "web", "sdks", "docs":
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
-			return nil
-		}
-		rel, relErr := filepath.Rel(root, path)
-		if relErr != nil {
-			return relErr
-		}
-		raw, readErr := os.ReadFile(path)
+	for _, rel := range guardedGoFiles(t, root) {
+		raw, readErr := os.ReadFile(filepath.Join(root, filepath.FromSlash(rel)))
 		if readErr != nil {
-			return readErr
+			t.Fatalf("read %s: %v", rel, readErr)
 		}
 		checked++
 		if !subjectContentPattern.Match(raw) {
-			return nil
+			continue
 		}
-		if _, ok := subjectLogPatternAllowlist[filepath.ToSlash(rel)]; ok {
-			return nil
+		if _, ok := subjectLogPatternAllowlist[rel]; ok {
+			continue
 		}
 		for i, line := range strings.Split(string(raw), "\n") {
 			if subjectLogViolation(line) {
@@ -106,13 +89,9 @@ func TestNoSubjectContentInLogFormats(t *testing.T) {
 					rel, i+1, strings.TrimSpace(line))
 			}
 		}
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("walk module source: %v", err)
 	}
 	if checked == 0 {
-		t.Fatal("scanned no Go source files — the module-root discovery or the walk is wrong")
+		t.Fatal("scanned no Go source files — the module-root discovery or the file listing is wrong")
 	}
 
 	// Prune the allowlist when a file stops carrying the pattern, so it stays
@@ -175,6 +154,76 @@ func TestSubjectLogViolationDiscrimination(t *testing.T) {
 			t.Errorf("guard false-positived on a non-log line: %s", line)
 		}
 	}
+}
+
+// guardedGoFiles returns the module-relative, non-test Go sources this guard
+// must check: the ones git TRACKS.
+//
+// Walking the filesystem instead scans whatever happens to sit under the module
+// root. This repo's worktree workflow puts checked-out branches in
+// .claude/worktrees/ and .worktrees/ (both gitignored), which added 5,548 .go
+// files against 550 tracked — and the guard then reported OTHER branches' code
+// as violations of this working tree. CI never caught it because a fresh
+// checkout has no worktrees, so it only ever failed locally, for every agent
+// using a worktree.
+//
+// Tracked files are also the correct scope on the merits: the rule governs
+// COMMITTED source. Falls back to a filesystem walk where git is unavailable
+// (source tarball, no VCS), there skipping nested checkouts by their .git marker.
+func guardedGoFiles(t *testing.T, root string) []string {
+	t.Helper()
+
+	// --cached --others --exclude-standard: tracked files PLUS untracked ones that
+	// are not gitignored. Tracked alone would miss a violation in a brand-new file
+	// the author has not committed yet; --exclude-standard is what drops the
+	// gitignored worktree trees.
+	if out, err := exec.Command("git", "-C", root, "ls-files", "-z",
+		"--cached", "--others", "--exclude-standard", "*.go").Output(); err == nil {
+		var files []string
+		seen := map[string]bool{}
+		for _, rel := range strings.Split(string(out), "\x00") {
+			if rel == "" || strings.HasSuffix(rel, "_test.go") || seen[rel] {
+				continue
+			}
+			seen[rel] = true
+			files = append(files, rel)
+		}
+		return files
+	}
+
+	var files []string
+	if err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			// Only Go source can call log; skip trees that never hold it.
+			switch d.Name() {
+			case ".git", "node_modules", "vendor", "web", "sdks", "docs":
+				return filepath.SkipDir
+			}
+			// A nested checkout or git worktree carries its own .git entry. Its
+			// contents belong to a different tree and must not be attributed here.
+			if path != root {
+				if _, statErr := os.Stat(filepath.Join(path, ".git")); statErr == nil {
+					return filepath.SkipDir
+				}
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		files = append(files, filepath.ToSlash(rel))
+		return nil
+	}); err != nil {
+		t.Fatalf("walk module source: %v", err)
+	}
+	return files
 }
 
 // moduleRoot walks up from the test's working directory to the directory


### PR DESCRIPTION
## Summary

`TestNoSubjectContentInLogFormats` (added in #686) defined its scope as *"every `.go` file under the module root"* when it meant *"every `.go` file in this repository."* Those differ by an order of magnitude:

| | Go files |
|---|---|
| under the module root, here | **6,098** |
| in the repository | **550** |

Every violation it reported lived in that extra 91%.

## What triggered it

This repo's worktree workflow. Checked-out branches live in `.claude/worktrees/` and `.worktrees/` — both gitignored — and the walk skipped directories only by basename (`.git, node_modules, vendor, web, sdks, docs`), so it descended into all 12 present here and attributed **other branches' code** to this working tree.

The flagged sites were real but **stale**: those worktrees sit on commits predating the fix that removed the logging, so the guard was reporting history as the present.

```
main            internal/agent/api.go:  0 occurrences of subject=%q
worktree copy                        :  3
```

CI never saw this because a fresh checkout has no worktrees — so it failed only locally, deterministically, for any agent using one. I confirmed the repo itself is clean by running the guard in a pristine clone of the same commit, where it passes.

## The fix

Ask git what belongs to the tree rather than walking the filesystem:

```
git ls-files -z --cached --others --exclude-standard '*.go'
```

- `--cached` — committed source, which is what the rule governs
- `--others` — plus untracked files, so a violation in a **brand-new uncommitted file** is still caught. Tracked-only would have silently weakened the guard for the person most likely to trip it: someone adding a log line right now.
- `--exclude-standard` — honors `.gitignore`, which is what drops the worktrees

The walk survives as a **fallback** where git is unavailable (source tarball, no VCS), hardened there too: it now skips nested checkouts by their `.git` marker, so a worktree can't leak in that way either.

**Why not the two-line denylist.** Adding `.claude` and `.worktrees` to the basename list would also go green, but it's a denylist — it misses a worktree at any other path, a vendored copy, an extracted tarball, a symlinked tree. Scoping to what git considers part of the repo is definitionally correct, and it happens to cut the scan 11×.

## Verification

The real risk with a scoping change is neutering the guard — a version that passes because it scans nothing would be worse than the false positive. So both directions are covered:

| check | result |
|---|---|
| Violation injected into a **tracked** file | **caught** (`internal/ws/hub.go:145`) |
| Violation in a **new untracked** file | **caught** (`internal/ws/zz_new_violation.go:6`) |
| This worktree-polluted tree | **passes** (was failing 2/2) |
| Pristine clone of main's tip | passes |
| Fallback path, `.git` removed | passes |
| `go vet`, `make test-unit` | clean, exit 0 |

Test-only, one file.

## Broader note

This is the second phantom failure today from the same underlying condition — several agents working in one directory. The first was the shared `e2a_test` database carrying an unmerged branch's migration (see the follow-up in #687); this is stale worktrees inside the module root. Both cost real investigation time on failures unrelated to the code under test.

The common shape is tooling that reads the **filesystem** or a **shared server** instead of the **repo checkout**. Worth auditing other guards for the same assumption — and `make cover` / `make test` still hardcode the shared test database, which is the other half of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
