### PR TITLE
test(db): isolate test databases per workspace, not just per package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,30 +88,39 @@ make openapi-compat-check  # oasdiff backward-compat gate vs origin/main:api/ope
 make openapi-compat-test   # runs the compat-gate's own test harness (scripts/test-openapi-compat.sh)
 ```
 
-DB-backed tests need
-`E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable"`.
+DB-backed tests default to
+`E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable"`;
+exporting your own value overrides it (the Make targets honor the environment).
 The test harness (`internal/testutil/db.go`) truncates tables between tests
-and auto-applies all migrations on connect. Each test binary automatically
-derives a **per-package database** (`<base>_pkg_<package>`, self-provisioned
-on first run) from the configured base URL, so parallel packages (`-p 4` in
-the Make targets) cannot truncate each other; `E2A_TEST_DB_SHARED=1` forces
-the old single-DB behavior. **Concurrent sessions/agents/worktrees running
-the SAME package still contend** — give each runner its own base database:
+and auto-applies all migrations on connect. Each test binary derives its
+database name beneath the configured base along **two** dimensions
+(`<base>_ws<workspace>_pkg_<package>`, self-provisioned on first run):
 
-```bash
-psql "postgres://e2a:e2a@localhost:5433/e2a" -c 'CREATE DATABASE e2a_test_<name>'
-export E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test_<name>?sslmode=disable"
-```
+- **per package**, so parallel packages (`-p 4` in the Make targets) cannot
+  truncate each other;
+- **per workspace** — a digest of the module root's path — so **two checkouts
+  never collide**. Concurrent sessions, agents, and worktrees are isolated
+  automatically, with nothing to configure.
 
-A fresh base database needs no manual setup — the harness creates the
-per-package databases and applies all `migrations/*.sql` on connect (the
-BASE database itself must exist). Per-package databases accumulate on the
-local server; they are disposable — drop any `*_pkg_*` database at will,
-the next run recreates it. Note that dropping a BASE database does not drop
-its `_pkg_` siblings (harmless — migrate+truncate on connect — but a "reset"
-that only recreates the base leaves them behind). `-p 1` is no longer required for
-cross-package isolation; it remains useful only when reproducing ordering-
-sensitive failures.
+`E2A_TEST_DB_SHARED=1` forces the old single-DB behavior. Point a run at an
+entirely separate server by exporting `E2A_TEST_DATABASE_URL`.
+
+A fresh base database needs no manual setup — the harness creates the derived
+databases and applies all `migrations/*.sql` on connect (the BASE database
+itself must exist). Derived databases accumulate on the local server; they are
+disposable — drop any `*_pkg_*` database at will, the next run recreates it.
+Note that dropping a BASE database does not drop its derived siblings
+(harmless — migrate+truncate on connect — but a "reset" that only recreates
+the base leaves them behind). `-p 1` is no longer required for cross-package
+isolation; it remains useful only when reproducing ordering-sensitive failures.
+
+**Filesystem-walking guards must never walk from the module root.** Walk a
+known subtree (`<root>/internal`) or ask git for the file list
+(`git ls-files --cached --others --exclude-standard`). Checkouts and worktrees
+placed under the root would otherwise be scanned as if they were this tree —
+which is exactly how the log-redaction guard started reporting other branches'
+stale code as violations. Keeping worktrees OUTSIDE the module root avoids the
+class entirely.
 
 ### TypeScript (npm workspaces — always use `--workspace` and `npm ci`)
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,20 @@
 # Docker — no local Java needed.
 OAG_IMAGE := openapitools/openapi-generator-cli:v7.16.0
 
+# Base database URL for every DB-backed target. `?=` so an exported
+# E2A_TEST_DATABASE_URL WINS: these recipes used to pin it inline, which
+# overrides the caller's environment, so AGENTS.md's "give each runner its own
+# base database" could not actually be followed through make. Concurrent
+# sessions then shared one base and corrupted each other — an unmerged branch's
+# migration in a shared database produced ~40 spurious failures and deadlocks
+# that looked exactly like real regressions.
+#
+# The harness derives per-workspace + per-package names beneath this base
+# (internal/testutil.TestDBURL), so overriding is rarely needed now; it stays
+# available for pointing a run at an entirely separate server.
+E2A_TEST_DATABASE_URL ?= postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable
+export E2A_TEST_DATABASE_URL
+
 build:
 	go build -o bin/e2a ./cmd/e2a
 
