### PR TITLE
test(cli): close CLI command-coverage gap — 10 covered + 1 allowlisted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,5 +51,8 @@ cli/coverage/
 sdks/typescript/coverage/
 mcp/coverage/
 
+# CLI command-coverage gate shards (npm run test:e2e:coverage --workspace @e2a/cli)
+cli/test/reports/
+
 # Isolated feature worktrees.
 .worktrees/

--- a/cli/package.json
+++ b/cli/package.json
@@ -14,6 +14,8 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "vitest run --config vitest.e2e.config.ts",
+    "coverage:gate:cli": "node test/cli-coverage-gate.ts",
+    "test:e2e:coverage": "rm -rf test/reports/cli-coverage && npm run test:e2e && npm run coverage:gate:cli",
     "prepublishOnly": "npm run build"
   },
   "engines": {

--- a/cli/test/cli-coverage-gate.ts
+++ b/cli/test/cli-coverage-gate.ts
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+/**
+ * CLI command-coverage gate.
+ *
+ * Every top-level command the BUILT BINARY advertises on `--help` must be
+ * exercised (and asserted successful) by test/e2e.test.ts, or this gate
+ * fails — the CLI analogue of tests/e2e-prod/mcp_coverage_gate.py, which
+ * does the same job for MCP tools/list.
+ *
+ * SCOPE / denominator choice: the catalog comes from parsing the live
+ * `dist/bin/e2a.js --help` output (captured by test/harness/cli-coverage.ts
+ * during the e2e run), NOT from grepping cli/src/bin/e2a.ts's switch
+ * statement or its USAGE string as source text. A source grep measures the
+ * repo instead of the shipped artifact — it would go quietly wrong the
+ * moment a command's `case` and its USAGE line drift apart (either one
+ * added without the other). This is the same reasoning that caught the
+ * MCP-side drift: grepping mcp/src/tools/*.ts for registerTool() found 58
+ * tools while the deployed server actually advertised 60. The binary's own
+ * advertisement — what a real `e2a --help` invocation shows a user they can
+ * run — is the only honest catalog.
+ *
+ * Inputs:
+ *   test/reports/cli-coverage/*.json : shards written by
+ *   test/harness/cli-coverage.ts, each {"advertised": [...], "covered": [...]}.
+ *
+ * "Covered" means a suite invoked the command and asserted its OUTPUT or
+ * EXIT CODE, per test/harness/cli-coverage.ts's recordCovered() contract —
+ * not merely that the binary ran and exited without a crash.
+ *
+ * Usage: node cli-coverage-gate.ts [--reports DIR]
+ * Exit 0 = every advertised command covered (or allowlisted);
+ * Exit 1 = coverage gap;
+ * Exit 2 = usage/IO error (including "no shards", which must never read as
+ * a pass — an absent run is not a pass).
+ */
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+// Commands the black-box e2e suite intentionally does NOT drive to a
+// successful invocation, with the reason. Keep this SHORT and justified —
+// every entry is coverage we knowingly forgo.
+const ALLOWLIST: Record<string, string> = {
+  login:
+    "opens an interactive browser OAuth flow (spawns a local HTTP callback " +
+    "server and waits up to 2 minutes for a human to complete a browser " +
+    "redirect) — there is no headless way to drive it to a successful " +
+    "invocation in CI/e2e without a real browser and a human. Its " +
+    "non-interactive PREFLIGHT failure path (unreachable E2A_URL: fails " +
+    "fast with a clear error, exit 1, before opening any browser or " +
+    "blocking) IS exercised in e2e.test.ts ('login fails fast against an " +
+    "unreachable API, before opening a browser') as a defense-in-depth " +
+    "check on real code the interactive flow shares — but that is a " +
+    "failure-mode assertion, not a successful login, so per this gate's " +
+    "success-only coverage rule it does not count as 'covered'.",
+};
+
+interface Shard {
+  advertised?: string[];
+  covered?: string[];
+}
+
+function loadShards(reportsDir: string): { advertised: Set<string>; covered: Set<string>; shardCount: number } {
+  const advertised = new Set<string>();
+  const covered = new Set<string>();
+  const files = readdirSync(reportsDir)
+    .filter((f) => f.endsWith(".json"))
+    .sort();
+  for (const f of files) {
+    const raw = readFileSync(path.join(reportsDir, f), "utf8");
+    const shard = JSON.parse(raw) as Shard;
+    for (const n of shard.advertised ?? []) advertised.add(n);
+    for (const n of shard.covered ?? []) covered.add(n);
+  }
+  return { advertised, covered, shardCount: files.length };
+}
+
+function main(): number {
+  const args = process.argv.slice(2);
+  const idx = args.indexOf("--reports");
+  const reportsDir = idx !== -1 && args[idx + 1] ? args[idx + 1] : path.join(HERE, "reports", "cli-coverage");
+
+  if (!existsSync(reportsDir)) {
+    console.error(
+      `cli_coverage_gate: no shard directory at ${reportsDir}. ` +
+        "Run the e2e suite first (`npm run test:e2e --workspace @e2a/cli` against staging); " +
+        "an absent run is not a pass.",
+    );
+    return 2;
+  }
+
+  const { advertised, covered, shardCount } = loadShards(reportsDir);
+
+  if (shardCount === 0 || advertised.size === 0) {
+    console.error(
+      "cli_coverage_gate: no --help denominator was recorded. " +
+        "At least one e2e test must call `e2a --help` and record its output via recordAdvertised().",
+    );
+    return 2;
+  }
+
+  // An allowlist entry that no longer names an advertised command is a
+  // silent hole (e.g. the command was renamed/removed) — fail loudly so the
+  // allowlist can't drift stale.
+  const stale = Object.keys(ALLOWLIST).filter((name) => !advertised.has(name));
+  if (stale.length > 0) {
+    console.error(
+      `cli_coverage_gate: allowlist entries the binary does not advertise (renamed/removed?): ${JSON.stringify(stale)}`,
+    );
+    return 2;
+  }
+
+  // A covered command the binary never advertised means the recorder and
+  // the catalog disagree — report it, but it cannot mask a real gap.
+  const unadvertised = [...covered].filter((n) => !advertised.has(n)).sort();
+
+  const missing = [...advertised].filter((n) => !covered.has(n));
+  const allowlisted = missing.filter((n) => n in ALLOWLIST).sort();
+  const uncovered = missing.filter((n) => !(n in ALLOWLIST)).sort();
+
+  console.log(`Shards             : ${shardCount}`);
+  console.log(`Advertised commands: ${advertised.size} ${JSON.stringify([...advertised].sort())}`);
+  console.log(`Covered            : ${[...covered].filter((n) => advertised.has(n)).length}`);
+  console.log(`Allowlisted        : ${allowlisted.length} ${allowlisted.length ? JSON.stringify(allowlisted) : ""}`);
+  if (unadvertised.length > 0) {
+    console.log(`Called but not advertised: ${JSON.stringify(unadvertised)}`);
+  }
+
+  if (uncovered.length > 0) {
+    console.error(`\nUNCOVERED (${uncovered.length}):`);
+    for (const name of uncovered) console.error(`  ${name}`);
+    console.error(
+      "\nEvery advertised e2a command needs an e2e test that invokes it and asserts a real " +
+        "success (output or exit code). Add a test, or add an ALLOWLIST entry with a justification.",
+    );
+    return 1;
+  }
+
+  console.log("\nPASS: every advertised e2a command is exercised.");
+  return 0;
+}
+
+process.exit(main());

--- a/cli/test/e2e.test.ts
+++ b/cli/test/e2e.test.ts
@@ -18,8 +18,9 @@
  *   E2A_SHARED_DOMAIN   shared domain for throwaway agents (e.g. agents-staging.e2a.dev)
  */
 import { describe, it, expect, afterAll } from "vitest";
-import { spawnSync } from "node:child_process";
+import { spawnSync, spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import { parseHelpCommands, recordAdvertised, recordCovered, flushCliCoverage } from "./harness/cli-coverage.js";
 
 const CLI = fileURLToPath(new URL("../dist/bin/e2a.js", import.meta.url));
 
@@ -54,6 +55,32 @@ function run(args: string[], extra: Record<string, string> = {}): Run {
   return { code: r.status ?? -1, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
 }
 
+// Async counterpart to run(), for commands that must be started and left
+// running WHILE another `run()` call happens concurrently (only `listen`
+// needs this — every other command is a single synchronous request/response
+// round-trip). Same VITEST_* stripping as run(); see its comment above for
+// why that stripping is load-bearing.
+function runAsync(args: string[], extra: Record<string, string> = {}): Promise<Run> {
+  const env: Record<string, string | undefined> = {
+    ...process.env,
+    E2A_URL: URL_,
+    E2A_API_KEY: KEY,
+    HOME: "/tmp/e2a-cli-e2e-home",
+    ...extra,
+  };
+  delete env.VITEST_WORKER_ID;
+  delete env.VITEST;
+  delete env.VITEST_POOL_ID;
+  return new Promise((resolve) => {
+    const child = spawn("node", [CLI, ...args], { env });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => (stdout += d));
+    child.stderr.on("data", (d) => (stderr += d));
+    child.on("close", (code) => resolve({ code: code ?? -1, stdout, stderr }));
+  });
+}
+
 const sleep = (ms: number) => new Promise((res) => setTimeout(res, ms));
 
 // The CLI can't delete agents; clean up created inboxes over the API.
@@ -67,15 +94,51 @@ async function apiDeleteAgent(email: string): Promise<void> {
 const createdAgents: string[] = [];
 afterAll(async () => {
   for (const a of createdAgents) await apiDeleteAgent(a);
+  // Explicit flush: this suite runs inside a vitest worker, whose 'exit'
+  // lifecycle (the recorder's best-effort fallback) is not guaranteed to
+  // line up with the outer vitest process — see cli-coverage.ts. Calling
+  // this here, unconditionally, is what actually gets the shard written for
+  // `npm run coverage:gate:cli` to read.
+  flushCliCoverage();
 });
 
 describe.skipIf(!live)("cli live parity", () => {
+  // Coverage-gate denominator. Parses the command catalog from the REAL
+  // built binary's `--help` stdout — not from grepping cli/src/bin/e2a.ts's
+  // switch statement or USAGE string as source text — so the gate measures
+  // what a user invoking `e2a --help` actually sees they can run. See
+  // test/harness/cli-coverage.ts and test/cli-coverage-gate.ts for the full
+  // rationale (mirrors the MCP tools/list coverage gate's reasoning).
+  it("--help advertises the full command catalog (denominator for the coverage gate)", () => {
+    const r = run(["--help"]);
+    expect(r.code, r.stderr).toBe(0);
+    const commands = parseHelpCommands(r.stdout);
+    // Pinned so a CLI surface change (command added/removed/renamed) fails
+    // loudly and specifically HERE, not just as a silent shift in the gate's
+    // total — a human reviewing this diff should see exactly what changed.
+    expect(commands).toEqual([
+      "agents",
+      "config",
+      "doctor",
+      "keys",
+      "listen",
+      "login",
+      "messages",
+      "protection",
+      "reply",
+      "send",
+      "whoami",
+    ]);
+    recordAdvertised(commands);
+  });
+
   it("whoami --json → identity (exit 0)", () => {
     const r = run(["whoami", "--json"]);
     expect(r.code, r.stderr).toBe(0);
     const j = JSON.parse(r.stdout);
     expect(j.user?.email).toBeTruthy();
     expect(j.scope).toBe("account");
+    recordCovered("whoami");
   });
 
   it("agents create → get → list, then send → messages list (self loopback)", async () => {
@@ -93,12 +156,15 @@ describe.skipIf(!live)("cli live parity", () => {
     const list = run(["agents", "list", "--json"]);
     expect(list.code, list.stderr).toBe(0);
     expect(list.stdout).toContain(bot);
+    recordCovered("agents");
 
     // Send self→self on the fresh (unprotected) inbox: delivers + loops back.
     const subject = `cli-live ${Date.now()}`;
     const sent = run(["send", "--agent", bot, "--to", bot, "--subject", subject, "--body", "hi from cli e2e", "--json"]);
     expect(sent.code, sent.stderr).toBe(0); // 3 would mean HELD; a fresh inbox is unprotected
-    expect(JSON.parse(sent.stdout).messageId).toBeTruthy();
+    const sentId = JSON.parse(sent.stdout).messageId;
+    expect(sentId).toBeTruthy();
+    recordCovered("send");
 
     // Poll messages list until the loopback lands (NDJSON, one row per line).
     let rows: string[] = [];
@@ -116,6 +182,47 @@ describe.skipIf(!live)("cli live parity", () => {
     const gotMsg = run(["messages", "get", firstId, "--agent", bot, "--json"]);
     expect(gotMsg.code, gotMsg.stderr).toBe(0);
     expect(JSON.parse(gotMsg.stdout).subject).toBe(subject);
+
+    // `messages lifecycle` real depth check (bonus — the coverage gate only
+    // requires the top-level `messages` command, already satisfied by
+    // list/get above, but this exercises the third subcommand for real).
+    const lifecycle = run(["messages", "lifecycle", sentId, "--agent", bot, "--json"]);
+    expect(lifecycle.code, lifecycle.stderr).toBe(0);
+    const lifecycleJson = JSON.parse(lifecycle.stdout);
+    expect(Array.isArray(lifecycleJson.items)).toBe(true);
+    expect(lifecycleJson.items.length).toBeGreaterThan(0);
+    recordCovered("messages");
+  }, 40_000);
+
+  it("reply threads a reply onto an inbound message (exit 0)", async () => {
+    const bot = `cli-live-reply-${Date.now().toString(36)}@${DOMAIN}`;
+    const created = run(["agents", "create", bot, "--name", "cli live reply e2e", "--json"]);
+    expect(created.code, created.stderr).toBe(0);
+    createdAgents.push(bot);
+
+    const subject = `cli-live-reply ${Date.now()}`;
+    const sent = run(["send", "--agent", bot, "--to", bot, "--subject", subject, "--body", "hi from cli e2e reply setup", "--json"]);
+    expect(sent.code, sent.stderr).toBe(0);
+
+    // Poll for the inbound loopback copy to reply to (need a real received
+    // message id — replying to our own outbound send id is not the same
+    // in-thread operation `e2a reply` is documented to perform).
+    let inboundId = "";
+    for (let i = 0; i < 12 && !inboundId; i++) {
+      const ml = run(["messages", "list", "--agent", bot, "--limit", "20", "--json"]);
+      expect(ml.code, ml.stderr).toBe(0);
+      const rows = ml.stdout.split("\n").filter((l) => l.trim().length > 0);
+      if (rows.length > 0) inboundId = JSON.parse(rows[0]).id ?? JSON.parse(rows[0]).messageId;
+      else await sleep(1500);
+    }
+    expect(inboundId, "the loopback message must appear before replying to it").toBeTruthy();
+
+    const replied = run(["reply", inboundId, "--agent", bot, "--body", "hi from cli e2e reply", "--json"]);
+    expect(replied.code, replied.stderr).toBe(0);
+    const replyResult = JSON.parse(replied.stdout);
+    expect(replyResult.messageId).toBeTruthy();
+    expect(replyResult.status).not.toBe("pending_review");
+    recordCovered("reply");
   }, 40_000);
 
   it("keys create → list → delete (exit 0 each)", () => {
@@ -131,10 +238,150 @@ describe.skipIf(!live)("cli live parity", () => {
 
       const del = run(["keys", "delete", keyId]);
       expect(del.code, del.stderr).toBe(0);
+      recordCovered("keys");
     } finally {
       // Guarantee the key never lingers on staging even if an assertion threw.
       run(["keys", "delete", keyId]);
     }
+  });
+
+  it("protection get → set → get reflects the change (throwaway agent)", () => {
+    const bot = `cli-live-protection-${Date.now().toString(36)}@${DOMAIN}`;
+    const created = run(["agents", "create", bot, "--name", "cli live protection e2e", "--json"]);
+    expect(created.code, created.stderr).toBe(0);
+    createdAgents.push(bot);
+
+    const before = run(["protection", "get", bot, "--json"]);
+    expect(before.code, before.stderr).toBe(0);
+    const beforeCfg = JSON.parse(before.stdout);
+    // A fresh agent starts with outbound review off (gate action "flag").
+    expect(beforeCfg.outbound.gate.action).toBe("flag");
+
+    const setOn = run(["protection", "set", bot, "--outbound-review", "on", "--json"]);
+    expect(setOn.code, setOn.stderr).toBe(0);
+    const setOnCfg = JSON.parse(setOn.stdout);
+    expect(setOnCfg.outbound.gate.action).toBe("review");
+
+    const after = run(["protection", "get", bot, "--json"]);
+    expect(after.code, after.stderr).toBe(0);
+    expect(JSON.parse(after.stdout).outbound.gate.action).toBe("review");
+
+    // Restore, so a later probe against this (soon-deleted) agent doesn't
+    // trip on a held send.
+    const setOff = run(["protection", "set", bot, "--outbound-review", "off", "--json"]);
+    expect(setOff.code, setOff.stderr).toBe(0);
+    recordCovered("protection");
+  });
+
+  it("doctor: healthy (0), warnings-only (8), and config failure (9) exit codes", () => {
+    // Healthy: valid creds, a real agent, no custom domains/webhooks
+    // registered on this dedicated account → every check is pass or a
+    // benign skip, no warn/fail anywhere.
+    const healthy = run(["doctor", "--json"]);
+    const healthyReport = JSON.parse(healthy.stdout);
+    expect(healthy.code, healthy.stderr).toBe(healthyReport.exit_code);
+    expect(healthy.code, JSON.stringify(healthyReport, null, 2)).toBe(0);
+    expect(healthyReport.schema).toBe("e2a.doctor/v1");
+    expect(healthyReport.status).toBe("healthy");
+    const agentCheck = healthyReport.checks.find((c: { id: string }) => c.id === "agent.access");
+    expect(agentCheck?.status).toBe("pass");
+
+    // Warnings-only (8): force the ONE warn-producing, side-effect-free
+    // client-side condition doctor has — a partially-configured
+    // E2A_OUTBOUND_SMTP_* environment (host without from_domain) — with
+    // nothing else in a fail/auth/config state, so the exit-code priority
+    // (auth > config > transient > warn) lands on WARN.
+    const warn = run(["doctor", "--json"], { E2A_OUTBOUND_SMTP_HOST: "smtp.example.com" });
+    const warnReport = JSON.parse(warn.stdout);
+    expect(warn.code, warn.stderr).toBe(8);
+    expect(warnReport.exit_code).toBe(8);
+    expect(warnReport.status).toBe("warnings");
+    const smtpCheck = warnReport.checks.find((c: { id: string }) => c.id === "smtp.config");
+    expect(smtpCheck?.status).toBe("warn");
+    expect(smtpCheck?.reason_code).toBe("smtp_partial");
+
+    // Definite configuration failure (9): a nonexistent agent is a config
+    // problem, not a network one — read-only (GET only), no fixture needed.
+    const bogusAgent = `cli-live-doctor-missing-${Date.now().toString(36)}@${DOMAIN}`;
+    const fail = run(["doctor", "--agent", bogusAgent, "--json"]);
+    const failReport = JSON.parse(fail.stdout);
+    expect(fail.code, fail.stderr).toBe(9);
+    expect(failReport.exit_code).toBe(9);
+    expect(failReport.status).toBe("failed");
+    const failedCheck = failReport.checks.find((c: { id: string }) => c.id === "agent.access");
+    expect(failedCheck?.status).toBe("fail");
+    expect(failedCheck?.reason_code).toBe("agent_not_found");
+
+    recordCovered("doctor");
+  });
+
+  it("config: list/get/set round-trip against an isolated HOME", () => {
+    // A HOME distinct from every other test's shared /tmp/e2a-cli-e2e-home,
+    // so a written config.json can't leak into (or be clobbered by) any
+    // other test in this file.
+    const configHome = `/tmp/e2a-cli-e2e-config-home-${Date.now()}`;
+    // E2A_AGENT_EMAIL overrides the file on read (cli/src/config.ts) — unset
+    // it (empty string beats the shell-inherited value) so `config get`
+    // proves the FILE round-trip, not the environment shadowing it.
+    const noAgentEnvOverride = { HOME: configHome, E2A_AGENT_EMAIL: "" };
+
+    const list = run(["config", "list"], noAgentEnvOverride);
+    expect(list.code, list.stderr).toBe(0);
+    for (const key of ["api_key=", "api_url=", "agent_email=", "shared_domain=", "key_scope="]) {
+      expect(list.stdout).toContain(key);
+    }
+
+    const value = `cli-live-config-${Date.now().toString(36)}@example.com`;
+    const set = run(["config", "set", "agent_email", value], noAgentEnvOverride);
+    expect(set.code, set.stderr).toBe(0);
+    expect(set.stdout.trim()).toBe(`agent_email=${value}`);
+
+    const get = run(["config", "get", "agent_email"], noAgentEnvOverride);
+    expect(get.code, get.stderr).toBe(0);
+    expect(get.stdout.trim()).toBe(value);
+
+    recordCovered("config");
+  });
+
+  it("listen --once streams a real inbound loopback message, then exits 0", async () => {
+    const bot = `cli-live-listen-${Date.now().toString(36)}@${DOMAIN}`;
+    const created = run(["agents", "create", bot, "--name", "cli live listen e2e", "--json"]);
+    expect(created.code, created.stderr).toBe(0);
+    createdAgents.push(bot);
+
+    const until = new Date(Date.now() + 20_000).toISOString();
+    const listening = runAsync(["listen", "--once", "--agent", bot, "--until", until, "--json"]);
+
+    // Give the WebSocket a moment to connect before the message is sent —
+    // listen must be observing BEFORE the send, or it would only prove
+    // --once's own poll-on-connect fallback rather than the live stream.
+    await sleep(2000);
+    const subject = `cli-live-listen ${Date.now()}`;
+    const sent = run(["send", "--agent", bot, "--to", bot, "--subject", subject, "--body", "hi from cli e2e listen", "--json"]);
+    expect(sent.code, sent.stderr).toBe(0);
+
+    const result = await listening;
+    expect(result.code, result.stderr).toBe(0); // 6 would mean TIMEOUT — no message observed
+    const notification = JSON.parse(result.stdout);
+    expect(notification.subject).toBe(subject);
+    // Documented side effect: --once with --json fetches the message over
+    // the API GET, which marks it read.
+    expect(notification.readStatus).toBe("read");
+
+    recordCovered("listen");
+  }, 30_000);
+
+  it("login fails fast against an unreachable API, before opening a browser (exit 1)", () => {
+    // `login`'s interactive browser-OAuth success path cannot be driven
+    // headlessly (see cli-coverage-gate.ts's ALLOWLIST entry for the full
+    // justification) — this asserts the real preflight failure mode instead:
+    // an unreachable E2A_URL must abort BEFORE the local callback server
+    // opens or any browser launches, not hang for the 2-minute login timeout.
+    const r = run(["login"], { E2A_URL: "https://nonexistent-host-e2a-cli-e2e-test.invalid" });
+    expect(r.code, r.stdout).toBe(1);
+    expect(r.stderr).toContain("could not reach");
+    // Deliberately NOT recordCovered("login") — this proves the failure
+    // mode, not a successful login. `login` stays allowlisted.
   });
 
   it("honors the frozen exit-code contract (usage=2, auth=4)", () => {

--- a/cli/test/harness/cli-coverage.ts
+++ b/cli/test/harness/cli-coverage.ts
@@ -1,0 +1,103 @@
+import { writeFileSync, mkdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+// CLI command-coverage recorder — the CLI analogue of
+// tests/e2e-prod/harness/mcp-coverage.ts, which does the same job for MCP
+// tools/list.
+//
+// The denominator is NOT derived from source (grepping bin/e2a.ts's switch
+// statement, or its USAGE string, from a file on disk). It is whatever the
+// BUILT BINARY advertises on `--help` when actually invoked — captured live
+// during the e2e run by parseHelpCommands() below, from the real stdout of a
+// spawned `dist/bin/e2a.js --help`. This mirrors the exact reasoning that
+// caught the MCP-side drift (58 grepped vs 60 advertised): the binary's own
+// advertisement is the only honest catalog, because it's exactly what a real
+// user invoking `e2a --help` sees they can run — a source grep can drift the
+// moment a command is documented without being wired (or vice versa).
+//
+// A command counts as covered only when an invocation of it returned a
+// *documented success* — not merely that the binary ran and exited zero on
+// some incidental usage. Callers decide this per test and call
+// recordCovered() only after asserting real output/behavior, exactly as
+// suites call recordToolCall() only after checking `isError !== true`.
+//
+// Shards live in test/reports/cli-coverage/ — analogous to
+// tests/e2e-prod/reports/mcp-coverage/, kept out of cli/coverage/ (the
+// Vitest --coverage output dir) so the two can never collide.
+const CLI_COVERAGE_DIR = fileURLToPath(new URL("../reports/cli-coverage/", import.meta.url));
+
+const covered = new Set<string>();
+const advertised = new Set<string>();
+let installed = false;
+
+/** Write the shard now. Safe to call more than once (idempotent overwrite). */
+function flush(): void {
+  if (covered.size === 0 && advertised.size === 0) return;
+  try {
+    mkdirSync(CLI_COVERAGE_DIR, { recursive: true });
+    writeFileSync(
+      `${CLI_COVERAGE_DIR}${process.pid}.json`,
+      JSON.stringify({ advertised: [...advertised], covered: [...covered] }),
+    );
+  } catch {
+    /* best-effort: coverage is advisory and must never fail a suite */
+  }
+}
+
+function installFlush(): void {
+  if (installed) return;
+  installed = true;
+  // Best-effort net for a plain `node --test`-style consumer (matching
+  // mcp-coverage.ts): 'exit' does not fire on SIGKILL, so a force-killed run
+  // contributes no shard and its commands read UNCOVERED — a safe
+  // false-FAIL, never a false-PASS, because the shard dir is cleared before
+  // each run (see package.json's test:e2e:coverage) so no stale shard can
+  // mask the loss.
+  //
+  // This is NOT sufficient under vitest, though: the e2e suite runs inside a
+  // worker (thread or fork) whose lifecycle 'exit' does not reliably line up
+  // with — and may never fire relative to — the outer vitest process, so
+  // e2e.test.ts also calls flushCliCoverage() explicitly from its own
+  // afterAll(). Both paths write the exact same shard shape, so whichever
+  // fires first is a no-op duplicate of whichever fires second.
+  process.on("exit", flush);
+}
+
+/** Explicit flush for runners (vitest) where 'exit' isn't a reliable hook. */
+export function flushCliCoverage(): void {
+  flush();
+}
+
+/**
+ * Parse the top-level command catalog out of `e2a --help`'s stdout.
+ *
+ * Every genuine top-level command line in USAGE (cli/src/bin/e2a.ts) is
+ * indented by EXACTLY two spaces before `e2a <command>` — e.g.
+ * "  e2a doctor [options]" or "  e2a agents create <email> [--name <n>]".
+ * Deeper-indented option/continuation lines (8+ spaces, e.g.
+ * "        --agent <email>") and the later "Options:"/"Exit codes:"
+ * sections (which reference `e2a` only inside prose, at 17+ spaces of
+ * indent, e.g. "e2a send -h — always before any network call") never match
+ * this pattern, so only real command entries are picked up. Multi-line
+ * subcommand groups (agents/keys/protection/messages each get 2-3 lines)
+ * naturally dedupe via the Set.
+ */
+export function parseHelpCommands(helpText: string): string[] {
+  const names = new Set<string>();
+  for (const m of helpText.matchAll(/^ {2}e2a (\S+)/gm)) {
+    names.add(m[1]);
+  }
+  return [...names].sort();
+}
+
+/** Record the live command catalog the binary advertised on `--help`. */
+export function recordAdvertised(names: readonly string[]): void {
+  for (const n of names) advertised.add(n);
+  installFlush();
+}
+
+/** Record one top-level command as genuinely exercised (output/exit asserted). */
+export function recordCovered(name: string): void {
+  covered.add(name);
+  installFlush();
+}

--- a/mcp/src/tools/messages.ts
+++ b/mcp/src/tools/messages.ts
@@ -2,7 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { McpClient, SendOpts } from "../client.js";
 import type { MessageView } from "@e2a/sdk/v1";
 import { z } from "zod";
-import { runTool, strictInputSchema, paginationInput } from "./util.js";
+import { runTool, strictInputSchema, paginationInput, emailSelector } from "./util.js";
 import { attachmentsArraySchema, type AttachmentInput } from "./attachments.js";
 
 // Map the snake_case attachment wire shape (filename, content_type, data)
@@ -116,12 +116,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
           .describe(
             "Stable key for retry-safe sends. Set to deduplicate when the caller has its own retry loop (e.g. a stable triggering event id). When omitted the SDK mints a fresh UUIDv4 per call — protects against network-layer retries only, not user-driven retries.",
           ),
-        email: z
-          .string()
-          .optional()
-          .describe(
-            "Sending agent's inbox. Omit to use the credential's bound agent (agent-scoped credentials).",
-          ),
+        email: emailSelector,
       }),
     },
     async (args) =>
@@ -194,7 +189,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
           .describe(
             "Stable key for retry-safe replies. A natural choice is the inbound `message_id` you're replying to — the same triggering event yields the same key, so a retry replays the original response instead of double-sending. Omit to let the SDK mint a fresh UUIDv4 per call.",
           ),
-        email: z.string().optional(),
+        email: emailSelector,
       }),
     },
     async (args) =>
@@ -263,7 +258,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
           .describe(
             "Stable key for retry-safe forwards. The inbound `message_id` plus target list is a natural choice.",
           ),
-        email: z.string().optional(),
+        email: emailSelector,
       }),
     },
     async (args) =>
@@ -313,7 +308,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
           .array(z.string())
           .optional()
           .describe("Labels to remove. Entries not on the message are no-ops."),
-        email: z.string().optional(),
+        email: emailSelector,
       }),
     },
     async (args) =>
@@ -350,7 +345,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
           .describe(
             "RFC3339 timestamp. Only conversations whose latest message is < until.",
           ),
-        email: z.string().optional(),
+        email: emailSelector,
       }),
     },
     async (args) =>
