### PR TITLE
test(sdks/python): ergonomic-facade coverage gate for AsyncE2AClient

### DIFF
--- a/mcp/src/tools/messages.ts
+++ b/mcp/src/tools/messages.ts
@@ -2,7 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { McpClient, SendOpts } from "../client.js";
 import type { MessageView } from "@e2a/sdk/v1";
 import { z } from "zod";
-import { runTool, strictInputSchema, paginationInput } from "./util.js";
+import { runTool, strictInputSchema, paginationInput, emailSelector } from "./util.js";
 import { attachmentsArraySchema, type AttachmentInput } from "./attachments.js";
 
 // Map the snake_case attachment wire shape (filename, content_type, data)
@@ -116,12 +116,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
           .describe(
             "Stable key for retry-safe sends. Set to deduplicate when the caller has its own retry loop (e.g. a stable triggering event id). When omitted the SDK mints a fresh UUIDv4 per call — protects against network-layer retries only, not user-driven retries.",
           ),
-        email: z
-          .string()
-          .optional()
-          .describe(
-            "Sending agent's inbox. Omit to use the credential's bound agent (agent-scoped credentials).",
-          ),
+        email: emailSelector,
       }),
     },
     async (args) =>
@@ -194,7 +189,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
           .describe(
             "Stable key for retry-safe replies. A natural choice is the inbound `message_id` you're replying to — the same triggering event yields the same key, so a retry replays the original response instead of double-sending. Omit to let the SDK mint a fresh UUIDv4 per call.",
           ),
-        email: z.string().optional(),
+        email: emailSelector,
       }),
     },
     async (args) =>
@@ -263,7 +258,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
           .describe(
             "Stable key for retry-safe forwards. The inbound `message_id` plus target list is a natural choice.",
           ),
-        email: z.string().optional(),
+        email: emailSelector,
       }),
     },
     async (args) =>
@@ -313,7 +308,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
           .array(z.string())
           .optional()
           .describe("Labels to remove. Entries not on the message are no-ops."),
-        email: z.string().optional(),
+        email: emailSelector,
       }),
     },
     async (args) =>
@@ -350,7 +345,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
           .describe(
             "RFC3339 timestamp. Only conversations whose latest message is < until.",
           ),
-        email: z.string().optional(),
+        email: emailSelector,
       }),
     },
     async (args) =>
@@ -377,7 +372,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
         "Returns the full thread — aggregate counts, the participants union (sender + recipient + to + cc + bcc across members), the labels union, and every live member message in chronological order (oldest first). Returns a not-found error when no live messages exist for `(agent, conversation_id)`. Use this after `list_conversations` (or whenever you have a `conversation_id` from an inbound/outbound payload) to read the full thread.",
       inputSchema: strictInputSchema({
         conversation_id: z.string(),
-        email: z.string().optional(),
+        email: emailSelector,
       }),
     },
     async (args) =>
@@ -447,7 +442,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
           .boolean()
           .optional()
           .describe("List the message trash instead of live messages."),
-        email: z.string().optional(),
+        email: emailSelector,
       }),
     },
     async (args) =>
@@ -484,7 +479,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
         "Restore a soft-deleted message before its trash-retention window expires. Time spent in trash does not consume the message's normal retention. Returns the restored message; a live message returns `not_in_trash`.",
       inputSchema: strictInputSchema({
         message_id: z.string().describe("ID of the trashed message to restore."),
-        email: z.string().optional().describe("Owning agent; defaults to the bound agent."),
+        email: emailSelector,
       }),
     },
     async (args) => runTool(() => client.restoreMessage(args.message_id, args.email)),
@@ -499,7 +494,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
         "Move a message to the trash. It disappears from lists, threads, and reply targets, but stays restorable with `restore_message` until the trash-retention window expires (30 days by default). Permanent deletion (\"delete forever\") is deliberately NOT exposed here — use the REST API/SDK for that. A message held for review cannot be deleted (`message_held`) — resolve it in the review queue first. Requires `confirm: true` — set it explicitly to acknowledge the destructive action.",
       inputSchema: strictInputSchema({
         message_id: z.string().describe("ID of the message to move to trash."),
-        email: z.string().optional().describe("Owning agent; defaults to the bound agent."),
+        email: emailSelector,
         confirm: z
           .literal(true)
           .describe(
@@ -528,7 +523,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
         "Use after `list_messages` to read one inbound or outbound message in full; for outbound messages, this is also how you poll a send's terminal outcome. Returns text + HTML, direction, labels, delivery/review lifecycle, suspicious-message flags and protection findings, header_from, envelope_from, verified_domain, SPF/DKIM/DMARC evidence, conversation id, and attachment metadata. `truncated:true` means the inbound parser clipped the decoded body. A non-null verified_domain means DMARC passed for the RFC 5322 From domain; it does not authenticate the mailbox local part, a person, or message content. Pass the message's `id` from the list response. **Side effect:** fetching an unread inbound message marks it read — there is no peek-without-consuming and no mark-unread, so only open a message when you mean to consume it. Attachment bytes and raw MIME are intentionally omitted to protect context; the response lists each attachment's filename, content_type, 0-based `index`, and size_bytes. Call `get_attachment` with that index to fetch one file by reference.",
       inputSchema: strictInputSchema({
         message_id: z.string(),
-        email: z.string().optional(),
+        email: emailSelector,
       }),
     },
     async (args) =>
@@ -550,7 +545,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
         "Beta: returns the ordered transitions e2a observed for one persisted inbound or outbound message; the lifecycle contract may change before it is declared stable. SMTP acceptance, upstream submission, provider delivery feedback, and complaint feedback remain distinct; this does not claim inbox placement. **Cursor-paginated:** returns one page in `transitions` plus `next_cursor` only when more pages remain; pass it back as `cursor` to continue, and stop when it is absent.",
       inputSchema: strictInputSchema({
         message_id: z.string(),
-        email: z.string().optional(),
+        email: emailSelector,
         cursor: z.string().optional(),
         limit: z.number().int().min(1).max(100).optional(),
       }),
@@ -597,12 +592,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
           .describe(
             "When true, also include the bytes as base64 `data` — ONLY for attachments ≤256 KB (larger requests error). Default false: use `download_url`.",
           ),
-        email: z
-          .string()
-          .optional()
-          .describe(
-            "Agent inbox holding the message. Omit to use the credential's bound agent (agent-scoped credentials).",
-          ),
+        email: emailSelector,
       }),
     },
     async (args) =>

--- a/mcp/src/tools/util.ts
+++ b/mcp/src/tools/util.ts
@@ -139,6 +139,22 @@ export const paginationInput = {
     .describe("Max items in this page (1–100). Defaults to a server-chosen page size (100)."),
 } as const;
 
+// emailSelector is the ONE agent-selector field for every tool that acts on a
+// single agent's mailbox. The credential's scope decides whether it may be
+// omitted: an agent-scoped credential IS one agent, so the field defaults to
+// that bound agent; an account-scoped credential owns many agents and has no
+// default, so the field is REQUIRED at runtime even though the schema marks it
+// optional (the schema cannot know the credential's scope). Share this field —
+// and its wording — everywhere the selector appears so agents learn one rule,
+// not ten. Description-only contract: do NOT change the optionality; making it
+// schema-required would break agent-scoped callers that correctly omit it.
+export const emailSelector = z
+  .string()
+  .optional()
+  .describe(
+    "Owning agent's inbox (full email address). REQUIRED when the credential is account-scoped — an account-scoped credential owns many agents and has no bound agent to default to, so omitting `email` fails the call. Defaults to the bound agent for agent-scoped credentials (omit it there).",
+  );
+
 // CodedError: a wrapper-thrown error that carries a stable machine `code`
 // from the SERVER'S canonical vocabulary (e.g. "not_found") instead of the
 // blanket `invalid_request` that plain wrapper Errors map to. Use it when the

--- a/sdks/python/tests/.gitignore
+++ b/sdks/python/tests/.gitignore
@@ -1,0 +1,5 @@
+# Shards written by tests/resource_coverage_lib/tracker.py (mark_covered()),
+# read by tests/resource_coverage_gate.py. Same rationale as
+# tests/e2e-prod/.gitignore's `reports/`: these are per-run output, not
+# source, and must never be checked in stale.
+reports/

--- a/sdks/python/tests/conftest.py
+++ b/sdks/python/tests/conftest.py
@@ -1,0 +1,33 @@
+import os
+
+import pytest
+
+from .resource_coverage_lib.discovery import assert_no_reflection_bugs
+from .resource_coverage_lib.tracker import clear_reports
+
+_LIVE = bool(
+    os.environ.get("E2A_TEST_BASE_URL")
+    and os.environ.get("E2A_TEST_API_KEY")
+    and os.environ.get("E2A_TEST_AGENT_EMAIL")
+)
+
+# Cheap (no I/O, no credentials needed) sanity check that the resource-walk
+# heuristic in discovery.py hasn't silently broken — runs on every collection,
+# live or offline, so a refactor that breaks it fails fast instead of the gate
+# quietly reporting a shrunken denominator.
+assert_no_reflection_bugs()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _reset_resource_coverage_reports():
+    """Wipe stale resource-coverage shards once per live session.
+
+    A shard left over from a previous partial/aborted run could otherwise mask
+    a method THIS run failed to cover — the gate would see an old "covered"
+    entry and pass vacuously. Only runs when live creds are present: an
+    offline-only `pytest tests/` run never writes shards in the first place, so
+    there's nothing to reset (and nothing to protect against).
+    """
+    if _LIVE:
+        clear_reports()
+    yield

