### PR TITLE
docs: fix stale/inaccurate documentation from a repo-wide audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,8 +189,9 @@ Key packages, grouped (name — a few words each):
   River worker), `delivery` SES bounce/complaint feedback via SNS
   (`POST /webhooks/ses`, signature-verified, fail-closed).
 - Inbound screening: `inboundprocess`/`inboundpolicy` async worker +
-  allow/review/block decisions; `piguard` prompt-injection/phishing
-  screening — dependency-free heuristics plus optional Gemini
+  allow/review/block decisions; `inboundscreen` shared screening core used by
+  both the SMTP and loopback self-send paths; `piguard` prompt-injection/
+  phishing screening — dependency-free heuristics plus optional Gemini
   LLM-as-detector (`GEMINI_API_KEY`, kill switch
   `E2A_GEMINI_DETECTOR_ENABLED=false`).
 - HITL & lifecycle: `hitlworker`/`hitlnotify` review holds (`pending_review`)
@@ -208,11 +209,12 @@ Key packages, grouped (name — a few words each):
   entitlements; `sendramp` per-domain recipient-volume ramping.
 - Auth: `auth` API key authentication; `oauth` fosite-based MCP OAuth
   server; Google OAuth + optional generic OIDC login.
-- Misc/infra: `ratelimit`; `telemetry` (metrics interface); `emailtemplate`+
-  `startertemplates` (server templates + starter catalog); `mailfrom`
-  (custom MAIL FROM); `selftest` (prober's self-test); `openapicompat`
-  (compat-gate normalization); `config` (YAML+env); `testutil` (test
-  harness); `e2e` (end-to-end suites).
+- Misc/infra: `ratelimit`; `telemetry` (metrics interface); `logredact`
+  PII redaction for process logs before centralized log shipping;
+  `emailtemplate`+`startertemplates` (server templates + starter catalog);
+  `mailfrom` (custom MAIL FROM); `selftest` (prober's self-test);
+  `openapicompat` (compat-gate normalization); `config` (YAML+env);
+  `testutil` (test harness); `e2e` (end-to-end suites).
 
 Async-migration feature flags: inbound async processing is opt-in
 (`E2A_INBOUND_MODE=async`, default `sync`) and webhook fan-out on River is
@@ -262,7 +264,8 @@ manually on every API change even though the template won't remind you.
   --forward` proxies WebSocket messages to a local HTTP endpoint. **Exit codes
   (`cli/src/exit.ts`) are a frozen contract** — 0 ok, 1 transient, 2 usage,
   3 held-for-review, 4 auth, 5 permanent request error, 6 timeout,
-  7 send-outcome. Add new codes, never renumber.
+  7 send-outcome, 8 warn (`doctor` warnings only), 9 config (`doctor` found a
+  definite configuration failure). Add new codes, never renumber.
 - **MCP server** (`mcp/`): inbox tools over the REST API; hosted HTTP
   transport (image `ghcr.io/tokencanopy/e2a-mcp-http`). **npm publishing is
   retired** (`@e2a/mcp-server` frozen at 0.4.0) — do not configure a trusted

--- a/cli/README.md
+++ b/cli/README.md
@@ -195,11 +195,12 @@ e2a send --to alice@example.com --subject "Hi" --html-file body.html \
 e2a reply msg_abc123 --body "On it." --agent bot@acme.com
 ```
 
-Common `send`/`reply` flags: `--to` (repeatable), `--subject`, `--body` /
-`--body-file`, `--html-file` (text fallback derived if no `--body`), `--attach`
-(repeatable; max 10 files, 10 MB each, 25 MB total), `--conversation-id`
-(alias `--conversation`), `--reply-to`, `--idempotency-key`, `--agent`, `--json`
-(print the full send result).
+Common `send`/`reply` flags: `--body` / `--body-file`, `--html-file` (text
+fallback derived if no `--body`), `--attach` (repeatable; max 10 files, 10 MB
+each, 25 MB total), `--reply-to`, `--idempotency-key`, `--agent`, `--json`
+(print the full send result). `send`-only: `--to` (repeatable), `--subject`,
+`--conversation-id` (alias `--conversation`) — `reply` infers these from the
+message being replied to and rejects them as unknown flags.
 
 ### `e2a messages`
 

--- a/design-system/.design-sync/NOTES.md
+++ b/design-system/.design-sync/NOTES.md
@@ -53,14 +53,14 @@ Durable, human-readable notes for future syncs. Committed.
 ## Accepted deviations (the oracle can't see these)
 
 - **`[FONT_MISSING]` — accepted, system substitutes.** The CSS references
-  `"Geist"` (`--f-ui`) and `"JetBrains Mono"` (`--f-mono`), but this package does
+  `"Inter"` (`--f-ui`) and `"JetBrains Mono"` (`--f-mono`), but this package does
   not vendor the woff2 files (the app loads them via `next/font`). Both panels of
   the compare oracle fall back to the same system fonts, so grades pass while
-  claude.ai/design users see system sans/mono instead of Geist/JetBrains Mono.
+  claude.ai/design users see system sans/mono instead of Inter/JetBrains Mono.
   This is acceptable for now — the tokens declare close system fallbacks
   (`-apple-system …`, `ui-monospace …`). **To make it faithful:** add the woff2s
-  (e.g. the `geist` and `@fontsource/jetbrains-mono` packages) and wire
-  `cfg.extraFonts` with matching `@font-face` blocks, then inject the same
+  (e.g. the `@fontsource/inter` and `@fontsource/jetbrains-mono` packages) and
+  wire `cfg.extraFonts` with matching `@font-face` blocks, then inject the same
   `@font-face` into `.design-sync/sb-reference/iframe.html` so the oracle verifies
   with the real fonts on both sides.
 

--- a/plugins/e2a/clients/README.md
+++ b/plugins/e2a/clients/README.md
@@ -14,7 +14,7 @@ Clients that speak remote MCP take the URL directly and run OAuth in the browser
 older or stdio-only clients can wrap it with `npx -y mcp-remote …`.
 
 **Full per-client guide** — Zed, Goose, headless API-key auth, and more:
-https://e2a.dev/setup.md (the "Connecting other MCP clients" section)
+https://e2a.dev/setup.md (the "1. Connect your client" section)
 
 **Claude Code / Codex** users don't need any of this — install the plugin
 instead (it registers the MCP server via the plugin's `.mcp.json`). See

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -351,8 +351,11 @@ listener for the same agent superseded this one; terminal, no auto-reconnect),
 `E2AWebhookSignatureError`. The 402/429 split is permanent — branch on
 the exception type: 402 → surface a quota/upgrade path, 429 → back off and retry.
 
-> e2a hides the existence of agents you don't own — `agents.get` of an unknown
-> address raises `E2APermissionError` (403), not `E2ANotFoundError`.
+> e2a hides the existence of agents you don't own — `agents.get` of an
+> unknown *or* unowned address raises `E2ANotFoundError` (404); the two cases
+> are deliberately indistinguishable, so a 404 is not proof the agent doesn't
+> exist. `E2APermissionError` (403) means something else: an *agent-scoped*
+> credential tried to act on a different agent in the account.
 
 ### Pagination
 

--- a/tests/e2e-prod/README.md
+++ b/tests/e2e-prod/README.md
@@ -7,7 +7,20 @@ Run this harness only against the intended production-compatible deployment. Con
 - `E2A_AGENT_EMAIL`: primary agent owned by that test account.
 - `E2E_SINK_EMAIL`: explicit safe test sink. This is required; never use a real agent or user mailbox. CI uses the Amazon SES mailbox simulator.
 - `E2A_SITE_URL`: optional site URL override when it cannot be derived from `E2A_URL`.
+- `E2A_MCP_URL`: optional MCP endpoint override; defaults to `${E2A_URL}/mcp`.
+- `E2A_QUOTA_API_KEY` / `E2A_QUOTA_AGENT_EMAIL`: optional separate STANDARD-class,
+  low-cap account for the limit/rate-limit enforcement suite. Without these the
+  enforcement suite is skipped, since the main conformance account is
+  internal-class and exempt by construction.
 
 The registration rate-limit stress probe is disabled by default. Set `E2E_PROD_STRESS=1` only for an intentional stress run.
 
 Do not commit credentials or print secret values in reports or logs.
+
+## Running
+
+```bash
+npm test              # run all suites (suites/*.test.ts)
+npm run smoke          # quick smoke check (smoke.ts)
+npm run coverage       # run all suites, then the coverage gate
+```


### PR DESCRIPTION
## Summary

Scheduled documentation audit across all `.md` files in the repo (READMEs, `docs/`, examples, plugin/skill docs). Every claim below was verified against the current code before being changed. `docs/design/**` and `docs/superpowers/**` (dated design docs/plans) were intentionally excluded — staleness there is expected and out of scope.

## What was outdated → what changed

- **`AGENTS.md`**
  - The CLI exit-code contract only listed 0–7; `cli/src/exit.ts` also defines `WARN=8` and `CONFIG=9` (both used by `e2a doctor`, which AGENTS.md itself references). Added them.
  - The "Key packages, grouped" overview omitted `internal/inboundscreen` (shared screening core used by both the SMTP and loopback self-send paths) and `internal/logredact` (the package that backs the log-PII-redaction guarantees `docs/data-handling.md`/`SECURITY.md` rely on). Added both.

- **`cli/README.md`** — the "Common `send`/`reply` flags" line claimed `--to`, `--subject`, and `--conversation-id`/`--conversation` apply to both commands. `reply`'s actual flag allowlist (`cli/src/bin/e2a.ts`) doesn't include any of the three — passing them to `reply` exits 2 with "unknown flag". Reworded to separate the shared flags from the `send`-only ones.

- **`sdks/python/README.md`** — stated `agents.get` of an unknown address raises `E2APermissionError` (403). The server (`resolveOwnedAgent` in `internal/httpapi/operations.go`, confirmed by `apikeys_test.go`) and the SDK's own behavior are actually `E2ANotFoundError` (404) — the sibling `sdks/typescript/README.md` already documents this correctly. Fixed the Python doc to match reality (and the TS doc's wording).

- **`design-system/.design-sync/NOTES.md`** — claimed the CSS references `"Geist"` for `--f-ui`. `tokens.css` actually defines `--f-ui: "Inter", …` and "Geist" doesn't appear anywhere in the design-system or web app source. Fixed the font name (and the suggested fontsource package to add).

- **`tests/e2e-prod/README.md`** — the "Configure:" list omitted `E2A_MCP_URL` and `E2A_QUOTA_API_KEY`/`E2A_QUOTA_AGENT_EMAIL`, which `harness/env.ts` reads and which silently change harness behavior (MCP suites target a derived URL by default; the quota-enforcement suite is skipped entirely without the quota account). Added them, and added a "Running" section since the README never said how to actually invoke the harness (`npm test` / `npm run smoke` / `npm run coverage`).

- **`plugins/e2a/clients/README.md`** — pointed readers at a "Connecting other MCP clients" section of `setup.md` that doesn't exist; the actual heading is "1. Connect your client". Fixed the reference.

Everything else audited (root docs, CLI/SDK docs, MCP + example docs, web/plugin docs) checked out against current code — no other high-confidence issues found. Notably, `web/public/{auth,sdk,setup,templates}.md` and `plugins/e2a/docs/{auth,sdk,setup,templates}.md` are intentionally byte-identical mirrors kept in sync by `scripts/sync-agent-docs.mjs` (verified fresh, not a duplication bug).

## Test plan
- [x] `bash scripts/check-repository-text-integrity.sh` passes
- [x] Every changed claim cross-checked against the cited source file/line
- [ ] Reviewer sanity-check of wording/tone

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01QXovzVnRjhT3UgsztJkH5A

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXovzVnRjhT3UgsztJkH5A)_