@@ -17,18 +31,18 @@ run: build
 # not the core count — so N × pgxpool connections stay under Postgres's
 # default max_connections=100 on many-core dev machines.
 test:
-	E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable" go test -tags integration -p 4 ./...
+	go test -tags integration -p 4 ./...
 
 test-unit:
 	go test -short ./internal/outbound/ ./internal/relay/ ./internal/config/ ./internal/webhook/ ./internal/approvaltoken/ ./internal/unsubscribe/ ./internal/limits/ ./internal/httpapi/ ./internal/ratelimit/
 
 test-integration:
-	E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable" go test -p 4 ./internal/identity/ ./internal/agent/ ./internal/hitlworker/ ./internal/hitlnotify/ ./internal/limits/ ./internal/relay/ ./internal/sendramp/
+	go test -p 4 ./internal/identity/ ./internal/agent/ ./internal/hitlworker/ ./internal/hitlnotify/ ./internal/limits/ ./internal/relay/ ./internal/sendramp/
 
 test-e2e:
 	@packages="$$(find ./cmd ./internal ./tests -name '*_test.go' -exec grep -l '^//go:build integration$$' {} + | xargs -n 1 dirname | sort -u)"; \
 	test -n "$$packages"; \
-	E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable" go test -tags integration -p 4 $$packages
+	go test -tags integration -p 4 $$packages
 
 # cover writes a coverage profile across the internal packages (needs Postgres
 # on :5433, like `make test`; per-package DBs make the -p 4 parallel run safe).
@@ -36,7 +50,7 @@ test-e2e:
 # same gate via the vladopajic/go-test-coverage action.
 GO_TEST_COVERAGE_VERSION ?= v2.14.3
 cover:
-	E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable" go test -p 4 -covermode=atomic -coverprofile=cover.out ./internal/...
+	go test -p 4 -covermode=atomic -coverprofile=cover.out ./internal/...
 
 cover-check: cover
 	go run github.com/vladopajic/go-test-coverage/v2@$(GO_TEST_COVERAGE_VERSION) --config=.testcoverage.yml