--- a/sdks/python/tests/resource_coverage_gate.py
+++ b/sdks/python/tests/resource_coverage_gate.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Python SDK ergonomic-facade coverage gate.
+
+``sdks/python/src/e2a/v1/client.py`` (+ ``inbound.py``) is a hand-written
+facade over a generated layer that is itself mechanically derived from
+``api/openapi.yaml`` and already covered transitively by the repo-root
+``/v1`` coverage gate (``tests/e2e-prod/coverage_gate.py``). The FACADE is
+where real bugs live — argument marshalling, response shaping, kwarg
+handling, request-body coercion (``_coerce``), pagination wiring — and until
+this gate existed it was almost untested: 6 methods exercised out of dozens.
+
+This is the Python-SDK analogue of ``tests/e2e-prod/mcp_coverage_gate.py``,
+with the same fail-closed discipline, and one deliberate difference in where
+the denominator comes from:
+
+  mcp_coverage_gate.py takes its denominator from shards the harness recorded
+  from the DEPLOYED SERVER's own `tools/list` advertisement, because a
+  server's tool catalog can vary by deployment/tier and there is no
+  drift-gated catalog file for it.
+
+  This gate takes its denominator from LIVE RUNTIME INTROSPECTION of
+  ``AsyncE2AClient`` (``tests/coverage/discovery.py``), computed fresh every
+  time the gate runs — not from a source grep, and not from a recorded shard.
+  A Python class's public surface doesn't vary by deployment the way a
+  server's advertised tool list can, so there's no need for the shard
+  indirection on the denominator side; asking the live object graph directly
+  is both simpler and more honest than grepping ``client.py``, which
+  undercounts the moment a resource is nested (see ``discovery.py``'s
+  docstring for the concrete miss this would otherwise cause: 57 vs the true
+  62 methods).
+
+SCOPE — async only. ``sync_client.py``'s ``E2AClient`` is a pure runtime
+mirror of ``AsyncE2AClient`` (``__getattr__`` + ``_wrap_attr``/``_wrap_value``)
+— there is exactly one implementation of resources / retries / error mapping
+/ pagination, the async one, by design (see that module's docstring). A
+marshalling bug lives in the async resource method; the sync facade can only
+fail to *relay* it, and that relay mechanism (bridging, error transparency,
+AutoPager -> SyncAutoPager, InboundResource wrapping, the async-context guard)
+already has dedicated offline coverage in ``tests/test_v1_sync_client.py``,
+including a structural parity test
+(``test_parity_every_async_method_reachable_sync``) that fails if a new async
+resource/method is ever unreachable from the sync facade. Re-running the same
+live argument-marshalling assertions twice (once per facade) against staging
+would double API/quota usage for zero incremental bug-catching power. This is
+a scope call, not an oversight — see the PR description for the full
+reasoning.
+
+Inputs:
+  - reports/resource-coverage/*.json : shards written by
+    tests/coverage/tracker.py's mark_covered(), one per pytest process.
+
+"Covered" means a test called the method, it returned without raising, AND
+the test asserted something about the real result (see tracker.py — the
+"only after a real assertion" half is a review-enforced convention, same
+limit the MCP/API gates accept for their own "isError!==true" / "2xx" proxy).
+
+Usage:
+    python3 tests/resource_coverage_gate.py [--reports DIR]
+
+Exit 0 = every discovered method covered (or allowlisted); 1 = coverage gap;
+2 = usage/IO error (including "no shards", which must never read as a pass).
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)  # so `from resource_coverage_lib.discovery import ...` resolves when run as a script
+
+# NB: this package is deliberately NOT named `coverage` — `coverage` is the
+# pytest-cov dependency's own top-level module name, and sys.path.insert(0, HERE)
+# would shadow it for the rest of the process (breaking --cov for anything
+# imported after this gate module).
+from resource_coverage_lib.discovery import discover_client_methods  # noqa: E402
+
+# Methods the live suite intentionally does NOT exercise, with the reason.
+# Keep this SHORT and justified — every entry is coverage we knowingly forgo.
+ALLOWLIST: dict[str, str] = {
+    "account.delete": (
+        "destructive — the suite must never delete its own staging account "
+        "(same reasoning as the /v1 gate's deleteAccount entry)"
+    ),
+    "account.suppressions.delete": (
+        "no happy-path black-box: account-level suppressions "
+        "(/v1/account/suppressions) have no create operation — a real entry is "
+        "created only by a real SES bounce/complaint, so there is nothing to "
+        "delete (identical to the /v1 gate's deleteSuppression entry). NOTE this "
+        "is distinct from agent-scoped suppressions (agents.create_suppression /"
+        " agents.delete_suppression), which DO have a direct create path and are "
+        "fully covered — do not conflate the two when re-evaluating this entry."
+    ),
+    "listen": (
+        "constructs a WSStream synchronously with zero network I/O and zero "
+        "request-body/response-shape surface to marshal (the bug class this gate "
+        "targets) — it just closes over api_key/agent_email/base_url. Real "
+        "connection/reconnect/parse behavior is covered offline by "
+        "tests/test_v1_websocket.py and the sync-bridge tests in "
+        "tests/test_v1_sync_client.py. Wiring a live WS round-trip through the "
+        "e2e-prod-style harness is a materially different piece of infra than "
+        "the HTTP-response-shaping bugs this gate exists to catch."
+    ),
+}
+
+
+def load_shards(reports_dir: str) -> tuple[set[str], int]:
+    covered: set[str] = set()
+    paths = sorted(glob.glob(os.path.join(reports_dir, "*.json")))
+    for path in paths:
+        with open(path, encoding="utf-8") as fh:
+            shard = json.load(fh)
+        if isinstance(shard, dict):
+            covered.update(shard.get("covered") or [])
+    return covered, len(paths)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--reports", default=os.path.join(HERE, "reports", "resource-coverage"))
+    args = ap.parse_args()
+
+    # The denominator: live introspection, computed now, not read from a shard.
+    try:
+        advertised = set(discover_client_methods().keys())
+    except Exception as e:  # pragma: no cover - defensive
+        print(f"resource_coverage_gate: failed to introspect AsyncE2AClient: {e!r}", file=sys.stderr)
+        return 2
+
+    if not advertised:
+        print(
+            "resource_coverage_gate: runtime introspection found zero methods on "
+            "AsyncE2AClient — the discovery heuristic is broken, not the SDK. "
+            "Refusing to report a vacuous pass.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if not os.path.isdir(args.reports):
+        print(
+            f"resource_coverage_gate: no shard directory at {args.reports}. "
+            "Run the live suite first (`pytest tests/test_e2e.py tests/test_e2e_resources.py`, "
+            "with E2A_TEST_BASE_URL/E2A_TEST_API_KEY/E2A_TEST_AGENT_EMAIL set); "
+            "an absent run is not a pass.",
+            file=sys.stderr,
+        )
+        return 2
+
+    covered, shard_count = load_shards(args.reports)
+
+    if shard_count == 0:
+        print(
+            f"resource_coverage_gate: no shards in {args.reports} — did the live suite run?",
+            file=sys.stderr,
+        )
+        return 2
+
+    # An allowlist entry that no longer names a real method is a silent hole
+    # (e.g. the method was renamed/removed) — fail loudly so it can't drift stale.
+    stale = set(ALLOWLIST) - advertised
+    if stale:
+        print(
+            f"resource_coverage_gate: allowlist entries not found by introspection "
+            f"(renamed/removed?): {sorted(stale)}",
+            file=sys.stderr,
+        )
+        return 2
+
+    # A covered name introspection never found means the test and the discovery
+    # heuristic disagree — surface it, but it can't mask a real gap.
+    unadvertised = sorted(covered - advertised)
+
+    missing = advertised - covered
+    allowlisted = missing & set(ALLOWLIST)
+    uncovered = sorted(missing - set(ALLOWLIST))
+
+    print(f"Shards               : {shard_count}")
+    print(f"Discovered methods   : {len(advertised)}  (AsyncE2AClient, recursive runtime introspection)")
+    print(f"Covered              : {len(covered & advertised)}")
+    print(f"Allowlisted          : {len(allowlisted)} " + (str(sorted(allowlisted)) if allowlisted else ""))
+    if unadvertised:
+        print(f"Recorded but not discovered (stale tracker call?): {unadvertised}")
+
+    if uncovered:
+        print(f"\nUNCOVERED ({len(uncovered)}):", file=sys.stderr)
+        for name in uncovered:
+            print(f"  {name}", file=sys.stderr)
+        print(
+            "\nEvery method AsyncE2AClient exposes needs a live test that calls it "
+            "successfully and asserts on the result, or an ALLOWLIST entry with a "
+            "justification.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("\nPASS: every ergonomic method AsyncE2AClient exposes is exercised (or explicitly allowlisted).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sdks/python/tests/resource_coverage_lib/__init__.py
+++ b/sdks/python/tests/resource_coverage_lib/__init__.py
@@ -1,0 +1,11 @@
+"""Ergonomic-facade coverage tooling for the Python SDK.
+
+Named `resource_coverage_lib` (not `coverage`) deliberately — `coverage` is
+pytest-cov's own dependency's top-level module name, and this package's
+directory is added to `sys.path` by `tests/resource_coverage_gate.py`, which
+would shadow the real one for the rest of the process.
+
+See ``tests/resource_coverage_gate.py`` for the gate's usage/design docstring
+(the MCP/`/v1` analogue: ``tests/e2e-prod/mcp_coverage_gate.py`` +
+``tests/e2e-prod/coverage_gate.py`` in the repo root).
+"""

--- a/sdks/python/tests/resource_coverage_lib/discovery.py
+++ b/sdks/python/tests/resource_coverage_lib/discovery.py
@@ -1,0 +1,110 @@
+"""Runtime introspection of AsyncE2AClient's public ergonomic surface.
+
+This is the Python-SDK analogue of ``tests/e2e-prod/harness/mcp-coverage.ts``'s
+``recordToolList`` (denominator = whatever the live MCP server advertises) and
+``scripts/check-sdk-operation-coverage.py``'s TS-side AST walk: the count of
+"things this gate is accountable for" comes from asking the real object graph
+what it exposes, NOT from grepping ``client.py`` for ``async def`` / ``def``.
+
+Why a grep would go quietly wrong here specifically:
+
+  - Nested resource namespaces. ``client.account`` is one ``AccountResource``,
+    but it also carries ``.suppressions`` (a ``SuppressionsResource``) and
+    ``.api_keys`` (an ``APIKeysResource``) assigned dynamically in
+    ``AccountResource.__init__`` — a regex over method definitions in
+    ``client.py`` has no reliable way to know those five methods
+    (``suppressions.list/delete``, ``api_keys.list/create/delete``) are
+    reachable as ``client.account.suppressions.*`` / ``client.account.api_keys.*``
+    without re-deriving the exact attribute-assignment graph the source encodes
+    procedurally. A one-level-deep walk of the ten top-level resource names
+    (the natural first cut) undercounts by exactly this nesting: 57 methods
+    instead of the true 62. This is the same class of miss that made a TS SDK
+    regex report 32 methods against runtime's 59, and an MCP tool grep find 58
+    tools against the server's real 60 — the grep sees the resources it already
+    knows to look for and silently drops what it doesn't.
+  - Sync/async parity is achieved by ``sync_client.py`` wrapping the async tree
+    at RUNTIME (``__getattr__`` + ``_wrap_attr``), not by hand-written sync
+    methods a grep could find at all.
+
+So this module walks the live object graph instead: ``dir()``/``getattr()`` on
+a real ``AsyncE2AClient`` instance, recursing into nested resource namespaces
+with the identical "is this a resource, not a data model" heuristic
+``sync_client.py`` already uses for its own drift guard
+(``_is_resource`` there) — reusing that heuristic here (rather than inventing a
+second one) means this gate and the sync mirror can never quietly disagree
+about what counts as a resource.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Optional
+
+from e2a import AsyncE2AClient
+
+#: Public attributes that are lifecycle plumbing, not ergonomic API surface —
+#: excluded from the denominator for the same reason sync_client.py's
+#: ``_EXCLUDED_ATTRS`` keeps ``aclose`` off the sync facade: it has no request
+#: body to marshal and no response to shape, so there is no "argument
+#: marshalling / response shaping" bug for a coverage gate to catch here.
+_SKIP_NAMES = frozenset({"aclose"})
+
+
+def _is_resource(value: Any) -> bool:
+    """A nested resource namespace (e.g. ``account.suppressions``): a
+    non-callable, non-primitive object defined in the ``e2a`` package that
+    isn't a pydantic data model. Mirrors ``sync_client.py``'s ``_is_resource``
+    exactly — see the module docstring for why sharing the heuristic matters.
+    """
+    if callable(value) or isinstance(value, (str, bytes, int, float, bool, type(None))):
+        return False
+    cls = type(value)
+    if not cls.__module__.startswith("e2a."):
+        return False
+    return not hasattr(cls, "model_fields")  # pydantic models are data, not namespaces
+
+
+def discover_methods(obj: Any, prefix: str = "") -> Dict[str, Callable[..., Any]]:
+    """Recursively enumerate every public callable reachable from ``obj``.
+
+    Returns a ``{"agents.create": <bound method>, ...}`` map (dotted path ->
+    the live bound callable), built purely from runtime introspection
+    (``dir()``/``getattr()`` on the actual instance — the ``inspect`` module's
+    own recommended way to enumerate an object's members; equivalent in spirit
+    to ``vars(type(obj))`` but also picks up instance attributes assigned
+    dynamically in ``__init__``, which nested resources like
+    ``account.suppressions`` are).
+    """
+    found: Dict[str, Callable[..., Any]] = {}
+    for name in dir(obj):
+        if name.startswith("_") or name in _SKIP_NAMES:
+            continue
+        value = getattr(obj, name)
+        full = f"{prefix}{name}"
+        if callable(value):
+            found[full] = value
+        elif _is_resource(value):
+            found.update(discover_methods(value, prefix=f"{full}."))
+    return found
+
+
+def discover_client_methods(client: Optional[AsyncE2AClient] = None) -> Dict[str, Callable[..., Any]]:
+    """Discover the full ergonomic method surface of ``AsyncE2AClient``.
+
+    Builds a throwaway client when none is given — construction performs no
+    I/O (see ``client.py``: the constructor only builds the httpx transport
+    and resource wrappers), so this is safe to call at gate/collection time
+    without live credentials.
+    """
+    c = client or AsyncE2AClient(api_key="introspection-only", base_url="http://introspection.invalid")
+    return discover_methods(c)
+
+
+def assert_no_reflection_bugs() -> None:  # pragma: no cover - debugging helper
+    """Fail fast if ``discover_client_methods`` returns something absurd (e.g.
+    zero methods, meaning the heuristic broke against a refactor)."""
+    methods = discover_client_methods()
+    if len(methods) < 10:
+        raise AssertionError(
+            f"discover_client_methods found only {len(methods)} methods — "
+            "the resource-walk heuristic likely broke; fix before trusting the gate"
+        )

--- a/sdks/python/tests/resource_coverage_lib/tracker.py
+++ b/sdks/python/tests/resource_coverage_lib/tracker.py
@@ -1,0 +1,66 @@
+"""Records which ergonomic methods a live test run actually exercised.
+
+The numerator half of the gate (see ``discovery.py`` for the denominator).
+Mirrors ``tests/e2e-prod/harness/mcp-coverage.ts``'s shard-per-process design:
+each pytest process writes its own ``reports/resource-coverage/<pid>.json``,
+and the gate script (``tests/resource_coverage_gate.py``) unions every shard in
+the directory. That indirection (write-to-file, read-back-in-a-separate-step)
+is deliberate, not incidental complexity — it's what lets the gate be run as
+an independent, re-runnable check after the test process has already exited
+(`` `pytest ...` then `python tests/resource_coverage_gate.py` ``), exactly
+like the MCP/API gates, instead of only being trustworthy from inside a
+special pytest plugin hook.
+
+"Covered" is asserted by the CALLER: ``mark_covered(name)`` must only be
+called after the method call succeeded AND the test asserted something about
+the real result — never merely "it didn't raise". This mirrors
+``mcp-coverage.ts``'s ``recordToolCall``, which records a tool only when
+``isError !== true``: a rejected/erroring call proves the surface exists, not
+that it works. There's no way for this module to enforce the "asserted on the
+result" half automatically (same limitation the MCP/API gates accept) — that
+discipline is enforced by code review and by the `` `if not x: return` `` /
+bare-skip ban called out in the task, not by the tracker itself.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Set
+
+REPORTS_DIR = Path(__file__).resolve().parent.parent / "reports" / "resource-coverage"
+
+_covered: Set[str] = set()
+
+
+def mark_covered(name: str) -> None:
+    """Record that ergonomic method ``name`` (a dotted path matching
+    ``discovery.discover_client_methods``'s keys, e.g. ``"messages.send"``)
+    was called and its result asserted on.
+
+    Flushes synchronously (not on process exit) so a gate run in the SAME
+    process right after the test session — or a crash/SIGKILL mid-run — never
+    loses a recorded call: the shard on disk is always at least as complete as
+    what has actually been asserted so far.
+    """
+    if name in _covered:
+        return
+    _covered.add(name)
+    REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+    path = REPORTS_DIR / f"{os.getpid()}.json"
+    path.write_text(json.dumps({"covered": sorted(_covered)}))
+
+
+def clear_reports() -> None:
+    """Wipe every shard in the reports directory.
+
+    Called once at the start of a live test session (see ``tests/conftest.py``)
+    so a stale shard from a previous partial/aborted run can never mask a
+    method this run failed to cover — the same "pretest clears the directory"
+    discipline ``mcp-coverage.ts`` documents for the same reason.
+    """
+    if not REPORTS_DIR.exists():
+        return
+    for shard in REPORTS_DIR.glob("*.json"):
+        shard.unlink()

--- a/sdks/python/tests/test_e2e.py
+++ b/sdks/python/tests/test_e2e.py
@@ -28,6 +28,8 @@ import pytest
 from e2a import AsyncE2AClient, E2ANotFoundError
 from e2a.v1 import ReplyRequest, SendEmailRequest
 
+from .resource_coverage_lib.tracker import mark_covered
+
 BASE_URL = os.environ.get("E2A_TEST_BASE_URL", "")
 API_KEY = os.environ.get("E2A_TEST_API_KEY", "")
 AGENT = os.environ.get("E2A_TEST_AGENT_EMAIL", "")
@@ -51,6 +53,7 @@ async def test_info_reports_deployment() -> None:
     async with AsyncE2AClient(api_key=API_KEY, base_url=BASE_URL) as client:
         info = await client.info()
         assert isinstance(info.version, str) and info.version
+        mark_covered("info")
 
 
 async def test_send_find_get_reply_self_loopback() -> None:
@@ -62,6 +65,7 @@ async def test_send_find_get_reply_self_loopback() -> None:
     async with AsyncE2AClient(api_key=API_KEY, base_url=BASE_URL) as client:
         created = await client.agents.create({"email": bot, "name": "py-sdk live e2e"})
         assert created.email == bot
+        mark_covered("agents.create")
         try:
             subject = f"py-sdk-live {int(time.time() * 1000)}"
             sent = await client.messages.send(
@@ -74,6 +78,7 @@ async def test_send_find_get_reply_self_loopback() -> None:
             )
             assert sent.message_id
             assert sent.status in ("sent", "accepted")
+            mark_covered("messages.send")
 
             # Self-send loopback lands an INBOUND copy; filter to inbound so the
             # just-sent outbound copy (same subject) can't match.
@@ -85,6 +90,7 @@ async def test_send_find_get_reply_self_loopback() -> None:
                     break
                 await asyncio.sleep(1.5)
             assert found is not None, f"an inbound message with subject {subject!r} must appear within ~18s"
+            mark_covered("messages.list")
 
             full = await client.messages.get(bot, found.id)
             assert full.id == found.id
@@ -92,6 +98,7 @@ async def test_send_find_get_reply_self_loopback() -> None:
             # The delivered body is under `parsed` (inbound-extracted MIME), not
             # `body` (the held-outbound draft field, null for inbound by design).
             assert full.parsed is not None and "Hello from the Python SDK live e2e" in full.parsed.text
+            mark_covered("messages.get")
 
             reply = await client.messages.reply(
                 bot,
@@ -101,8 +108,11 @@ async def test_send_find_get_reply_self_loopback() -> None:
             assert reply.message_id
             # Fresh unprotected inbox → the reply sends immediately (same as send).
             assert reply.status in ("sent", "accepted")
+            mark_covered("messages.reply")
         finally:
-            await client.agents.delete(bot)
+            deleted = await client.agents.delete(bot)
+            assert deleted.deleted is True
+            mark_covered("agents.delete")
 
 
 async def test_list_bounded_page() -> None:

--- a/sdks/python/tests/test_e2e_resources.py
+++ b/sdks/python/tests/test_e2e_resources.py
@@ -1,0 +1,512 @@
+"""Live ergonomic-facade coverage for the Python SDK — the resource-coverage
+gate's test half (see ``tests/resource_coverage_gate.py`` for the gate itself
+and the full scope/design writeup).
+
+``tests/test_e2e.py`` already exercises 7 methods (``info``, ``agents.create``,
+``agents.delete``, ``messages.send``, ``messages.list``, ``messages.get``,
+``messages.reply``) as part of its self-loopback round trip and now calls
+``mark_covered`` for each. This module fills in the rest of the 64 methods
+runtime introspection finds on ``AsyncE2AClient``
+(``tests/resource_coverage_lib/discovery.py``), minus the two destructive/
+no-happy-path entries allowlisted in the gate (``account.delete``,
+``account.suppressions.delete``) and ``listen`` (allowlisted — see the gate
+for why).
+
+Every test here calls a real method against LIVE staging and asserts on the
+ACTUAL RETURNED DATA, then calls ``mark_covered("resource.method")`` — never
+the other way around, and never behind a bare ``pytest.skip()`` or an
+``if not x: return``. A missing fixture (no starter templates, no held
+review, ...) is a hard test failure, not a silent skip — that exact anti-
+pattern (a happy path silently no-op'ing on an empty precondition while the
+suite reports green) is the bug class this whole exercise exists to close.
+
+Same env contract as test_e2e.py: E2A_TEST_BASE_URL / E2A_TEST_API_KEY /
+E2A_TEST_AGENT_EMAIL (skips cleanly when absent). E2E_SINK_EMAIL defaults to
+the SES mailbox simulator's always-succeeds address, matching the e2e-prod
+harness's convention (tests/e2e-prod/harness/fixtures.ts).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import os
+import time
+
+import pytest
+
+from e2a import AsyncE2AClient
+
+from .resource_coverage_lib.tracker import mark_covered
+
+BASE_URL = os.environ.get("E2A_TEST_BASE_URL", "")
+API_KEY = os.environ.get("E2A_TEST_API_KEY", "")
+AGENT = os.environ.get("E2A_TEST_AGENT_EMAIL", "")
+SINK_EMAIL = os.environ.get("E2E_SINK_EMAIL", "success@simulator.amazonses.com")
+
+pytestmark = [
+    pytest.mark.anyio,
+    pytest.mark.skipif(
+        not BASE_URL or not API_KEY or not AGENT,
+        reason="E2A_TEST_BASE_URL, E2A_TEST_API_KEY, E2A_TEST_AGENT_EMAIL required for live e2e",
+    ),
+]
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    # Pin the asyncio backend, matching test_e2e.py.
+    return "asyncio"
+
+
+def _domain() -> str:
+    return AGENT.split("@", 1)[1]
+
+
+def _slug(label: str) -> str:
+    return f"py-sdk-cov-{label}-{int(time.time() * 1000):x}-{os.getpid()}"
+
+
+def _bot(label: str) -> str:
+    return f"{_slug(label)}@{_domain()}"
+
+
+def _client() -> AsyncE2AClient:
+    return AsyncE2AClient(api_key=API_KEY, base_url=BASE_URL)
+
+
+async def _find_inbound(client: AsyncE2AClient, email: str, subject: str, *, attempts: int = 15, delay: float = 1.5):
+    for _ in range(attempts):
+        msgs = await client.messages.list(email, direction="inbound", limit=20).to_list(limit=20)
+        found = next((m for m in msgs if m.subject == subject), None)
+        if found:
+            return found
+        await asyncio.sleep(delay)
+    raise AssertionError(f"no inbound message with subject {subject!r} appeared within ~{attempts * delay:.0f}s")
+
+
+async def _hold_all_outbound(client: AsyncE2AClient, email: str):
+    # Same shape as tests/e2e-prod/harness/fixtures.ts's holdAllOutbound(): an
+    # outbound review gate with policy=allowlist + action=review and an empty
+    # allowlist, so every recipient is unknown and every send is held.
+    return await client.agents.replace_protection(
+        email,
+        {
+            "inbound": {"gate": {}, "scan": {}},
+            "outbound": {"gate": {"policy": "allowlist", "action": "review", "allowlist": []}, "scan": {}},
+            "holds": {},
+        },
+    )
+
+
+# ── account + api keys ──────────────────────────────────────────────
+
+
+async def test_account_and_api_keys():
+    async with _client() as client:
+        account = await client.account.get()
+        assert account.scope == "account"
+        assert account.usage.agents >= 0
+        mark_covered("account.get")
+
+        export = await client.account.export()
+        assert export.schema_version
+        assert isinstance(export.suppressions, list)
+        mark_covered("account.export")
+
+        # Account-level suppressions have no create operation (only bounces /
+        # complaints populate them — see resource_coverage_gate.py's ALLOWLIST
+        # for .delete), so .list is exercised for its shape, not its contents.
+        page = await client.account.suppressions.list().to_list(limit=5)
+        assert isinstance(page, list)
+        mark_covered("account.suppressions.list")
+
+        key_name = f"py-sdk-cov-key-{int(time.time() * 1000):x}"
+        created = await client.account.api_keys.create({"name": key_name})
+        assert created.key.startswith("e2a_acct_")
+        assert created.name == key_name
+        mark_covered("account.api_keys.create")
+        try:
+            keys = await client.account.api_keys.list(limit=50).to_list(limit=50)
+            assert any(k.id == created.id for k in keys)
+            mark_covered("account.api_keys.list")
+        finally:
+            deleted = await client.account.api_keys.delete(created.id)
+            assert deleted.deleted is True
+            assert deleted.id == created.id
+            mark_covered("account.api_keys.delete")
+
+
+# ── agents lifecycle + agent-scoped suppressions ────────────────────
+
+
+async def test_agents_lifecycle_and_suppressions():
+    async with _client() as client:
+        email = _bot("agents")
+        created = await client.agents.create({"email": email, "name": "cov agents"})
+        assert created.email == email
+        mark_covered("agents.create")
+        try:
+            got = await client.agents.get(email)
+            assert got.email == email
+            mark_covered("agents.get")
+
+            updated = await client.agents.update(email, {"name": "cov agents updated"})
+            assert updated.name == "cov agents updated"
+            mark_covered("agents.update")
+
+            agents = await client.agents.list(limit=100).to_list(limit=100)
+            assert any(a.email == email for a in agents)
+            mark_covered("agents.list")
+
+            protection = await client.agents.get_protection(email)
+            assert protection.outbound.gate.policy == "open"  # default, before replace below
+            mark_covered("agents.get_protection")
+
+            replaced = await _hold_all_outbound(client, email)
+            assert replaced.outbound.gate.policy == "allowlist"
+            assert replaced.outbound.gate.action == "review"
+            mark_covered("agents.replace_protection")
+
+            tested = await client.agents.test(email)
+            assert tested.message_id
+            assert tested.status in ("accepted", "sent", "pending_review")
+            mark_covered("agents.test")
+
+            suppress_addr = f"suppressed-{int(time.time() * 1000):x}@example.com"
+            suppression = await client.agents.create_suppression(
+                email, {"address": suppress_addr, "reason": "py-sdk coverage gate"}
+            )
+            assert suppression.address == suppress_addr
+            mark_covered("agents.create_suppression")
+
+            suppressions = await client.agents.list_suppressions(email).to_list(limit=20)
+            assert any(s.address == suppress_addr for s in suppressions)
+            mark_covered("agents.list_suppressions")
+
+            deleted_suppression = await client.agents.delete_suppression(email, suppress_addr)
+            assert deleted_suppression.deleted is True
+            mark_covered("agents.delete_suppression")
+
+            deleted_agent = await client.agents.delete(email)
+            assert deleted_agent.deleted is True
+            assert deleted_agent.email == email
+            mark_covered("agents.delete")
+
+            restored = await client.agents.restore(email)
+            assert restored.email == email
+            assert restored.deleted_at is None
+            mark_covered("agents.restore")
+        finally:
+            await client.agents.delete(email)
+
+
+# ── messages extended surface + conversations + the inbound facade ──
+
+
+async def test_messages_extended_surface_conversations_and_inbound_facade():
+    async with _client() as client:
+        email = _bot("msg")
+        await client.agents.create({"email": email, "name": "cov messages"})
+        try:
+            subject = f"py-sdk-cov-msg {int(time.time() * 1000)}"
+            attachment_bytes = b"hello from the python sdk coverage gate"
+            sent = await client.messages.send(
+                email,
+                {
+                    "to": [email],
+                    "subject": subject,
+                    "text": "cov msg body",
+                    "attachments": [
+                        {
+                            "filename": "note.txt",
+                            "content_type": "text/plain",
+                            "data": base64.b64encode(attachment_bytes).decode(),
+                        }
+                    ],
+                },
+            )
+            assert sent.status in ("sent", "accepted")
+
+            found = await _find_inbound(client, email, subject)
+            assert found.subject == subject
+
+            full = await client.messages.get(email, found.id)
+            assert full.attachments and full.attachments[0].filename == "note.txt"
+
+            attachment = await client.messages.get_attachment(email, found.id, 0, inline=True)
+            assert attachment.filename == "note.txt"
+            assert base64.b64decode(attachment.data) == attachment_bytes
+            mark_covered("messages.get_attachment")
+
+            lifecycle = await client.messages.get_lifecycle(email, found.id)
+            assert lifecycle.items, "expected at least one recorded lifecycle transition"
+            assert lifecycle.items[0].message_id == found.id
+            mark_covered("messages.get_lifecycle")
+
+            labeled = await client.messages.update_labels(email, found.id, {"add_labels": ["cov-test"]})
+            assert "cov-test" in labeled.labels
+            assert labeled.message_id == found.id
+            mark_covered("messages.update_labels")
+
+            forwarded = await client.messages.forward(
+                email, found.id, {"to": [SINK_EMAIL], "text": "forwarded by the py-sdk coverage gate"}
+            )
+            assert forwarded.message_id
+            assert forwarded.status in ("sent", "accepted", "pending_review")
+            mark_covered("messages.forward")
+
+            deleted = await client.messages.delete(email, found.id)
+            assert deleted.deleted is True
+            assert deleted.id == found.id
+            mark_covered("messages.delete")
+
+            restored = await client.messages.restore(email, found.id)
+            assert restored.id == found.id
+            assert restored.deleted_at is None
+            mark_covered("messages.restore")
+
+            conversations = await client.conversations.list(email).to_list(limit=20)
+            assert any(c.id == found.conversation_id for c in conversations)
+            mark_covered("conversations.list")
+
+            detail = await client.conversations.get(email, found.conversation_id)
+            assert detail.id == found.conversation_id
+            assert detail.message_count >= 1
+            mark_covered("conversations.get")
+
+            class _Envelope:
+                """Minimal structural stand-in for the webhook/WS event
+                envelope (matches inbound.InboundEvent / client.EventLike)."""
+
+                id = "evt_cov_placeholder"
+                type = "email.received"
+                schema_version = "1"
+                created_at = "2026-01-01T00:00:00Z"
+                data = {"message_id": found.id, "delivered_to": email}
+
+            inbound_email = await client.inbound.from_event(_Envelope())
+            assert inbound_email.id == found.id
+            assert inbound_email.subject == subject
+            mark_covered("inbound.from_event")
+
+            fetched = await client.webhooks.fetch_message(_Envelope())
+            assert fetched.id == found.id
+            mark_covered("webhooks.fetch_message")
+        finally:
+            await client.agents.delete(email)
+
+
+# ── reviews: the account-level human-review queue ───────────────────
+
+
+async def test_reviews_list_get_approve_reject():
+    async with _client() as client:
+        approve_email = _bot("rev-a")
+        reject_email = _bot("rev-r")
+        await client.agents.create({"email": approve_email, "name": "cov review approve"})
+        await client.agents.create({"email": reject_email, "name": "cov review reject"})
+        try:
+            for email in (approve_email, reject_email):
+                await _hold_all_outbound(client, email)
+
+            approve_subject = f"py-sdk-cov-rev-approve {int(time.time() * 1000)}"
+            reject_subject = f"py-sdk-cov-rev-reject {int(time.time() * 1000)}"
+            approve_send = await client.messages.send(
+                approve_email, {"to": [SINK_EMAIL], "subject": approve_subject, "text": "held for approve"}
+            )
+            reject_send = await client.messages.send(
+                reject_email, {"to": [SINK_EMAIL], "subject": reject_subject, "text": "held for reject"}
+            )
+            assert approve_send.status == "pending_review"
+            assert reject_send.status == "pending_review"
+
+            reviews = await client.reviews.list(limit=100).to_list(limit=100)
+            ids = {r.id for r in reviews}
+            assert approve_send.message_id in ids
+            assert reject_send.message_id in ids
+            mark_covered("reviews.list")
+
+            got = await client.reviews.get(approve_send.message_id)
+            assert got.id == approve_send.message_id
+            mark_covered("reviews.get")
+
+            approved = await client.reviews.approve(approve_send.message_id)
+            assert approved.message_id == approve_send.message_id
+            assert approved.status in ("sent", "accepted")
+            mark_covered("reviews.approve")
+
+            rejected = await client.reviews.reject(reject_send.message_id, {"reason": "py-sdk coverage gate reject"})
+            assert rejected.message_id == reject_send.message_id
+            assert rejected.status == "review_rejected"
+            mark_covered("reviews.reject")
+        finally:
+            await client.agents.delete(approve_email)
+            await client.agents.delete(reject_email)
+
+
+# ── templates: CRUD + validate + the starter catalog ────────────────
+
+
+async def test_templates_full_crud_and_starters():
+    async with _client() as client:
+        starters = await client.templates.list_starters(limit=10).to_list(limit=10)
+        assert starters, "expected at least one starter template in the deployment's catalog"
+        mark_covered("templates.list_starters")
+
+        starter_detail = await client.templates.get_starter(starters[0].alias)
+        assert starter_detail.alias == starters[0].alias
+        assert starter_detail.subject
+        mark_covered("templates.get_starter")
+
+        name = f"py-sdk-cov-tmpl-{int(time.time() * 1000):x}"
+        created = await client.templates.create({"name": name, "subject": "Hi {{name}}", "text": "Hello {{name}}"})
+        assert created.name == name
+        assert created.id.startswith("tmpl_")
+        mark_covered("templates.create")
+        try:
+            got = await client.templates.get(created.id)
+            assert got.id == created.id
+            assert got.subject == "Hi {{name}}"
+            mark_covered("templates.get")
+
+            listed = await client.templates.list(limit=100).to_list(limit=100)
+            assert any(t.id == created.id for t in listed)
+            mark_covered("templates.list")
+
+            validated = await client.templates.validate(
+                {"subject": "Hi {{name}}", "text": "Hello {{name}}", "test_data": {"name": "Ada"}}
+            )
+            assert validated.valid is True
+            assert validated.rendered is not None
+            assert validated.rendered.subject == "Hi Ada"
+            mark_covered("templates.validate")
+
+            updated = await client.templates.update(created.id, {"subject": "Hi again {{name}}"})
+            assert updated.subject == "Hi again {{name}}"
+            mark_covered("templates.update")
+        finally:
+            deleted = await client.templates.delete(created.id)
+            assert deleted.deleted is True
+            assert deleted.id == created.id
+            mark_covered("templates.delete")
+
+
+# ── domains: register/get/list/verify/delete ─────────────────────────
+
+
+async def test_domains_register_get_list_verify_delete():
+    async with _client() as client:
+        # .example.com is RFC 2606-reserved — safe to register-then-never-
+        # verify without colliding with real DNS (same convention as
+        # tests/e2e-prod/suites/10-domains.test.ts's fakeDomain()).
+        domain = f"py-sdk-cov-{int(time.time() * 1000):x}.example.com"
+        created = await client.domains.create({"domain": domain})
+        assert created.domain == domain
+        assert created.verified is False
+        mark_covered("domains.create")
+        try:
+            got = await client.domains.get(domain)
+            assert got.domain == domain
+            mark_covered("domains.get")
+
+            listed = await client.domains.list(limit=100).to_list(limit=100)
+            assert any(d.domain == domain for d in listed)
+            mark_covered("domains.list")
+
+            verified = await client.domains.verify(domain)
+            assert verified.domain == domain
+            # No real DNS was ever published for this throwaway domain, so the
+            # honest assertion is "still unverified" — asserting True here
+            # would be the exact "assert on a result you didn't actually
+            # produce" anti-pattern the task calls out.
+            assert verified.verified is False
+            mark_covered("domains.verify")
+        finally:
+            deleted = await client.domains.delete(domain)
+            assert deleted.deleted is True
+            assert deleted.domain == domain
+            mark_covered("domains.delete")
+
+
+# ── webhooks (full CRUD + test + deliveries) and events ──────────────
+
+
+async def test_webhooks_and_events_full_surface():
+    async with _client() as client:
+        email = _bot("evt")
+        await client.agents.create({"email": email, "name": "cov events"})
+        hook = await client.webhooks.create(
+            {
+                "url": "https://example.com/py-sdk-coverage-webhook",
+                "events": ["email.sent"],
+                "description": "py-sdk resource coverage gate",
+            }
+        )
+        assert hook.id.startswith("wh_")
+        assert hook.signing_secret.startswith("whsec_")
+        mark_covered("webhooks.create")
+        try:
+            got = await client.webhooks.get(hook.id)
+            assert got.id == hook.id
+            mark_covered("webhooks.get")
+
+            listed = await client.webhooks.list(limit=100).to_list(limit=100)
+            assert any(w.id == hook.id for w in listed)
+            mark_covered("webhooks.list")
+
+            updated = await client.webhooks.update(hook.id, {"description": "patched by the coverage gate"})
+            assert updated.description == "patched by the coverage gate"
+            mark_covered("webhooks.update")
+
+            rotated = await client.webhooks.rotate_secret(hook.id)
+            assert rotated.signing_secret.startswith("whsec_")
+            assert rotated.signing_secret != hook.signing_secret
+            mark_covered("webhooks.rotate_secret")
+
+            tested = await client.webhooks.test(hook.id, {"type": "email.sent", "data": {}})
+            assert tested.delivery_id
+            mark_covered("webhooks.test")
+
+            # webhooks.deliveries: the test() call above enqueues a real
+            # delivery attempt — give it a moment to land, then assert it's
+            # actually visible (not just that the call didn't raise).
+            deliveries = []
+            for _ in range(10):
+                deliveries = await client.webhooks.deliveries(hook.id, limit=20).to_list(limit=20)
+                if deliveries:
+                    break
+                await asyncio.sleep(1.0)
+            assert deliveries, "expected at least one delivery to be visible after webhooks.test()"
+            assert any(d.id == tested.delivery_id for d in deliveries)
+            mark_covered("webhooks.deliveries")
+
+            # events.list/get/redeliver need a REAL event (not the synthetic
+            # payload webhooks.test() sent) — trigger one with a real send.
+            subject = f"py-sdk-cov-evt {int(time.time() * 1000)}"
+            sent = await client.messages.send(email, {"to": [SINK_EMAIL], "subject": subject, "text": "for events coverage"})
+
+            event = None
+            for _ in range(20):
+                events = await client.events.list(type="email.sent", agent_email=email, limit=20).to_list(limit=20)
+                event = next((e for e in events if e.message_id == sent.message_id), None)
+                if event:
+                    break
+                await asyncio.sleep(1.5)
+            assert event is not None, "expected an email.sent event for the just-sent message within ~30s"
+            assert event.message_id == sent.message_id
+            mark_covered("events.list")
+
+            fetched_event = await client.events.get(event.id)
+            assert fetched_event.id == event.id
+            mark_covered("events.get")
+
+            redelivered = await client.events.redeliver(event.id, {"webhook_id": hook.id})
+            assert redelivered.event_id == event.id
+            assert redelivered.status
+            mark_covered("events.redeliver")
+        finally:
+            deleted_hook = await client.webhooks.delete(hook.id)
+            assert deleted_hook.deleted is True
+            mark_covered("webhooks.delete")
+            await client.agents.delete(email)

--- a/tests/e2e-prod/consolidate.ts
+++ b/tests/e2e-prod/consolidate.ts
@@ -54,3 +54,14 @@ if (bySeverity.warn.length > 0) {
 }
 console.log("=== INFO (highlights) ===");
 for (const f of bySeverity.info) console.log(`  [${f.suite}] ${f.test}: ${f.message}`);
+
+// Gate: any recorded FAIL finding fails the run. Suites deliberately record
+// several findings and keep going (fail() must not throw mid-test), so the
+// exit-code decision lives here at consolidation — the documented design is
+// "the gate MUST read the JSON". Without this, every fail() in every suite is
+// decorative: a pipeline that runs the suites and never consolidates (or
+// consolidates but ignores the exit code) reports green over real failures.
+if (bySeverity.fail.length > 0) {
+  console.error(`\nconsolidate: ${bySeverity.fail.length} FAIL finding(s) recorded — failing the run.`);
+  process.exit(1);
+}

--- a/tests/e2e-prod/harness/mcp-coverage.ts
+++ b/tests/e2e-prod/harness/mcp-coverage.ts
@@ -1,0 +1,61 @@
+import { writeFileSync, mkdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+// MCP tool-coverage recorder — the MCP analogue of coverage.ts, which does the
+// same job for the typed /v1 OpenAPI operations.
+//
+// The denominator is NOT derived from source. It is whatever the DEPLOYED server
+// advertises on `tools/list`, captured live during the run. Grepping
+// mcp/src/tools/*.ts for registerTool() would measure the repo instead of the
+// thing under test, and would silently drift the moment a tool is registered
+// conditionally, renamed, or gated behind a tier. The server's own advertisement
+// is the only honest catalog: whatever a real MCP client can see is exactly what
+// the suite is accountable for.
+//
+// A tool counts as covered only when a `tools/call` returned a result with
+// isError !== true. An error result means the tool's handler rejected — the same
+// reasoning as coverage.ts recording only 2xx: a rejected call proves the route
+// exists, not that the tool works.
+//
+// Shards live in reports/mcp-coverage/ — a separate subdir from the API
+// recorder's reports/coverage/ so the two gates can never read each other's
+// files, and neither collides with the per-suite {findings} JSONs in reports/.
+const MCP_COVERAGE_DIR = fileURLToPath(new URL("../reports/mcp-coverage/", import.meta.url));
+
+const covered = new Set<string>();
+const advertised = new Set<string>();
+let installed = false;
+
+function installFlush(): void {
+  if (installed) return;
+  installed = true;
+  // Sync flush on 'exit', matching coverage.ts. 'exit' does not fire on
+  // SIGKILL, so a force-killed suite contributes no shard and its tools read
+  // UNCOVERED — a safe false-FAIL, never a false-PASS, because `pretest` clears
+  // the directory so no stale shard can mask the loss.
+  process.on("exit", () => {
+    if (covered.size === 0 && advertised.size === 0) return;
+    try {
+      mkdirSync(MCP_COVERAGE_DIR, { recursive: true });
+      writeFileSync(
+        `${MCP_COVERAGE_DIR}${process.pid}.json`,
+        JSON.stringify({ advertised: [...advertised], covered: [...covered] }),
+      );
+    } catch {
+      /* best-effort: coverage is advisory and must never fail a suite */
+    }
+  });
+}
+
+/** Record the live tool catalog the server advertised on `tools/list`. */
+export function recordToolList(names: readonly string[]): void {
+  for (const n of names) advertised.add(n);
+  installFlush();
+}
+
+/** Record one `tools/call`. Only a non-error result counts as covered. */
+export function recordToolCall(name: string, isError: boolean | undefined): void {
+  if (isError === true) return;
+  covered.add(name);
+  installFlush();
+}