@@ -377,7 +372,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
         "Returns the full thread — aggregate counts, the participants union (sender + recipient + to + cc + bcc across members), the labels union, and every live member message in chronological order (oldest first). Returns a not-found error when no live messages exist for `(agent, conversation_id)`. Use this after `list_conversations` (or whenever you have a `conversation_id` from an inbound/outbound payload) to read the full thread.",
       inputSchema: strictInputSchema({
         conversation_id: z.string(),
-        email: z.string().optional(),
+        email: emailSelector,
       }),
     },
     async (args) =>
@@ -447,7 +442,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
           .boolean()
           .optional()
           .describe("List the message trash instead of live messages."),
-        email: z.string().optional(),
+        email: emailSelector,
       }),
     },
     async (args) =>
@@ -484,7 +479,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
         "Restore a soft-deleted message before its trash-retention window expires. Time spent in trash does not consume the message's normal retention. Returns the restored message; a live message returns `not_in_trash`.",
       inputSchema: strictInputSchema({
         message_id: z.string().describe("ID of the trashed message to restore."),
-        email: z.string().optional().describe("Owning agent; defaults to the bound agent."),
+        email: emailSelector,
       }),
     },
     async (args) => runTool(() => client.restoreMessage(args.message_id, args.email)),
@@ -499,7 +494,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
         "Move a message to the trash. It disappears from lists, threads, and reply targets, but stays restorable with `restore_message` until the trash-retention window expires (30 days by default). Permanent deletion (\"delete forever\") is deliberately NOT exposed here — use the REST API/SDK for that. A message held for review cannot be deleted (`message_held`) — resolve it in the review queue first. Requires `confirm: true` — set it explicitly to acknowledge the destructive action.",
       inputSchema: strictInputSchema({
         message_id: z.string().describe("ID of the message to move to trash."),
-        email: z.string().optional().describe("Owning agent; defaults to the bound agent."),
+        email: emailSelector,
         confirm: z
           .literal(true)
           .describe(
@@ -528,7 +523,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
         "Use after `list_messages` to read one inbound or outbound message in full; for outbound messages, this is also how you poll a send's terminal outcome. Returns text + HTML, direction, labels, delivery/review lifecycle, suspicious-message flags and protection findings, header_from, envelope_from, verified_domain, SPF/DKIM/DMARC evidence, conversation id, and attachment metadata. `truncated:true` means the inbound parser clipped the decoded body. A non-null verified_domain means DMARC passed for the RFC 5322 From domain; it does not authenticate the mailbox local part, a person, or message content. Pass the message's `id` from the list response. **Side effect:** fetching an unread inbound message marks it read — there is no peek-without-consuming and no mark-unread, so only open a message when you mean to consume it. Attachment bytes and raw MIME are intentionally omitted to protect context; the response lists each attachment's filename, content_type, 0-based `index`, and size_bytes. Call `get_attachment` with that index to fetch one file by reference.",
       inputSchema: strictInputSchema({
         message_id: z.string(),
-        email: z.string().optional(),
+        email: emailSelector,
       }),
     },
     async (args) =>
@@ -550,7 +545,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
         "Beta: returns the ordered transitions e2a observed for one persisted inbound or outbound message; the lifecycle contract may change before it is declared stable. SMTP acceptance, upstream submission, provider delivery feedback, and complaint feedback remain distinct; this does not claim inbox placement. **Cursor-paginated:** returns one page in `transitions` plus `next_cursor` only when more pages remain; pass it back as `cursor` to continue, and stop when it is absent.",
       inputSchema: strictInputSchema({
         message_id: z.string(),
-        email: z.string().optional(),
+        email: emailSelector,
         cursor: z.string().optional(),
         limit: z.number().int().min(1).max(100).optional(),
       }),
@@ -597,12 +592,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
           .describe(
             "When true, also include the bytes as base64 `data` — ONLY for attachments ≤256 KB (larger requests error). Default false: use `download_url`.",
           ),
-        email: z
-          .string()
-          .optional()
-          .describe(
-            "Agent inbox holding the message. Omit to use the credential's bound agent (agent-scoped credentials).",
-          ),
+        email: emailSelector,
       }),
     },
     async (args) =>

--- a/mcp/src/tools/util.ts
+++ b/mcp/src/tools/util.ts
@@ -139,6 +139,22 @@ export const paginationInput = {
     .describe("Max items in this page (1–100). Defaults to a server-chosen page size (100)."),
 } as const;
 
+// emailSelector is the ONE agent-selector field for every tool that acts on a
+// single agent's mailbox. The credential's scope decides whether it may be
+// omitted: an agent-scoped credential IS one agent, so the field defaults to
+// that bound agent; an account-scoped credential owns many agents and has no
+// default, so the field is REQUIRED at runtime even though the schema marks it
+// optional (the schema cannot know the credential's scope). Share this field —
+// and its wording — everywhere the selector appears so agents learn one rule,
+// not ten. Description-only contract: do NOT change the optionality; making it
+// schema-required would break agent-scoped callers that correctly omit it.
+export const emailSelector = z
+  .string()
+  .optional()
+  .describe(
+    "Owning agent's inbox (full email address). REQUIRED when the credential is account-scoped — an account-scoped credential owns many agents and has no bound agent to default to, so omitting `email` fails the call. Defaults to the bound agent for agent-scoped credentials (omit it there).",
+  );
+
 // CodedError: a wrapper-thrown error that carries a stable machine `code`
 // from the SERVER'S canonical vocabulary (e.g. "not_found") instead of the
 // blanket `invalid_request` that plain wrapper Errors map to. Use it when the