--- a/internal/testutil/db.go
+++ b/internal/testutil/db.go
@@ -2,6 +2,8 @@ package testutil
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net/url"
@@ -56,7 +58,7 @@ func baseTestDBURL() string {
 // still contend, so per-session base URLs remain the guidance in AGENTS.md.
 func TestDBURL() string {
 	base := baseTestDBURL()
-	suffix := packageDBSuffix()
+	suffix := derivedDBSuffix()
 	if suffix == "" {
 		return base
 	}
@@ -77,9 +79,24 @@ func TestDBURL() string {
 	return u.String()
 }
 
-// packageDBSuffix derives the per-package database suffix, or "" when the
-// process is not a test binary or sharing is forced.
-func packageDBSuffix() string {
+// derivedDBSuffix derives the database-name suffix beneath the configured base:
+// a per-WORKSPACE component plus a per-PACKAGE component, or "" when the process
+// is not a test binary or sharing is forced.
+//
+// Two dimensions, because per-package alone was not enough. It stops packages in
+// ONE run from truncating each other, but every checkout computed the same names,
+// so two agents (or two worktrees, or a second terminal) running the same package
+// shared a database and corrupted each other. AGENTS.md asked people to hand out
+// their own base URL; that is convention, and convention does not scale across
+// callers who do not know about each other. Deriving from the module root path
+// makes the isolation structural: two checkouts cannot collide even when nobody
+// configures anything.
+//
+// Name length: <base>_ws<8>_pkg_<package> runs ~40 chars for this repo's longest
+// package names, well inside Postgres's 63-byte identifier limit. A much longer
+// custom base could push past it, where Postgres truncates silently — keep bases
+// short.
+func derivedDBSuffix() string {
 	switch strings.ToLower(os.Getenv("E2A_TEST_DB_SHARED")) {
 	case "1", "true", "yes":
 		return ""
@@ -98,7 +115,44 @@ func packageDBSuffix() string {
 			sanitized = append(sanitized, '_')
 		}
 	}
-	return "_pkg_" + string(sanitized)
+	return workspaceSuffix(moduleRootDir()) + "_pkg_" + string(sanitized)
+}
+
+// workspaceSuffix is the per-checkout component: a short, stable digest of the
+// module root's absolute path. Empty when the root cannot be resolved, which
+// degrades to the previous per-package-only behavior rather than failing.
+//
+// Pure and path-taking so it is directly testable: the same path must always
+// give the same suffix, and different paths must differ.
+func workspaceSuffix(moduleRoot string) string {
+	if moduleRoot == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(filepath.Clean(moduleRoot)))
+	return "_ws" + hex.EncodeToString(sum[:])[:8]
+}
+
+// moduleRootDir returns the directory holding go.mod at or above the working
+// directory, or "" if there is none. Symlinks are resolved so two paths that
+// reach the same checkout derive the same workspace suffix.
+func moduleRootDir() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	if resolved, rerr := filepath.EvalSymlinks(dir); rerr == nil {
+		dir = resolved
+	}
+	for {
+		if _, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
 }
 
 func OpenPreparedTestDB(ctx context.Context, dbURL string) (*pgxpool.Pool, error) {

--- a/internal/testutil/db.go
+++ b/internal/testutil/db.go
@@ -54,8 +54,10 @@ func baseTestDBURL() string {
 // pools, the in-process contract server — lands on the same database.
 // Non-test binaries (cmd/e2a-contract-server) and E2A_TEST_DB_SHARED=1 get
 // the base URL verbatim. Missing databases self-provision on first open
-// (see OpenPreparedTestDB); concurrent SESSIONS running the SAME package
-// still contend, so per-session base URLs remain the guidance in AGENTS.md.
+// (see OpenPreparedTestDB). Concurrent sessions, agents, and worktrees are
+// isolated by the per-workspace component below, so handing each runner its
+// own base URL is no longer required — only useful for pointing a run at an
+// entirely separate server.
 func TestDBURL() string {
 	base := baseTestDBURL()
 	suffix := derivedDBSuffix()
@@ -76,8 +78,25 @@ func TestDBURL() string {
 		return base
 	}
 	u.Path = u.Path + suffix
+	// Postgres truncates identifiers past maxPostgresIdentifier bytes, and it does
+	// so SILENTLY. Truncation lands at the END — inside the package component — so
+	// sibling packages sharing a prefix collapse onto ONE database: internal/identity
+	// and internal/idempotency both become ..._pkg_ide, then truncate each other's
+	// tables under -p 4. That is exactly the corruption this derivation exists to
+	// prevent, so a base too long to derive from has to fail loudly rather than
+	// quietly reintroduce it.
+	if name := strings.TrimPrefix(u.Path, "/"); len(name) > maxPostgresIdentifier {
+		panic(fmt.Sprintf("testutil: derived test database name %q is %d bytes, over Postgres's "+
+			"%d-byte identifier limit — Postgres would truncate it silently and collide sibling "+
+			"packages onto one database. Shorten the base in E2A_TEST_DATABASE_URL; the derived "+
+			"suffix needs %d bytes.", name, len(name), maxPostgresIdentifier, len(suffix)))
+	}
 	return u.String()
 }
+
+// maxPostgresIdentifier is Postgres's NAMEDATALEN-1 ceiling for identifiers,
+// database names included. Measured in BYTES, which is what len() reports.
+const maxPostgresIdentifier = 63
 
 // derivedDBSuffix derives the database-name suffix beneath the configured base:
 // a per-WORKSPACE component plus a per-PACKAGE component, or "" when the process

--- a/internal/testutil/db_test.go
+++ b/internal/testutil/db_test.go
@@ -3,6 +3,7 @@ package testutil
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/url"
 	"os"
 	"os/exec"
@@ -231,6 +232,15 @@ func TestWorkspaceSuffixIsStablePerPathAndDistinctAcrossPaths(t *testing.T) {
 // The derived name must carry BOTH components, so a database is unique to
 // (checkout, package) rather than to package alone.
 func TestTestDBURLIsUniquePerWorkspaceAndPackage(t *testing.T) {
+	// Pin BOTH inputs. Reading the ambient environment made this test fail for
+	// reasons that were nothing to do with the code: E2A_TEST_DB_SHARED=1 (a
+	// documented escape hatch) suppresses derivation entirely, and a long custom
+	// base — which this PR newly makes possible through make — blew the length
+	// assertion below. A test that fails because of how the developer configured
+	// their machine is the same defect as a test with a wall-clock budget.
+	t.Setenv("E2A_TEST_DB_SHARED", "")
+	t.Setenv("E2A_TEST_DATABASE_URL", "postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable")
+
 	u, err := url.Parse(TestDBURL())
 	if err != nil {
 		t.Fatalf("parse TestDBURL: %v", err)
@@ -245,11 +255,37 @@ func TestTestDBURLIsUniquePerWorkspaceAndPackage(t *testing.T) {
 	if ws := workspaceSuffix(moduleRootDir()); ws == "" || !strings.Contains(name, ws) {
 		t.Errorf("dbname = %q, want it to contain this checkout's suffix %q", name, ws)
 	}
-	// Postgres truncates identifiers past 63 bytes, which would silently
-	// re-collide the very names this derivation separates.
-	if len(name) > 63 {
-		t.Errorf("dbname %q is %d bytes, over Postgres's 63-byte identifier limit", name, len(name))
+	// With the base pinned above this is a real assertion about the derivation's
+	// size, not about the machine it runs on.
+	if len(name) > maxPostgresIdentifier {
+		t.Errorf("dbname %q is %d bytes, over Postgres's %d-byte identifier limit",
+			name, len(name), maxPostgresIdentifier)
 	}
+}
+
+// A base too long to derive from must FAIL, not silently truncate. Postgres cuts
+// identifiers at 63 bytes from the end — inside the package component — so
+// internal/identity and internal/idempotency would collapse onto ..._pkg_ide and
+// truncate each other's tables: precisely the corruption this derivation prevents.
+// Reachable now that the Makefile honors an exported base, where naming it after a
+// branch is the obvious first thing someone tries.
+func TestTestDBURLPanicsRatherThanLetPostgresTruncate(t *testing.T) {
+	t.Setenv("E2A_TEST_DB_SHARED", "")
+	t.Setenv("E2A_TEST_DATABASE_URL",
+		"postgres://e2a:e2a@localhost:5433/"+strings.Repeat("b", 60)+"?sslmode=disable")
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("an over-long derived name must panic, not silently truncate into a collision")
+		}
+		msg := fmt.Sprint(r)
+		if !strings.Contains(msg, "63") || !strings.Contains(msg, "E2A_TEST_DATABASE_URL") {
+			t.Errorf("panic should name the limit and the fix, got: %q", msg)
+		}
+	}()
+
+	_ = TestDBURL()
 }
 
 func TestTestDBURLDerivesPerPackageDatabase(t *testing.T) {

--- a/internal/testutil/db_test.go
+++ b/internal/testutil/db_test.go
@@ -201,6 +201,57 @@ func testDBChildEnv(testName, dbURL string) []string {
 	return append(env, testDBErrorChildEnv+"="+testName, "E2A_TEST_DATABASE_URL="+dbURL)
 }
 
+// workspaceSuffix is the per-CHECKOUT half of the isolation. Per-package alone
+// let two agents (or two worktrees, or a second terminal) running the same
+// package share a database and corrupt each other, which is how an unmerged
+// branch's migration ended up producing ~40 spurious failures in a run.
+func TestWorkspaceSuffixIsStablePerPathAndDistinctAcrossPaths(t *testing.T) {
+	const a = "/Users/dev/Desktop/e2a"
+	const b = "/Users/dev/.agents/worktrees/e2a/feature-x"
+
+	if got, again := workspaceSuffix(a), workspaceSuffix(a); got != again {
+		t.Errorf("same path must derive the same suffix: %q vs %q", got, again)
+	}
+	if workspaceSuffix(a) == workspaceSuffix(b) {
+		t.Errorf("different checkouts must derive different suffixes; both gave %q", workspaceSuffix(a))
+	}
+	// Trailing separators and redundant elements name the same checkout.
+	if workspaceSuffix(a) != workspaceSuffix(a+"/") {
+		t.Errorf("path must be cleaned before hashing: %q vs %q", workspaceSuffix(a), workspaceSuffix(a+"/"))
+	}
+	if got := workspaceSuffix(a); !strings.HasPrefix(got, "_ws") || len(got) != len("_ws")+8 {
+		t.Errorf("suffix = %q, want _ws + 8 hex chars", got)
+	}
+	// Unresolvable root degrades to per-package-only rather than failing.
+	if got := workspaceSuffix(""); got != "" {
+		t.Errorf("empty root should yield no workspace component, got %q", got)
+	}
+}
+
+// The derived name must carry BOTH components, so a database is unique to
+// (checkout, package) rather than to package alone.
+func TestTestDBURLIsUniquePerWorkspaceAndPackage(t *testing.T) {
+	u, err := url.Parse(TestDBURL())
+	if err != nil {
+		t.Fatalf("parse TestDBURL: %v", err)
+	}
+	name := strings.TrimPrefix(u.Path, "/")
+	if !strings.Contains(name, "_ws") {
+		t.Errorf("dbname = %q, want a _ws<hash> workspace component", name)
+	}
+	if !strings.HasSuffix(name, "_pkg_testutil") {
+		t.Errorf("dbname = %q, want the _pkg_testutil suffix retained", name)
+	}
+	if ws := workspaceSuffix(moduleRootDir()); ws == "" || !strings.Contains(name, ws) {
+		t.Errorf("dbname = %q, want it to contain this checkout's suffix %q", name, ws)
+	}
+	// Postgres truncates identifiers past 63 bytes, which would silently
+	// re-collide the very names this derivation separates.
+	if len(name) > 63 {
+		t.Errorf("dbname %q is %d bytes, over Postgres's 63-byte identifier limit", name, len(name))
+	}
+}
+
 func TestTestDBURLDerivesPerPackageDatabase(t *testing.T) {
 	// Inside a `go test` binary (os.Args[0] ends in ".test"), TestDBURL
 	// appends a per-package suffix to the base database name so packages


### PR DESCRIPTION
## Summary

Two small changes that together make test-database isolation **structural** rather than a convention nobody could follow.

### 1. The Makefile now honors the environment

It pinned `E2A_TEST_DATABASE_URL` inline in four recipes (`test`, `test-integration`, `test-e2e`, `cover`). An inline assignment in a recipe *overrides* the caller's environment — so AGENTS.md's instruction to "give each runner its own base database" was **mechanically impossible** through `make`. Hoisted to `?=` plus `export`:

```
$ make show                                   # default
make sees: postgres://…/e2a_test?sslmode=disable
$ E2A_TEST_DATABASE_URL=…/OVERRIDDEN make show # now wins
make sees: postgres://…/OVERRIDDEN?sslmode=disable
```

### 2. Database names are per-workspace, not just per-package

The harness derived only `<base>_pkg_<package>`. That stops packages in *one run* from truncating each other, but every checkout computed the **same names** — so two agents, two worktrees, or a second terminal running the same package shared a database.

Not theoretical. An unmerged branch's migration reached a shared base and produced **~40 spurious failures** plus `deadlock detected` inside `truncate`, which read exactly like real regressions and cost a full investigation to attribute (see #687's follow-up note).

Names now carry a workspace component — a digest of the module root's real path:

```
<base>_ws<workspace>_pkg_<package>
```

Two checkouts cannot collide even when nobody configures anything. Convention doesn't scale across callers who don't know about each other; naming does.

Details: symlinks are resolved so two paths reaching one checkout agree; an unresolvable module root degrades to the previous per-package-only behavior rather than failing; `E2A_TEST_DB_SHARED=1` still forces a single database.

## Verification

End-to-end, both changes at once — `make test-integration` with an exported custom base:

```
e2a_iso_demo_ws113e0962_pkg_agent
e2a_iso_demo_ws113e0962_pkg_identity
e2a_iso_demo_ws113e0962_pkg_relay          … 7 packages, exit 0

path:  /Users/…/worktrees/e2a/test-isolation
digest: _ws113e0962      ← matches
```

That single run proves the override was honored (databases exist under the custom base at all, previously impossible) *and* that the derivation carries both dimensions.

**`make cover` — the command whose flakiness started this whole investigation — now runs green from a worktree alongside the primary checkout:** exit 0, 0 failures, 21 private databases. `make test-unit` green. New unit tests cover suffix stability per path, distinctness across paths, path cleaning, the empty-root degradation, and that the composed name stays inside Postgres's 63-byte identifier limit.

## Migration note

Existing `*_pkg_*` databases are orphaned by the rename. They're documented as disposable and the next run provisions the new names; drop them at leisure with `DROP DATABASE` on anything matching `*_pkg_*`.

## Docs

AGENTS.md now describes both dimensions and drops the manual `CREATE DATABASE e2a_test_<name>` workaround, which is obsolete. It also records the rule the log-guard bug (#706) taught:

> Filesystem-walking guards must never walk from the module root. Walk a known subtree, or ask git for the file list.

Verified: `errorcode_vocab_test.go` walks `<root>/internal` and is immune for exactly that reason; `logguard_test.go` walked the root and wasn't.

## What this does not fix

Worktrees living **inside** the module root (`.claude/worktrees/`, `.worktrees/`) remain a hazard for any root-level walk — #706 fixed the one guard that tripped on it. Moving worktrees outside the root removes the class entirely, but that's a workflow choice rather than a code change. This PR was authored from `~/.agents/worktrees/e2a/test-isolation` to avoid the problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