--- a/tests/e2e-prod/harness/mcp.ts
+++ b/tests/e2e-prod/harness/mcp.ts
@@ -1,8 +1,34 @@
+import { recordToolCall, recordToolList } from "./mcp-coverage.ts";
+
 interface JsonRpcRequest {
   jsonrpc: "2.0";
   id: number;
   method: string;
   params?: unknown;
+}
+
+// Feed the MCP tool-coverage recorder from the single JSON-RPC choke point, so
+// coverage is recorded whether a suite goes through callTool() or calls
+// `mcp.call("tools/call", …)` directly. Never throws: coverage is advisory and
+// must not be able to fail a suite.
+function recordMcpResult(method: string, params: unknown, result: unknown): void {
+  try {
+    if (method === "tools/list") {
+      const tools = (result as { tools?: Array<{ name?: string }> })?.tools;
+      if (Array.isArray(tools)) {
+        recordToolList(tools.map((t) => t?.name).filter((n): n is string => typeof n === "string"));
+      }
+      return;
+    }
+    if (method === "tools/call") {
+      const name = (params as { name?: string })?.name;
+      if (typeof name === "string") {
+        recordToolCall(name, (result as { isError?: boolean })?.isError);
+      }
+    }
+  } catch {
+    /* advisory only */
+  }
 }
 
 interface JsonRpcResponse<T = unknown> {
@@ -82,6 +108,7 @@ export class HttpMcpClient implements McpRpcClient {
     if (env.error) {
       throw new Error(`MCP ${method} error ${env.error.code}: ${env.error.message}`);
     }
+    recordMcpResult(method, params, env.result);
     return env.result as T;
   }
 

--- a/tests/e2e-prod/mcp_coverage_gate.py
+++ b/tests/e2e-prod/mcp_coverage_gate.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""MCP tool coverage gate.
+
+Every tool the deployed MCP server advertises must be exercised by the e2e-prod
+suite, or the gate fails — so a tool that ships without a test is caught the same
+way an unexercised /v1 operation is caught by coverage_gate.py.
+
+This is the MCP analogue of coverage_gate.py, with one deliberate difference:
+
+  coverage_gate.py takes its denominator from a REPO FILE (api/openapi.yaml,
+  which is itself drift-gated against the server).
+
+  This gate takes its denominator from the DEPLOYED SERVER — whatever it
+  advertised on `tools/list` during the run, captured by harness/mcp-coverage.ts.
+
+There is no drift-gated catalog file for MCP tools, so grepping
+mcp/src/tools/*.ts for registerTool() would measure the repo rather than the
+thing under test, and would go quietly wrong the moment a tool is registered
+conditionally or gated behind a tier. The server's own advertisement is the only
+honest catalog: what a real MCP client can see is exactly what we are
+accountable for testing.
+
+Inputs:
+  - reports/mcp-coverage/*.json : shards written by harness/mcp-coverage.ts, each
+    {"advertised": [...tool names...], "covered": [...tool names...]}.
+
+"Covered" means a `tools/call` returned a result with isError !== true, i.e. the
+tool actually ran — not merely that it was probed with a rejected request.
+
+Usage: python3 mcp_coverage_gate.py [--reports DIR]
+Exit 0 = every advertised tool covered (or allowlisted); 1 = coverage gap;
+2 = usage/IO error (including "no shards", which must never read as a pass).
+"""
+import argparse
+import glob
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+# Tools the black-box suite intentionally does NOT exercise, with the reason.
+# Keep this SHORT and justified — every entry is coverage we knowingly forgo.
+ALLOWLIST: dict[str, str] = {}
+
+
+def load_shards(reports_dir: str) -> tuple[set[str], set[str], int]:
+    advertised: set[str] = set()
+    covered: set[str] = set()
+    paths = sorted(glob.glob(os.path.join(reports_dir, "*.json")))
+    for path in paths:
+        with open(path, encoding="utf-8") as fh:
+            shard = json.load(fh)
+        # Tolerate a bare-list shard shape defensively, but the recorder always
+        # writes the object form.
+        if isinstance(shard, dict):
+            advertised.update(shard.get("advertised") or [])
+            covered.update(shard.get("covered") or [])
+    return advertised, covered, len(paths)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--reports", default=os.path.join(HERE, "reports", "mcp-coverage"))
+    args = ap.parse_args()
+
+    if not os.path.isdir(args.reports):
+        print(
+            f"mcp_coverage_gate: no shard directory at {args.reports}. "
+            "Run the suite first (`npm test`); an absent run is not a pass.",
+            file=sys.stderr,
+        )
+        return 2
+
+    advertised, covered, shard_count = load_shards(args.reports)
+
+    if shard_count == 0 or not advertised:
+        # Without a denominator there is nothing to verify. Failing loudly here is
+        # the whole point: a silent 0-of-0 "pass" would hide a broken harness.
+        print(
+            "mcp_coverage_gate: no tools/list denominator was recorded. "
+            "At least one suite must call tools/list against the deployed server.",
+            file=sys.stderr,
+        )
+        return 2
+
+    # An allowlist entry that no longer names an advertised tool is a silent hole
+    # (e.g. the tool was renamed) — fail loudly so the allowlist can't drift stale.
+    stale = set(ALLOWLIST) - advertised
+    if stale:
+        print(
+            f"mcp_coverage_gate: allowlist entries the server does not advertise "
+            f"(renamed/removed?): {sorted(stale)}",
+            file=sys.stderr,
+        )
+        return 2
+
+    # A covered tool the server never advertised means the recorder and the
+    # catalog disagree — report it, but it cannot mask a real gap.
+    unadvertised = sorted(covered - advertised)
+
+    missing = advertised - covered
+    allowlisted = missing & set(ALLOWLIST)
+    uncovered = sorted(missing - set(ALLOWLIST))
+
+    print(f"Shards             : {shard_count}")
+    print(f"Advertised tools   : {len(advertised)}")
+    print(f"Covered            : {len(covered & advertised)}")
+    print(f"Allowlisted        : {len(allowlisted)} " + (str(sorted(allowlisted)) if allowlisted else ""))
+    if unadvertised:
+        print(f"Called but not advertised: {unadvertised}")
+
+    if uncovered:
+        print(f"\nUNCOVERED ({len(uncovered)}):", file=sys.stderr)
+        for name in uncovered:
+            print(f"  {name}", file=sys.stderr)
+        print(
+            "\nEvery advertised MCP tool needs a suite that calls it successfully. "
+            "Add a test, or add an ALLOWLIST entry with a justification.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("\nPASS: every advertised MCP tool is exercised.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/e2e-prod/mcp_coverage_gate.py
+++ b/tests/e2e-prod/mcp_coverage_gate.py
@@ -41,7 +41,19 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 
 # Tools the black-box suite intentionally does NOT exercise, with the reason.
 # Keep this SHORT and justified — every entry is coverage we knowingly forgo.
-ALLOWLIST: dict[str, str] = {}
+#
+# Each of these three is, per mcp/src/tools/legacy.ts, literally titled
+# "Deprecated alias: <canonical>" and routes straight to that canonical tool,
+# which IS covered elsewhere in this suite. Allowlisting them loses no real
+# signal — the underlying behavior is exercised via the canonical tool — and
+# we deliberately do not want to commit to happy-path testing of deprecated
+# surface. Their continued *advertisement* is still asserted by
+# suites/08-mcp.test.ts, so removal of the alias itself would still be caught.
+ALLOWLIST: dict[str, str] = {
+    "send_email": "deprecated alias for send_message (covered)",
+    "approve_pending_message": "deprecated alias for approve_review (covered)",
+    "reject_pending_message": "deprecated alias for reject_review (covered)",
+}
 
 
 def load_shards(reports_dir: str) -> tuple[set[str], set[str], int]:

--- a/tests/e2e-prod/package.json
+++ b/tests/e2e-prod/package.json
@@ -4,10 +4,11 @@
   "type": "module",
   "scripts": {
     "smoke": "node smoke.ts",
-    "pretest": "rm -rf reports/coverage",
+    "pretest": "rm -rf reports/coverage reports/mcp-coverage",
     "test": "node --test --test-concurrency=1 --test-reporter=spec suites/*.test.ts",
     "test:unit": "node --test harness/*.test.ts",
     "coverage:gate": "python3 coverage_gate.py",
+    "coverage:gate:mcp": "python3 mcp_coverage_gate.py",
     "coverage": "npm test; npm run coverage:gate",
     "typecheck": "tsc --noEmit"
   },

--- a/tests/e2e-prod/package.json
+++ b/tests/e2e-prod/package.json
@@ -10,6 +10,7 @@
     "coverage:gate": "python3 coverage_gate.py",
     "coverage:gate:mcp": "python3 mcp_coverage_gate.py",
     "coverage": "npm test; npm run coverage:gate",
+    "report:gate": "node consolidate.ts",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/tests/e2e-prod/suites/11-messaging.test.ts
+++ b/tests/e2e-prod/suites/11-messaging.test.ts
@@ -240,7 +240,7 @@ test("messaging: reply to bogus message ID returns 404", async () => {
   assert.ok(r.status === 404 || (r.status >= 400 && r.status < 500), `expected 4xx (404), got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
-test("messaging: reply with empty body returns 400", async () => {
+test("messaging: reply with empty body is rejected as invalid_request", async () => {
   // /reply requires the target message be inbound and belong to the
   // agent in the path. The previous version fell back to any message
   // including outbound, which routinely 404'd before the 400-missing-
@@ -269,7 +269,21 @@ test("messaging: reply with empty body returns 400", async () => {
     info(SUITE, "reply-empty-404-on-listed-msg", `inbound list returned ${candidate.message_id} but /reply 404'd — possible listing/storage skew`);
     return;
   }
-  assert.equal(r.status, 400, `expected 400 (empty body) on owned inbound message, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  // The v1 contract treats 400 and 422 as the SAME outcome for input validation:
+  // "invalid_request is the single canonical code for input-validation failures
+  // whether they arrive as 400 (malformed) or 422 (semantically invalid)"
+  // (api/openapi.yaml, ErrorEnvelope.code). A missing required `text` is
+  // semantically invalid, so the server answers 422 — contract-compliant. The
+  // old exact-400 assertion encoded one of two permitted statuses and so
+  // recorded a permanent failure, invisible until findings started gating the
+  // run. Assert the contract (a validation rejection carrying invalid_request),
+  // not one particular status code.
+  assert.ok(
+    r.status === 400 || r.status === 422,
+    `expected a validation rejection (400 or 422) on owned inbound message, got ${r.status}: ${r.raw.slice(0, 200)}`,
+  );
+  const code = (JSON.parse(r.raw) as { error?: { code?: string } })?.error?.code;
+  assert.equal(code, "invalid_request", `expected canonical validation code invalid_request, got "${code}"`);
 });
 
 test("messaging: /messages search filters — surface what's supported", async () => {

--- a/tests/e2e-prod/suites/12-mcp-extended.test.ts
+++ b/tests/e2e-prod/suites/12-mcp-extended.test.ts
@@ -139,10 +139,8 @@ test("mcp-ext: list_reviews and get_review round-trip", async () => {
   const s = await apiClient.post<{ message_id: string }>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
     body: { to: [SINK_EMAIL], subject: uniqueSubject("mcp pending"), text: "x" },
   });
-  if (s.status !== 202 || !s.body?.message_id) {
-    info(SUITE, "pending-setup-failed", `send returned ${s.status}, can't probe pending tools`);
-    return;
-  }
+  assert.equal(s.status, 202, `pending setup send expected 202: ${s.raw.slice(0, 200)}`);
+  assert.ok(s.body?.message_id, "pending setup send must return a message_id — a missing fixture is a broken test, not a skip");
   const id = s.body.message_id;
 
   // list_reviews — should include our queued msg. The MCP
@@ -154,9 +152,10 @@ test("mcp-ext: list_reviews and get_review round-trip", async () => {
     fail(SUITE, "list-pending-error", `list_reviews isError: ${extractText(lp).slice(0, 200)}`);
   } else {
     const text = extractText(lp);
-    if (!text.includes(id)) {
-      info(SUITE, "list-pending-missing-msg", `queued ${id} not in list_reviews response (may be paginated or filtered)`);
-    }
+    assert.ok(
+      text.includes(id),
+      `queued ${id} must appear in list_reviews (the MCP tool exposes no pagination or filter that could hide it)`,
+    );
   }
 
   // get_review.
@@ -166,9 +165,7 @@ test("mcp-ext: list_reviews and get_review round-trip", async () => {
   } else {
     const parsed = JSON.parse(extractText(gp)) as { id?: string; message_id?: string; status?: string };
     const returnedId = parsed.id ?? parsed.message_id;
-    if (returnedId !== id) {
-      info(SUITE, "get-pending-id-mismatch", `get_review returned id=${returnedId}, expected ${id}`);
-    }
+    assert.equal(returnedId, id, `get_review returned id=${returnedId}, expected ${id}`);
   }
 
   // Cleanup
@@ -246,9 +243,7 @@ test("mcp-ext: get_message returns shape and only own messages", async () => {
 
   // Bogus id — should isError.
   const r2 = await callTool(mcp, "get_message", { message_id: `msg_bogus_${Date.now()}`, email: apiClient.env.primaryAgentEmail });
-  if (!r2.isError) {
-    info(SUITE, "get-msg-bogus-not-error", "get_message with bogus id did not surface as error");
-  }
+  assert.equal(r2.isError, true, "get_message with a bogus id must surface as an error");
 });
 
 test("mcp-ext: reply_to_message happy path replies to a real message", async () => {
@@ -298,15 +293,15 @@ test("mcp-ext: cross-tool consistency — list_agents matches API surface", asyn
   const r = await callTool(mcp, "list_agents");
   const text = extractText(r);
   const mcpAgents = (JSON.parse(text) as { agents: Array<{ email: string }> }).agents.map((a) => a.email).sort();
-  const apiResp = await apiClient.get<{ agents: Array<{ email: string }> }>("/v1/agents");
-  const apiAgents = (apiResp.body?.agents ?? []).map((a) => a.email).sort();
-  if (mcpAgents.length !== apiAgents.length || JSON.stringify(mcpAgents) !== JSON.stringify(apiAgents)) {
-    info(
-      SUITE,
-      "list-agents-divergence",
-      `MCP list_agents (${mcpAgents.length}) differs from API /agents (${apiAgents.length})`,
-    );
-  } else {
-    info(SUITE, "list-agents-aligned", `MCP and API agent lists match: ${apiAgents.length} agents`);
-  }
+  // REST list envelope is Page[T] = {items, next_cursor}; the MCP envelope is
+  // {agents, next_cursor?} — deliberately different shapes (frozen MCP
+  // contract, see paginationInput in mcp/src/tools/util.ts). Compare contents.
+  const apiResp = await apiClient.get<{ items: Array<{ email: string }> }>("/v1/agents");
+  const apiAgents = (apiResp.body?.items ?? []).map((a) => a.email).sort();
+  assert.deepEqual(
+    mcpAgents,
+    apiAgents,
+    `MCP list_agents (${mcpAgents.length}) must match API /agents (${apiAgents.length})`,
+  );
+  info(SUITE, "list-agents-aligned", `MCP and API agent lists match: ${apiAgents.length} agents`);
 });

--- a/tests/e2e-prod/suites/12-mcp-extended.test.ts
+++ b/tests/e2e-prod/suites/12-mcp-extended.test.ts
@@ -32,6 +32,45 @@ function extractText(r: { content?: Array<{ type: string; text?: string }> }): s
   return r.content?.find((c) => c.type === "text")?.text ?? "";
 }
 
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// A single self-send loopback message, shared by the get_message and
+// reply_to_message happy-path tests below. Self-send (an agent emailing
+// itself) is the reliable way to produce a real inbound message on the
+// shared domain without needing an external MX — the same mechanism the
+// staging loopback path relies on. Sharing one fixture between both tests
+// keeps mail volume down against the free-plan monthly cap instead of
+// self-sending twice.
+interface MessageFixture {
+  id: string;
+  subject: string;
+}
+let messageFixturePromise: Promise<MessageFixture> | undefined;
+function messageFixture(): Promise<MessageFixture> {
+  messageFixturePromise ??= (async () => {
+    const pinnedAgent = apiClient.env.primaryAgentEmail;
+    const subject = uniqueSubject("mcp-ext get-msg fixture");
+    const send = await apiClient.post<{ message_id: string }>(
+      `/v1/agents/${encodeURIComponent(pinnedAgent)}/messages`,
+      { body: { to: [pinnedAgent], subject, text: "12-mcp-extended self-send fixture" }, expect: [200, 202] },
+    );
+    if (!send.body?.message_id) {
+      throw new Error(`self-send fixture did not return a message_id: ${send.raw.slice(0, 200)}`);
+    }
+    for (let i = 0; i < 12; i++) {
+      const poll = await apiClient.get<{ items: Array<{ id: string; subject: string }> }>(
+        `/v1/agents/${encodeURIComponent(pinnedAgent)}/messages`,
+        { query: { direction: "inbound", read_status: "all", limit: 20 } },
+      );
+      const m = poll.body?.items?.find((x) => x.subject === subject);
+      if (m) return { id: m.id, subject };
+      await sleep(1500);
+    }
+    throw new Error(`self-send fixture "${subject}" never appeared for ${pinnedAgent}`);
+  })();
+  return messageFixturePromise;
+}
+
 async function ensureHitlAgent(): Promise<string> {
   const slug = uniqueSlug("mcpe");
   const c = await apiClient.post<{ email: string }>("/v1/agents", {
@@ -187,20 +226,16 @@ test("mcp-ext: get_message returns shape and only own messages", async () => {
   }
   // The MCP get_message tool fetches via the AGENT-scoped endpoint
   // GET /v1/agents/{agent_email}/messages/{id} — anti-enumeration
-  // 404s on any message that doesn't belong to the pinned agent. We
-  // pull candidate IDs from the same scope so the test exercises the
-  // happy path instead of accidentally tripping the cross-agent guard.
-  const pinnedAgent = apiClient.env.primaryAgentEmail;
-  const listMsgs = await apiClient.get<{ items: Array<{ id: string }> }>(
-    `/v1/agents/${encodeURIComponent(pinnedAgent)}/messages`,
-    { query: { limit: 1 } },
-  );
-  const id = listMsgs.body?.items?.[0]?.id;
-  if (!id) {
-    info(SUITE, "get-msg-no-fixture", `no messages in agent ${pinnedAgent}'s inbox — cannot probe get_message happy path`);
-    return;
-  }
-  const r = await callTool(mcp, "get_message", { message_id: id });
+  // 404s on any message that doesn't belong to the pinned agent. Rather
+  // than hoping the pinned agent's inbox already has something in it
+  // (a prior version of this test silently `return`ed when it was empty,
+  // which let the suite report all-green while never actually exercising
+  // get_message's happy path), we produce a real fixture via self-send.
+  const { id } = await messageFixture();
+  // The conformance credential here is account-scoped (no agent_email to
+  // pin — see the 08-mcp "whoami" test), so get_message needs an explicit
+  // `email` to resolve which agent's mailbox to read from.
+  const r = await callTool(mcp, "get_message", { message_id: id, email: apiClient.env.primaryAgentEmail });
   if (r.isError) {
     fail(SUITE, "get-msg-error", `get_message isError for our own ${id}: ${extractText(r).slice(0, 200)}`);
     return;
@@ -210,9 +245,37 @@ test("mcp-ext: get_message returns shape and only own messages", async () => {
   assert.equal(returnedId, id, `expected id ${id}, got ${returnedId}`);
 
   // Bogus id — should isError.
-  const r2 = await callTool(mcp, "get_message", { message_id: `msg_bogus_${Date.now()}` });
+  const r2 = await callTool(mcp, "get_message", { message_id: `msg_bogus_${Date.now()}`, email: apiClient.env.primaryAgentEmail });
   if (!r2.isError) {
     info(SUITE, "get-msg-bogus-not-error", "get_message with bogus id did not surface as error");
+  }
+});
+
+test("mcp-ext: reply_to_message happy path replies to a real message", async () => {
+  const list = await mcp.call<{ tools: Array<{ name: string }> }>("tools/list");
+  if (!list.tools.find((t) => t.name === "reply_to_message")) {
+    info(SUITE, "reply-tool-absent", "no reply_to_message tool — skipping");
+    return;
+  }
+  const { id } = await messageFixture();
+  // Same account-scoped-credential caveat as get_message above.
+  const r = await callTool(mcp, "reply_to_message", {
+    message_id: id,
+    text: "reply from 12-mcp-extended happy path",
+    email: apiClient.env.primaryAgentEmail,
+  });
+  assert.equal(r.isError, undefined, `reply_to_message isError: ${extractText(r).slice(0, 200)}`);
+  const parsed = JSON.parse(extractText(r)) as { message_id?: string; status?: string };
+  assert.ok(parsed.message_id?.startsWith("msg_"), `expected msg_ prefix, got "${parsed.message_id}"`);
+  assert.ok(
+    parsed.status === "accepted" || parsed.status === "sent" || parsed.status === "pending_review",
+    `reply_to_message must report accepted/sent/pending_review, got "${parsed.status}"`,
+  );
+  if (parsed.status === "pending_review") {
+    const cleanupReview = await apiClient.post(`/v1/reviews/${parsed.message_id}/reject`, {
+      body: { reason: "e2e mcp reply cleanup" },
+    });
+    assert.equal(cleanupReview.status, 200, `cleanup rejection failed: ${cleanupReview.status}`);
   }
 });
 

--- a/tests/e2e-prod/suites/13-billing-surface.test.ts
+++ b/tests/e2e-prod/suites/13-billing-surface.test.ts
@@ -190,8 +190,20 @@ test("billing: POST /api/billing/webhook with invalid signature returns 400", as
 
 // --- Static pricing page ---
 
-test("billing: GET /pricing returns 200 HTML", async () => {
+// /pricing is an OPTIONAL, deployment-specific marketing route, not part of the
+// v1 contract. Prod serves it from this repo's static `pricing/` directory;
+// staging deliberately does not (Caddyfile.staging: "Differences from prod: no
+// /pricing (prod-only marketing)"), and a self-hoster has no reason to. So a 404
+// means "this deployment doesn't host the page", which is not a defect — only a
+// deployment that DOES serve it is held to the content contract below. Asserting
+// it unconditionally made this suite record a permanent FAIL finding against
+// staging, invisible until findings started gating the run.
+test("billing: GET /pricing returns 200 HTML where the deployment serves it", async () => {
   const r = await siteClient.get("/pricing", { apiKey: null });
+  if (r.status === 404) {
+    info(SUITE, "pricing-not-hosted", `/pricing is not served by this deployment (404) — prod-only marketing route`);
+    return;
+  }
   if (r.status !== 200) {
     fail(SUITE, "pricing-non-200", `/pricing returned ${r.status}: ${r.raw.slice(0, 200)}`);
     return;

--- a/tests/e2e-prod/suites/25-mcp-templates.test.ts
+++ b/tests/e2e-prod/suites/25-mcp-templates.test.ts
@@ -1,0 +1,269 @@
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient } from "../harness/client.ts";
+import { HttpMcpClient, callTool } from "../harness/mcp.ts";
+import { uniqueSlug } from "../harness/fixtures.ts";
+import { info, warn, writeReport } from "../harness/report.ts";
+
+// Black-box MCP conformance for the beta template tools (create/get/list/
+// update/delete/validate_template + list/get_starter_template) and the
+// API-key tools (create/list/delete_api_key), exercised over the DEPLOYED
+// streamable-HTTP /mcp server — the same surface 08-mcp.test.ts and
+// 12-mcp-extended.test.ts target, not a locally-built stdio binary.
+//
+// All 8 template tools are account-scope only (agent-scoped credentials get
+// a 403), and create_api_key/delete_api_key are likewise account-scope —
+// the conformance key here is account-scoped, matching every other MCP
+// suite in this repo.
+//
+// Cleanup is self-contained (like 17-templates.test.ts's REST suite): every
+// created template/key is deleted inline via the very tool under test
+// (delete_template / delete_api_key), in a try/finally, rather than via the
+// shared cleanup harness (harness/cleanup.ts only tracks agent/domain
+// kinds). The api-key lifecycle binds to the account's existing primary
+// probe agent instead of minting a throwaway agent, to stay well inside the
+// free-plan 3-agent cap.
+const SUITE = "25-mcp-templates";
+const apiClient = new ApiClient();
+const mcp = new HttpMcpClient(apiClient.env.mcpUrl, apiClient.env.apiKey);
+
+const REQUIRED_TOOLS = [
+  "create_template",
+  "get_template",
+  "list_templates",
+  "update_template",
+  "delete_template",
+  "validate_template",
+  "list_starter_templates",
+  "get_starter_template",
+  "create_api_key",
+  "list_api_keys",
+  "delete_api_key",
+] as const;
+
+before(async () => {
+  info(SUITE, "transport", `MCP over HTTP → ${apiClient.env.mcpUrl}`);
+});
+
+after(async () => {
+  await mcp.stop();
+  writeReport(`./reports/${SUITE}.json`);
+});
+
+function extractText(r: { content?: Array<{ type: string; text?: string }> }): string {
+  return r.content?.find((c) => c.type === "text")?.text ?? "";
+}
+
+function parseJson<T>(r: { content?: Array<{ type: string; text?: string }> }): T {
+  return JSON.parse(extractText(r)) as T;
+}
+
+interface TemplateView {
+  id?: string;
+  name?: string;
+  subject?: string;
+  text?: string;
+  html?: string;
+  alias?: string;
+  created_at?: string;
+  updated_at?: string;
+  from_starter_alias?: string;
+  from_starter_version?: string;
+}
+interface DeleteResult {
+  deleted?: boolean;
+  id?: string;
+}
+interface StarterTemplateView {
+  alias?: string;
+  name?: string;
+  description?: string;
+  version?: string;
+  subject?: string;
+  variables?: Array<{ name: string; required: boolean; raw: boolean; description: string; example: string }>;
+}
+interface StarterTemplateDetailView extends StarterTemplateView {
+  text?: string;
+  html?: string;
+}
+interface ValidateTemplateResponse {
+  valid?: boolean;
+  errors?: Array<{ part: string; message: string }>;
+  rendered?: { subject?: string; text?: string; html?: string };
+  suggested_data?: Record<string, unknown>;
+}
+interface ApiKeyView {
+  id?: string;
+  name?: string;
+  key_prefix?: string;
+  scope?: string;
+  agent_email?: string;
+  created_at?: string;
+}
+interface CreateApiKeyResult extends ApiKeyView {
+  key?: string;
+}
+
+test("mcp-templates: tools/list advertises all 11 template + API-key tools", async () => {
+  const r = await mcp.call<{ tools: Array<{ name: string }> }>("tools/list");
+  const names = new Set(r.tools.map((t) => t.name));
+  for (const req of REQUIRED_TOOLS) {
+    assert.ok(names.has(req), `expected tool "${req}" in the advertised surface`);
+  }
+});
+
+test("mcp-templates: create_template + get_template + list_templates + update_template + delete_template lifecycle", async () => {
+  const alias = uniqueSlug("mcptmpl");
+  let id: string | null = null;
+  try {
+    const create = await callTool(mcp, "create_template", {
+      name: `e2e ${alias}`,
+      subject: "Hi {{name}}",
+      text: "Hello {{name}}, welcome to {{company}}.",
+      alias,
+    });
+    assert.equal(create.isError, undefined, `create_template isError: ${extractText(create).slice(0, 300)}`);
+    const created = parseJson<TemplateView>(create);
+    assert.ok(created.id?.startsWith("tmpl_"), `expected tmpl_ id, got "${created.id}"`);
+    id = created.id!;
+    assert.equal(created.name, `e2e ${alias}`, "create_template echoes name");
+    assert.equal(created.subject, "Hi {{name}}", "create_template echoes subject");
+    assert.equal(created.alias, alias, "create_template echoes alias");
+
+    const get = await callTool(mcp, "get_template", { id });
+    assert.equal(get.isError, undefined, `get_template isError: ${extractText(get).slice(0, 300)}`);
+    const gotten = parseJson<TemplateView>(get);
+    assert.equal(gotten.id, id, "get_template returns the created template");
+    assert.equal(gotten.text, "Hello {{name}}, welcome to {{company}}.", "get_template returns the full body source");
+
+    const list = await callTool(mcp, "list_templates");
+    assert.equal(list.isError, undefined, `list_templates isError: ${extractText(list).slice(0, 300)}`);
+    const listed = parseJson<{ templates?: TemplateView[] }>(list);
+    assert.ok(Array.isArray(listed.templates), "list_templates returns a templates array");
+    // Assert on the specific resource we created, never on account-wide count.
+    assert.ok(listed.templates!.some((t) => t.id === id), `created template ${id} appears in list_templates`);
+
+    const update = await callTool(mcp, "update_template", { id, name: `${alias}-updated`, subject: "Hi {{name}}!" });
+    assert.equal(update.isError, undefined, `update_template isError: ${extractText(update).slice(0, 300)}`);
+    const updated = parseJson<TemplateView>(update);
+    assert.equal(updated.name, `${alias}-updated`, "update_template applies the new name");
+    assert.equal(updated.subject, "Hi {{name}}!", "update_template applies the new subject");
+    assert.equal(updated.text, "Hello {{name}}, welcome to {{company}}.", "update_template leaves an unpassed field untouched");
+
+    const del = await callTool(mcp, "delete_template", { id, confirm: true });
+    assert.equal(del.isError, undefined, `delete_template isError: ${extractText(del).slice(0, 300)}`);
+    const deleted = parseJson<DeleteResult>(del);
+    assert.equal(deleted.deleted, true, "delete_template reports deleted:true");
+    assert.equal(deleted.id, id, "delete_template echoes the deleted id");
+    const deletedId = id;
+    id = null;
+
+    const getAfterDelete = await callTool(mcp, "get_template", { id: deletedId! });
+    if (getAfterDelete.isError !== true) {
+      warn(SUITE, "get-after-delete", `get_template for a deleted id ${deletedId} did not surface isError`);
+    }
+  } finally {
+    if (id) await callTool(mcp, "delete_template", { id, confirm: true });
+  }
+});
+
+test("mcp-templates: validate_template dry-run renders a preview without persisting", async () => {
+  const r = await callTool(mcp, "validate_template", {
+    subject: "Hi {{name}}",
+    text: "Welcome {{name}} to {{company}}",
+    test_data: { name: "Ada", company: "Acme" },
+  });
+  assert.equal(r.isError, undefined, `validate_template isError: ${extractText(r).slice(0, 300)}`);
+  const parsed = parseJson<ValidateTemplateResponse>(r);
+  assert.equal(parsed.valid, true, "valid source reports valid:true");
+  assert.equal(parsed.rendered?.subject, "Hi Ada", "subject rendered against test_data");
+  assert.equal(parsed.rendered?.text, "Welcome Ada to Acme", "body rendered against test_data");
+  assert.ok(parsed.suggested_data, "suggested_data present");
+  assert.ok(
+    "name" in (parsed.suggested_data as object) && "company" in (parsed.suggested_data as object),
+    "suggested_data covers every referenced variable",
+  );
+});
+
+test("mcp-templates: list_starter_templates + get_starter_template", async () => {
+  const list = await callTool(mcp, "list_starter_templates");
+  assert.equal(list.isError, undefined, `list_starter_templates isError: ${extractText(list).slice(0, 300)}`);
+  const listed = parseJson<{ starter_templates?: StarterTemplateView[] }>(list);
+  assert.ok(Array.isArray(listed.starter_templates), "list_starter_templates returns a starter_templates array");
+  assert.ok(listed.starter_templates!.length >= 1, "deployment ships at least one starter template");
+  const alias = listed.starter_templates![0].alias;
+  assert.ok(alias, "picked a starter alias from the list");
+
+  const get = await callTool(mcp, "get_starter_template", { alias: alias! });
+  assert.equal(get.isError, undefined, `get_starter_template isError: ${extractText(get).slice(0, 300)}`);
+  const detail = parseJson<StarterTemplateDetailView>(get);
+  assert.equal(detail.alias, alias, "get_starter_template returns the requested alias");
+  assert.equal(typeof detail.text, "string", "detail carries a plain-text body source");
+  assert.equal(typeof detail.html, "string", "detail carries an html body source");
+  assert.ok(Array.isArray(detail.variables), "detail carries a variables array");
+});
+
+test("mcp-templates: create_api_key + list_api_keys + delete_api_key — agent-scoped key lifecycle", async () => {
+  // create_api_key needs an existing agent to bind to. This account starts
+  // with zero agents (the pinned E2A_AGENT_EMAIL is a reserved slug, not a
+  // pre-provisioned inbox), so create it here if absent and tear it back
+  // down afterwards — stays well inside the free-plan 3-agent cap either way.
+  const agentEmail = apiClient.env.primaryAgentEmail;
+  let createdAgent = false;
+  const existing = await apiClient.get(`/v1/agents/${encodeURIComponent(agentEmail)}`);
+  if (existing.status === 404) {
+    const createAgent = await apiClient.post("/v1/agents", { body: { email: agentEmail, name: "mcp templates probe" } });
+    assert.equal(createAgent.status, 201, `agent setup failed: ${createAgent.status} ${createAgent.raw.slice(0, 200)}`);
+    createdAgent = true;
+  } else {
+    assert.equal(existing.status, 200, `unexpected status probing agent: ${existing.status} ${existing.raw.slice(0, 200)}`);
+  }
+
+  const keyName = uniqueSlug("mcpkey");
+  let id: string | null = null;
+  try {
+    const create = await callTool(mcp, "create_api_key", {
+      agent_email: agentEmail,
+      name: keyName,
+    });
+    assert.equal(create.isError, undefined, `create_api_key isError: ${extractText(create).slice(0, 300)}`);
+    const created = parseJson<CreateApiKeyResult>(create);
+    assert.ok(created.id, "create_api_key returns an id");
+    id = created.id!;
+    // The plaintext secret is shown exactly once — assert it exists without
+    // ever logging or persisting its value (report.ts writes findings to disk).
+    assert.equal(typeof created.key, "string", "create_api_key returns the one-time plaintext key");
+    assert.ok(created.key!.length > 0, "plaintext key is non-empty");
+    assert.equal(created.scope, "agent", "create_api_key mints an agent-scoped key");
+    assert.equal(created.agent_email, agentEmail, "key is bound to the requested agent");
+    assert.equal(created.name, keyName, "create_api_key echoes the name");
+
+    const list = await callTool(mcp, "list_api_keys");
+    assert.equal(list.isError, undefined, `list_api_keys isError: ${extractText(list).slice(0, 300)}`);
+    const listed = parseJson<{ api_keys?: ApiKeyView[] }>(list);
+    assert.ok(Array.isArray(listed.api_keys), "list_api_keys returns an api_keys array");
+    // Assert on the specific key we created, never on account-wide count —
+    // this account accumulates keys across suite runs.
+    const found = listed.api_keys!.find((k) => k.id === id);
+    assert.ok(found, `created key ${id} appears in list_api_keys`);
+    assert.equal(found!.name, keyName, "listed key carries the name");
+    assert.ok(!("key" in (found as object)), "list_api_keys never echoes the plaintext secret");
+
+    const del = await callTool(mcp, "delete_api_key", { id, confirm: true });
+    assert.equal(del.isError, undefined, `delete_api_key isError: ${extractText(del).slice(0, 300)}`);
+    const deleted = parseJson<DeleteResult>(del);
+    assert.equal(deleted.deleted, true, "delete_api_key reports deleted:true");
+    assert.equal(deleted.id, id, "delete_api_key echoes the revoked id");
+    id = null;
+  } finally {
+    if (id) await callTool(mcp, "delete_api_key", { id, confirm: true });
+    // Only remove the agent if this test provisioned it — leave a
+    // pre-existing primary agent alone.
+    if (createdAgent) {
+      const del = await apiClient.delete(`/v1/agents/${encodeURIComponent(agentEmail)}?confirm=DELETE`);
+      if (del.status !== 204 && del.status !== 200) {
+        warn(SUITE, "agent-cleanup-failed", `could not delete probe agent ${agentEmail}: HTTP ${del.status}`);
+      }
+    }
+  }
+});

--- a/tests/e2e-prod/suites/25-mcp-templates.test.ts
+++ b/tests/e2e-prod/suites/25-mcp-templates.test.ts
@@ -258,11 +258,17 @@ test("mcp-templates: create_api_key + list_api_keys + delete_api_key — agent-s
   } finally {
     if (id) await callTool(mcp, "delete_api_key", { id, confirm: true });
     // Only remove the agent if this test provisioned it — leave a
-    // pre-existing primary agent alone.
+    // pre-existing primary agent alone. `permanent=true` is required here:
+    // a plain DELETE only soft-deletes (30-day trash) and RESERVES the
+    // address, so the very next run of this suite against the same account
+    // would hit 409 address_in_trash trying to recreate agentEmail — this
+    // suite must be re-runnable back to back on a fresh account.
     if (createdAgent) {
-      const del = await apiClient.delete(`/v1/agents/${encodeURIComponent(agentEmail)}?confirm=DELETE`);
+      const del = await apiClient.delete(
+        `/v1/agents/${encodeURIComponent(agentEmail)}?confirm=DELETE&permanent=true`,
+      );
       if (del.status !== 204 && del.status !== 200) {
-        warn(SUITE, "agent-cleanup-failed", `could not delete probe agent ${agentEmail}: HTTP ${del.status}`);
+        warn(SUITE, "agent-cleanup-failed", `could not permanently delete probe agent ${agentEmail}: HTTP ${del.status}`);
       }
     }
   }

--- a/tests/e2e-prod/suites/26-mcp-webhooks.test.ts
+++ b/tests/e2e-prod/suites/26-mcp-webhooks.test.ts
@@ -1,0 +1,451 @@
+import { test, before, after, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient } from "../harness/client.ts";
+import { cleanup, track } from "../harness/cleanup.ts";
+import { HttpMcpClient, callTool, type McpToolResult } from "../harness/mcp.ts";
+import { isEventsLogDisabled } from "../harness/event-capability.ts";
+import { uniqueSlug, uniqueSubject } from "../harness/fixtures.ts";
+import { fail, info, writeReport } from "../harness/report.ts";
+
+// Black-box MCP conformance for the webhooks + events tool surface (11 tools)
+// against the DEPLOYED streamable-HTTP /mcp server. This is the MCP analogue
+// of suites 16-webhooks.test.ts (REST webhook CRUD) and 21-webhook-events.test.ts
+// (REST event emission) — same domain, same server-side semantics, but every
+// call here goes through tools/call so the mcp_coverage_gate.py recorder
+// credits the tool.
+//
+// Tools exercised (exactly 11, per the coverage batch):
+//   create_webhook, get_webhook, list_webhooks, update_webhook, delete_webhook,
+//   rotate_webhook_secret, test_webhook, list_webhook_deliveries,
+//   list_events, get_event, redeliver_event
+//
+// Shapes verified against mcp/src/tools/webhooks.ts + events.ts (the MCP tool
+// registrations) and cross-checked against the REST WebhookView/EventView
+// shapes in 16-webhooks.test.ts / 21-webhook-events.test.ts — the MCP layer's
+// toMcpOutput() snake-cases the SDK's camelCase fields back to the same REST
+// vocabulary, so the JSON text content matches those interfaces field-for-field.
+//
+// Coverage note: `test_webhook` delivers a REAL synthetic event to the
+// configured URL (bypassing filter matching); we do not depend on an external
+// request-bin sink — the dummy https://example.com target 404/405s the POST,
+// which still proves the delivery ATTEMPT ran (asserted via
+// list_webhook_deliveries), matching the "assert the API's own response plus
+// the resulting delivery record" guidance rather than requiring a 2xx from a
+// sink we don't control.
+//
+// `redeliver_event` needs a prior delivered event to replay honestly, so this
+// suite drives one real email.sent emission (no HITL hold, real send to the
+// SES simulator) exactly like 21-webhook-events.test.ts, then replays THAT
+// event. The event-log capability probe + skip semantics are copied verbatim
+// from harness/event-capability.ts (501 + events_log_disabled ONLY) — no
+// looser skip is invented, and a capability-disabled target legitimately
+// leaves list_events/get_event/redeliver_event uncovered rather than faking it.
+const SUITE = "26-mcp-webhooks";
+const apiClient = new ApiClient();
+const mcp = new HttpMcpClient(apiClient.env.mcpUrl, apiClient.env.apiKey);
+
+const SIMULATOR = "success@simulator.amazonses.com";
+
+interface WebhookView {
+  id: string;
+  url: string;
+  description?: string;
+  events: string[];
+  filters?: Record<string, unknown>;
+  enabled: boolean;
+  created_at: string;
+  last_delivered_at?: string;
+  auto_disabled_at?: string;
+  signing_secret?: string;
+}
+interface ListWebhooksResult {
+  webhooks: WebhookView[];
+  next_cursor?: string;
+}
+interface DeleteWebhookResult {
+  deleted: boolean;
+  id: string;
+}
+interface RotateSecretResult {
+  signing_secret: string;
+  previous_secret_expires_at: string;
+}
+interface TestWebhookResult {
+  delivery_id: string;
+}
+interface WebhookDeliveryView {
+  id: string;
+  type: string;
+  status: string;
+  attempts: number;
+  next_retry_at?: string;
+  created_at: string;
+  last_status_code?: number;
+  last_error?: string;
+}
+interface ListWebhookDeliveriesResult {
+  deliveries: WebhookDeliveryView[];
+  next_cursor?: string;
+}
+interface EventView {
+  id: string;
+  type: string;
+  schema_version: string;
+  created_at: string;
+  status: string;
+  data: Record<string, unknown>;
+  agent_email?: string;
+  message_id?: string;
+  delivery_status?: { matched_webhooks?: number };
+}
+interface ListEventsResult {
+  events: EventView[];
+  next_cursor?: string;
+}
+interface RedeliverResult {
+  event_id: string;
+  status: string;
+  delivery_id?: string;
+  webhook_id?: string;
+  deliveries?: Array<{ webhook_id?: string; delivery_id?: string; status?: string }>;
+}
+interface SendResult {
+  status?: string;
+  message_id?: string;
+}
+
+const REQUIRED_TOOLS = [
+  "create_webhook",
+  "get_webhook",
+  "list_webhooks",
+  "update_webhook",
+  "delete_webhook",
+  "rotate_webhook_secret",
+  "test_webhook",
+  "list_webhook_deliveries",
+  "list_events",
+  "get_event",
+  "redeliver_event",
+];
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function extractText(r: McpToolResult): string {
+  return r.content?.find((c) => c.type === "text")?.text ?? "";
+}
+
+function parseOk<T>(r: McpToolResult, label: string): T {
+  assert.equal(r.isError, undefined, `${label} isError: ${extractText(r).slice(0, 300)}`);
+  const text = extractText(r);
+  assert.ok(text, `${label} returned text content`);
+  return JSON.parse(text) as T;
+}
+
+async function deleteHook(id: string): Promise<void> {
+  // Best-effort: the delete_webhook happy path is asserted explicitly in the
+  // CRUD test, which already deletes the hook — this is only a cleanup net
+  // for tests that create a hook and exit early on assertion failure.
+  await callTool(mcp, "delete_webhook", { id, confirm: true }).catch(() => {});
+}
+
+async function createAgent(label: string): Promise<string> {
+  const slug = uniqueSlug(label);
+  const c = await apiClient.post<{ email: string }>("/v1/agents", {
+    body: { email: `${slug}@${apiClient.env.sharedDomain}`, name: `mcp webhooks ${label}` },
+  });
+  if (c.status !== 201 || !c.body?.email) {
+    throw new Error(`create agent failed: ${c.status} ${c.raw.slice(0, 200)}`);
+  }
+  track("agent", c.body.email);
+  return c.body.email;
+}
+
+// pollWebhookDelivery: poll list_webhook_deliveries (via MCP) until a
+// delivery matching `match` appears, or the bounded window elapses.
+async function pollWebhookDelivery(
+  hookId: string,
+  match: (d: WebhookDeliveryView) => boolean,
+  timeoutMs = 15000,
+): Promise<WebhookDeliveryView | null> {
+  const deadline = Date.now() + timeoutMs;
+  let delay = 500;
+  while (Date.now() < deadline) {
+    const r = await callTool(mcp, "list_webhook_deliveries", { id: hookId, limit: 50 });
+    if (!r.isError) {
+      const parsed = JSON.parse(extractText(r)) as ListWebhookDeliveriesResult;
+      const found = parsed.deliveries?.find(match);
+      if (found) return found;
+    }
+    await sleep(delay);
+    delay = Math.min(Math.floor(delay * 1.5), 3000);
+  }
+  return null;
+}
+
+// pollEvent: poll list_events (via MCP) until an event matching `match`
+// appears, or the bounded window elapses. Mirrors 21-webhook-events.test.ts's
+// REST pollEvent, but driven through the MCP tool so this suite's own
+// tools/call traffic is what the coverage recorder sees.
+async function pollEvent(
+  params: { type: string; agentEmail: string; since: string },
+  match: (e: EventView) => boolean,
+  timeoutMs = 15000,
+): Promise<EventView | null> {
+  const deadline = Date.now() + timeoutMs;
+  let delay = 500;
+  while (Date.now() < deadline) {
+    const r = await callTool(mcp, "list_events", {
+      type: params.type,
+      agent_email: params.agentEmail,
+      since: params.since,
+      limit: 50,
+    });
+    if (!r.isError) {
+      const parsed = JSON.parse(extractText(r)) as ListEventsResult;
+      const found = parsed.events?.find(match);
+      if (found) return found;
+    }
+    await sleep(delay);
+    delay = Math.min(Math.floor(delay * 1.5), 3000);
+  }
+  return null;
+}
+
+before(async () => {
+  info(SUITE, "transport", `MCP over HTTP -> ${apiClient.env.mcpUrl}`);
+});
+
+afterEach(async () => {
+  await cleanup(apiClient);
+});
+
+after(async () => {
+  await mcp.stop();
+  await cleanup(apiClient);
+  writeReport(`./reports/${SUITE}.json`);
+});
+
+test("mcp-webhooks: tools/list advertises all 11 target tools", async () => {
+  const list = await mcp.call<{ tools: Array<{ name: string }> }>("tools/list");
+  const names = new Set(list.tools.map((t) => t.name));
+  const missing = REQUIRED_TOOLS.filter((n) => !names.has(n));
+  assert.deepEqual(missing, [], `deployed MCP server must advertise every target tool; missing: ${missing.join(", ")}`);
+});
+
+// create_webhook + get_webhook + list_webhooks + update_webhook +
+// rotate_webhook_secret + test_webhook + list_webhook_deliveries +
+// delete_webhook — the full webhook-subscriber CRUD round-trip over MCP.
+test("mcp-webhooks: full webhook CRUD round-trip via MCP", async () => {
+  const url = `https://example.com/e2e-mcp-webhook-${uniqueSlug("wh")}`;
+
+  // create_webhook
+  const created = await parseOk<WebhookView>(
+    await callTool(mcp, "create_webhook", {
+      url,
+      events: ["email.received", "email.sent"],
+      description: `e2e mcp ${uniqueSlug("wh")}`,
+    }),
+    "create_webhook",
+  );
+  assert.ok(created.id?.startsWith("wh_"), `create_webhook id has wh_ prefix: ${created.id}`);
+  assert.equal(created.url, url);
+  assert.deepEqual(created.events, ["email.received", "email.sent"]);
+  assert.equal(created.enabled, true, "new webhook defaults to enabled");
+  assert.ok(
+    created.signing_secret?.startsWith("whsec_"),
+    `create_webhook returns a whsec_ signing_secret: ${created.signing_secret}`,
+  );
+  const id = created.id;
+
+  try {
+    // get_webhook
+    const got = await parseOk<WebhookView>(await callTool(mcp, "get_webhook", { id }), "get_webhook");
+    assert.equal(got.id, id);
+    assert.equal(got.url, url);
+    assert.equal(got.enabled, true);
+    assert.equal(got.signing_secret, undefined, "get_webhook must NOT return signing_secret");
+
+    // list_webhooks
+    const listed = await parseOk<ListWebhooksResult>(await callTool(mcp, "list_webhooks", {}), "list_webhooks");
+    assert.ok(Array.isArray(listed.webhooks), "list_webhooks.webhooks is an array");
+    const inList = listed.webhooks.find((w) => w.id === id);
+    assert.ok(inList, `created webhook ${id} is present in list_webhooks`);
+    assert.equal(inList!.signing_secret, undefined, "list_webhooks items must NOT carry signing_secret");
+
+    // update_webhook — partial update; events is a full replace when present.
+    const updated = await parseOk<WebhookView>(
+      await callTool(mcp, "update_webhook", {
+        id,
+        description: "e2e mcp updated",
+        events: ["email.received", "email.sent", "email.failed"],
+      }),
+      "update_webhook",
+    );
+    assert.equal(updated.description, "e2e mcp updated");
+    assert.deepEqual(updated.events, ["email.received", "email.sent", "email.failed"]);
+    assert.equal(updated.enabled, true, "update_webhook left enabled untouched (not passed)");
+
+    // rotate_webhook_secret — new secret, distinct from the created one.
+    const rotated = await parseOk<RotateSecretResult>(
+      await callTool(mcp, "rotate_webhook_secret", { id }),
+      "rotate_webhook_secret",
+    );
+    assert.ok(
+      rotated.signing_secret?.startsWith("whsec_"),
+      `rotate_webhook_secret returns a whsec_ secret: ${rotated.signing_secret}`,
+    );
+    assert.notEqual(rotated.signing_secret, created.signing_secret, "rotated secret differs from the original");
+    assert.ok(
+      typeof rotated.previous_secret_expires_at === "string" && rotated.previous_secret_expires_at.length > 0,
+      "rotate_webhook_secret returns previous_secret_expires_at (grace window)",
+    );
+
+    // test_webhook — fires a synthetic event at the (unreachable, but valid
+    // HTTPS/public) target. Does not depend on the sink responding 2xx.
+    const tested = await parseOk<TestWebhookResult>(
+      await callTool(mcp, "test_webhook", { id, type: "email.received" }),
+      "test_webhook",
+    );
+    assert.ok(
+      typeof tested.delivery_id === "string" && tested.delivery_id.length > 0,
+      `test_webhook returns a delivery_id: ${tested.delivery_id}`,
+    );
+
+    // list_webhook_deliveries — the delivery test_webhook scheduled must
+    // surface here (proves the tool + the resulting delivery record, per the
+    // "don't depend on an external sink" guidance).
+    const delivery = await pollWebhookDelivery(id, (d) => d.id === tested.delivery_id);
+    assert.ok(delivery, `test_webhook's delivery ${tested.delivery_id} must appear in list_webhook_deliveries`);
+    assert.equal(delivery!.type, "email.received");
+    info(SUITE, "test_webhook", `delivery=${delivery!.id} status=${delivery!.status} attempts=${delivery!.attempts} last_status=${delivery!.last_status_code}`);
+  } finally {
+    // delete_webhook — DESTRUCTIVE; requires confirm:true.
+    const deleted = await parseOk<DeleteWebhookResult>(
+      await callTool(mcp, "delete_webhook", { id, confirm: true }),
+      "delete_webhook",
+    );
+    assert.equal(deleted.deleted, true, "delete_webhook returns deleted:true");
+    assert.equal(deleted.id, id, "delete_webhook echoes the webhook id");
+
+    // Confirm it is actually gone.
+    const gone = await callTool(mcp, "get_webhook", { id });
+    if (!gone.isError) {
+      fail(SUITE, "delete-webhook-not-gone", `get_webhook still succeeds for deleted ${id}`);
+    }
+  }
+});
+
+// delete_webhook without confirm:true must be rejected by the tool's own
+// guard (never reaches the API) — a cheap extra proof the destructive guard
+// works, using a throwaway hook so the CRUD test above stays the sole owner
+// of the "real" delete path.
+test("mcp-webhooks: delete_webhook without confirm:true is rejected", async () => {
+  const url = `https://example.com/e2e-mcp-webhook-${uniqueSlug("whguard")}`;
+  const created = await parseOk<WebhookView>(
+    await callTool(mcp, "create_webhook", { url, events: ["email.received"] }),
+    "create_webhook (guard fixture)",
+  );
+  try {
+    const r = await callTool(mcp, "delete_webhook", { id: created.id, confirm: false });
+    assert.equal(r.isError, true, "delete_webhook must reject confirm:false");
+  } finally {
+    await deleteHook(created.id);
+  }
+});
+
+// list_events + get_event + redeliver_event — driven by one real email.sent
+// emission (no HITL hold, real send to the SES simulator), exactly the
+// trigger 21-webhook-events.test.ts uses on the REST side. The event-log
+// capability probe below is copied verbatim from that suite: skip ONLY on
+// the exact 501 events_log_disabled signal, never on a looser heuristic, and
+// never treat a connectivity failure as a skip.
+let eventsSkip: string | false = false;
+try {
+  const probe = await apiClient.get("/v1/events", { query: { limit: 1 } });
+  if (isEventsLogDisabled(probe.status, probe.body)) {
+    eventsSkip = "event-log capability disabled on this target (events_log_disabled)";
+  }
+} catch {
+  // Probe couldn't reach the target — do NOT skip; let the tests run and
+  // surface the real connectivity error instead of masking an outage.
+}
+
+test(
+  "mcp-webhooks: list_events / get_event / redeliver_event round-trip via a real send",
+  { skip: eventsSkip },
+  async () => {
+    const email = await createAgent("mcpev");
+    const url = `https://example.com/e2e-mcp-webhook-events-${uniqueSlug("wh")}`;
+    const hook = await parseOk<WebhookView>(
+      await callTool(mcp, "create_webhook", { url, events: ["email.sent"] }),
+      "create_webhook (events fixture)",
+    );
+    const since = new Date(Date.now() - 5000).toISOString();
+    try {
+      // Real (no-hold) send to the SES simulator, exactly like
+      // 21-webhook-events.test.ts's email.sent emission test.
+      const send = await apiClient.post<SendResult>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
+        body: { to: [SIMULATOR], subject: uniqueSubject("mcp emit sent"), text: "real send via MCP events suite" },
+      });
+      assert.equal(send.status, 202, `real send expected 202 accepted, got ${send.status}: ${send.raw.slice(0, 200)}`);
+      assert.equal(send.body?.status, "accepted", "no-hold agent send is accepted for async delivery");
+      const messageId = send.body!.message_id!;
+      assert.ok(messageId?.startsWith("msg_"), "send returns a msg_ id");
+
+      // list_events (via MCP), filtered — polled until the emitted event lands.
+      const ev = await pollEvent({ type: "email.sent", agentEmail: email, since }, (e) =>
+        e.message_id === messageId || e.data.message_id === messageId,
+      );
+      assert.ok(ev, `email.sent event for ${messageId} must appear via list_events within 15s`);
+      assert.ok(ev!.id?.startsWith("evt_"), `event id has evt_ prefix: ${ev!.id}`);
+      assert.equal(ev!.type, "email.sent");
+      assert.equal(ev!.agent_email, email, "event.agent_email is the sending agent");
+
+      // get_event — single-event fetch by id.
+      const got = await parseOk<EventView>(await callTool(mcp, "get_event", { event_id: ev!.id }), "get_event");
+      assert.equal(got.id, ev!.id, "get_event echoes the requested id");
+      assert.equal(got.type, "email.sent");
+
+      // Nonexistent event id -> isError.
+      const missGet = await callTool(mcp, "get_event", { event_id: `evt_nonexistent_${Date.now()}` });
+      if (!missGet.isError) {
+        fail(SUITE, "get-event-bogus-not-error", "get_event with a nonexistent id did not surface as error");
+      }
+
+      // redeliver_event — replay to our fresh webhook by id. Uses the SAME
+      // envelope id as the original (documented, non-dedup-safe replay
+      // semantics); we only assert the tool's own response shape plus the
+      // resulting delivery record, not a receiver-side outcome.
+      const redelivered = await parseOk<RedeliverResult>(
+        await callTool(mcp, "redeliver_event", { event_id: ev!.id, webhook_id: hook.id }),
+        "redeliver_event",
+      );
+      assert.equal(redelivered.event_id, ev!.id, "redeliver_event echoes the event id");
+      assert.ok(
+        typeof redelivered.status === "string" && redelivered.status.length > 0,
+        "redeliver_event returns a status",
+      );
+      const newDeliveryIds = [
+        redelivered.delivery_id,
+        ...(redelivered.deliveries ?? []).map((d) => d.delivery_id),
+      ].filter((x): x is string => typeof x === "string" && x.length > 0);
+      assert.ok(newDeliveryIds.length >= 1, `redeliver_event returns at least one delivery id: ${JSON.stringify(redelivered)}`);
+
+      const requeued = await pollWebhookDelivery(hook.id, (d) => newDeliveryIds.includes(d.id));
+      assert.ok(requeued, `redelivered delivery ${newDeliveryIds[0]} must appear in list_webhook_deliveries`);
+      info(
+        SUITE,
+        "redeliver_event",
+        `event=${ev!.id} webhook=${hook.id} -> delivery=${requeued!.id} status=${requeued!.status} attempts=${requeued!.attempts}`,
+      );
+
+      // Nonexistent event id -> isError.
+      const missRedeliver = await callTool(mcp, "redeliver_event", { event_id: `evt_nonexistent_${Date.now()}` });
+      if (!missRedeliver.isError) {
+        fail(SUITE, "redeliver-event-bogus-not-error", "redeliver_event with a nonexistent id did not surface as error");
+      }
+    } finally {
+      await deleteHook(hook.id);
+    }
+  },
+);

--- a/tests/e2e-prod/suites/27-mcp-agents-messages.test.ts
+++ b/tests/e2e-prod/suites/27-mcp-agents-messages.test.ts
@@ -361,10 +361,7 @@ function attachmentFixture(): Promise<AttachmentFixture | null> {
 test("mcp-agents-msgs: get_attachment returns metadata + a short-lived download_url", async () => {
   const email = await agent();
   const fixture = await attachmentFixture();
-  if (!fixture) {
-    info(SUITE, "get-attachment-skip", "no attachment fixture available; skipping get_attachment happy path");
-    return;
-  }
+  assert.ok(fixture, "no attachment fixture available — a missing fixture is a broken test, not a reason to pass");
   const r = await callTool(mcp, "get_attachment", { message_id: fixture.messageId, attachment_index: 0, email });
   assert.equal(r.isError, undefined, `get_attachment isError: ${extractText(r).slice(0, 200)}`);
   const parsed = parseJson<{
@@ -387,10 +384,7 @@ test("mcp-agents-msgs: get_attachment returns metadata + a short-lived download_
 test("mcp-agents-msgs: get_attachment_data (legacy alias) returns inline base64 that round-trips", async () => {
   const email = await agent();
   const fixture = await attachmentFixture();
-  if (!fixture) {
-    info(SUITE, "get-attachment-data-skip", "no attachment fixture available; skipping get_attachment_data happy path");
-    return;
-  }
+  assert.ok(fixture, "no attachment fixture available — a missing fixture is a broken test, not a reason to pass");
   const r = await callTool(mcp, "get_attachment_data", { message_id: fixture.messageId, attachment_index: 0, agent_email: email });
   assert.equal(r.isError, undefined, `get_attachment_data isError: ${extractText(r).slice(0, 200)}`);
   const parsed = parseJson<{ filename?: string; content_type?: string; size_bytes?: number; data?: string }>(r);

--- a/tests/e2e-prod/suites/27-mcp-agents-messages.test.ts
+++ b/tests/e2e-prod/suites/27-mcp-agents-messages.test.ts
@@ -1,0 +1,431 @@
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient } from "../harness/client.ts";
+import { cleanup, track } from "../harness/cleanup.ts";
+import { HttpMcpClient, callTool } from "../harness/mcp.ts";
+import { uniqueSlug, uniqueSubject } from "../harness/fixtures.ts";
+import { info, warn, writeReport } from "../harness/report.ts";
+
+// Coverage-gate fill: agents + messages + attachments, the largest single
+// batch of the 4-way MCP tool-coverage split (see mcp_coverage_gate.py /
+// harness/mcp-coverage.ts). This suite is the sole owner of:
+//   get_agent, update_agent, delete_agent, restore_agent, get_protection,
+//   update_protection, delete_message, restore_message, forward_message,
+//   update_message_labels, get_message_lifecycle, get_conversation,
+//   list_conversations, get_attachment, get_attachment_data
+//
+// Free-plan budget (3 agents / 1 domain / 3000 msgs-mo) is tight, so this
+// file creates exactly ONE throwaway agent for the whole suite and reuses it
+// end to end: identity/protection tools first, then a single self-send
+// loopback message drives labels/conversations/lifecycle/forward/trash, then
+// one real send (no hold) to the SES simulator produces a retrievable
+// attachment (the same pattern 20-attachments.test.ts establishes — a HELD
+// draft has no raw_message, so getAttachment 404s on it), and finally the
+// agent itself goes through its own delete/restore cycle.
+//
+// Tests are intentionally sequential and share one lazily-created agent —
+// mirrors 24-trash-lifecycle.test.ts's economy-of-agents convention — so run
+// order matters here (this file is always run alone per the task brief, and
+// `npm test` runs suites with --test-concurrency=1).
+
+const SUITE = "27-mcp-agents-messages";
+const apiClient = new ApiClient();
+const mcp = new HttpMcpClient(apiClient.env.mcpUrl, apiClient.env.apiKey);
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+before(async () => {
+  info(SUITE, "transport", `MCP over HTTP → ${apiClient.env.mcpUrl}`);
+  // Feeds the mcp-coverage denominator (tools/list) even if every other test
+  // in the file somehow short-circuits.
+  const list = await mcp.call<{ tools: Array<{ name: string }> }>("tools/list");
+  info(SUITE, "tools-list", `server advertises ${list.tools.length} tools`);
+});
+
+after(async () => {
+  await mcp.stop();
+  const r = await cleanup(apiClient);
+  if (r.failed.length) warn(SUITE, "cleanup", `failed ${r.failed.length}`, r.failed);
+  writeReport(`./reports/${SUITE}.json`);
+});
+
+function extractText(r: { content?: Array<{ type: string; text?: string }> }): string {
+  return r.content?.find((c) => c.type === "text")?.text ?? "";
+}
+
+function parseJson<T>(r: { content?: Array<{ type: string; text?: string }> }): T {
+  return JSON.parse(extractText(r)) as T;
+}
+
+// ── The one throwaway agent shared by the whole file ─────────────────────
+
+let agentPromise: Promise<string> | undefined;
+function agent(): Promise<string> {
+  agentPromise ??= (async () => {
+    const slug = uniqueSlug("mcpam");
+    const email = `${slug}@${apiClient.env.sharedDomain}`;
+    const created = await apiClient.post<{ email: string }>("/v1/agents", {
+      body: { email, name: "mcp agents-messages batch" },
+      expect: 201,
+    });
+    // Track before assertions so teardown owns cleanup even if the response
+    // is malformed.
+    track("agent", email);
+    assert.equal(created.body?.email, email);
+    return email;
+  })();
+  return agentPromise;
+}
+
+// ── get_agent / update_agent ──────────────────────────────────────────────
+
+test("mcp-agents-msgs: get_agent returns the created agent's identity", async () => {
+  const email = await agent();
+  const r = await callTool(mcp, "get_agent", { email });
+  assert.equal(r.isError, undefined, `get_agent isError: ${extractText(r).slice(0, 200)}`);
+  const parsed = parseJson<{ email?: string; name?: string }>(r);
+  assert.equal(parsed.email, email, "get_agent returns the requested agent");
+  assert.equal(parsed.name, "mcp agents-messages batch", "get_agent echoes the display name set at creation");
+});
+
+test("mcp-agents-msgs: update_agent renames the agent", async () => {
+  const email = await agent();
+  const newName = `mcp batch renamed ${Date.now()}`;
+  const r = await callTool(mcp, "update_agent", { email, name: newName });
+  assert.equal(r.isError, undefined, `update_agent isError: ${extractText(r).slice(0, 200)}`);
+  const parsed = parseJson<{ email?: string; name?: string }>(r);
+  assert.equal(parsed.email, email);
+  assert.equal(parsed.name, newName, "update_agent applies the new display name");
+
+  // Confirm it stuck via a fresh read.
+  const check = await callTool(mcp, "get_agent", { email });
+  assert.equal(check.isError, undefined);
+  assert.equal(parseJson<{ name?: string }>(check).name, newName, "renamed name persists across a fresh get_agent");
+});
+
+// ── get_protection / update_protection (beta) ─────────────────────────────
+
+test("mcp-agents-msgs: get_protection reads the agent's protection posture", async () => {
+  const email = await agent();
+  const r = await callTool(mcp, "get_protection", { email });
+  assert.equal(r.isError, undefined, `get_protection isError: ${extractText(r).slice(0, 200)}`);
+  const parsed = parseJson<{
+    inbound?: { gate?: { policy?: string } };
+    outbound?: { gate?: { policy?: string } };
+    holds?: { on_expiry?: string; ttl_seconds?: number };
+  }>(r);
+  assert.ok(parsed.inbound?.gate?.policy, "protection view carries an inbound gate policy");
+  assert.ok(parsed.outbound?.gate?.policy, "protection view carries an outbound gate policy");
+  // suppress_notifications is boolean `false`-omitted on the wire (only
+  // present when true), so assert on a field that's always emitted instead.
+  assert.ok(parsed.holds?.on_expiry, "protection view carries a holds.on_expiry");
+  assert.equal(typeof parsed.holds?.ttl_seconds, "number", "holds.ttl_seconds is a number");
+});
+
+test("mcp-agents-msgs: update_protection read-modify-writes a single field", async () => {
+  const email = await agent();
+  // holds_suppress_notifications is a purely-cosmetic toggle (no gate/scan
+  // change), so it can't perturb the later real-send/forward tests in this
+  // file that depend on the default open outbound policy.
+  const before = await callTool(mcp, "get_protection", { email });
+  assert.equal(before.isError, undefined);
+  const beforeCfg = parseJson<{ holds?: { suppress_notifications?: boolean } }>(before);
+  const flipped = !beforeCfg.holds?.suppress_notifications;
+
+  const r = await callTool(mcp, "update_protection", { email, holds_suppress_notifications: flipped });
+  assert.equal(r.isError, undefined, `update_protection isError: ${extractText(r).slice(0, 200)}`);
+  const parsed = parseJson<{ holds?: { suppress_notifications?: boolean } }>(r);
+  assert.equal(parsed.holds?.suppress_notifications, flipped, "update_protection applies the requested field");
+
+  // Read-modify-write: everything else should be untouched.
+  const after = await callTool(mcp, "get_protection", { email });
+  const afterCfg = parseJson<{ inbound?: { gate?: { policy?: string } }; outbound?: { gate?: { policy?: string } } }>(after);
+  const beforeFull = parseJson<{ inbound?: { gate?: { policy?: string } }; outbound?: { gate?: { policy?: string } } }>(before);
+  assert.equal(afterCfg.inbound?.gate?.policy, beforeFull.inbound?.gate?.policy, "unrelated inbound gate policy untouched");
+  assert.equal(afterCfg.outbound?.gate?.policy, beforeFull.outbound?.gate?.policy, "unrelated outbound gate policy untouched");
+
+  // Restore the original value so later tests in this file see the agent's
+  // original posture (defensive; the field itself is inert either way).
+  const restore = await callTool(mcp, "update_protection", { email, holds_suppress_notifications: !flipped });
+  assert.equal(restore.isError, undefined);
+});
+
+// ── A self-send loopback message, shared by labels/conversations/lifecycle/forward/trash ──
+
+interface LoopbackFixture {
+  messageId: string;
+  conversationId: string;
+  subject: string;
+}
+
+let loopbackPromise: Promise<LoopbackFixture> | undefined;
+function loopback(): Promise<LoopbackFixture> {
+  loopbackPromise ??= (async () => {
+    const email = await agent();
+    const subject = uniqueSubject("mcp-batch-loopback");
+    const send = await apiClient.post<{ status: string; message_id: string }>(
+      `/v1/agents/${encodeURIComponent(email)}/messages`,
+      { body: { to: [email], subject, text: "27-mcp-agents-messages loopback body" }, expect: [200, 202] },
+    );
+    assert.ok(send.body?.message_id, `loopback send did not return a message_id: ${send.raw.slice(0, 200)}`);
+
+    for (let i = 0; i < 12; i++) {
+      const list = await apiClient.get<{ items: Array<{ id: string; subject: string; conversation_id: string }> }>(
+        `/v1/agents/${encodeURIComponent(email)}/messages`,
+        { query: { direction: "inbound", read_status: "all", limit: 20 } },
+      );
+      const m = list.body?.items?.find((x) => x.subject === subject);
+      if (m) return { messageId: m.id, conversationId: m.conversation_id, subject };
+      await sleep(1500);
+    }
+    throw new Error(`loopback message "${subject}" never appeared for ${email}`);
+  })();
+  return loopbackPromise;
+}
+
+// ── update_message_labels ─────────────────────────────────────────────────
+
+test("mcp-agents-msgs: update_message_labels adds then removes a label", async () => {
+  const email = await agent();
+  const { messageId } = await loopback();
+  const label = "e2e-mcp-batch";
+
+  const add = await callTool(mcp, "update_message_labels", { message_id: messageId, add_labels: [label], email });
+  assert.equal(add.isError, undefined, `update_message_labels(add) isError: ${extractText(add).slice(0, 200)}`);
+  const added = parseJson<{ message_id?: string; labels?: string[] }>(add);
+  assert.equal(added.message_id, messageId);
+  assert.ok(added.labels?.includes(label), `expected "${label}" in labels, got ${JSON.stringify(added.labels)}`);
+
+  const remove = await callTool(mcp, "update_message_labels", { message_id: messageId, remove_labels: [label], email });
+  assert.equal(remove.isError, undefined, `update_message_labels(remove) isError: ${extractText(remove).slice(0, 200)}`);
+  const removed = parseJson<{ labels?: string[] }>(remove);
+  assert.ok(!removed.labels?.includes(label), `expected "${label}" removed, got ${JSON.stringify(removed.labels)}`);
+});
+
+// ── list_conversations / get_conversation ─────────────────────────────────
+
+test("mcp-agents-msgs: list_conversations surfaces the loopback thread", async () => {
+  const email = await agent();
+  const { conversationId } = await loopback();
+
+  const r = await callTool(mcp, "list_conversations", { email });
+  assert.equal(r.isError, undefined, `list_conversations isError: ${extractText(r).slice(0, 200)}`);
+  const parsed = parseJson<{ conversations?: Array<{ id: string; message_count: number }> }>(r);
+  const conv = parsed.conversations?.find((c) => c.id === conversationId);
+  assert.ok(conv, `conversation ${conversationId} not found in list_conversations (${parsed.conversations?.length ?? 0} rows)`);
+  assert.ok(conv!.message_count >= 1, "our conversation has at least the loopback message");
+});
+
+test("mcp-agents-msgs: get_conversation returns the loopback thread with its member message", async () => {
+  const email = await agent();
+  const { conversationId, messageId } = await loopback();
+
+  const r = await callTool(mcp, "get_conversation", { conversation_id: conversationId, email });
+  assert.equal(r.isError, undefined, `get_conversation isError: ${extractText(r).slice(0, 200)}`);
+  const parsed = parseJson<{ id?: string; messages?: Array<{ id: string }>; participants?: string[] }>(r);
+  assert.equal(parsed.id, conversationId);
+  assert.ok(parsed.messages?.some((m) => m.id === messageId), "get_conversation includes our loopback message");
+  assert.ok(parsed.participants?.includes(email), "participants includes the self-send agent");
+});
+
+// ── get_message_lifecycle (beta) ──────────────────────────────────────────
+
+test("mcp-agents-msgs: get_message_lifecycle (beta) returns transitions for the loopback message", async () => {
+  const email = await agent();
+  const { messageId } = await loopback();
+
+  const r = await callTool(mcp, "get_message_lifecycle", { message_id: messageId, email });
+  assert.equal(r.isError, undefined, `get_message_lifecycle isError: ${extractText(r).slice(0, 200)}`);
+  const parsed = parseJson<{ transitions?: Array<{ message_id: string; outcome: string; reason_code: string }> }>(r);
+  assert.ok(Array.isArray(parsed.transitions) && parsed.transitions.length > 0, "at least one lifecycle transition recorded");
+  for (const t of parsed.transitions!) {
+    assert.equal(t.message_id, messageId, `transition message_id mismatch: ${JSON.stringify(t)}`);
+  }
+});
+
+// ── forward_message ────────────────────────────────────────────────────────
+
+test("mcp-agents-msgs: forward_message forwards the loopback message as a new thread", async () => {
+  const email = await agent();
+  const { messageId } = await loopback();
+
+  const r = await callTool(mcp, "forward_message", {
+    message_id: messageId,
+    to: [email],
+    text: "fwd comment from 27-mcp-agents-messages",
+    email,
+  });
+  assert.equal(r.isError, undefined, `forward_message isError: ${extractText(r).slice(0, 200)}`);
+  const parsed = parseJson<{ status?: string; message_id?: string }>(r);
+  assert.ok(parsed.message_id?.startsWith("msg_"), `expected msg_ id, got "${parsed.message_id}"`);
+  assert.ok(
+    parsed.status === "accepted" || parsed.status === "sent" || parsed.status === "pending_review",
+    `forward_message must be accepted, sent, or held, got "${parsed.status}"`,
+  );
+  if (parsed.status === "pending_review") {
+    // Default protection is open (no gate hold expected), but resolve
+    // defensively so no dangling review-queue item survives the suite.
+    const rej = await apiClient.post(`/v1/reviews/${parsed.message_id}/reject`, {
+      body: { reason: "27-mcp-agents-messages forward cleanup" },
+    });
+    assert.ok(rej.status === 200, `failed to reject held forward: ${rej.status} ${rej.raw.slice(0, 200)}`);
+  }
+});
+
+// ── delete_message / restore_message ──────────────────────────────────────
+
+test("mcp-agents-msgs: delete_message then restore_message round-trips the loopback message", async () => {
+  const email = await agent();
+  const { messageId } = await loopback();
+
+  const del = await callTool(mcp, "delete_message", { message_id: messageId, email, confirm: true });
+  assert.equal(del.isError, undefined, `delete_message isError: ${extractText(del).slice(0, 200)}`);
+  const delParsed = parseJson<{ deleted?: boolean; id?: string }>(del);
+  assert.deepEqual(delParsed, { deleted: true, id: messageId }, "delete_message result shape");
+
+  // Confirm it dropped out of the live listing via the REST surface.
+  const liveList = await apiClient.get<{ items: Array<{ id: string }> }>(
+    `/v1/agents/${encodeURIComponent(email)}/messages`,
+    { query: { direction: "inbound", read_status: "all", limit: 20 } },
+  );
+  assert.ok(!liveList.body?.items?.some((m) => m.id === messageId), "message absent from live listing after delete_message");
+
+  const restore = await callTool(mcp, "restore_message", { message_id: messageId, email });
+  assert.equal(restore.isError, undefined, `restore_message isError: ${extractText(restore).slice(0, 200)}`);
+  const restoreParsed = parseJson<{ id?: string; deleted_at?: string | null }>(restore);
+  assert.equal(restoreParsed.id, messageId);
+  assert.equal(restoreParsed.deleted_at, undefined, "restored message view omits deleted_at");
+
+  const liveAgain = await apiClient.get<{ items: Array<{ id: string }> }>(
+    `/v1/agents/${encodeURIComponent(email)}/messages`,
+    { query: { direction: "inbound", read_status: "all", limit: 20 } },
+  );
+  assert.ok(liveAgain.body?.items?.some((m) => m.id === messageId), "message back in live listing after restore_message");
+});
+
+// ── get_attachment / get_attachment_data ──────────────────────────────────
+//
+// A HELD (pending_review) draft has NO raw_message, so its attachments[] is
+// empty and getAttachment 404s (see 20-attachments.test.ts). The default
+// protection posture on our throwaway agent is open (never held), so a real
+// no-hold send to the SES simulator is a reliable way to get retrievable
+// attachment bytes without depending on external MX.
+
+const ATTACH_TEXT = "hello mcp-agents-messages attachment";
+const ATTACH_B64 = Buffer.from(ATTACH_TEXT, "utf8").toString("base64");
+const ATTACH_FILENAME = "hello.txt";
+const ATTACH_CTYPE = "text/plain";
+
+interface AttachmentFixture {
+  messageId: string;
+}
+
+let attachmentPromise: Promise<AttachmentFixture | null> | undefined;
+function attachmentFixture(): Promise<AttachmentFixture | null> {
+  attachmentPromise ??= (async () => {
+    const email = await agent();
+    const send = await apiClient.post<{ status: string; message_id: string }>(
+      `/v1/agents/${encodeURIComponent(email)}/messages`,
+      {
+        body: {
+          to: ["success@simulator.amazonses.com"],
+          subject: uniqueSubject("mcp-batch-attach"),
+          text: "see attached",
+          attachments: [{ filename: ATTACH_FILENAME, content_type: ATTACH_CTYPE, data: ATTACH_B64 }],
+        },
+      },
+    );
+    if ((send.status !== 200 && send.status !== 202) || !send.body?.message_id) {
+      warn(SUITE, "attachment-setup", `real send with attachment did not return 200/202+message_id (got ${send.status}); attachment tests flagged`, send.raw.slice(0, 200));
+      return null;
+    }
+    const messageId = send.body.message_id;
+    for (let attempt = 0; attempt < 24; attempt++) {
+      const msg = await apiClient.get<{ attachments?: Array<{ index: number }> }>(
+        `/v1/agents/${encodeURIComponent(email)}/messages/${messageId}`,
+      );
+      if (msg.status === 200 && Array.isArray(msg.body?.attachments) && msg.body!.attachments.length > 0) {
+        return { messageId };
+      }
+      await sleep(1000);
+    }
+    warn(
+      SUITE,
+      "attachment-setup",
+      "real send accepted the attachment but never exposed a retrievable attachments[] within the poll window; attachment tests flagged",
+    );
+    return null;
+  })();
+  return attachmentPromise;
+}
+
+test("mcp-agents-msgs: get_attachment returns metadata + a short-lived download_url", async () => {
+  const email = await agent();
+  const fixture = await attachmentFixture();
+  if (!fixture) {
+    info(SUITE, "get-attachment-skip", "no attachment fixture available; skipping get_attachment happy path");
+    return;
+  }
+  const r = await callTool(mcp, "get_attachment", { message_id: fixture.messageId, attachment_index: 0, email });
+  assert.equal(r.isError, undefined, `get_attachment isError: ${extractText(r).slice(0, 200)}`);
+  const parsed = parseJson<{
+    index?: number;
+    filename?: string;
+    content_type?: string;
+    size_bytes?: number;
+    download_url?: string;
+    expires_at?: string;
+    data?: string;
+  }>(r);
+  assert.equal(parsed.index, 0);
+  assert.equal(parsed.filename, ATTACH_FILENAME);
+  assert.equal(parsed.content_type, ATTACH_CTYPE);
+  assert.equal(parsed.size_bytes, ATTACH_TEXT.length);
+  assert.ok(parsed.download_url?.length, "download_url present");
+  assert.ok(parsed.data === undefined, "no inline data unless inline:true was requested");
+});
+
+test("mcp-agents-msgs: get_attachment_data (legacy alias) returns inline base64 that round-trips", async () => {
+  const email = await agent();
+  const fixture = await attachmentFixture();
+  if (!fixture) {
+    info(SUITE, "get-attachment-data-skip", "no attachment fixture available; skipping get_attachment_data happy path");
+    return;
+  }
+  const r = await callTool(mcp, "get_attachment_data", { message_id: fixture.messageId, attachment_index: 0, agent_email: email });
+  assert.equal(r.isError, undefined, `get_attachment_data isError: ${extractText(r).slice(0, 200)}`);
+  const parsed = parseJson<{ filename?: string; content_type?: string; size_bytes?: number; data?: string }>(r);
+  assert.equal(parsed.filename, ATTACH_FILENAME);
+  assert.equal(parsed.content_type, ATTACH_CTYPE);
+  assert.ok(typeof parsed.data === "string" && parsed.data.length > 0, "inline base64 data present");
+  const decoded = Buffer.from(parsed.data!, "base64").toString("utf8");
+  assert.equal(decoded, ATTACH_TEXT, "get_attachment_data round-trips the exact sent bytes");
+});
+
+// ── delete_agent / restore_agent ──────────────────────────────────────────
+// Runs LAST: everything above depends on the agent staying live.
+
+test("mcp-agents-msgs: delete_agent then restore_agent round-trips the throwaway agent", async () => {
+  const email = await agent();
+
+  const del = await callTool(mcp, "delete_agent", { email, confirm: true });
+  assert.equal(del.isError, undefined, `delete_agent isError: ${extractText(del).slice(0, 200)}`);
+  const delParsed = parseJson<{ deleted?: boolean; email?: string }>(del);
+  assert.equal(delParsed.deleted, true);
+  assert.equal(delParsed.email, email);
+
+  // Trashed agent 404s on a live GET (via REST, matching 24-trash-lifecycle).
+  const getAfterDelete = await apiClient.get(`/v1/agents/${encodeURIComponent(email)}`);
+  assert.equal(getAfterDelete.status, 404, `expected 404 for trashed agent, got ${getAfterDelete.status}`);
+
+  const restore = await callTool(mcp, "restore_agent", { email });
+  assert.equal(restore.isError, undefined, `restore_agent isError: ${extractText(restore).slice(0, 200)}`);
+  const restoreParsed = parseJson<{ email?: string; deleted_at?: string | null }>(restore);
+  assert.equal(restoreParsed.email, email);
+  assert.equal(restoreParsed.deleted_at, undefined, "restored agent view omits deleted_at");
+
+  const getAfterRestore = await apiClient.get(`/v1/agents/${encodeURIComponent(email)}`);
+  assert.equal(getAfterRestore.status, 200, `expected 200 after restore, got ${getAfterRestore.status}`);
+
+  // `after()`'s cleanup() re-trashes this tracked throwaway agent (soft
+  // delete), matching every other suite's teardown-into-trash convention.
+});

--- a/tests/e2e-prod/suites/28-mcp-domains-reviews.test.ts
+++ b/tests/e2e-prod/suites/28-mcp-domains-reviews.test.ts
@@ -1,0 +1,219 @@
+import { test, before, after, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient } from "../harness/client.ts";
+import { cleanup, track, untrack } from "../harness/cleanup.ts";
+import { HttpMcpClient, callTool } from "../harness/mcp.ts";
+import { uniqueSlug, uniqueSubject, runId, SINK_EMAIL, holdAllOutbound } from "../harness/fixtures.ts";
+import { fail, info, warn, writeReport } from "../harness/report.ts";
+
+// MCP coverage for the domains tool family (register_domain, get_domain,
+// list_domains, verify_domain, delete_domain) and the pending-review-queue
+// legacy alias family (approve_message, reject_message, get_pending_message,
+// list_pending_messages — deprecated aliases that all route through the same
+// unified review queue as approve_review/reject_review/get_review/list_reviews,
+// see mcp/src/tools/legacy.ts). Both families are exercised over the deployed
+// streamable-HTTP /mcp server, mirroring suites/12-mcp-extended.test.ts style.
+const apiClient = new ApiClient();
+const SUITE = "28-mcp-domains-reviews";
+const mcp = new HttpMcpClient(apiClient.env.mcpUrl, apiClient.env.apiKey);
+
+// .example.com is reserved by RFC 2606 for documentation/testing — safe to
+// register-then-never-publish-DNS without colliding with anything real. Same
+// convention as suites/10-domains.test.ts.
+function fakeDomain(label: string): string {
+  return `e2e-${runId()}-${label}-${Math.random().toString(36).slice(2, 8)}.example.com`;
+}
+
+function extractText(r: { content?: Array<{ type: string; text?: string }> }): string {
+  return r.content?.find((c) => c.type === "text")?.text ?? "";
+}
+
+before(async () => {
+  info(SUITE, "transport", `MCP over HTTP → ${apiClient.env.mcpUrl}`);
+});
+
+afterEach(async () => {
+  const r = await cleanup(apiClient);
+  if (r.failed.length) warn(SUITE, "cleanup-after-each", `failed ${r.failed.length}`, r.failed);
+});
+
+after(async () => {
+  await mcp.stop();
+  const r = await cleanup(apiClient);
+  if (r.failed.length) warn(SUITE, "cleanup", `failed ${r.failed.length}`, r.failed);
+  writeReport(`./reports/28-mcp-domains-reviews.json`);
+});
+
+// createHeldReview: throwaway shared-domain agent -> hold-all-outbound ->
+// send. Returns the agent email + the held message id. Mirrors
+// suites/18-reviews.test.ts's createHeldReview / suites/12-mcp-extended.test.ts's
+// ensureHitlAgent — the proven mechanism for landing a message in
+// pending_review that the review/pending-message MCP tools can then act on.
+// Caller MUST delete the agent (via track("agent", email) + cleanup, or
+// explicitly) once done.
+async function createHeldReview(label: string): Promise<{ email: string; id: string; subject: string }> {
+  const slug = uniqueSlug(label);
+  const c = await apiClient.post<{ email: string }>("/v1/agents", {
+    body: { email: `${slug}@${apiClient.env.sharedDomain}`, name: `mcp-dr ${label}` },
+  });
+  if (c.status !== 201) throw new Error(`create agent failed: ${c.status} ${c.raw.slice(0, 200)}`);
+  const email = c.body!.email;
+  track("agent", email);
+  const u = await holdAllOutbound(apiClient, email);
+  if (u.status !== 200) throw new Error(`hold-all-outbound failed: ${u.status} ${u.raw.slice(0, 200)}`);
+  const subject = uniqueSubject(`mcp-dr ${label}`);
+  const s = await apiClient.post<{ message_id: string; status: string }>(
+    `/v1/agents/${encodeURIComponent(email)}/messages`,
+    { body: { to: [SINK_EMAIL], subject, text: "held for review via MCP — must never actually go out" } },
+  );
+  if (s.status !== 202 || !s.body?.message_id) {
+    throw new Error(`held send expected 202 pending_review, got ${s.status}: ${s.raw.slice(0, 200)}`);
+  }
+  assert.equal(s.body.status, "pending_review", "held send status is pending_review");
+  return { email, id: s.body.message_id, subject };
+}
+
+test("mcp-domains: register_domain / get_domain / list_domains / verify_domain (negative control) / delete_domain", async () => {
+  // Call tools/list once so the coverage gate records the live denominator
+  // (harness/mcp.ts feeds mcp-coverage.ts from this same JSON-RPC call).
+  const list = await mcp.call<{ tools: Array<{ name: string }> }>("tools/list");
+  for (const name of [
+    "register_domain",
+    "get_domain",
+    "list_domains",
+    "verify_domain",
+    "delete_domain",
+    "approve_message",
+    "reject_message",
+    "get_pending_message",
+    "list_pending_messages",
+  ]) {
+    assert.ok(list.tools.some((t) => t.name === name), `deployed server must advertise ${name}`);
+  }
+
+  const domain = fakeDomain("mcpdom");
+
+  // register_domain — step 1 of the custom-domain flow. Track immediately so
+  // the afterEach/after cleanup net catches it even if a later assertion in
+  // this test throws (free-plan account: 1 domain total, must not leak it).
+  const reg = await callTool(mcp, "register_domain", { domain });
+  if (reg.isError) {
+    fail(SUITE, "register-domain-error", `register_domain isError: ${extractText(reg).slice(0, 200)}`);
+    return;
+  }
+  track("domain", domain);
+  const regParsed = JSON.parse(extractText(reg)) as {
+    domain?: string;
+    dns_records?: Array<{ type: string; purpose: string }>;
+    verified?: boolean;
+  };
+  assert.equal(regParsed.domain, domain, "register_domain echoes the requested domain");
+  assert.ok(Array.isArray(regParsed.dns_records) && regParsed.dns_records.length > 0, "register_domain returns dns_records to publish");
+  assert.equal(regParsed.verified, false, "a freshly-registered domain starts unverified");
+
+  // get_domain — poll target, single-domain read.
+  const got = await callTool(mcp, "get_domain", { domain });
+  assert.equal(got.isError, undefined, `get_domain isError: ${extractText(got).slice(0, 200)}`);
+  const gotParsed = JSON.parse(extractText(got)) as { domain?: string; verified?: boolean };
+  assert.equal(gotParsed.domain, domain, "get_domain returns the same domain we registered");
+
+  // list_domains — assert OUR domain is present by name. No account-global
+  // count assertion: other suites/agents may share this account.
+  const listed = await callTool(mcp, "list_domains", {});
+  assert.equal(listed.isError, undefined, `list_domains isError: ${extractText(listed).slice(0, 200)}`);
+  const listedParsed = JSON.parse(extractText(listed)) as { domains?: Array<{ domain: string }> };
+  assert.ok(
+    listedParsed.domains?.some((d) => d.domain === domain),
+    `list_domains must include our freshly-registered ${domain}`,
+  );
+
+  // verify_domain — NEGATIVE CONTROL. We deliberately never publish the DNS
+  // records for this .example.com domain, so this must report verified:false
+  // as a NORMAL 200-equivalent success (not isError) — the honest way to
+  // cover verify_domain here per the task brief: calling it on a domain
+  // whose DNS IS published would either hang forever or (if it isn't yet
+  // propagated) negative-cache the miss for up to the zone's SOA minimum
+  // (~30min), which no in-test poll can outlast. This also guards against a
+  // dev-mode DNS short-circuit tautology (suites/22-domain-lifecycle.test.ts
+  // runs the equivalent REST-side negative control).
+  const verify = await callTool(mcp, "verify_domain", { domain });
+  assert.equal(verify.isError, undefined, `verify_domain (negative control) must be a normal success, not isError: ${extractText(verify).slice(0, 200)}`);
+  const verifyParsed = JSON.parse(extractText(verify)) as { domain?: string; verified?: boolean };
+  assert.equal(verifyParsed.domain, domain, "verify_domain echoes the domain");
+  assert.equal(verifyParsed.verified, false, "unpublished-DNS domain must report verified:false, not a DNS/dev-mode short-circuit");
+
+  // delete_domain — DESTRUCTIVE, requires confirm:true (schema-level literal
+  // guard against an LLM hallucinating a delete). No agents were ever
+  // created on this domain (it never verified), so no domain_has_agents risk.
+  const del = await callTool(mcp, "delete_domain", { domain, confirm: true });
+  assert.equal(del.isError, undefined, `delete_domain isError: ${extractText(del).slice(0, 200)}`);
+  const delParsed = JSON.parse(extractText(del)) as { deleted?: boolean; domain?: string };
+  assert.equal(delParsed.deleted, true, "delete_domain result has deleted:true");
+  assert.equal(delParsed.domain, domain, "delete_domain result echoes the domain");
+  // Already deleted via the tool call above — untrack so the redundant
+  // afterEach cleanup DELETE (which would 404, itself harmless) is skipped.
+  untrack("domain", domain);
+});
+
+test("mcp-domains-reviews: list_pending_messages + get_pending_message + approve_message round-trip", async () => {
+  const { email, id, subject } = await createHeldReview("approve");
+  try {
+    // list_pending_messages — deprecated alias for list_reviews; walks every
+    // page of the unified account-level review queue and returns the
+    // historical {messages: [...]} envelope. Assert OUR held message is
+    // present by id, not an account-global count.
+    const listed = await callTool(mcp, "list_pending_messages", {});
+    assert.equal(listed.isError, undefined, `list_pending_messages isError: ${extractText(listed).slice(0, 200)}`);
+    const listedParsed = JSON.parse(extractText(listed)) as { messages?: Array<{ id?: string }> };
+    assert.ok(
+      listedParsed.messages?.some((m) => m.id === id),
+      `list_pending_messages must include our held message ${id}`,
+    );
+
+    // get_pending_message — deprecated alias for get_review; full detail.
+    const got = await callTool(mcp, "get_pending_message", { message_id: id });
+    assert.equal(got.isError, undefined, `get_pending_message isError: ${extractText(got).slice(0, 200)}`);
+    const gotParsed = JSON.parse(extractText(got)) as { id?: string; review_status?: string; subject?: string };
+    assert.equal(gotParsed.id, id, "get_pending_message returns the same message id");
+    assert.equal(gotParsed.review_status, "pending_review", "held message is still pending_review before approval");
+    assert.equal(gotParsed.subject, subject, "get_pending_message echoes the held subject");
+
+    // approve_message — deprecated alias for approve_review; releases the
+    // outbound hold for async send (queued, not necessarily synchronous).
+    const approved = await callTool(mcp, "approve_message", { message_id: id });
+    assert.equal(approved.isError, undefined, `approve_message isError: ${extractText(approved).slice(0, 200)}`);
+    const approvedParsed = JSON.parse(extractText(approved)) as { message_id?: string; status?: string };
+    assert.equal(approvedParsed.message_id, id, "approve_message result echoes the approved message id");
+    assert.ok(
+      approvedParsed.status === "accepted" || approvedParsed.status === "sent",
+      `approve_message must transition to accepted/sent, got "${approvedParsed.status}"`,
+    );
+
+    // Re-approve a resolved hold must surface as a terminal-state tool error.
+    const reapproved = await callTool(mcp, "approve_message", { message_id: id });
+    assert.equal(reapproved.isError, true, "re-approve of an already-resolved message must isError");
+  } finally {
+    // Agent delete cascades to its held/sent messages; explicit and tracked
+    // regardless so a mid-test throw still gets cleaned up.
+    await apiClient.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE`);
+    untrack("agent", email);
+  }
+});
+
+test("mcp-domains-reviews: reject_message discards the held draft", async () => {
+  const { email, id } = await createHeldReview("reject");
+  try {
+    const rejected = await callTool(mcp, "reject_message", { message_id: id, reason: "e2e mcp-domains-reviews reject" });
+    assert.equal(rejected.isError, undefined, `reject_message isError: ${extractText(rejected).slice(0, 200)}`);
+    const rejectedParsed = JSON.parse(extractText(rejected)) as { message_id?: string; status?: string };
+    assert.equal(rejectedParsed.message_id, id, "reject_message result echoes the rejected message id");
+    assert.equal(rejectedParsed.status, "review_rejected", "reject_message transitions the hold to review_rejected");
+
+    // Re-reject a resolved hold must surface as a terminal-state tool error.
+    const rereject = await callTool(mcp, "reject_message", { message_id: id, reason: "should fail" });
+    assert.equal(rereject.isError, true, "re-reject of an already-resolved message must isError");
+  } finally {
+    await apiClient.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE`);
+    untrack("agent", email);
+  }
+});

--- a/tests/e2e-prod/suites/28-mcp-domains-reviews.test.ts
+++ b/tests/e2e-prod/suites/28-mcp-domains-reviews.test.ts
@@ -4,7 +4,7 @@ import { ApiClient } from "../harness/client.ts";
 import { cleanup, track, untrack } from "../harness/cleanup.ts";
 import { HttpMcpClient, callTool } from "../harness/mcp.ts";
 import { uniqueSlug, uniqueSubject, runId, SINK_EMAIL, holdAllOutbound } from "../harness/fixtures.ts";
-import { fail, info, warn, writeReport } from "../harness/report.ts";
+import { info, warn, writeReport } from "../harness/report.ts";
 
 // MCP coverage for the domains tool family (register_domain, get_domain,
 // list_domains, verify_domain, delete_domain) and the pending-review-queue
@@ -97,10 +97,7 @@ test("mcp-domains: register_domain / get_domain / list_domains / verify_domain (
   // the afterEach/after cleanup net catches it even if a later assertion in
   // this test throws (free-plan account: 1 domain total, must not leak it).
   const reg = await callTool(mcp, "register_domain", { domain });
-  if (reg.isError) {
-    fail(SUITE, "register-domain-error", `register_domain isError: ${extractText(reg).slice(0, 200)}`);
-    return;
-  }
+  assert.equal(reg.isError, undefined, `register_domain isError: ${extractText(reg).slice(0, 200)}`);
   track("domain", domain);
   const regParsed = JSON.parse(extractText(reg)) as {
     domain?: string;


### PR DESCRIPTION
## Summary

The Python SDK's hand-written ergonomic facade (`sdks/python/src/e2a/v1/client.py` + `inbound.py`) sits over a generated layer that's mechanically derived from `api/openapi.yaml` and already covered transitively by the repo-root `/v1` coverage gate. The facade is where real bugs live — argument marshalling, response shaping, kwarg handling, request-body coercion — and it was almost untested: `tests/test_e2e.py` exercised **6** methods.

This PR adds a coverage gate + live test suite for the ergonomic surface, modelled on `tests/e2e-prod/mcp_coverage_gate.py` + `harness/mcp-coverage.ts`.

## Denominator: introspection, not a grep — and why it isn't the cited 57

Per the task brief, runtime introspection of `AsyncE2AClient` was reported at **57** methods across the 10 named resources (account, agents, conversations, domains, events, inbound, messages, reviews, templates, webhooks). That number came from a **one-level-deep** walk of those 10 resource attributes.

Doing the walk **recursively** (`tests/resource_coverage_lib/discovery.py`, reusing `sync_client.py`'s own `_is_resource` heuristic so this gate and the sync mirror can never quietly disagree about what counts as a resource) finds **64** — the 57 plus:
- `account.suppressions.{list,delete}` (2) and `account.api_keys.{list,create,delete}` (3) — nested one level inside `account`, assigned dynamically in `AccountResource.__init__`, invisible to a walk that only checks the 10 top-level names
- `info` and `listen` (2) — top-level client methods, not under any of the 10 named resources at all

This is exactly the failure mode the task warns about: a shallow/regex-shaped denominator silently drops methods it wasn't already looking for (the TS SDK regex missing 27 real methods; the MCP tool grep missing 2 real tools). A one-level resource walk is a more sophisticated grep, but it's still a grep in spirit. The gate's denominator is computed **fresh at gate-run time** via `discover_client_methods()` — genuine recursive runtime introspection (`dir()`/`getattr()` on a live instance), not a recorded/shard-based catalog, since a Python class's public surface (unlike a deployed server's advertised tool list) doesn't vary by deployment.

## Async/sync scope: async only

`sync_client.py`'s `E2AClient` is a **pure runtime mirror** of `AsyncE2AClient` (`__getattr__` + `_wrap_attr`/`_wrap_value`) — by the module's own docstring, "there is exactly ONE implementation of resources / retries / error mapping / pagination — the async one — so the sync surface cannot drift from it." A marshalling bug lives in the async resource method; the sync facade can only fail to *relay* it correctly, and that relay mechanism already has dedicated offline coverage in `tests/test_v1_sync_client.py`, including a structural drift guard (`test_parity_every_async_method_reachable_sync`) that fails if any async method ever becomes unreachable from the sync facade.

Re-running the same live argument-marshalling assertions a second time through the sync bridge would double staging API/quota usage for zero incremental bug-catching power. This is a deliberate scope call (explicitly permitted by the task), not an oversight.

## What's new

- **`tests/resource_coverage_lib/discovery.py`** — the denominator (recursive introspection, see above).
- **`tests/resource_coverage_lib/tracker.py`** — the numerator: `mark_covered("resource.method")` writes a per-process shard, unioned by the gate. Named `resource_coverage_lib` (not `coverage`) deliberately, to avoid shadowing pytest-cov's own `coverage` package on `sys.path`.
- **`tests/resource_coverage_gate.py`** — the gate script, mirroring `mcp_coverage_gate.py`'s fail-closed discipline: exit 0 = every discovered method covered or allowlisted, 1 = coverage gap, 2 = usage/IO error (no shard dir, no shards, or a stale allowlist entry) — never a vacuous pass. Runnable directly: `python tests/resource_coverage_gate.py`.
- **`tests/test_e2e_resources.py`** — live tests for the 61 covered methods. Every test calls the real method against staging and asserts on the **actual returned data** (not just "didn't raise"), then calls `mark_covered(...)` — no bare skips, no `if not x: return` on a missing fixture (that exact bug already bit `get_message` here once — 18/18 green while the happy path silently no-op'd on an empty inbox).
- **`tests/test_e2e.py`** — added `mark_covered(...)` calls for the 7 methods its existing self-loopback test already exercises (`info`, `agents.create`/`delete`, `messages.send`/`list`/`get`/`reply`); no behavior changes.
- **`tests/conftest.py`** — clears stale shards once per live session (so a leftover shard from a previous aborted run can't mask a real gap) and runs a zero-I/O sanity check (`assert_no_reflection_bugs`) on every collection, live or offline, so a refactor that breaks the discovery heuristic fails fast.
- **`tests/.gitignore`** — ignores the shard output dir, mirroring `tests/e2e-prod/.gitignore`.

## Allowlist (3 entries, all in `resource_coverage_gate.py`)

| Method | Reason |
|---|---|
| `account.delete` | Destructive — the suite must never delete its own staging account (mirrors the `/v1` gate's `deleteAccount` entry). |
| `account.suppressions.delete` | No happy-path black-box: `/v1/account/suppressions` has no create operation — an entry is only ever created by a real SES bounce/complaint (mirrors the `/v1` gate's `deleteSuppression` entry). **Evaluated, not assumed**: `agents.create_suppression`/`delete_suppression` (agent-scoped) DO have a direct create path via `POST /v1/agents/{email}/suppressions` — those are fully covered, not allowlisted. |
| `listen` | Constructs a `WSStream` synchronously with zero network I/O and zero request/response-shape surface to marshal (the bug class this gate targets). Real connection/reconnect/parse behavior is already covered offline by `tests/test_v1_websocket.py` + the sync-bridge WS tests. |

## TS SDK "meta" finding — investigated, and it is NOT a real product gap

The task brief states runtime introspection shows the TS SDK exposing a `meta` resource (`getInfo`) that Python lacks entirely (Python 57, TS 59, delta = `meta`). I checked both sources directly (`sdks/typescript/src/v1/client.ts` vs `sdks/python/src/e2a/v1/client.py`) and the two SDKs are structurally identical here, not asymmetric:

- **Python**: `self._meta = MetaApi(self._api_client)` in `__init__` — leading-underscore, the Python convention for "internal." The sanctioned public surface is `client.info()`, which calls `self._meta.get_info(...)`. A `dir()`-based introspector correctly treats `_meta` as private and skips it (matches this gate's own `_SKIP`-adjacent, underscore-based filtering), so it never appears as a 65th method — it isn't public API.
- **TypeScript**: `private readonly meta: PromiseMetaApi` in the class body, with the identical pattern — `info(): Promise<DeploymentInfoView> { return call(() => this.meta.getInfo()); }`. Same intent (meta is an internal implementation detail; `info()` is the real public entry point) — but TS's `private` keyword is compile-time-only. At runtime, `client.meta` is a completely ordinary, enumerable object property; nothing hides it from a runtime-introspection walk the way Python's underscore convention does.

So the "TS has `meta`, Python doesn't" delta isn't a missing capability in Python — both SDKs expose the exact same one operation (`.info()`) with identical wire semantics, and both privately wrap it in a `MetaApi`/`PromiseMetaApi` helper. The apparent asymmetry is an artifact of a runtime-introspection-based TS gate picking up a `private`-declared-but-runtime-public field as if it were a real, additional resource. **Recommendation for the sibling TS coverage PR** (not acted on here, out of scope for a Python-only PR): either exclude TS `private` members from the discovered surface (mirroring this gate's underscore-based exclusion), or — if `meta.getInfo` is kept in TS's denominator — allowlist it there with this same "internal alias of `.info()`" justification rather than adding a live test for what would be a redundant assertion. No AGENTS.md-mandated cross-SDK symmetry fix is needed: there is no capability gap, only a counting artifact.

## Verification

- `uv run --extra dev pytest tests/test_e2e.py tests/test_e2e_resources.py -q -o addopts=` against `api-staging.e2a.dev` → **11 passed**.
- `python tests/resource_coverage_gate.py` → **64 discovered / 61 covered / 3 allowlisted, exit 0**.
- **Gate bites**: temporarily removed the `mark_covered("templates.validate")` call, reran the suite (still 11 passed — pytest itself doesn't care) and the gate → **exit 1, `UNCOVERED: templates.validate`**. Restored; gate back to exit 0. Confirms the gate is checking real coverage, not proxying pytest's pass/fail.
- `uv run --extra dev pytest tests/ -q` (no live creds) → **471 passed, 28 skipped** — offline suite unaffected.
- Staging fixtures (throwaway agents/domains/webhooks/templates/api-keys, all `py-sdk-cov-*`-prefixed) verified cleaned up after the run — none left over.

## Test plan

- [x] Live suite green against staging
- [x] Gate passes (64/61/3)
- [x] Gate demonstrably bites (red on a removed assertion, restored to green)
- [x] Offline unit suite unaffected
- [x] No leftover staging fixtures