--- a/tests/e2e-prod/consolidate.ts
+++ b/tests/e2e-prod/consolidate.ts
@@ -54,3 +54,14 @@ if (bySeverity.warn.length > 0) {
 }
 console.log("=== INFO (highlights) ===");
 for (const f of bySeverity.info) console.log(`  [${f.suite}] ${f.test}: ${f.message}`);
+
+// Gate: any recorded FAIL finding fails the run. Suites deliberately record
+// several findings and keep going (fail() must not throw mid-test), so the
+// exit-code decision lives here at consolidation — the documented design is
+// "the gate MUST read the JSON". Without this, every fail() in every suite is
+// decorative: a pipeline that runs the suites and never consolidates (or
+// consolidates but ignores the exit code) reports green over real failures.
+if (bySeverity.fail.length > 0) {
+  console.error(`\nconsolidate: ${bySeverity.fail.length} FAIL finding(s) recorded — failing the run.`);
+  process.exit(1);
+}

--- a/tests/e2e-prod/harness/mcp-coverage.ts
+++ b/tests/e2e-prod/harness/mcp-coverage.ts
@@ -1,0 +1,61 @@
+import { writeFileSync, mkdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+// MCP tool-coverage recorder — the MCP analogue of coverage.ts, which does the
+// same job for the typed /v1 OpenAPI operations.
+//
+// The denominator is NOT derived from source. It is whatever the DEPLOYED server
+// advertises on `tools/list`, captured live during the run. Grepping
+// mcp/src/tools/*.ts for registerTool() would measure the repo instead of the
+// thing under test, and would silently drift the moment a tool is registered
+// conditionally, renamed, or gated behind a tier. The server's own advertisement
+// is the only honest catalog: whatever a real MCP client can see is exactly what
+// the suite is accountable for.
+//
+// A tool counts as covered only when a `tools/call` returned a result with
+// isError !== true. An error result means the tool's handler rejected — the same
+// reasoning as coverage.ts recording only 2xx: a rejected call proves the route
+// exists, not that the tool works.
+//
+// Shards live in reports/mcp-coverage/ — a separate subdir from the API
+// recorder's reports/coverage/ so the two gates can never read each other's
+// files, and neither collides with the per-suite {findings} JSONs in reports/.
+const MCP_COVERAGE_DIR = fileURLToPath(new URL("../reports/mcp-coverage/", import.meta.url));
+
+const covered = new Set<string>();
+const advertised = new Set<string>();
+let installed = false;
+
+function installFlush(): void {
+  if (installed) return;
+  installed = true;
+  // Sync flush on 'exit', matching coverage.ts. 'exit' does not fire on
+  // SIGKILL, so a force-killed suite contributes no shard and its tools read
+  // UNCOVERED — a safe false-FAIL, never a false-PASS, because `pretest` clears
+  // the directory so no stale shard can mask the loss.
+  process.on("exit", () => {
+    if (covered.size === 0 && advertised.size === 0) return;
+    try {
+      mkdirSync(MCP_COVERAGE_DIR, { recursive: true });
+      writeFileSync(
+        `${MCP_COVERAGE_DIR}${process.pid}.json`,
+        JSON.stringify({ advertised: [...advertised], covered: [...covered] }),
+      );
+    } catch {
+      /* best-effort: coverage is advisory and must never fail a suite */
+    }
+  });
+}
+
+/** Record the live tool catalog the server advertised on `tools/list`. */
+export function recordToolList(names: readonly string[]): void {
+  for (const n of names) advertised.add(n);
+  installFlush();
+}
+
+/** Record one `tools/call`. Only a non-error result counts as covered. */
+export function recordToolCall(name: string, isError: boolean | undefined): void {
+  if (isError === true) return;
+  covered.add(name);
+  installFlush();
+}

--- a/tests/e2e-prod/harness/mcp.ts
+++ b/tests/e2e-prod/harness/mcp.ts
@@ -1,8 +1,34 @@
+import { recordToolCall, recordToolList } from "./mcp-coverage.ts";
+
 interface JsonRpcRequest {
   jsonrpc: "2.0";
   id: number;
   method: string;
   params?: unknown;
+}
+
+// Feed the MCP tool-coverage recorder from the single JSON-RPC choke point, so
+// coverage is recorded whether a suite goes through callTool() or calls
+// `mcp.call("tools/call", …)` directly. Never throws: coverage is advisory and
+// must not be able to fail a suite.
+function recordMcpResult(method: string, params: unknown, result: unknown): void {
+  try {
+    if (method === "tools/list") {
+      const tools = (result as { tools?: Array<{ name?: string }> })?.tools;
+      if (Array.isArray(tools)) {
+        recordToolList(tools.map((t) => t?.name).filter((n): n is string => typeof n === "string"));
+      }
+      return;
+    }
+    if (method === "tools/call") {
+      const name = (params as { name?: string })?.name;
+      if (typeof name === "string") {
+        recordToolCall(name, (result as { isError?: boolean })?.isError);
+      }
+    }
+  } catch {
+    /* advisory only */
+  }
 }
 
 interface JsonRpcResponse<T = unknown> {
@@ -82,6 +108,7 @@ export class HttpMcpClient implements McpRpcClient {
     if (env.error) {
       throw new Error(`MCP ${method} error ${env.error.code}: ${env.error.message}`);
     }
+    recordMcpResult(method, params, env.result);
     return env.result as T;
   }
 

--- a/tests/e2e-prod/mcp_coverage_gate.py
+++ b/tests/e2e-prod/mcp_coverage_gate.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""MCP tool coverage gate.
+
+Every tool the deployed MCP server advertises must be exercised by the e2e-prod
+suite, or the gate fails — so a tool that ships without a test is caught the same
+way an unexercised /v1 operation is caught by coverage_gate.py.
+
+This is the MCP analogue of coverage_gate.py, with one deliberate difference:
+
+  coverage_gate.py takes its denominator from a REPO FILE (api/openapi.yaml,
+  which is itself drift-gated against the server).
+
+  This gate takes its denominator from the DEPLOYED SERVER — whatever it
+  advertised on `tools/list` during the run, captured by harness/mcp-coverage.ts.
+
+There is no drift-gated catalog file for MCP tools, so grepping
+mcp/src/tools/*.ts for registerTool() would measure the repo rather than the
+thing under test, and would go quietly wrong the moment a tool is registered
+conditionally or gated behind a tier. The server's own advertisement is the only
+honest catalog: what a real MCP client can see is exactly what we are
+accountable for testing.
+
+Inputs:
+  - reports/mcp-coverage/*.json : shards written by harness/mcp-coverage.ts, each
+    {"advertised": [...tool names...], "covered": [...tool names...]}.
+
+"Covered" means a `tools/call` returned a result with isError !== true, i.e. the
+tool actually ran — not merely that it was probed with a rejected request.
+
+Usage: python3 mcp_coverage_gate.py [--reports DIR]
+Exit 0 = every advertised tool covered (or allowlisted); 1 = coverage gap;
+2 = usage/IO error (including "no shards", which must never read as a pass).
+"""
+import argparse
+import glob
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+# Tools the black-box suite intentionally does NOT exercise, with the reason.
+# Keep this SHORT and justified — every entry is coverage we knowingly forgo.
+ALLOWLIST: dict[str, str] = {}
+
+
+def load_shards(reports_dir: str) -> tuple[set[str], set[str], int]:
+    advertised: set[str] = set()
+    covered: set[str] = set()
+    paths = sorted(glob.glob(os.path.join(reports_dir, "*.json")))
+    for path in paths:
+        with open(path, encoding="utf-8") as fh:
+            shard = json.load(fh)
+        # Tolerate a bare-list shard shape defensively, but the recorder always
+        # writes the object form.
+        if isinstance(shard, dict):
+            advertised.update(shard.get("advertised") or [])
+            covered.update(shard.get("covered") or [])
+    return advertised, covered, len(paths)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--reports", default=os.path.join(HERE, "reports", "mcp-coverage"))
+    args = ap.parse_args()
+
+    if not os.path.isdir(args.reports):
+        print(
+            f"mcp_coverage_gate: no shard directory at {args.reports}. "
+            "Run the suite first (`npm test`); an absent run is not a pass.",
+            file=sys.stderr,
+        )
+        return 2
+
+    advertised, covered, shard_count = load_shards(args.reports)
+
+    if shard_count == 0 or not advertised:
+        # Without a denominator there is nothing to verify. Failing loudly here is
+        # the whole point: a silent 0-of-0 "pass" would hide a broken harness.
+        print(
+            "mcp_coverage_gate: no tools/list denominator was recorded. "
+            "At least one suite must call tools/list against the deployed server.",
+            file=sys.stderr,
+        )
+        return 2
+
+    # An allowlist entry that no longer names an advertised tool is a silent hole
+    # (e.g. the tool was renamed) — fail loudly so the allowlist can't drift stale.
+    stale = set(ALLOWLIST) - advertised
+    if stale:
+        print(
+            f"mcp_coverage_gate: allowlist entries the server does not advertise "
+            f"(renamed/removed?): {sorted(stale)}",
+            file=sys.stderr,
+        )
+        return 2
+
+    # A covered tool the server never advertised means the recorder and the
+    # catalog disagree — report it, but it cannot mask a real gap.
+    unadvertised = sorted(covered - advertised)
+
+    missing = advertised - covered
+    allowlisted = missing & set(ALLOWLIST)
+    uncovered = sorted(missing - set(ALLOWLIST))
+
+    print(f"Shards             : {shard_count}")
+    print(f"Advertised tools   : {len(advertised)}")
+    print(f"Covered            : {len(covered & advertised)}")
+    print(f"Allowlisted        : {len(allowlisted)} " + (str(sorted(allowlisted)) if allowlisted else ""))
+    if unadvertised:
+        print(f"Called but not advertised: {unadvertised}")
+
+    if uncovered:
+        print(f"\nUNCOVERED ({len(uncovered)}):", file=sys.stderr)
+        for name in uncovered:
+            print(f"  {name}", file=sys.stderr)
+        print(
+            "\nEvery advertised MCP tool needs a suite that calls it successfully. "
+            "Add a test, or add an ALLOWLIST entry with a justification.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("\nPASS: every advertised MCP tool is exercised.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/e2e-prod/mcp_coverage_gate.py
+++ b/tests/e2e-prod/mcp_coverage_gate.py
@@ -41,7 +41,19 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 
 # Tools the black-box suite intentionally does NOT exercise, with the reason.
 # Keep this SHORT and justified — every entry is coverage we knowingly forgo.
-ALLOWLIST: dict[str, str] = {}
+#
+# Each of these three is, per mcp/src/tools/legacy.ts, literally titled
+# "Deprecated alias: <canonical>" and routes straight to that canonical tool,
+# which IS covered elsewhere in this suite. Allowlisting them loses no real
+# signal — the underlying behavior is exercised via the canonical tool — and
+# we deliberately do not want to commit to happy-path testing of deprecated
+# surface. Their continued *advertisement* is still asserted by
+# suites/08-mcp.test.ts, so removal of the alias itself would still be caught.
+ALLOWLIST: dict[str, str] = {
+    "send_email": "deprecated alias for send_message (covered)",
+    "approve_pending_message": "deprecated alias for approve_review (covered)",
+    "reject_pending_message": "deprecated alias for reject_review (covered)",
+}
 
 
 def load_shards(reports_dir: str) -> tuple[set[str], set[str], int]:

--- a/tests/e2e-prod/package.json
+++ b/tests/e2e-prod/package.json
@@ -4,10 +4,11 @@
   "type": "module",
   "scripts": {
     "smoke": "node smoke.ts",
-    "pretest": "rm -rf reports/coverage",
+    "pretest": "rm -rf reports/coverage reports/mcp-coverage",
     "test": "node --test --test-concurrency=1 --test-reporter=spec suites/*.test.ts",
     "test:unit": "node --test harness/*.test.ts",
     "coverage:gate": "python3 coverage_gate.py",
+    "coverage:gate:mcp": "python3 mcp_coverage_gate.py",
     "coverage": "npm test; npm run coverage:gate",
     "typecheck": "tsc --noEmit"
   },

--- a/tests/e2e-prod/package.json
+++ b/tests/e2e-prod/package.json
@@ -10,6 +10,7 @@
     "coverage:gate": "python3 coverage_gate.py",
     "coverage:gate:mcp": "python3 mcp_coverage_gate.py",
     "coverage": "npm test; npm run coverage:gate",
+    "report:gate": "node consolidate.ts",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/tests/e2e-prod/suites/11-messaging.test.ts
+++ b/tests/e2e-prod/suites/11-messaging.test.ts
@@ -240,7 +240,7 @@ test("messaging: reply to bogus message ID returns 404", async () => {
   assert.ok(r.status === 404 || (r.status >= 400 && r.status < 500), `expected 4xx (404), got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
-test("messaging: reply with empty body returns 400", async () => {
+test("messaging: reply with empty body is rejected as invalid_request", async () => {
   // /reply requires the target message be inbound and belong to the
   // agent in the path. The previous version fell back to any message
   // including outbound, which routinely 404'd before the 400-missing-
@@ -269,7 +269,21 @@ test("messaging: reply with empty body returns 400", async () => {
     info(SUITE, "reply-empty-404-on-listed-msg", `inbound list returned ${candidate.message_id} but /reply 404'd — possible listing/storage skew`);
     return;
   }
-  assert.equal(r.status, 400, `expected 400 (empty body) on owned inbound message, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  // The v1 contract treats 400 and 422 as the SAME outcome for input validation:
+  // "invalid_request is the single canonical code for input-validation failures
+  // whether they arrive as 400 (malformed) or 422 (semantically invalid)"
+  // (api/openapi.yaml, ErrorEnvelope.code). A missing required `text` is
+  // semantically invalid, so the server answers 422 — contract-compliant. The
+  // old exact-400 assertion encoded one of two permitted statuses and so
+  // recorded a permanent failure, invisible until findings started gating the
+  // run. Assert the contract (a validation rejection carrying invalid_request),
+  // not one particular status code.
+  assert.ok(
+    r.status === 400 || r.status === 422,
+    `expected a validation rejection (400 or 422) on owned inbound message, got ${r.status}: ${r.raw.slice(0, 200)}`,
+  );
+  const code = (JSON.parse(r.raw) as { error?: { code?: string } })?.error?.code;
+  assert.equal(code, "invalid_request", `expected canonical validation code invalid_request, got "${code}"`);
 });
 
 test("messaging: /messages search filters — surface what's supported", async () => {

--- a/tests/e2e-prod/suites/12-mcp-extended.test.ts
+++ b/tests/e2e-prod/suites/12-mcp-extended.test.ts
@@ -139,10 +139,8 @@ test("mcp-ext: list_reviews and get_review round-trip", async () => {
   const s = await apiClient.post<{ message_id: string }>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
     body: { to: [SINK_EMAIL], subject: uniqueSubject("mcp pending"), text: "x" },
   });
-  if (s.status !== 202 || !s.body?.message_id) {
-    info(SUITE, "pending-setup-failed", `send returned ${s.status}, can't probe pending tools`);
-    return;
-  }
+  assert.equal(s.status, 202, `pending setup send expected 202: ${s.raw.slice(0, 200)}`);
+  assert.ok(s.body?.message_id, "pending setup send must return a message_id — a missing fixture is a broken test, not a skip");
   const id = s.body.message_id;
 
   // list_reviews — should include our queued msg. The MCP
@@ -154,9 +152,10 @@ test("mcp-ext: list_reviews and get_review round-trip", async () => {
     fail(SUITE, "list-pending-error", `list_reviews isError: ${extractText(lp).slice(0, 200)}`);
   } else {
     const text = extractText(lp);
-    if (!text.includes(id)) {
-      info(SUITE, "list-pending-missing-msg", `queued ${id} not in list_reviews response (may be paginated or filtered)`);
-    }
+    assert.ok(
+      text.includes(id),
+      `queued ${id} must appear in list_reviews (the MCP tool exposes no pagination or filter that could hide it)`,
+    );
   }
 
   // get_review.
@@ -166,9 +165,7 @@ test("mcp-ext: list_reviews and get_review round-trip", async () => {
   } else {
     const parsed = JSON.parse(extractText(gp)) as { id?: string; message_id?: string; status?: string };
     const returnedId = parsed.id ?? parsed.message_id;
-    if (returnedId !== id) {
-      info(SUITE, "get-pending-id-mismatch", `get_review returned id=${returnedId}, expected ${id}`);
-    }
+    assert.equal(returnedId, id, `get_review returned id=${returnedId}, expected ${id}`);
   }
 
   // Cleanup
@@ -246,9 +243,7 @@ test("mcp-ext: get_message returns shape and only own messages", async () => {
 
   // Bogus id — should isError.
   const r2 = await callTool(mcp, "get_message", { message_id: `msg_bogus_${Date.now()}`, email: apiClient.env.primaryAgentEmail });
-  if (!r2.isError) {
-    info(SUITE, "get-msg-bogus-not-error", "get_message with bogus id did not surface as error");
-  }
+  assert.equal(r2.isError, true, "get_message with a bogus id must surface as an error");
 });
 
 test("mcp-ext: reply_to_message happy path replies to a real message", async () => {
@@ -298,15 +293,15 @@ test("mcp-ext: cross-tool consistency — list_agents matches API surface", asyn
   const r = await callTool(mcp, "list_agents");
   const text = extractText(r);
   const mcpAgents = (JSON.parse(text) as { agents: Array<{ email: string }> }).agents.map((a) => a.email).sort();
-  const apiResp = await apiClient.get<{ agents: Array<{ email: string }> }>("/v1/agents");
-  const apiAgents = (apiResp.body?.agents ?? []).map((a) => a.email).sort();
-  if (mcpAgents.length !== apiAgents.length || JSON.stringify(mcpAgents) !== JSON.stringify(apiAgents)) {
-    info(
-      SUITE,
-      "list-agents-divergence",
-      `MCP list_agents (${mcpAgents.length}) differs from API /agents (${apiAgents.length})`,
-    );
-  } else {
-    info(SUITE, "list-agents-aligned", `MCP and API agent lists match: ${apiAgents.length} agents`);
-  }
+  // REST list envelope is Page[T] = {items, next_cursor}; the MCP envelope is
+  // {agents, next_cursor?} — deliberately different shapes (frozen MCP
+  // contract, see paginationInput in mcp/src/tools/util.ts). Compare contents.
+  const apiResp = await apiClient.get<{ items: Array<{ email: string }> }>("/v1/agents");
+  const apiAgents = (apiResp.body?.items ?? []).map((a) => a.email).sort();
+  assert.deepEqual(
+    mcpAgents,
+    apiAgents,
+    `MCP list_agents (${mcpAgents.length}) must match API /agents (${apiAgents.length})`,
+  );
+  info(SUITE, "list-agents-aligned", `MCP and API agent lists match: ${apiAgents.length} agents`);
 });

--- a/tests/e2e-prod/suites/12-mcp-extended.test.ts
+++ b/tests/e2e-prod/suites/12-mcp-extended.test.ts
@@ -32,6 +32,45 @@ function extractText(r: { content?: Array<{ type: string; text?: string }> }): s
   return r.content?.find((c) => c.type === "text")?.text ?? "";
 }
 
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// A single self-send loopback message, shared by the get_message and
+// reply_to_message happy-path tests below. Self-send (an agent emailing
+// itself) is the reliable way to produce a real inbound message on the
+// shared domain without needing an external MX — the same mechanism the
+// staging loopback path relies on. Sharing one fixture between both tests
+// keeps mail volume down against the free-plan monthly cap instead of
+// self-sending twice.
+interface MessageFixture {
+  id: string;
+  subject: string;
+}
+let messageFixturePromise: Promise<MessageFixture> | undefined;
+function messageFixture(): Promise<MessageFixture> {
+  messageFixturePromise ??= (async () => {
+    const pinnedAgent = apiClient.env.primaryAgentEmail;
+    const subject = uniqueSubject("mcp-ext get-msg fixture");
+    const send = await apiClient.post<{ message_id: string }>(
+      `/v1/agents/${encodeURIComponent(pinnedAgent)}/messages`,
+      { body: { to: [pinnedAgent], subject, text: "12-mcp-extended self-send fixture" }, expect: [200, 202] },
+    );
+    if (!send.body?.message_id) {
+      throw new Error(`self-send fixture did not return a message_id: ${send.raw.slice(0, 200)}`);
+    }
+    for (let i = 0; i < 12; i++) {
+      const poll = await apiClient.get<{ items: Array<{ id: string; subject: string }> }>(
+        `/v1/agents/${encodeURIComponent(pinnedAgent)}/messages`,
+        { query: { direction: "inbound", read_status: "all", limit: 20 } },
+      );
+      const m = poll.body?.items?.find((x) => x.subject === subject);
+      if (m) return { id: m.id, subject };
+      await sleep(1500);
+    }
+    throw new Error(`self-send fixture "${subject}" never appeared for ${pinnedAgent}`);
+  })();
+  return messageFixturePromise;
+}
+
 async function ensureHitlAgent(): Promise<string> {
   const slug = uniqueSlug("mcpe");
   const c = await apiClient.post<{ email: string }>("/v1/agents", {
@@ -187,20 +226,16 @@ test("mcp-ext: get_message returns shape and only own messages", async () => {
   }
   // The MCP get_message tool fetches via the AGENT-scoped endpoint
   // GET /v1/agents/{agent_email}/messages/{id} — anti-enumeration
-  // 404s on any message that doesn't belong to the pinned agent. We
-  // pull candidate IDs from the same scope so the test exercises the
-  // happy path instead of accidentally tripping the cross-agent guard.
-  const pinnedAgent = apiClient.env.primaryAgentEmail;
-  const listMsgs = await apiClient.get<{ items: Array<{ id: string }> }>(
-    `/v1/agents/${encodeURIComponent(pinnedAgent)}/messages`,
-    { query: { limit: 1 } },
-  );
-  const id = listMsgs.body?.items?.[0]?.id;
-  if (!id) {
-    info(SUITE, "get-msg-no-fixture", `no messages in agent ${pinnedAgent}'s inbox — cannot probe get_message happy path`);
-    return;
-  }
-  const r = await callTool(mcp, "get_message", { message_id: id });
+  // 404s on any message that doesn't belong to the pinned agent. Rather
+  // than hoping the pinned agent's inbox already has something in it
+  // (a prior version of this test silently `return`ed when it was empty,
+  // which let the suite report all-green while never actually exercising
+  // get_message's happy path), we produce a real fixture via self-send.
+  const { id } = await messageFixture();
+  // The conformance credential here is account-scoped (no agent_email to
+  // pin — see the 08-mcp "whoami" test), so get_message needs an explicit
+  // `email` to resolve which agent's mailbox to read from.
+  const r = await callTool(mcp, "get_message", { message_id: id, email: apiClient.env.primaryAgentEmail });
   if (r.isError) {
     fail(SUITE, "get-msg-error", `get_message isError for our own ${id}: ${extractText(r).slice(0, 200)}`);
     return;
@@ -210,9 +245,37 @@ test("mcp-ext: get_message returns shape and only own messages", async () => {
   assert.equal(returnedId, id, `expected id ${id}, got ${returnedId}`);
 
   // Bogus id — should isError.
-  const r2 = await callTool(mcp, "get_message", { message_id: `msg_bogus_${Date.now()}` });
+  const r2 = await callTool(mcp, "get_message", { message_id: `msg_bogus_${Date.now()}`, email: apiClient.env.primaryAgentEmail });
   if (!r2.isError) {
     info(SUITE, "get-msg-bogus-not-error", "get_message with bogus id did not surface as error");
+  }
+});
+
+test("mcp-ext: reply_to_message happy path replies to a real message", async () => {
+  const list = await mcp.call<{ tools: Array<{ name: string }> }>("tools/list");
+  if (!list.tools.find((t) => t.name === "reply_to_message")) {
+    info(SUITE, "reply-tool-absent", "no reply_to_message tool — skipping");
+    return;
+  }
+  const { id } = await messageFixture();
+  // Same account-scoped-credential caveat as get_message above.
+  const r = await callTool(mcp, "reply_to_message", {
+    message_id: id,
+    text: "reply from 12-mcp-extended happy path",
+    email: apiClient.env.primaryAgentEmail,
+  });
+  assert.equal(r.isError, undefined, `reply_to_message isError: ${extractText(r).slice(0, 200)}`);
+  const parsed = JSON.parse(extractText(r)) as { message_id?: string; status?: string };
+  assert.ok(parsed.message_id?.startsWith("msg_"), `expected msg_ prefix, got "${parsed.message_id}"`);
+  assert.ok(
+    parsed.status === "accepted" || parsed.status === "sent" || parsed.status === "pending_review",
+    `reply_to_message must report accepted/sent/pending_review, got "${parsed.status}"`,
+  );
+  if (parsed.status === "pending_review") {
+    const cleanupReview = await apiClient.post(`/v1/reviews/${parsed.message_id}/reject`, {
+      body: { reason: "e2e mcp reply cleanup" },
+    });
+    assert.equal(cleanupReview.status, 200, `cleanup rejection failed: ${cleanupReview.status}`);
   }
 });
 

--- a/tests/e2e-prod/suites/13-billing-surface.test.ts
+++ b/tests/e2e-prod/suites/13-billing-surface.test.ts
@@ -190,8 +190,20 @@ test("billing: POST /api/billing/webhook with invalid signature returns 400", as
 
 // --- Static pricing page ---
 
-test("billing: GET /pricing returns 200 HTML", async () => {
+// /pricing is an OPTIONAL, deployment-specific marketing route, not part of the
+// v1 contract. Prod serves it from this repo's static `pricing/` directory;
+// staging deliberately does not (Caddyfile.staging: "Differences from prod: no
+// /pricing (prod-only marketing)"), and a self-hoster has no reason to. So a 404
+// means "this deployment doesn't host the page", which is not a defect — only a
+// deployment that DOES serve it is held to the content contract below. Asserting
+// it unconditionally made this suite record a permanent FAIL finding against
+// staging, invisible until findings started gating the run.
+test("billing: GET /pricing returns 200 HTML where the deployment serves it", async () => {
   const r = await siteClient.get("/pricing", { apiKey: null });
+  if (r.status === 404) {
+    info(SUITE, "pricing-not-hosted", `/pricing is not served by this deployment (404) — prod-only marketing route`);
+    return;
+  }
   if (r.status !== 200) {
     fail(SUITE, "pricing-non-200", `/pricing returned ${r.status}: ${r.raw.slice(0, 200)}`);
     return;

--- a/tests/e2e-prod/suites/25-mcp-templates.test.ts
+++ b/tests/e2e-prod/suites/25-mcp-templates.test.ts
@@ -1,0 +1,269 @@
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient } from "../harness/client.ts";
+import { HttpMcpClient, callTool } from "../harness/mcp.ts";
+import { uniqueSlug } from "../harness/fixtures.ts";
+import { info, warn, writeReport } from "../harness/report.ts";
+
+// Black-box MCP conformance for the beta template tools (create/get/list/
+// update/delete/validate_template + list/get_starter_template) and the
+// API-key tools (create/list/delete_api_key), exercised over the DEPLOYED
+// streamable-HTTP /mcp server — the same surface 08-mcp.test.ts and
+// 12-mcp-extended.test.ts target, not a locally-built stdio binary.
+//
+// All 8 template tools are account-scope only (agent-scoped credentials get
+// a 403), and create_api_key/delete_api_key are likewise account-scope —
+// the conformance key here is account-scoped, matching every other MCP
+// suite in this repo.
+//
+// Cleanup is self-contained (like 17-templates.test.ts's REST suite): every
+// created template/key is deleted inline via the very tool under test
+// (delete_template / delete_api_key), in a try/finally, rather than via the
+// shared cleanup harness (harness/cleanup.ts only tracks agent/domain
+// kinds). The api-key lifecycle binds to the account's existing primary
+// probe agent instead of minting a throwaway agent, to stay well inside the
+// free-plan 3-agent cap.
+const SUITE = "25-mcp-templates";
+const apiClient = new ApiClient();
+const mcp = new HttpMcpClient(apiClient.env.mcpUrl, apiClient.env.apiKey);
+
+const REQUIRED_TOOLS = [
+  "create_template",
+  "get_template",
+  "list_templates",
+  "update_template",
+  "delete_template",
+  "validate_template",
+  "list_starter_templates",
+  "get_starter_template",
+  "create_api_key",
+  "list_api_keys",
+  "delete_api_key",
+] as const;
+
+before(async () => {
+  info(SUITE, "transport", `MCP over HTTP → ${apiClient.env.mcpUrl}`);
+});
+
+after(async () => {
+  await mcp.stop();
+  writeReport(`./reports/${SUITE}.json`);
+});
+
+function extractText(r: { content?: Array<{ type: string; text?: string }> }): string {
+  return r.content?.find((c) => c.type === "text")?.text ?? "";
+}
+
+function parseJson<T>(r: { content?: Array<{ type: string; text?: string }> }): T {
+  return JSON.parse(extractText(r)) as T;
+}
+
+interface TemplateView {
+  id?: string;
+  name?: string;
+  subject?: string;
+  text?: string;
+  html?: string;
+  alias?: string;
+  created_at?: string;
+  updated_at?: string;
+  from_starter_alias?: string;
+  from_starter_version?: string;
+}
+interface DeleteResult {
+  deleted?: boolean;
+  id?: string;
+}
+interface StarterTemplateView {
+  alias?: string;
+  name?: string;
+  description?: string;
+  version?: string;
+  subject?: string;
+  variables?: Array<{ name: string; required: boolean; raw: boolean; description: string; example: string }>;
+}
+interface StarterTemplateDetailView extends StarterTemplateView {
+  text?: string;
+  html?: string;
+}
+interface ValidateTemplateResponse {
+  valid?: boolean;
+  errors?: Array<{ part: string; message: string }>;
+  rendered?: { subject?: string; text?: string; html?: string };
+  suggested_data?: Record<string, unknown>;
+}
+interface ApiKeyView {
+  id?: string;
+  name?: string;
+  key_prefix?: string;
+  scope?: string;
+  agent_email?: string;
+  created_at?: string;
+}
+interface CreateApiKeyResult extends ApiKeyView {
+  key?: string;
+}
+
+test("mcp-templates: tools/list advertises all 11 template + API-key tools", async () => {
+  const r = await mcp.call<{ tools: Array<{ name: string }> }>("tools/list");
+  const names = new Set(r.tools.map((t) => t.name));
+  for (const req of REQUIRED_TOOLS) {
+    assert.ok(names.has(req), `expected tool "${req}" in the advertised surface`);
+  }
+});
+
+test("mcp-templates: create_template + get_template + list_templates + update_template + delete_template lifecycle", async () => {
+  const alias = uniqueSlug("mcptmpl");
+  let id: string | null = null;
+  try {
+    const create = await callTool(mcp, "create_template", {
+      name: `e2e ${alias}`,
+      subject: "Hi {{name}}",
+      text: "Hello {{name}}, welcome to {{company}}.",
+      alias,
+    });
+    assert.equal(create.isError, undefined, `create_template isError: ${extractText(create).slice(0, 300)}`);
+    const created = parseJson<TemplateView>(create);
+    assert.ok(created.id?.startsWith("tmpl_"), `expected tmpl_ id, got "${created.id}"`);
+    id = created.id!;
+    assert.equal(created.name, `e2e ${alias}`, "create_template echoes name");
+    assert.equal(created.subject, "Hi {{name}}", "create_template echoes subject");
+    assert.equal(created.alias, alias, "create_template echoes alias");
+
+    const get = await callTool(mcp, "get_template", { id });
+    assert.equal(get.isError, undefined, `get_template isError: ${extractText(get).slice(0, 300)}`);
+    const gotten = parseJson<TemplateView>(get);
+    assert.equal(gotten.id, id, "get_template returns the created template");
+    assert.equal(gotten.text, "Hello {{name}}, welcome to {{company}}.", "get_template returns the full body source");
+
+    const list = await callTool(mcp, "list_templates");
+    assert.equal(list.isError, undefined, `list_templates isError: ${extractText(list).slice(0, 300)}`);
+    const listed = parseJson<{ templates?: TemplateView[] }>(list);
+    assert.ok(Array.isArray(listed.templates), "list_templates returns a templates array");
+    // Assert on the specific resource we created, never on account-wide count.
+    assert.ok(listed.templates!.some((t) => t.id === id), `created template ${id} appears in list_templates`);
+
+    const update = await callTool(mcp, "update_template", { id, name: `${alias}-updated`, subject: "Hi {{name}}!" });
+    assert.equal(update.isError, undefined, `update_template isError: ${extractText(update).slice(0, 300)}`);
+    const updated = parseJson<TemplateView>(update);
+    assert.equal(updated.name, `${alias}-updated`, "update_template applies the new name");
+    assert.equal(updated.subject, "Hi {{name}}!", "update_template applies the new subject");
+    assert.equal(updated.text, "Hello {{name}}, welcome to {{company}}.", "update_template leaves an unpassed field untouched");
+
+    const del = await callTool(mcp, "delete_template", { id, confirm: true });
+    assert.equal(del.isError, undefined, `delete_template isError: ${extractText(del).slice(0, 300)}`);
+    const deleted = parseJson<DeleteResult>(del);
+    assert.equal(deleted.deleted, true, "delete_template reports deleted:true");
+    assert.equal(deleted.id, id, "delete_template echoes the deleted id");
+    const deletedId = id;
+    id = null;
+
+    const getAfterDelete = await callTool(mcp, "get_template", { id: deletedId! });
+    if (getAfterDelete.isError !== true) {
+      warn(SUITE, "get-after-delete", `get_template for a deleted id ${deletedId} did not surface isError`);
+    }
+  } finally {
+    if (id) await callTool(mcp, "delete_template", { id, confirm: true });
+  }
+});
+
+test("mcp-templates: validate_template dry-run renders a preview without persisting", async () => {
+  const r = await callTool(mcp, "validate_template", {
+    subject: "Hi {{name}}",
+    text: "Welcome {{name}} to {{company}}",
+    test_data: { name: "Ada", company: "Acme" },
+  });
+  assert.equal(r.isError, undefined, `validate_template isError: ${extractText(r).slice(0, 300)}`);
+  const parsed = parseJson<ValidateTemplateResponse>(r);
+  assert.equal(parsed.valid, true, "valid source reports valid:true");
+  assert.equal(parsed.rendered?.subject, "Hi Ada", "subject rendered against test_data");
+  assert.equal(parsed.rendered?.text, "Welcome Ada to Acme", "body rendered against test_data");
+  assert.ok(parsed.suggested_data, "suggested_data present");
+  assert.ok(
+    "name" in (parsed.suggested_data as object) && "company" in (parsed.suggested_data as object),
+    "suggested_data covers every referenced variable",
+  );
+});
+
+test("mcp-templates: list_starter_templates + get_starter_template", async () => {
+  const list = await callTool(mcp, "list_starter_templates");
+  assert.equal(list.isError, undefined, `list_starter_templates isError: ${extractText(list).slice(0, 300)}`);
+  const listed = parseJson<{ starter_templates?: StarterTemplateView[] }>(list);
+  assert.ok(Array.isArray(listed.starter_templates), "list_starter_templates returns a starter_templates array");
+  assert.ok(listed.starter_templates!.length >= 1, "deployment ships at least one starter template");
+  const alias = listed.starter_templates![0].alias;
+  assert.ok(alias, "picked a starter alias from the list");
+
+  const get = await callTool(mcp, "get_starter_template", { alias: alias! });
+  assert.equal(get.isError, undefined, `get_starter_template isError: ${extractText(get).slice(0, 300)}`);
+  const detail = parseJson<StarterTemplateDetailView>(get);
+  assert.equal(detail.alias, alias, "get_starter_template returns the requested alias");
+  assert.equal(typeof detail.text, "string", "detail carries a plain-text body source");
+  assert.equal(typeof detail.html, "string", "detail carries an html body source");
+  assert.ok(Array.isArray(detail.variables), "detail carries a variables array");
+});
+
+test("mcp-templates: create_api_key + list_api_keys + delete_api_key — agent-scoped key lifecycle", async () => {
+  // create_api_key needs an existing agent to bind to. This account starts
+  // with zero agents (the pinned E2A_AGENT_EMAIL is a reserved slug, not a
+  // pre-provisioned inbox), so create it here if absent and tear it back
+  // down afterwards — stays well inside the free-plan 3-agent cap either way.
+  const agentEmail = apiClient.env.primaryAgentEmail;
+  let createdAgent = false;
+  const existing = await apiClient.get(`/v1/agents/${encodeURIComponent(agentEmail)}`);
+  if (existing.status === 404) {
+    const createAgent = await apiClient.post("/v1/agents", { body: { email: agentEmail, name: "mcp templates probe" } });
+    assert.equal(createAgent.status, 201, `agent setup failed: ${createAgent.status} ${createAgent.raw.slice(0, 200)}`);
+    createdAgent = true;
+  } else {
+    assert.equal(existing.status, 200, `unexpected status probing agent: ${existing.status} ${existing.raw.slice(0, 200)}`);
+  }
+
+  const keyName = uniqueSlug("mcpkey");
+  let id: string | null = null;
+  try {
+    const create = await callTool(mcp, "create_api_key", {
+      agent_email: agentEmail,
+      name: keyName,
+    });
+    assert.equal(create.isError, undefined, `create_api_key isError: ${extractText(create).slice(0, 300)}`);
+    const created = parseJson<CreateApiKeyResult>(create);
+    assert.ok(created.id, "create_api_key returns an id");
+    id = created.id!;
+    // The plaintext secret is shown exactly once — assert it exists without
+    // ever logging or persisting its value (report.ts writes findings to disk).
+    assert.equal(typeof created.key, "string", "create_api_key returns the one-time plaintext key");
+    assert.ok(created.key!.length > 0, "plaintext key is non-empty");
+    assert.equal(created.scope, "agent", "create_api_key mints an agent-scoped key");
+    assert.equal(created.agent_email, agentEmail, "key is bound to the requested agent");
+    assert.equal(created.name, keyName, "create_api_key echoes the name");
+
+    const list = await callTool(mcp, "list_api_keys");
+    assert.equal(list.isError, undefined, `list_api_keys isError: ${extractText(list).slice(0, 300)}`);
+    const listed = parseJson<{ api_keys?: ApiKeyView[] }>(list);
+    assert.ok(Array.isArray(listed.api_keys), "list_api_keys returns an api_keys array");
+    // Assert on the specific key we created, never on account-wide count —
+    // this account accumulates keys across suite runs.
+    const found = listed.api_keys!.find((k) => k.id === id);
+    assert.ok(found, `created key ${id} appears in list_api_keys`);
+    assert.equal(found!.name, keyName, "listed key carries the name");
+    assert.ok(!("key" in (found as object)), "list_api_keys never echoes the plaintext secret");
+
+    const del = await callTool(mcp, "delete_api_key", { id, confirm: true });
+    assert.equal(del.isError, undefined, `delete_api_key isError: ${extractText(del).slice(0, 300)}`);
+    const deleted = parseJson<DeleteResult>(del);
+    assert.equal(deleted.deleted, true, "delete_api_key reports deleted:true");
+    assert.equal(deleted.id, id, "delete_api_key echoes the revoked id");
+    id = null;
+  } finally {
+    if (id) await callTool(mcp, "delete_api_key", { id, confirm: true });
+    // Only remove the agent if this test provisioned it — leave a
+    // pre-existing primary agent alone.
+    if (createdAgent) {
+      const del = await apiClient.delete(`/v1/agents/${encodeURIComponent(agentEmail)}?confirm=DELETE`);
+      if (del.status !== 204 && del.status !== 200) {
+        warn(SUITE, "agent-cleanup-failed", `could not delete probe agent ${agentEmail}: HTTP ${del.status}`);
+      }
+    }
+  }
+});

--- a/tests/e2e-prod/suites/25-mcp-templates.test.ts
+++ b/tests/e2e-prod/suites/25-mcp-templates.test.ts
@@ -258,11 +258,17 @@ test("mcp-templates: create_api_key + list_api_keys + delete_api_key — agent-s
   } finally {
     if (id) await callTool(mcp, "delete_api_key", { id, confirm: true });
     // Only remove the agent if this test provisioned it — leave a
-    // pre-existing primary agent alone.
+    // pre-existing primary agent alone. `permanent=true` is required here:
+    // a plain DELETE only soft-deletes (30-day trash) and RESERVES the
+    // address, so the very next run of this suite against the same account
+    // would hit 409 address_in_trash trying to recreate agentEmail — this
+    // suite must be re-runnable back to back on a fresh account.
     if (createdAgent) {
-      const del = await apiClient.delete(`/v1/agents/${encodeURIComponent(agentEmail)}?confirm=DELETE`);
+      const del = await apiClient.delete(
+        `/v1/agents/${encodeURIComponent(agentEmail)}?confirm=DELETE&permanent=true`,
+      );
       if (del.status !== 204 && del.status !== 200) {
-        warn(SUITE, "agent-cleanup-failed", `could not delete probe agent ${agentEmail}: HTTP ${del.status}`);
+        warn(SUITE, "agent-cleanup-failed", `could not permanently delete probe agent ${agentEmail}: HTTP ${del.status}`);
       }
     }
   }

--- a/tests/e2e-prod/suites/26-mcp-webhooks.test.ts
+++ b/tests/e2e-prod/suites/26-mcp-webhooks.test.ts
@@ -1,0 +1,451 @@
+import { test, before, after, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient } from "../harness/client.ts";
+import { cleanup, track } from "../harness/cleanup.ts";
+import { HttpMcpClient, callTool, type McpToolResult } from "../harness/mcp.ts";
+import { isEventsLogDisabled } from "../harness/event-capability.ts";
+import { uniqueSlug, uniqueSubject } from "../harness/fixtures.ts";
+import { fail, info, writeReport } from "../harness/report.ts";
+
+// Black-box MCP conformance for the webhooks + events tool surface (11 tools)
+// against the DEPLOYED streamable-HTTP /mcp server. This is the MCP analogue
+// of suites 16-webhooks.test.ts (REST webhook CRUD) and 21-webhook-events.test.ts
+// (REST event emission) — same domain, same server-side semantics, but every
+// call here goes through tools/call so the mcp_coverage_gate.py recorder
+// credits the tool.
+//
+// Tools exercised (exactly 11, per the coverage batch):
+//   create_webhook, get_webhook, list_webhooks, update_webhook, delete_webhook,
+//   rotate_webhook_secret, test_webhook, list_webhook_deliveries,
+//   list_events, get_event, redeliver_event
+//
+// Shapes verified against mcp/src/tools/webhooks.ts + events.ts (the MCP tool
+// registrations) and cross-checked against the REST WebhookView/EventView
+// shapes in 16-webhooks.test.ts / 21-webhook-events.test.ts — the MCP layer's
+// toMcpOutput() snake-cases the SDK's camelCase fields back to the same REST
+// vocabulary, so the JSON text content matches those interfaces field-for-field.
+//
+// Coverage note: `test_webhook` delivers a REAL synthetic event to the
+// configured URL (bypassing filter matching); we do not depend on an external
+// request-bin sink — the dummy https://example.com target 404/405s the POST,
+// which still proves the delivery ATTEMPT ran (asserted via
+// list_webhook_deliveries), matching the "assert the API's own response plus
+// the resulting delivery record" guidance rather than requiring a 2xx from a
+// sink we don't control.
+//
+// `redeliver_event` needs a prior delivered event to replay honestly, so this
+// suite drives one real email.sent emission (no HITL hold, real send to the
+// SES simulator) exactly like 21-webhook-events.test.ts, then replays THAT
+// event. The event-log capability probe + skip semantics are copied verbatim
+// from harness/event-capability.ts (501 + events_log_disabled ONLY) — no
+// looser skip is invented, and a capability-disabled target legitimately
+// leaves list_events/get_event/redeliver_event uncovered rather than faking it.
+const SUITE = "26-mcp-webhooks";
+const apiClient = new ApiClient();
+const mcp = new HttpMcpClient(apiClient.env.mcpUrl, apiClient.env.apiKey);
+
+const SIMULATOR = "success@simulator.amazonses.com";
+
+interface WebhookView {
+  id: string;
+  url: string;
+  description?: string;
+  events: string[];
+  filters?: Record<string, unknown>;
+  enabled: boolean;
+  created_at: string;
+  last_delivered_at?: string;
+  auto_disabled_at?: string;
+  signing_secret?: string;
+}
+interface ListWebhooksResult {
+  webhooks: WebhookView[];
+  next_cursor?: string;
+}
+interface DeleteWebhookResult {
+  deleted: boolean;
+  id: string;
+}
+interface RotateSecretResult {
+  signing_secret: string;
+  previous_secret_expires_at: string;
+}
+interface TestWebhookResult {
+  delivery_id: string;
+}
+interface WebhookDeliveryView {
+  id: string;
+  type: string;
+  status: string;
+  attempts: number;
+  next_retry_at?: string;
+  created_at: string;
+  last_status_code?: number;
+  last_error?: string;
+}
+interface ListWebhookDeliveriesResult {
+  deliveries: WebhookDeliveryView[];
+  next_cursor?: string;
+}
+interface EventView {
+  id: string;
+  type: string;
+  schema_version: string;
+  created_at: string;
+  status: string;
+  data: Record<string, unknown>;
+  agent_email?: string;
+  message_id?: string;
+  delivery_status?: { matched_webhooks?: number };
+}
+interface ListEventsResult {
+  events: EventView[];
+  next_cursor?: string;
+}
+interface RedeliverResult {
+  event_id: string;
+  status: string;
+  delivery_id?: string;
+  webhook_id?: string;
+  deliveries?: Array<{ webhook_id?: string; delivery_id?: string; status?: string }>;
+}
+interface SendResult {
+  status?: string;
+  message_id?: string;
+}
+
+const REQUIRED_TOOLS = [
+  "create_webhook",
+  "get_webhook",
+  "list_webhooks",
+  "update_webhook",
+  "delete_webhook",
+  "rotate_webhook_secret",
+  "test_webhook",
+  "list_webhook_deliveries",
+  "list_events",
+  "get_event",
+  "redeliver_event",
+];
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function extractText(r: McpToolResult): string {
+  return r.content?.find((c) => c.type === "text")?.text ?? "";
+}
+
+function parseOk<T>(r: McpToolResult, label: string): T {
+  assert.equal(r.isError, undefined, `${label} isError: ${extractText(r).slice(0, 300)}`);
+  const text = extractText(r);
+  assert.ok(text, `${label} returned text content`);
+  return JSON.parse(text) as T;
+}
+
+async function deleteHook(id: string): Promise<void> {
+  // Best-effort: the delete_webhook happy path is asserted explicitly in the
+  // CRUD test, which already deletes the hook — this is only a cleanup net
+  // for tests that create a hook and exit early on assertion failure.
+  await callTool(mcp, "delete_webhook", { id, confirm: true }).catch(() => {});
+}
+
+async function createAgent(label: string): Promise<string> {
+  const slug = uniqueSlug(label);
+  const c = await apiClient.post<{ email: string }>("/v1/agents", {
+    body: { email: `${slug}@${apiClient.env.sharedDomain}`, name: `mcp webhooks ${label}` },
+  });
+  if (c.status !== 201 || !c.body?.email) {
+    throw new Error(`create agent failed: ${c.status} ${c.raw.slice(0, 200)}`);
+  }
+  track("agent", c.body.email);
+  return c.body.email;
+}
+
+// pollWebhookDelivery: poll list_webhook_deliveries (via MCP) until a
+// delivery matching `match` appears, or the bounded window elapses.
+async function pollWebhookDelivery(
+  hookId: string,
+  match: (d: WebhookDeliveryView) => boolean,
+  timeoutMs = 15000,
+): Promise<WebhookDeliveryView | null> {
+  const deadline = Date.now() + timeoutMs;
+  let delay = 500;
+  while (Date.now() < deadline) {
+    const r = await callTool(mcp, "list_webhook_deliveries", { id: hookId, limit: 50 });
+    if (!r.isError) {
+      const parsed = JSON.parse(extractText(r)) as ListWebhookDeliveriesResult;
+      const found = parsed.deliveries?.find(match);
+      if (found) return found;
+    }
+    await sleep(delay);
+    delay = Math.min(Math.floor(delay * 1.5), 3000);
+  }
+  return null;
+}
+
+// pollEvent: poll list_events (via MCP) until an event matching `match`
+// appears, or the bounded window elapses. Mirrors 21-webhook-events.test.ts's
+// REST pollEvent, but driven through the MCP tool so this suite's own
+// tools/call traffic is what the coverage recorder sees.
+async function pollEvent(
+  params: { type: string; agentEmail: string; since: string },
+  match: (e: EventView) => boolean,
+  timeoutMs = 15000,
+): Promise<EventView | null> {
+  const deadline = Date.now() + timeoutMs;
+  let delay = 500;
+  while (Date.now() < deadline) {
+    const r = await callTool(mcp, "list_events", {
+      type: params.type,
+      agent_email: params.agentEmail,
+      since: params.since,
+      limit: 50,
+    });
+    if (!r.isError) {
+      const parsed = JSON.parse(extractText(r)) as ListEventsResult;
+      const found = parsed.events?.find(match);
+      if (found) return found;
+    }
+    await sleep(delay);
+    delay = Math.min(Math.floor(delay * 1.5), 3000);
+  }
+  return null;
+}
+
+before(async () => {
+  info(SUITE, "transport", `MCP over HTTP -> ${apiClient.env.mcpUrl}`);
+});
+
+afterEach(async () => {
+  await cleanup(apiClient);
+});
+
+after(async () => {
+  await mcp.stop();
+  await cleanup(apiClient);
+  writeReport(`./reports/${SUITE}.json`);
+});
+
+test("mcp-webhooks: tools/list advertises all 11 target tools", async () => {
+  const list = await mcp.call<{ tools: Array<{ name: string }> }>("tools/list");
+  const names = new Set(list.tools.map((t) => t.name));
+  const missing = REQUIRED_TOOLS.filter((n) => !names.has(n));
+  assert.deepEqual(missing, [], `deployed MCP server must advertise every target tool; missing: ${missing.join(", ")}`);
+});
+
+// create_webhook + get_webhook + list_webhooks + update_webhook +
+// rotate_webhook_secret + test_webhook + list_webhook_deliveries +
+// delete_webhook — the full webhook-subscriber CRUD round-trip over MCP.
+test("mcp-webhooks: full webhook CRUD round-trip via MCP", async () => {
+  const url = `https://example.com/e2e-mcp-webhook-${uniqueSlug("wh")}`;
+
+  // create_webhook
+  const created = await parseOk<WebhookView>(
+    await callTool(mcp, "create_webhook", {
+      url,
+      events: ["email.received", "email.sent"],
+      description: `e2e mcp ${uniqueSlug("wh")}`,
+    }),
+    "create_webhook",
+  );
+  assert.ok(created.id?.startsWith("wh_"), `create_webhook id has wh_ prefix: ${created.id}`);
+  assert.equal(created.url, url);
+  assert.deepEqual(created.events, ["email.received", "email.sent"]);
+  assert.equal(created.enabled, true, "new webhook defaults to enabled");
+  assert.ok(
+    created.signing_secret?.startsWith("whsec_"),
+    `create_webhook returns a whsec_ signing_secret: ${created.signing_secret}`,
+  );
+  const id = created.id;
+
+  try {
+    // get_webhook
+    const got = await parseOk<WebhookView>(await callTool(mcp, "get_webhook", { id }), "get_webhook");
+    assert.equal(got.id, id);
+    assert.equal(got.url, url);
+    assert.equal(got.enabled, true);
+    assert.equal(got.signing_secret, undefined, "get_webhook must NOT return signing_secret");
+
+    // list_webhooks
+    const listed = await parseOk<ListWebhooksResult>(await callTool(mcp, "list_webhooks", {}), "list_webhooks");
+    assert.ok(Array.isArray(listed.webhooks), "list_webhooks.webhooks is an array");
+    const inList = listed.webhooks.find((w) => w.id === id);
+    assert.ok(inList, `created webhook ${id} is present in list_webhooks`);
+    assert.equal(inList!.signing_secret, undefined, "list_webhooks items must NOT carry signing_secret");
+
+    // update_webhook — partial update; events is a full replace when present.
+    const updated = await parseOk<WebhookView>(
+      await callTool(mcp, "update_webhook", {
+        id,
+        description: "e2e mcp updated",
+        events: ["email.received", "email.sent", "email.failed"],
+      }),
+      "update_webhook",
+    );
+    assert.equal(updated.description, "e2e mcp updated");
+    assert.deepEqual(updated.events, ["email.received", "email.sent", "email.failed"]);
+    assert.equal(updated.enabled, true, "update_webhook left enabled untouched (not passed)");
+
+    // rotate_webhook_secret — new secret, distinct from the created one.
+    const rotated = await parseOk<RotateSecretResult>(
+      await callTool(mcp, "rotate_webhook_secret", { id }),
+      "rotate_webhook_secret",
+    );
+    assert.ok(
+      rotated.signing_secret?.startsWith("whsec_"),
+      `rotate_webhook_secret returns a whsec_ secret: ${rotated.signing_secret}`,
+    );
+    assert.notEqual(rotated.signing_secret, created.signing_secret, "rotated secret differs from the original");
+    assert.ok(
+      typeof rotated.previous_secret_expires_at === "string" && rotated.previous_secret_expires_at.length > 0,
+      "rotate_webhook_secret returns previous_secret_expires_at (grace window)",
+    );
+
+    // test_webhook — fires a synthetic event at the (unreachable, but valid
+    // HTTPS/public) target. Does not depend on the sink responding 2xx.
+    const tested = await parseOk<TestWebhookResult>(
+      await callTool(mcp, "test_webhook", { id, type: "email.received" }),
+      "test_webhook",
+    );
+    assert.ok(
+      typeof tested.delivery_id === "string" && tested.delivery_id.length > 0,
+      `test_webhook returns a delivery_id: ${tested.delivery_id}`,
+    );
+
+    // list_webhook_deliveries — the delivery test_webhook scheduled must
+    // surface here (proves the tool + the resulting delivery record, per the
+    // "don't depend on an external sink" guidance).
+    const delivery = await pollWebhookDelivery(id, (d) => d.id === tested.delivery_id);
+    assert.ok(delivery, `test_webhook's delivery ${tested.delivery_id} must appear in list_webhook_deliveries`);
+    assert.equal(delivery!.type, "email.received");
+    info(SUITE, "test_webhook", `delivery=${delivery!.id} status=${delivery!.status} attempts=${delivery!.attempts} last_status=${delivery!.last_status_code}`);
+  } finally {
+    // delete_webhook — DESTRUCTIVE; requires confirm:true.
+    const deleted = await parseOk<DeleteWebhookResult>(
+      await callTool(mcp, "delete_webhook", { id, confirm: true }),
+      "delete_webhook",
+    );
+    assert.equal(deleted.deleted, true, "delete_webhook returns deleted:true");
+    assert.equal(deleted.id, id, "delete_webhook echoes the webhook id");
+
+    // Confirm it is actually gone.
+    const gone = await callTool(mcp, "get_webhook", { id });
+    if (!gone.isError) {
+      fail(SUITE, "delete-webhook-not-gone", `get_webhook still succeeds for deleted ${id}`);
+    }
+  }
+});
+
+// delete_webhook without confirm:true must be rejected by the tool's own
+// guard (never reaches the API) — a cheap extra proof the destructive guard
+// works, using a throwaway hook so the CRUD test above stays the sole owner
+// of the "real" delete path.
+test("mcp-webhooks: delete_webhook without confirm:true is rejected", async () => {
+  const url = `https://example.com/e2e-mcp-webhook-${uniqueSlug("whguard")}`;
+  const created = await parseOk<WebhookView>(
+    await callTool(mcp, "create_webhook", { url, events: ["email.received"] }),
+    "create_webhook (guard fixture)",
+  );
+  try {
+    const r = await callTool(mcp, "delete_webhook", { id: created.id, confirm: false });
+    assert.equal(r.isError, true, "delete_webhook must reject confirm:false");
+  } finally {
+    await deleteHook(created.id);
+  }
+});
+
+// list_events + get_event + redeliver_event — driven by one real email.sent
+// emission (no HITL hold, real send to the SES simulator), exactly the
+// trigger 21-webhook-events.test.ts uses on the REST side. The event-log
+// capability probe below is copied verbatim from that suite: skip ONLY on
+// the exact 501 events_log_disabled signal, never on a looser heuristic, and
+// never treat a connectivity failure as a skip.
+let eventsSkip: string | false = false;
+try {
+  const probe = await apiClient.get("/v1/events", { query: { limit: 1 } });
+  if (isEventsLogDisabled(probe.status, probe.body)) {
+    eventsSkip = "event-log capability disabled on this target (events_log_disabled)";
+  }
+} catch {
+  // Probe couldn't reach the target — do NOT skip; let the tests run and
+  // surface the real connectivity error instead of masking an outage.
+}
+
+test(
+  "mcp-webhooks: list_events / get_event / redeliver_event round-trip via a real send",
+  { skip: eventsSkip },
+  async () => {
+    const email = await createAgent("mcpev");
+    const url = `https://example.com/e2e-mcp-webhook-events-${uniqueSlug("wh")}`;
+    const hook = await parseOk<WebhookView>(
+      await callTool(mcp, "create_webhook", { url, events: ["email.sent"] }),
+      "create_webhook (events fixture)",
+    );
+    const since = new Date(Date.now() - 5000).toISOString();
+    try {
+      // Real (no-hold) send to the SES simulator, exactly like
+      // 21-webhook-events.test.ts's email.sent emission test.
+      const send = await apiClient.post<SendResult>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
+        body: { to: [SIMULATOR], subject: uniqueSubject("mcp emit sent"), text: "real send via MCP events suite" },
+      });
+      assert.equal(send.status, 202, `real send expected 202 accepted, got ${send.status}: ${send.raw.slice(0, 200)}`);
+      assert.equal(send.body?.status, "accepted", "no-hold agent send is accepted for async delivery");
+      const messageId = send.body!.message_id!;
+      assert.ok(messageId?.startsWith("msg_"), "send returns a msg_ id");
+
+      // list_events (via MCP), filtered — polled until the emitted event lands.
+      const ev = await pollEvent({ type: "email.sent", agentEmail: email, since }, (e) =>
+        e.message_id === messageId || e.data.message_id === messageId,
+      );
+      assert.ok(ev, `email.sent event for ${messageId} must appear via list_events within 15s`);
+      assert.ok(ev!.id?.startsWith("evt_"), `event id has evt_ prefix: ${ev!.id}`);
+      assert.equal(ev!.type, "email.sent");
+      assert.equal(ev!.agent_email, email, "event.agent_email is the sending agent");
+
+      // get_event — single-event fetch by id.
+      const got = await parseOk<EventView>(await callTool(mcp, "get_event", { event_id: ev!.id }), "get_event");
+      assert.equal(got.id, ev!.id, "get_event echoes the requested id");
+      assert.equal(got.type, "email.sent");
+
+      // Nonexistent event id -> isError.
+      const missGet = await callTool(mcp, "get_event", { event_id: `evt_nonexistent_${Date.now()}` });
+      if (!missGet.isError) {
+        fail(SUITE, "get-event-bogus-not-error", "get_event with a nonexistent id did not surface as error");
+      }
+
+      // redeliver_event — replay to our fresh webhook by id. Uses the SAME
+      // envelope id as the original (documented, non-dedup-safe replay
+      // semantics); we only assert the tool's own response shape plus the
+      // resulting delivery record, not a receiver-side outcome.
+      const redelivered = await parseOk<RedeliverResult>(
+        await callTool(mcp, "redeliver_event", { event_id: ev!.id, webhook_id: hook.id }),
+        "redeliver_event",
+      );
+      assert.equal(redelivered.event_id, ev!.id, "redeliver_event echoes the event id");
+      assert.ok(
+        typeof redelivered.status === "string" && redelivered.status.length > 0,
+        "redeliver_event returns a status",
+      );
+      const newDeliveryIds = [
+        redelivered.delivery_id,
+        ...(redelivered.deliveries ?? []).map((d) => d.delivery_id),
+      ].filter((x): x is string => typeof x === "string" && x.length > 0);
+      assert.ok(newDeliveryIds.length >= 1, `redeliver_event returns at least one delivery id: ${JSON.stringify(redelivered)}`);
+
+      const requeued = await pollWebhookDelivery(hook.id, (d) => newDeliveryIds.includes(d.id));
+      assert.ok(requeued, `redelivered delivery ${newDeliveryIds[0]} must appear in list_webhook_deliveries`);
+      info(
+        SUITE,
+        "redeliver_event",
+        `event=${ev!.id} webhook=${hook.id} -> delivery=${requeued!.id} status=${requeued!.status} attempts=${requeued!.attempts}`,
+      );
+
+      // Nonexistent event id -> isError.
+      const missRedeliver = await callTool(mcp, "redeliver_event", { event_id: `evt_nonexistent_${Date.now()}` });
+      if (!missRedeliver.isError) {
+        fail(SUITE, "redeliver-event-bogus-not-error", "redeliver_event with a nonexistent id did not surface as error");
+      }
+    } finally {
+      await deleteHook(hook.id);
+    }
+  },
+);

--- a/tests/e2e-prod/suites/27-mcp-agents-messages.test.ts
+++ b/tests/e2e-prod/suites/27-mcp-agents-messages.test.ts
@@ -361,10 +361,7 @@ function attachmentFixture(): Promise<AttachmentFixture | null> {
 test("mcp-agents-msgs: get_attachment returns metadata + a short-lived download_url", async () => {
   const email = await agent();
   const fixture = await attachmentFixture();
-  if (!fixture) {
-    info(SUITE, "get-attachment-skip", "no attachment fixture available; skipping get_attachment happy path");
-    return;
-  }
+  assert.ok(fixture, "no attachment fixture available — a missing fixture is a broken test, not a reason to pass");
   const r = await callTool(mcp, "get_attachment", { message_id: fixture.messageId, attachment_index: 0, email });
   assert.equal(r.isError, undefined, `get_attachment isError: ${extractText(r).slice(0, 200)}`);
   const parsed = parseJson<{
@@ -387,10 +384,7 @@ test("mcp-agents-msgs: get_attachment returns metadata + a short-lived download_
 test("mcp-agents-msgs: get_attachment_data (legacy alias) returns inline base64 that round-trips", async () => {
   const email = await agent();
   const fixture = await attachmentFixture();
-  if (!fixture) {
-    info(SUITE, "get-attachment-data-skip", "no attachment fixture available; skipping get_attachment_data happy path");
-    return;
-  }
+  assert.ok(fixture, "no attachment fixture available — a missing fixture is a broken test, not a reason to pass");
   const r = await callTool(mcp, "get_attachment_data", { message_id: fixture.messageId, attachment_index: 0, agent_email: email });
   assert.equal(r.isError, undefined, `get_attachment_data isError: ${extractText(r).slice(0, 200)}`);
   const parsed = parseJson<{ filename?: string; content_type?: string; size_bytes?: number; data?: string }>(r);

--- a/tests/e2e-prod/suites/27-mcp-agents-messages.test.ts
+++ b/tests/e2e-prod/suites/27-mcp-agents-messages.test.ts
@@ -1,0 +1,431 @@
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient } from "../harness/client.ts";
+import { cleanup, track } from "../harness/cleanup.ts";
+import { HttpMcpClient, callTool } from "../harness/mcp.ts";
+import { uniqueSlug, uniqueSubject } from "../harness/fixtures.ts";
+import { info, warn, writeReport } from "../harness/report.ts";
+
+// Coverage-gate fill: agents + messages + attachments, the largest single
+// batch of the 4-way MCP tool-coverage split (see mcp_coverage_gate.py /
+// harness/mcp-coverage.ts). This suite is the sole owner of:
+//   get_agent, update_agent, delete_agent, restore_agent, get_protection,
+//   update_protection, delete_message, restore_message, forward_message,
+//   update_message_labels, get_message_lifecycle, get_conversation,
+//   list_conversations, get_attachment, get_attachment_data
+//
+// Free-plan budget (3 agents / 1 domain / 3000 msgs-mo) is tight, so this
+// file creates exactly ONE throwaway agent for the whole suite and reuses it
+// end to end: identity/protection tools first, then a single self-send
+// loopback message drives labels/conversations/lifecycle/forward/trash, then
+// one real send (no hold) to the SES simulator produces a retrievable
+// attachment (the same pattern 20-attachments.test.ts establishes — a HELD
+// draft has no raw_message, so getAttachment 404s on it), and finally the
+// agent itself goes through its own delete/restore cycle.
+//
+// Tests are intentionally sequential and share one lazily-created agent —
+// mirrors 24-trash-lifecycle.test.ts's economy-of-agents convention — so run
+// order matters here (this file is always run alone per the task brief, and
+// `npm test` runs suites with --test-concurrency=1).
+
+const SUITE = "27-mcp-agents-messages";
+const apiClient = new ApiClient();
+const mcp = new HttpMcpClient(apiClient.env.mcpUrl, apiClient.env.apiKey);
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+before(async () => {
+  info(SUITE, "transport", `MCP over HTTP → ${apiClient.env.mcpUrl}`);
+  // Feeds the mcp-coverage denominator (tools/list) even if every other test
+  // in the file somehow short-circuits.
+  const list = await mcp.call<{ tools: Array<{ name: string }> }>("tools/list");
+  info(SUITE, "tools-list", `server advertises ${list.tools.length} tools`);
+});
+
+after(async () => {
+  await mcp.stop();
+  const r = await cleanup(apiClient);
+  if (r.failed.length) warn(SUITE, "cleanup", `failed ${r.failed.length}`, r.failed);
+  writeReport(`./reports/${SUITE}.json`);
+});
+
+function extractText(r: { content?: Array<{ type: string; text?: string }> }): string {
+  return r.content?.find((c) => c.type === "text")?.text ?? "";
+}
+
+function parseJson<T>(r: { content?: Array<{ type: string; text?: string }> }): T {
+  return JSON.parse(extractText(r)) as T;
+}
+
+// ── The one throwaway agent shared by the whole file ─────────────────────
+
+let agentPromise: Promise<string> | undefined;
+function agent(): Promise<string> {
+  agentPromise ??= (async () => {
+    const slug = uniqueSlug("mcpam");
+    const email = `${slug}@${apiClient.env.sharedDomain}`;
+    const created = await apiClient.post<{ email: string }>("/v1/agents", {
+      body: { email, name: "mcp agents-messages batch" },
+      expect: 201,
+    });
+    // Track before assertions so teardown owns cleanup even if the response
+    // is malformed.
+    track("agent", email);
+    assert.equal(created.body?.email, email);
+    return email;
+  })();
+  return agentPromise;
+}
+
+// ── get_agent / update_agent ──────────────────────────────────────────────
+
+test("mcp-agents-msgs: get_agent returns the created agent's identity", async () => {
+  const email = await agent();
+  const r = await callTool(mcp, "get_agent", { email });
+  assert.equal(r.isError, undefined, `get_agent isError: ${extractText(r).slice(0, 200)}`);
+  const parsed = parseJson<{ email?: string; name?: string }>(r);
+  assert.equal(parsed.email, email, "get_agent returns the requested agent");
+  assert.equal(parsed.name, "mcp agents-messages batch", "get_agent echoes the display name set at creation");
+});
+
+test("mcp-agents-msgs: update_agent renames the agent", async () => {
+  const email = await agent();
+  const newName = `mcp batch renamed ${Date.now()}`;
+  const r = await callTool(mcp, "update_agent", { email, name: newName });
+  assert.equal(r.isError, undefined, `update_agent isError: ${extractText(r).slice(0, 200)}`);
+  const parsed = parseJson<{ email?: string; name?: string }>(r);
+  assert.equal(parsed.email, email);
+  assert.equal(parsed.name, newName, "update_agent applies the new display name");
+
+  // Confirm it stuck via a fresh read.
+  const check = await callTool(mcp, "get_agent", { email });
+  assert.equal(check.isError, undefined);
+  assert.equal(parseJson<{ name?: string }>(check).name, newName, "renamed name persists across a fresh get_agent");
+});
+
+// ── get_protection / update_protection (beta) ─────────────────────────────
+
+test("mcp-agents-msgs: get_protection reads the agent's protection posture", async () => {
+  const email = await agent();
+  const r = await callTool(mcp, "get_protection", { email });
+  assert.equal(r.isError, undefined, `get_protection isError: ${extractText(r).slice(0, 200)}`);
+  const parsed = parseJson<{
+    inbound?: { gate?: { policy?: string } };
+    outbound?: { gate?: { policy?: string } };
+    holds?: { on_expiry?: string; ttl_seconds?: number };
+  }>(r);
+  assert.ok(parsed.inbound?.gate?.policy, "protection view carries an inbound gate policy");
+  assert.ok(parsed.outbound?.gate?.policy, "protection view carries an outbound gate policy");
+  // suppress_notifications is boolean `false`-omitted on the wire (only
+  // present when true), so assert on a field that's always emitted instead.
+  assert.ok(parsed.holds?.on_expiry, "protection view carries a holds.on_expiry");
+  assert.equal(typeof parsed.holds?.ttl_seconds, "number", "holds.ttl_seconds is a number");
+});
+
+test("mcp-agents-msgs: update_protection read-modify-writes a single field", async () => {
+  const email = await agent();
+  // holds_suppress_notifications is a purely-cosmetic toggle (no gate/scan
+  // change), so it can't perturb the later real-send/forward tests in this
+  // file that depend on the default open outbound policy.
+  const before = await callTool(mcp, "get_protection", { email });
+  assert.equal(before.isError, undefined);
+  const beforeCfg = parseJson<{ holds?: { suppress_notifications?: boolean } }>(before);
+  const flipped = !beforeCfg.holds?.suppress_notifications;
+
+  const r = await callTool(mcp, "update_protection", { email, holds_suppress_notifications: flipped });
+  assert.equal(r.isError, undefined, `update_protection isError: ${extractText(r).slice(0, 200)}`);
+  const parsed = parseJson<{ holds?: { suppress_notifications?: boolean } }>(r);
+  assert.equal(parsed.holds?.suppress_notifications, flipped, "update_protection applies the requested field");
+
+  // Read-modify-write: everything else should be untouched.
+  const after = await callTool(mcp, "get_protection", { email });
+  const afterCfg = parseJson<{ inbound?: { gate?: { policy?: string } }; outbound?: { gate?: { policy?: string } } }>(after);
+  const beforeFull = parseJson<{ inbound?: { gate?: { policy?: string } }; outbound?: { gate?: { policy?: string } } }>(before);
+  assert.equal(afterCfg.inbound?.gate?.policy, beforeFull.inbound?.gate?.policy, "unrelated inbound gate policy untouched");
+  assert.equal(afterCfg.outbound?.gate?.policy, beforeFull.outbound?.gate?.policy, "unrelated outbound gate policy untouched");
+
+  // Restore the original value so later tests in this file see the agent's
+  // original posture (defensive; the field itself is inert either way).
+  const restore = await callTool(mcp, "update_protection", { email, holds_suppress_notifications: !flipped });
+  assert.equal(restore.isError, undefined);
+});
+
+// ── A self-send loopback message, shared by labels/conversations/lifecycle/forward/trash ──
+
+interface LoopbackFixture {
+  messageId: string;
+  conversationId: string;
+  subject: string;
+}
+
+let loopbackPromise: Promise<LoopbackFixture> | undefined;
+function loopback(): Promise<LoopbackFixture> {
+  loopbackPromise ??= (async () => {
+    const email = await agent();
+    const subject = uniqueSubject("mcp-batch-loopback");
+    const send = await apiClient.post<{ status: string; message_id: string }>(
+      `/v1/agents/${encodeURIComponent(email)}/messages`,
+      { body: { to: [email], subject, text: "27-mcp-agents-messages loopback body" }, expect: [200, 202] },
+    );
+    assert.ok(send.body?.message_id, `loopback send did not return a message_id: ${send.raw.slice(0, 200)}`);
+
+    for (let i = 0; i < 12; i++) {
+      const list = await apiClient.get<{ items: Array<{ id: string; subject: string; conversation_id: string }> }>(
+        `/v1/agents/${encodeURIComponent(email)}/messages`,
+        { query: { direction: "inbound", read_status: "all", limit: 20 } },
+      );
+      const m = list.body?.items?.find((x) => x.subject === subject);
+      if (m) return { messageId: m.id, conversationId: m.conversation_id, subject };
+      await sleep(1500);
+    }
+    throw new Error(`loopback message "${subject}" never appeared for ${email}`);
+  })();
+  return loopbackPromise;
+}
+
+// ── update_message_labels ─────────────────────────────────────────────────
+
+test("mcp-agents-msgs: update_message_labels adds then removes a label", async () => {
+  const email = await agent();
+  const { messageId } = await loopback();
+  const label = "e2e-mcp-batch";
+
+  const add = await callTool(mcp, "update_message_labels", { message_id: messageId, add_labels: [label], email });
+  assert.equal(add.isError, undefined, `update_message_labels(add) isError: ${extractText(add).slice(0, 200)}`);
+  const added = parseJson<{ message_id?: string; labels?: string[] }>(add);
+  assert.equal(added.message_id, messageId);
+  assert.ok(added.labels?.includes(label), `expected "${label}" in labels, got ${JSON.stringify(added.labels)}`);
+
+  const remove = await callTool(mcp, "update_message_labels", { message_id: messageId, remove_labels: [label], email });
+  assert.equal(remove.isError, undefined, `update_message_labels(remove) isError: ${extractText(remove).slice(0, 200)}`);
+  const removed = parseJson<{ labels?: string[] }>(remove);
+  assert.ok(!removed.labels?.includes(label), `expected "${label}" removed, got ${JSON.stringify(removed.labels)}`);
+});
+
+// ── list_conversations / get_conversation ─────────────────────────────────
+
+test("mcp-agents-msgs: list_conversations surfaces the loopback thread", async () => {
+  const email = await agent();
+  const { conversationId } = await loopback();
+
+  const r = await callTool(mcp, "list_conversations", { email });
+  assert.equal(r.isError, undefined, `list_conversations isError: ${extractText(r).slice(0, 200)}`);
+  const parsed = parseJson<{ conversations?: Array<{ id: string; message_count: number }> }>(r);
+  const conv = parsed.conversations?.find((c) => c.id === conversationId);
+  assert.ok(conv, `conversation ${conversationId} not found in list_conversations (${parsed.conversations?.length ?? 0} rows)`);
+  assert.ok(conv!.message_count >= 1, "our conversation has at least the loopback message");
+});
+
+test("mcp-agents-msgs: get_conversation returns the loopback thread with its member message", async () => {
+  const email = await agent();
+  const { conversationId, messageId } = await loopback();
+
+  const r = await callTool(mcp, "get_conversation", { conversation_id: conversationId, email });
+  assert.equal(r.isError, undefined, `get_conversation isError: ${extractText(r).slice(0, 200)}`);
+  const parsed = parseJson<{ id?: string; messages?: Array<{ id: string }>; participants?: string[] }>(r);
+  assert.equal(parsed.id, conversationId);
+  assert.ok(parsed.messages?.some((m) => m.id === messageId), "get_conversation includes our loopback message");
+  assert.ok(parsed.participants?.includes(email), "participants includes the self-send agent");
+});
+
+// ── get_message_lifecycle (beta) ──────────────────────────────────────────
+
+test("mcp-agents-msgs: get_message_lifecycle (beta) returns transitions for the loopback message", async () => {
+  const email = await agent();
+  const { messageId } = await loopback();
+
+  const r = await callTool(mcp, "get_message_lifecycle", { message_id: messageId, email });
+  assert.equal(r.isError, undefined, `get_message_lifecycle isError: ${extractText(r).slice(0, 200)}`);
+  const parsed = parseJson<{ transitions?: Array<{ message_id: string; outcome: string; reason_code: string }> }>(r);
+  assert.ok(Array.isArray(parsed.transitions) && parsed.transitions.length > 0, "at least one lifecycle transition recorded");
+  for (const t of parsed.transitions!) {
+    assert.equal(t.message_id, messageId, `transition message_id mismatch: ${JSON.stringify(t)}`);
+  }
+});
+
+// ── forward_message ────────────────────────────────────────────────────────
+
+test("mcp-agents-msgs: forward_message forwards the loopback message as a new thread", async () => {
+  const email = await agent();
+  const { messageId } = await loopback();
+
+  const r = await callTool(mcp, "forward_message", {
+    message_id: messageId,
+    to: [email],
+    text: "fwd comment from 27-mcp-agents-messages",
+    email,
+  });
+  assert.equal(r.isError, undefined, `forward_message isError: ${extractText(r).slice(0, 200)}`);
+  const parsed = parseJson<{ status?: string; message_id?: string }>(r);
+  assert.ok(parsed.message_id?.startsWith("msg_"), `expected msg_ id, got "${parsed.message_id}"`);
+  assert.ok(
+    parsed.status === "accepted" || parsed.status === "sent" || parsed.status === "pending_review",
+    `forward_message must be accepted, sent, or held, got "${parsed.status}"`,
+  );
+  if (parsed.status === "pending_review") {
+    // Default protection is open (no gate hold expected), but resolve
+    // defensively so no dangling review-queue item survives the suite.
+    const rej = await apiClient.post(`/v1/reviews/${parsed.message_id}/reject`, {
+      body: { reason: "27-mcp-agents-messages forward cleanup" },
+    });
+    assert.ok(rej.status === 200, `failed to reject held forward: ${rej.status} ${rej.raw.slice(0, 200)}`);
+  }
+});
+
+// ── delete_message / restore_message ──────────────────────────────────────
+
+test("mcp-agents-msgs: delete_message then restore_message round-trips the loopback message", async () => {
+  const email = await agent();
+  const { messageId } = await loopback();
+
+  const del = await callTool(mcp, "delete_message", { message_id: messageId, email, confirm: true });
+  assert.equal(del.isError, undefined, `delete_message isError: ${extractText(del).slice(0, 200)}`);
+  const delParsed = parseJson<{ deleted?: boolean; id?: string }>(del);
+  assert.deepEqual(delParsed, { deleted: true, id: messageId }, "delete_message result shape");
+
+  // Confirm it dropped out of the live listing via the REST surface.
+  const liveList = await apiClient.get<{ items: Array<{ id: string }> }>(
+    `/v1/agents/${encodeURIComponent(email)}/messages`,
+    { query: { direction: "inbound", read_status: "all", limit: 20 } },
+  );
+  assert.ok(!liveList.body?.items?.some((m) => m.id === messageId), "message absent from live listing after delete_message");
+
+  const restore = await callTool(mcp, "restore_message", { message_id: messageId, email });
+  assert.equal(restore.isError, undefined, `restore_message isError: ${extractText(restore).slice(0, 200)}`);
+  const restoreParsed = parseJson<{ id?: string; deleted_at?: string | null }>(restore);
+  assert.equal(restoreParsed.id, messageId);
+  assert.equal(restoreParsed.deleted_at, undefined, "restored message view omits deleted_at");
+
+  const liveAgain = await apiClient.get<{ items: Array<{ id: string }> }>(
+    `/v1/agents/${encodeURIComponent(email)}/messages`,
+    { query: { direction: "inbound", read_status: "all", limit: 20 } },
+  );
+  assert.ok(liveAgain.body?.items?.some((m) => m.id === messageId), "message back in live listing after restore_message");
+});
+
+// ── get_attachment / get_attachment_data ──────────────────────────────────
+//
+// A HELD (pending_review) draft has NO raw_message, so its attachments[] is
+// empty and getAttachment 404s (see 20-attachments.test.ts). The default
+// protection posture on our throwaway agent is open (never held), so a real
+// no-hold send to the SES simulator is a reliable way to get retrievable
+// attachment bytes without depending on external MX.
+
+const ATTACH_TEXT = "hello mcp-agents-messages attachment";
+const ATTACH_B64 = Buffer.from(ATTACH_TEXT, "utf8").toString("base64");
+const ATTACH_FILENAME = "hello.txt";
+const ATTACH_CTYPE = "text/plain";
+
+interface AttachmentFixture {
+  messageId: string;
+}
+
+let attachmentPromise: Promise<AttachmentFixture | null> | undefined;
+function attachmentFixture(): Promise<AttachmentFixture | null> {
+  attachmentPromise ??= (async () => {
+    const email = await agent();
+    const send = await apiClient.post<{ status: string; message_id: string }>(
+      `/v1/agents/${encodeURIComponent(email)}/messages`,
+      {
+        body: {
+          to: ["success@simulator.amazonses.com"],
+          subject: uniqueSubject("mcp-batch-attach"),
+          text: "see attached",
+          attachments: [{ filename: ATTACH_FILENAME, content_type: ATTACH_CTYPE, data: ATTACH_B64 }],
+        },
+      },
+    );
+    if ((send.status !== 200 && send.status !== 202) || !send.body?.message_id) {
+      warn(SUITE, "attachment-setup", `real send with attachment did not return 200/202+message_id (got ${send.status}); attachment tests flagged`, send.raw.slice(0, 200));
+      return null;
+    }
+    const messageId = send.body.message_id;
+    for (let attempt = 0; attempt < 24; attempt++) {
+      const msg = await apiClient.get<{ attachments?: Array<{ index: number }> }>(
+        `/v1/agents/${encodeURIComponent(email)}/messages/${messageId}`,
+      );
+      if (msg.status === 200 && Array.isArray(msg.body?.attachments) && msg.body!.attachments.length > 0) {
+        return { messageId };
+      }
+      await sleep(1000);
+    }
+    warn(
+      SUITE,
+      "attachment-setup",
+      "real send accepted the attachment but never exposed a retrievable attachments[] within the poll window; attachment tests flagged",
+    );
+    return null;
+  })();
+  return attachmentPromise;
+}
+
+test("mcp-agents-msgs: get_attachment returns metadata + a short-lived download_url", async () => {
+  const email = await agent();
+  const fixture = await attachmentFixture();
+  if (!fixture) {
+    info(SUITE, "get-attachment-skip", "no attachment fixture available; skipping get_attachment happy path");
+    return;
+  }
+  const r = await callTool(mcp, "get_attachment", { message_id: fixture.messageId, attachment_index: 0, email });
+  assert.equal(r.isError, undefined, `get_attachment isError: ${extractText(r).slice(0, 200)}`);
+  const parsed = parseJson<{
+    index?: number;
+    filename?: string;
+    content_type?: string;
+    size_bytes?: number;
+    download_url?: string;
+    expires_at?: string;
+    data?: string;
+  }>(r);
+  assert.equal(parsed.index, 0);
+  assert.equal(parsed.filename, ATTACH_FILENAME);
+  assert.equal(parsed.content_type, ATTACH_CTYPE);
+  assert.equal(parsed.size_bytes, ATTACH_TEXT.length);
+  assert.ok(parsed.download_url?.length, "download_url present");
+  assert.ok(parsed.data === undefined, "no inline data unless inline:true was requested");
+});
+
+test("mcp-agents-msgs: get_attachment_data (legacy alias) returns inline base64 that round-trips", async () => {
+  const email = await agent();
+  const fixture = await attachmentFixture();
+  if (!fixture) {
+    info(SUITE, "get-attachment-data-skip", "no attachment fixture available; skipping get_attachment_data happy path");
+    return;
+  }
+  const r = await callTool(mcp, "get_attachment_data", { message_id: fixture.messageId, attachment_index: 0, agent_email: email });
+  assert.equal(r.isError, undefined, `get_attachment_data isError: ${extractText(r).slice(0, 200)}`);
+  const parsed = parseJson<{ filename?: string; content_type?: string; size_bytes?: number; data?: string }>(r);
+  assert.equal(parsed.filename, ATTACH_FILENAME);
+  assert.equal(parsed.content_type, ATTACH_CTYPE);
+  assert.ok(typeof parsed.data === "string" && parsed.data.length > 0, "inline base64 data present");
+  const decoded = Buffer.from(parsed.data!, "base64").toString("utf8");
+  assert.equal(decoded, ATTACH_TEXT, "get_attachment_data round-trips the exact sent bytes");
+});
+
+// ── delete_agent / restore_agent ──────────────────────────────────────────
+// Runs LAST: everything above depends on the agent staying live.
+
+test("mcp-agents-msgs: delete_agent then restore_agent round-trips the throwaway agent", async () => {
+  const email = await agent();
+
+  const del = await callTool(mcp, "delete_agent", { email, confirm: true });
+  assert.equal(del.isError, undefined, `delete_agent isError: ${extractText(del).slice(0, 200)}`);
+  const delParsed = parseJson<{ deleted?: boolean; email?: string }>(del);
+  assert.equal(delParsed.deleted, true);
+  assert.equal(delParsed.email, email);
+
+  // Trashed agent 404s on a live GET (via REST, matching 24-trash-lifecycle).
+  const getAfterDelete = await apiClient.get(`/v1/agents/${encodeURIComponent(email)}`);
+  assert.equal(getAfterDelete.status, 404, `expected 404 for trashed agent, got ${getAfterDelete.status}`);
+
+  const restore = await callTool(mcp, "restore_agent", { email });
+  assert.equal(restore.isError, undefined, `restore_agent isError: ${extractText(restore).slice(0, 200)}`);
+  const restoreParsed = parseJson<{ email?: string; deleted_at?: string | null }>(restore);
+  assert.equal(restoreParsed.email, email);
+  assert.equal(restoreParsed.deleted_at, undefined, "restored agent view omits deleted_at");
+
+  const getAfterRestore = await apiClient.get(`/v1/agents/${encodeURIComponent(email)}`);
+  assert.equal(getAfterRestore.status, 200, `expected 200 after restore, got ${getAfterRestore.status}`);
+
+  // `after()`'s cleanup() re-trashes this tracked throwaway agent (soft
+  // delete), matching every other suite's teardown-into-trash convention.
+});

--- a/tests/e2e-prod/suites/28-mcp-domains-reviews.test.ts
+++ b/tests/e2e-prod/suites/28-mcp-domains-reviews.test.ts
@@ -1,0 +1,219 @@
+import { test, before, after, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient } from "../harness/client.ts";
+import { cleanup, track, untrack } from "../harness/cleanup.ts";
+import { HttpMcpClient, callTool } from "../harness/mcp.ts";
+import { uniqueSlug, uniqueSubject, runId, SINK_EMAIL, holdAllOutbound } from "../harness/fixtures.ts";
+import { fail, info, warn, writeReport } from "../harness/report.ts";
+
+// MCP coverage for the domains tool family (register_domain, get_domain,
+// list_domains, verify_domain, delete_domain) and the pending-review-queue
+// legacy alias family (approve_message, reject_message, get_pending_message,
+// list_pending_messages — deprecated aliases that all route through the same
+// unified review queue as approve_review/reject_review/get_review/list_reviews,
+// see mcp/src/tools/legacy.ts). Both families are exercised over the deployed
+// streamable-HTTP /mcp server, mirroring suites/12-mcp-extended.test.ts style.
+const apiClient = new ApiClient();
+const SUITE = "28-mcp-domains-reviews";
+const mcp = new HttpMcpClient(apiClient.env.mcpUrl, apiClient.env.apiKey);
+
+// .example.com is reserved by RFC 2606 for documentation/testing — safe to
+// register-then-never-publish-DNS without colliding with anything real. Same
+// convention as suites/10-domains.test.ts.
+function fakeDomain(label: string): string {
+  return `e2e-${runId()}-${label}-${Math.random().toString(36).slice(2, 8)}.example.com`;
+}
+
+function extractText(r: { content?: Array<{ type: string; text?: string }> }): string {
+  return r.content?.find((c) => c.type === "text")?.text ?? "";
+}
+
+before(async () => {
+  info(SUITE, "transport", `MCP over HTTP → ${apiClient.env.mcpUrl}`);
+});
+
+afterEach(async () => {
+  const r = await cleanup(apiClient);
+  if (r.failed.length) warn(SUITE, "cleanup-after-each", `failed ${r.failed.length}`, r.failed);
+});
+
+after(async () => {
+  await mcp.stop();
+  const r = await cleanup(apiClient);
+  if (r.failed.length) warn(SUITE, "cleanup", `failed ${r.failed.length}`, r.failed);
+  writeReport(`./reports/28-mcp-domains-reviews.json`);
+});
+
+// createHeldReview: throwaway shared-domain agent -> hold-all-outbound ->
+// send. Returns the agent email + the held message id. Mirrors
+// suites/18-reviews.test.ts's createHeldReview / suites/12-mcp-extended.test.ts's
+// ensureHitlAgent — the proven mechanism for landing a message in
+// pending_review that the review/pending-message MCP tools can then act on.
+// Caller MUST delete the agent (via track("agent", email) + cleanup, or
+// explicitly) once done.
+async function createHeldReview(label: string): Promise<{ email: string; id: string; subject: string }> {
+  const slug = uniqueSlug(label);
+  const c = await apiClient.post<{ email: string }>("/v1/agents", {
+    body: { email: `${slug}@${apiClient.env.sharedDomain}`, name: `mcp-dr ${label}` },
+  });
+  if (c.status !== 201) throw new Error(`create agent failed: ${c.status} ${c.raw.slice(0, 200)}`);
+  const email = c.body!.email;
+  track("agent", email);
+  const u = await holdAllOutbound(apiClient, email);
+  if (u.status !== 200) throw new Error(`hold-all-outbound failed: ${u.status} ${u.raw.slice(0, 200)}`);
+  const subject = uniqueSubject(`mcp-dr ${label}`);
+  const s = await apiClient.post<{ message_id: string; status: string }>(
+    `/v1/agents/${encodeURIComponent(email)}/messages`,
+    { body: { to: [SINK_EMAIL], subject, text: "held for review via MCP — must never actually go out" } },
+  );
+  if (s.status !== 202 || !s.body?.message_id) {
+    throw new Error(`held send expected 202 pending_review, got ${s.status}: ${s.raw.slice(0, 200)}`);
+  }
+  assert.equal(s.body.status, "pending_review", "held send status is pending_review");
+  return { email, id: s.body.message_id, subject };
+}
+
+test("mcp-domains: register_domain / get_domain / list_domains / verify_domain (negative control) / delete_domain", async () => {
+  // Call tools/list once so the coverage gate records the live denominator
+  // (harness/mcp.ts feeds mcp-coverage.ts from this same JSON-RPC call).
+  const list = await mcp.call<{ tools: Array<{ name: string }> }>("tools/list");
+  for (const name of [
+    "register_domain",
+    "get_domain",
+    "list_domains",
+    "verify_domain",
+    "delete_domain",
+    "approve_message",
+    "reject_message",
+    "get_pending_message",
+    "list_pending_messages",
+  ]) {
+    assert.ok(list.tools.some((t) => t.name === name), `deployed server must advertise ${name}`);
+  }
+
+  const domain = fakeDomain("mcpdom");
+
+  // register_domain — step 1 of the custom-domain flow. Track immediately so
+  // the afterEach/after cleanup net catches it even if a later assertion in
+  // this test throws (free-plan account: 1 domain total, must not leak it).
+  const reg = await callTool(mcp, "register_domain", { domain });
+  if (reg.isError) {
+    fail(SUITE, "register-domain-error", `register_domain isError: ${extractText(reg).slice(0, 200)}`);
+    return;
+  }
+  track("domain", domain);
+  const regParsed = JSON.parse(extractText(reg)) as {
+    domain?: string;
+    dns_records?: Array<{ type: string; purpose: string }>;
+    verified?: boolean;
+  };
+  assert.equal(regParsed.domain, domain, "register_domain echoes the requested domain");
+  assert.ok(Array.isArray(regParsed.dns_records) && regParsed.dns_records.length > 0, "register_domain returns dns_records to publish");
+  assert.equal(regParsed.verified, false, "a freshly-registered domain starts unverified");
+
+  // get_domain — poll target, single-domain read.
+  const got = await callTool(mcp, "get_domain", { domain });
+  assert.equal(got.isError, undefined, `get_domain isError: ${extractText(got).slice(0, 200)}`);
+  const gotParsed = JSON.parse(extractText(got)) as { domain?: string; verified?: boolean };
+  assert.equal(gotParsed.domain, domain, "get_domain returns the same domain we registered");
+
+  // list_domains — assert OUR domain is present by name. No account-global
+  // count assertion: other suites/agents may share this account.
+  const listed = await callTool(mcp, "list_domains", {});
+  assert.equal(listed.isError, undefined, `list_domains isError: ${extractText(listed).slice(0, 200)}`);
+  const listedParsed = JSON.parse(extractText(listed)) as { domains?: Array<{ domain: string }> };
+  assert.ok(
+    listedParsed.domains?.some((d) => d.domain === domain),
+    `list_domains must include our freshly-registered ${domain}`,
+  );
+
+  // verify_domain — NEGATIVE CONTROL. We deliberately never publish the DNS
+  // records for this .example.com domain, so this must report verified:false
+  // as a NORMAL 200-equivalent success (not isError) — the honest way to
+  // cover verify_domain here per the task brief: calling it on a domain
+  // whose DNS IS published would either hang forever or (if it isn't yet
+  // propagated) negative-cache the miss for up to the zone's SOA minimum
+  // (~30min), which no in-test poll can outlast. This also guards against a
+  // dev-mode DNS short-circuit tautology (suites/22-domain-lifecycle.test.ts
+  // runs the equivalent REST-side negative control).
+  const verify = await callTool(mcp, "verify_domain", { domain });
+  assert.equal(verify.isError, undefined, `verify_domain (negative control) must be a normal success, not isError: ${extractText(verify).slice(0, 200)}`);
+  const verifyParsed = JSON.parse(extractText(verify)) as { domain?: string; verified?: boolean };
+  assert.equal(verifyParsed.domain, domain, "verify_domain echoes the domain");
+  assert.equal(verifyParsed.verified, false, "unpublished-DNS domain must report verified:false, not a DNS/dev-mode short-circuit");
+
+  // delete_domain — DESTRUCTIVE, requires confirm:true (schema-level literal
+  // guard against an LLM hallucinating a delete). No agents were ever
+  // created on this domain (it never verified), so no domain_has_agents risk.
+  const del = await callTool(mcp, "delete_domain", { domain, confirm: true });
+  assert.equal(del.isError, undefined, `delete_domain isError: ${extractText(del).slice(0, 200)}`);
+  const delParsed = JSON.parse(extractText(del)) as { deleted?: boolean; domain?: string };
+  assert.equal(delParsed.deleted, true, "delete_domain result has deleted:true");
+  assert.equal(delParsed.domain, domain, "delete_domain result echoes the domain");
+  // Already deleted via the tool call above — untrack so the redundant
+  // afterEach cleanup DELETE (which would 404, itself harmless) is skipped.
+  untrack("domain", domain);
+});
+
+test("mcp-domains-reviews: list_pending_messages + get_pending_message + approve_message round-trip", async () => {
+  const { email, id, subject } = await createHeldReview("approve");
+  try {
+    // list_pending_messages — deprecated alias for list_reviews; walks every
+    // page of the unified account-level review queue and returns the
+    // historical {messages: [...]} envelope. Assert OUR held message is
+    // present by id, not an account-global count.
+    const listed = await callTool(mcp, "list_pending_messages", {});
+    assert.equal(listed.isError, undefined, `list_pending_messages isError: ${extractText(listed).slice(0, 200)}`);
+    const listedParsed = JSON.parse(extractText(listed)) as { messages?: Array<{ id?: string }> };
+    assert.ok(
+      listedParsed.messages?.some((m) => m.id === id),
+      `list_pending_messages must include our held message ${id}`,
+    );
+
+    // get_pending_message — deprecated alias for get_review; full detail.
+    const got = await callTool(mcp, "get_pending_message", { message_id: id });
+    assert.equal(got.isError, undefined, `get_pending_message isError: ${extractText(got).slice(0, 200)}`);
+    const gotParsed = JSON.parse(extractText(got)) as { id?: string; review_status?: string; subject?: string };
+    assert.equal(gotParsed.id, id, "get_pending_message returns the same message id");
+    assert.equal(gotParsed.review_status, "pending_review", "held message is still pending_review before approval");
+    assert.equal(gotParsed.subject, subject, "get_pending_message echoes the held subject");
+
+    // approve_message — deprecated alias for approve_review; releases the
+    // outbound hold for async send (queued, not necessarily synchronous).
+    const approved = await callTool(mcp, "approve_message", { message_id: id });
+    assert.equal(approved.isError, undefined, `approve_message isError: ${extractText(approved).slice(0, 200)}`);
+    const approvedParsed = JSON.parse(extractText(approved)) as { message_id?: string; status?: string };
+    assert.equal(approvedParsed.message_id, id, "approve_message result echoes the approved message id");
+    assert.ok(
+      approvedParsed.status === "accepted" || approvedParsed.status === "sent",
+      `approve_message must transition to accepted/sent, got "${approvedParsed.status}"`,
+    );
+
+    // Re-approve a resolved hold must surface as a terminal-state tool error.
+    const reapproved = await callTool(mcp, "approve_message", { message_id: id });
+    assert.equal(reapproved.isError, true, "re-approve of an already-resolved message must isError");
+  } finally {
+    // Agent delete cascades to its held/sent messages; explicit and tracked
+    // regardless so a mid-test throw still gets cleaned up.
+    await apiClient.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE`);
+    untrack("agent", email);
+  }
+});
+
+test("mcp-domains-reviews: reject_message discards the held draft", async () => {
+  const { email, id } = await createHeldReview("reject");
+  try {
+    const rejected = await callTool(mcp, "reject_message", { message_id: id, reason: "e2e mcp-domains-reviews reject" });
+    assert.equal(rejected.isError, undefined, `reject_message isError: ${extractText(rejected).slice(0, 200)}`);
+    const rejectedParsed = JSON.parse(extractText(rejected)) as { message_id?: string; status?: string };
+    assert.equal(rejectedParsed.message_id, id, "reject_message result echoes the rejected message id");
+    assert.equal(rejectedParsed.status, "review_rejected", "reject_message transitions the hold to review_rejected");
+
+    // Re-reject a resolved hold must surface as a terminal-state tool error.
+    const rereject = await callTool(mcp, "reject_message", { message_id: id, reason: "should fail" });
+    assert.equal(rereject.isError, true, "re-reject of an already-resolved message must isError");
+  } finally {
+    await apiClient.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE`);
+    untrack("agent", email);
+  }
+});

--- a/tests/e2e-prod/suites/28-mcp-domains-reviews.test.ts
+++ b/tests/e2e-prod/suites/28-mcp-domains-reviews.test.ts
@@ -4,7 +4,7 @@ import { ApiClient } from "../harness/client.ts";
 import { cleanup, track, untrack } from "../harness/cleanup.ts";
 import { HttpMcpClient, callTool } from "../harness/mcp.ts";
 import { uniqueSlug, uniqueSubject, runId, SINK_EMAIL, holdAllOutbound } from "../harness/fixtures.ts";
-import { fail, info, warn, writeReport } from "../harness/report.ts";
+import { info, warn, writeReport } from "../harness/report.ts";
 
 // MCP coverage for the domains tool family (register_domain, get_domain,
 // list_domains, verify_domain, delete_domain) and the pending-review-queue
@@ -97,10 +97,7 @@ test("mcp-domains: register_domain / get_domain / list_domains / verify_domain (
   // the afterEach/after cleanup net catches it even if a later assertion in
   // this test throws (free-plan account: 1 domain total, must not leak it).
   const reg = await callTool(mcp, "register_domain", { domain });
-  if (reg.isError) {
-    fail(SUITE, "register-domain-error", `register_domain isError: ${extractText(reg).slice(0, 200)}`);
-    return;
-  }
+  assert.equal(reg.isError, undefined, `register_domain isError: ${extractText(reg).slice(0, 200)}`);
   track("domain", domain);
   const regParsed = JSON.parse(extractText(reg)) as {
     domain?: string;


### PR DESCRIPTION
## Summary

The CLI ships 11 top-level commands. Its e2e harness (`cli/test/e2e.test.ts`,
a live-binary-spawn parity suite against staging) exercised only 5 with a
real success assertion: `whoami`, `agents`, `send`, `messages`, `keys`.
`config`, `doctor`, `listen`, `login`, `protection`, and `reply` had **no**
live coverage at all.

This adds a command-coverage gate — the CLI analogue of
`tests/e2e-prod/mcp_coverage_gate.py` + `harness/mcp-coverage.ts` — and
extends the e2e suite to close the gap.

## The denominator: parsed from `--help`, not grepped from source

`cli-coverage-gate.ts`'s catalog comes from parsing the live
`node cli/dist/bin/e2a.js --help` stdout (captured during the e2e run by
`test/harness/cli-coverage.ts`'s `parseHelpCommands()`), **not** from
grepping `cli/src/bin/e2a.ts`'s switch statement or its `USAGE` string as
source text. A source grep measures the repo instead of the shipped
artifact — it would drift silently the moment a command's `case` and its
`USAGE` line come apart. This mirrors exactly the reasoning that caught the
MCP-side drift: grepping `mcp/src/tools/*.ts` for `registerTool()` found 58
tools while the deployed server actually advertised 60. The binary's own
advertisement — what a real `e2a --help` invocation shows a user they can
run — is the only honest catalog.

## Allowlist: `login`

`login` opens an interactive browser OAuth flow (spawns a local HTTP
callback server, waits up to 2 minutes for a human to complete a browser
redirect) — there's no headless way to drive it to a *successful*
invocation. It's allowlisted in `cli-coverage-gate.ts` with that
justification. As defense-in-depth (not counted as coverage), a new e2e
test asserts its non-interactive **failure** mode instead: an unreachable
`E2A_URL` must fail fast (exit 1, "could not reach …") *before* opening the
local callback server or any browser — proven by manually disabling the
harness's `VITEST_WORKER_ID` stripping and observing the documented silent
no-op (exit 0, empty stdout) this guards against.

## New e2e coverage

- **doctor** — read-only by design (never sends mail, never mutates
  DNS/webhooks/resources), so exercised fully: healthy (exit 0), the one
  side-effect-free warn condition doctor has (`E2A_OUTBOUND_SMTP_HOST` set
  without `_FROM_DOMAIN` → `smtp_partial`, exit 8), and a definite config
  failure (nonexistent agent → `agent_not_found`, exit 9). Asserts the
  versioned `e2a.doctor/v1` schema and exact exit codes per the frozen
  contract in `cli/src/exit.ts`.
- **listen** — `--once --until <deadline> --json` against a throwaway
  agent, racing a real concurrent `send` after the WebSocket connects;
  asserts the delivered message matches and that the documented side effect
  (the `--once`/`--json` API GET marks it read) actually happened.
- **login** — non-interactive preflight-failure assertion (see above).
- **config** — `list`/`get`/`set` round-trip against an isolated `HOME`
  (with `E2A_AGENT_EMAIL` unset for that invocation, since the env var
  otherwise shadows the file on read).
- **protection** — `get` → `set --outbound-review on` → `get` reflects the
  change, on a throwaway agent, then restored.
- **reply** — was silently uncovered too (not called out in the original
  gap list but genuinely untested): threads a reply onto a real inbound
  loopback message.

Bonus (not required by the gate, which only needs the top-level command):
`messages lifecycle` is now also exercised for real depth alongside
`list`/`get`.

## Proof the gate bites

Temporarily removed the `recordCovered("doctor")` call — the suite itself
stayed green (11/11, doctor's own assertions still ran and passed), but the
gate went red:

```
Covered            : 9
Allowlisted        : 1 ["login"]

UNCOVERED (1):
  doctor

Every advertised e2a command needs an e2e test that invokes it and asserts a
real success (output or exit code). Add a test, or add an ALLOWLIST entry
with a justification.
```
Restored, reran — back to green (10 covered + 1 allowlisted = 11 advertised).

## Vitest-env stripping (the documented harness gotcha)

Confirmed by breaking it: with `delete env.VITEST_WORKER_ID` (etc.) removed
from `run()`, the `whoami` test failed with `SyntaxError: Unexpected end of
JSON input` — `r.code` was `0` but `r.stdout` was empty, exactly the silent
no-op the harness comment warns about. Restored; my new `runAsync()` helper
(for `listen`, which must run concurrently with another `run()` call) does
the identical stripping.

## Results

- `npm test --workspace @e2a/cli` (unit): 244/244 pass.
- `npm run test:e2e:coverage --workspace @e2a/cli` against staging: 11/11
  e2e tests pass, gate reports **10 covered + 1 allowlisted = 11/11
  advertised**.

## Note on base branch

Branched from `origin/test/conformance-gate-integrity` per the task's
worktree setup (PR #703, currently open, not yet in `main`) rather than
`main` directly. This PR will show only this branch's own commit once #703
merges; until then the diff includes #703's commits too.

## Test plan

- [x] `npm test --workspace @e2a/cli` — 244/244 unit tests pass
- [x] `npm run test:e2e:coverage --workspace @e2a/cli` against staging —
      11/11 e2e tests pass, coverage gate PASS (10 covered + 1 allowlisted)
- [x] Demonstrated the gate bites (removed then restored one
      `recordCovered()` call)
- [x] Demonstrated the `VITEST_WORKER_ID` stripping is load-bearing (broke
      then restored it)
- [x] Cleaned up all throwaway agents/keys created against the dedicated
      staging account

🤖 Generated with [Claude Code](https://claude.com/claude-code)