### PR TITLE
test(e2e-prod): prod-only inbound-MX + SES delivery-feedback suites

### DIFF
--- a/tests/e2e-prod/coverage_gate.py
+++ b/tests/e2e-prod/coverage_gate.py
@@ -26,7 +26,7 @@ emission). Exercised paths that don't map to a /v1 operationId are reported (as
 (the harness only records successes — see harness/coverage.ts), i.e. the operation
 was actually exercised, not merely probed with a rejected request.
 
-Usage: python3 coverage_gate.py [--openapi PATH] [--reports DIR]
+Usage: python3 coverage_gate.py [--openapi PATH] [--reports DIR] [--target-dir DIR]
 Exit 0 = all covered (or allowlisted); 1 = coverage gap; 2 = usage/IO error.
 """
 import argparse
@@ -35,16 +35,27 @@ import json
 import os
 import sys
 
+from target_env import resolve_target
+
 HERE = os.path.dirname(os.path.abspath(__file__))
 
 # Operations the black-box conformance suite intentionally does NOT exercise, with
 # the reason. Keep this list SHORT and justified — every entry is coverage we're
-# knowingly forgoing.
-ALLOWLIST = {
+# knowingly forgoing. Allowlisted no matter what the run targeted.
+ALWAYS_ALLOWLIST = {
     "deleteAccount": "destructive — the suite must never delete its own account",
-    "deleteSuppression": "no happy path black-box: a suppression is created only by a "
-    "real SES bounce/complaint (no createSuppression API), so there's nothing to delete; "
-    "the 404-unknown-address path is exercised by 19-account",
+}
+
+# Allowlisted ONLY on a non-production run (see target_env.py for the
+# mechanism) — REQUIRED once the run's target shards show production.
+STAGING_ONLY_ALLOWLIST = {
+    "deleteSuppression": "no happy path black-box on staging: a suppression is created "
+    "only by a real SES bounce/complaint (no createSuppression API), and staging's "
+    "e2a-staging-smtp IAM policy denies ses:SendRawEmail to the bounce/complaint "
+    "mailbox-simulator addresses, so there's nothing to delete there; the "
+    "404-unknown-address path is exercised by 19-account. Production has no such "
+    "block — suites/prod/31-ses-feedback.test.ts creates a real account suppression "
+    "via a real bounce/complaint and exercises this happy path.",
 }
 
 
@@ -103,6 +114,7 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--openapi", default=os.path.join(HERE, "../../api/openapi.yaml"))
     ap.add_argument("--reports", default=os.path.join(HERE, "reports", "coverage"))
+    ap.add_argument("--target-dir", default=os.path.join(HERE, "reports", "target"))
     args = ap.parse_args()
 
     if not os.path.exists(args.openapi):
@@ -113,11 +125,24 @@ def main():
     all_ids = {opid for _, _, opid in ops}
 
     # An allowlist entry that no longer matches a real operationId is a silent hole
-    # (e.g. the op was renamed) — fail loudly so the allowlist can't drift stale.
-    stale = set(ALLOWLIST) - all_ids
+    # (e.g. the op was renamed) — fail loudly so either tier can't drift stale.
+    stale = (set(ALWAYS_ALLOWLIST) | set(STAGING_ONLY_ALLOWLIST)) - all_ids
     if stale:
         print(f"coverage_gate: allowlist entries not in the spec (renamed/removed?): {sorted(stale)}", file=sys.stderr)
         return 2
+
+    try:
+        targeted_prod, target_shard_count, hosts = resolve_target(args.target_dir)
+    except ValueError as e:
+        print(f"coverage_gate: {e}", file=sys.stderr)
+        return 2
+
+    allowlist = dict(ALWAYS_ALLOWLIST)
+    if targeted_prod:
+        env_label = "PRODUCTION"
+    else:
+        env_label = "non-production (staging/self-hosted)"
+        allowlist.update(STAGING_ONLY_ALLOWLIST)
 
     shards = glob.glob(os.path.join(args.reports, "*.json"))
     if not shards:
@@ -138,9 +163,10 @@ def main():
             non_v1.add(pair)
 
     missing = all_ids - covered_ids
-    allowlisted = missing & set(ALLOWLIST)
-    uncovered = missing - set(ALLOWLIST)
+    allowlisted = missing & set(allowlist)
+    uncovered = missing - set(allowlist)
 
+    print(f"Target environment : {env_label}  ({target_shard_count} target shard(s): {hosts})")
     print(f"OpenAPI operations : {len(all_ids)}  (/v1 operationId scope)")
     print(f"Covered (2xx)      : {len(covered_ids)}")
     print(f"Allowlisted        : {len(allowlisted)} " + (str(sorted(allowlisted)) if allowlisted else ""))
@@ -155,8 +181,9 @@ def main():
         print(f"\nUNCOVERED ({len(uncovered)}):")
         for opid in sorted(uncovered):
             m, t, _ = next(o for o in ops if o[2] == opid)
-            print(f"  - {opid:28s} {m} /{'/'.join(t)}")
-        print("\nGATE: FAIL — the above operation(s) are in the spec but no suite exercises them.")
+            tier = " (staging-only allowlist, REQUIRED on this prod run)" if opid in STAGING_ONLY_ALLOWLIST else ""
+            print(f"  - {opid:28s} {m} /{'/'.join(t)}{tier}")
+        print("\nGATE: FAIL — the above operation(s) are in the spec but no suite exercises them for this target environment.")
         return 1
 
     print("\nGATE: PASS — every OpenAPI operation is exercised (or explicitly allowlisted).")

--- a/tests/e2e-prod/event_coverage_gate.py
+++ b/tests/e2e-prod/event_coverage_gate.py
@@ -26,23 +26,38 @@ Inputs:
     would go quietly stale exactly when a 16th event type is added without a
     matching gate update.
   - reports/event-coverage/*.json: shards written by
-    suites/21-webhook-events.test.ts, each a JSON array of event-type strings
-    the suite VERIFIED this run. "Verified" is a deliberately high bar (see
-    that suite's module doc): the suite records a type here ONLY after BOTH
-    halves of its dual assertion passed — (1) the event's own
-    delivery_status.matched_webhooks >= 1 (event-scoped fanout) AND (2) a
-    listWebhookDeliveries entry for OUR webhook with attempts >= 1
-    (webhook-scoped delivery attempt). Neither alone proves emission (see
-    21-webhook-events.test.ts's module doc for why); merely subscribing a
-    webhook to a type, or a type appearing in listEvents, is NOT enough to be
-    recorded. There is no dedicated harness recorder for this (unlike
-    coverage.ts / mcp-coverage.ts) — the shard-writing lives directly in the
-    suite file so this gate stays a thin consumer of it, like the other two.
+    suites/21-webhook-events.test.ts AND suites/prod/*.test.ts, each a JSON
+    array of event-type strings the suite VERIFIED this run. "Verified" is a
+    deliberately high bar (see 21-webhook-events.test.ts's module doc): a
+    type is recorded ONLY after BOTH halves of the dual assertion passed —
+    (1) the event's own delivery_status.matched_webhooks >= 1 (event-scoped
+    fanout) AND (2) a listWebhookDeliveries entry for OUR webhook with
+    attempts >= 1 (webhook-scoped delivery attempt). Neither alone proves
+    emission; merely subscribing a webhook to a type, or a type appearing in
+    listEvents, is NOT enough to be recorded. There is no dedicated harness
+    recorder for this (unlike coverage.ts / mcp-coverage.ts) — the
+    shard-writing lives directly in each suite file so this gate stays a
+    thin consumer of it, like the other two.
+  - reports/target/*.json: shards written by harness/target.ts, used via
+    target_env.py to decide whether THIS run targeted production — see that
+    module's doc for the full mechanism. This is what makes the allowlist
+    below environment-aware instead of a permanent staging-shaped excuse.
 
-Usage: python3 event_coverage_gate.py [--openapi PATH] [--reports DIR]
+ENVIRONMENT-AWARE ALLOWLIST: two tiers.
+  - ALWAYS_ALLOWLIST: allowlisted regardless of target (the domain.sending_*
+    pair — needs real DKIM sending-identity provisioning against a *custom*
+    domain, which is a different, still-unbuilt fixture; not something a
+    prod-vs-staging distinction unlocks by itself).
+  - STAGING_ONLY_ALLOWLIST: allowlisted ONLY when this run did not target
+    production. These all trace back to the same real-SES-feedback blocker
+    that staging's e2a-staging-smtp IAM policy imposes; production has no
+    such block, so a production run REQUIRES them — an allowlisted-forever
+    entry would let a genuine prod gap hide behind a staging-only excuse.
+
+Usage: python3 event_coverage_gate.py [--openapi PATH] [--reports DIR] [--target-dir DIR]
 Exit 0 = every event type verified (or explicitly allowlisted); 1 = coverage
-gap; 2 = usage/IO error (including "no shards", which must never read as a
-pass).
+gap; 2 = usage/IO error (including "no shards" for either coverage or target
+data, which must never read as a pass).
 """
 import argparse
 import glob
@@ -50,38 +65,49 @@ import json
 import os
 import sys
 
+from target_env import resolve_target
+
 HERE = os.path.dirname(os.path.abspath(__file__))
 
-# Event types the black-box conformance suite intentionally does NOT verify
-# real emission for, with the SPECIFIC reason staging cannot produce each.
-# Keep this list SHORT and justified — every entry is coverage we're
-# knowingly forgoing, deferred to a prod-only differential suite (already
-# planned as the next phase) where the real infrastructure exists.
-ALLOWLIST = {
-    "email.delivered": "requires real SES delivery feedback (SNS); staging's "
-    "e2a-staging-smtp IAM policy denies ses:SendRawEmail to the bounce/complaint "
-    "mailbox-simulator addresses, so delivery feedback cannot be produced there "
-    "— deferred to the prod-only differential suite.",
-    "email.bounced": "same SES delivery-feedback blocker as email.delivered — "
-    "staging's e2a-staging-smtp IAM policy denies ses:SendRawEmail to the bounce "
-    "simulator address — deferred to the prod-only differential suite.",
-    "email.complained": "same SES delivery-feedback blocker as email.delivered — "
-    "staging's e2a-staging-smtp IAM policy denies ses:SendRawEmail to the complaint "
-    "simulator address — deferred to the prod-only differential suite.",
-    "domain.suppression_added": "a suppression is created only by a real SES "
-    "bounce/complaint (no createSuppression API — see coverage_gate.py's "
-    "deleteSuppression entry), which staging cannot produce for the same reason "
-    "as email.bounced/complained — deferred to the prod-only differential suite.",
-    "agent.suppression_added": "same real-bounce dependency as "
-    "domain.suppression_added — staging cannot produce the real bounce needed to "
-    "seed an agent-scoped suppression — deferred to the prod-only differential suite.",
+# Allowlisted no matter what the run targeted — see the module doc above.
+ALWAYS_ALLOWLIST = {
     "domain.sending_verified": "requires real SES sending-identity (DKIM) "
     "provisioning against a custom domain, verified asynchronously by AWS over "
     "minutes-to-hours; a throwaway shared-domain e2e agent has no sending identity "
-    "to provision — deferred to the prod-only differential suite.",
+    "to provision — needs a dedicated custom-domain + sender-identity fixture "
+    "(domain-lifecycle territory), independent of prod-vs-staging.",
     "domain.sending_failed": "same real SES sending-identity provisioning "
-    "dependency as domain.sending_verified — deferred to the prod-only "
-    "differential suite.",
+    "dependency as domain.sending_verified.",
+}
+
+# Allowlisted ONLY on a non-production run — REQUIRED once the run's target
+# shards (reports/target/*.json) show production. See the module doc above.
+STAGING_ONLY_ALLOWLIST = {
+    "email.delivered": "requires real SES delivery feedback (SNS); staging's "
+    "e2a-staging-smtp IAM policy denies ses:SendRawEmail to the mailbox-simulator "
+    "addresses, so delivery feedback cannot be produced there. Verified in "
+    "production by suites/prod/31-ses-feedback.test.ts.",
+    "email.bounced": "same SES delivery-feedback blocker as email.delivered. "
+    "Verified in production by suites/prod/31-ses-feedback.test.ts.",
+    "email.complained": "same SES delivery-feedback blocker as email.delivered. "
+    "Verified in production by suites/prod/31-ses-feedback.test.ts.",
+    "domain.suppression_added": "a suppression is created only by a real SES "
+    "bounce/complaint (no createSuppression API — see coverage_gate.py's "
+    "STAGING_ONLY_ALLOWLIST deleteSuppression entry), which staging cannot "
+    "produce for the same reason as email.bounced/complained. Verified in "
+    "production by suites/prod/31-ses-feedback.test.ts.",
+    "agent.suppression_added": "NOTE: unlike domain.suppression_added, this one "
+    "does not actually require a real bounce — internal/delivery/consumer.go's "
+    "SES-feedback path only ever fires domain.suppression_added (account-scoped); "
+    "an agent-scoped suppression is created solely by the manual "
+    "createAgentSuppression API or the unsubscribe-token flow, both already "
+    "black-box testable anywhere (see suites/24-agent-suppressions.test.ts). It "
+    "was allowlisted here under the same blanket real-bounce justification as its "
+    "siblings, which doesn't actually apply to it. Verified in production by "
+    "suites/prod/31-ses-feedback.test.ts (via the manual-create path); kept "
+    "staging-only-allowlisted rather than un-allowlisted everywhere because no "
+    "staging suite wires a webhook to it yet — a reasonable follow-up, not done "
+    "here to keep this change scoped to the prod-only suite.",
 }
 
 
@@ -114,6 +140,7 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--openapi", default=os.path.join(HERE, "../../api/openapi.yaml"))
     ap.add_argument("--reports", default=os.path.join(HERE, "reports", "event-coverage"))
+    ap.add_argument("--target-dir", default=os.path.join(HERE, "reports", "target"))
     args = ap.parse_args()
 
     if not os.path.exists(args.openapi):
@@ -123,8 +150,8 @@ def main():
     all_types = set(load_event_types(args.openapi))
 
     # An allowlist entry that no longer names a real event type is a silent hole
-    # (e.g. the type was renamed) — fail loudly so the allowlist can't drift stale.
-    stale = set(ALLOWLIST) - all_types
+    # (e.g. the type was renamed) — fail loudly so either tier can't drift stale.
+    stale = (set(ALWAYS_ALLOWLIST) | set(STAGING_ONLY_ALLOWLIST)) - all_types
     if stale:
         print(
             f"event_coverage_gate: allowlist entries not in the spec (renamed/removed?): {sorted(stale)}",
@@ -132,10 +159,24 @@ def main():
         )
         return 2
 
+    try:
+        targeted_prod, target_shard_count, hosts = resolve_target(args.target_dir)
+    except ValueError as e:
+        print(f"event_coverage_gate: {e}", file=sys.stderr)
+        return 2
+
+    allowlist = dict(ALWAYS_ALLOWLIST)
+    if targeted_prod:
+        env_label = "PRODUCTION"
+    else:
+        env_label = "non-production (staging/self-hosted)"
+        allowlist.update(STAGING_ONLY_ALLOWLIST)
+
     if not os.path.isdir(args.reports):
         print(
             f"event_coverage_gate: no shard directory at {args.reports}. "
-            "Run suites/21-webhook-events.test.ts first; an absent run is not a pass.",
+            "Run suites/21-webhook-events.test.ts (and, on a prod run, suites/prod/*.test.ts) first; "
+            "an absent run is not a pass.",
             file=sys.stderr,
         )
         return 2
@@ -157,9 +198,10 @@ def main():
         print(f"event_coverage_gate: shard(s) verified unknown event type(s) not in the spec: {unknown}", file=sys.stderr)
 
     missing = all_types - verified
-    allowlisted = missing & set(ALLOWLIST)
-    uncovered = missing - set(ALLOWLIST)
+    allowlisted = missing & set(allowlist)
+    uncovered = missing - set(allowlist)
 
+    print(f"Target environment   : {env_label}  ({target_shard_count} target shard(s): {hosts})")
     print(f"Webhook event types : {len(all_types)}  (CreateWebhookRequest.events enum, api/openapi.yaml)")
     print(f"Verified (dual-assertion emission) : {len(verified & all_types)}")
     print(f"Allowlisted          : {len(allowlisted)} " + (str(sorted(allowlisted)) if allowlisted else ""))
@@ -168,10 +210,12 @@ def main():
     if uncovered:
         print(f"\nUNVERIFIED ({len(uncovered)}):")
         for t in sorted(uncovered):
-            print(f"  - {t}")
+            tier = " (staging-only allowlist, REQUIRED on this prod run)" if t in STAGING_ONLY_ALLOWLIST else ""
+            print(f"  - {t}{tier}")
         print(
             "\nGATE: FAIL — the above event type(s) are in the spec but no suite verifies real emission "
-            "(add a test to suites/21-webhook-events.test.ts, or an ALLOWLIST entry with a specific reason)."
+            "for this target environment (add a test to suites/21-webhook-events.test.ts or "
+            "suites/prod/*.test.ts, or an ALLOWLIST entry with a specific reason)."
         )
         return 1
 

--- a/tests/e2e-prod/harness/client.ts
+++ b/tests/e2e-prod/harness/client.ts
@@ -1,5 +1,6 @@
 import { loadEnv, type ProdEnv } from "./env.ts";
 import { recordRequest } from "./coverage.ts";
+import { recordTarget } from "./target.ts";
 
 export interface RawResponse<T = unknown> {
   status: number;
@@ -42,6 +43,11 @@ export class ApiClient {
     this.env = env ?? loadEnv();
     this.limiter = new RateLimiter(rpsOverride ?? this.env.rateLimitRps);
     this.baseUrl = baseUrlOverride ?? this.env.apiUrl;
+    // Record which deployment this process's requests actually target — the
+    // event/operation coverage gates read this to decide whether the
+    // production-only allowlist entries are required or merely allowlisted.
+    // See target.ts for why this must be derived here, not from a flag.
+    recordTarget(this.env.apiUrl);
   }
 
   async request<T = unknown>(method: string, path: string, opts: RequestOpts = {}): Promise<RawResponse<T>> {

--- a/tests/e2e-prod/harness/target.ts
+++ b/tests/e2e-prod/harness/target.ts
@@ -1,0 +1,40 @@
+import { writeFileSync, mkdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { isProductionTarget } from "./env.ts";
+
+// Target-resolution recorder — the un-fudgeable signal event_coverage_gate.py
+// (and coverage_gate.py, for deleteSuppression) use to decide whether a run
+// requires or merely allowlists the handful of event types / operations only
+// production's real infrastructure (SES delivery feedback, a real external
+// MX) can produce.
+//
+// Deliberately NOT an operator-supplied flag (an env var or CLI switch could
+// be set wrongly, independent of what the suite actually talked to) — it's
+// derived from the SAME apiUrl every request in the process actually used,
+// through the SAME hostname allowlist (env.ts's isProductionTarget) that
+// gates the destructive prod opt-in in the first place. If the harness
+// talked to production, this says so; if it didn't, it can't.
+//
+// Mirrors harness/coverage.ts's per-pid shard pattern: `node --test` runs
+// each suite *.test.ts file in its own process, so one shard per process
+// unions cleanly across a whole run. Written once per process (guarded by
+// `recorded`), at ApiClient construction time — every suite file (staging
+// and prod-only alike) constructs one, so a shard exists whenever any suite
+// ran. The `pretest`/`pretest:prod` steps clear this directory first, so a
+// stale shard from a prior run's target can never leak forward and disguise
+// a later run's actual environment.
+const TARGET_DIR = fileURLToPath(new URL("../reports/target/", import.meta.url));
+
+let recorded = false;
+
+export function recordTarget(apiUrl: string): void {
+  if (recorded) return;
+  recorded = true;
+  try {
+    mkdirSync(TARGET_DIR, { recursive: true });
+    const payload = { apiUrl, isProd: isProductionTarget(apiUrl) };
+    writeFileSync(`${TARGET_DIR}${process.pid}.json`, JSON.stringify(payload));
+  } catch {
+    /* best-effort: target resolution is advisory to the gate, must never fail a suite */
+  }
+}

--- a/tests/e2e-prod/package.json
+++ b/tests/e2e-prod/package.json
@@ -4,8 +4,9 @@
   "type": "module",
   "scripts": {
     "smoke": "node smoke.ts",
-    "pretest": "rm -rf reports/coverage reports/mcp-coverage reports/event-coverage",
+    "pretest": "rm -rf reports/coverage reports/mcp-coverage reports/event-coverage reports/target",
     "test": "node --test --test-concurrency=1 --test-reporter=spec suites/*.test.ts",
+    "pretest:prod": "rm -rf reports/coverage reports/mcp-coverage reports/event-coverage reports/target",
     "test:prod": "node --test --test-concurrency=1 --test-reporter=spec suites/*.test.ts suites/prod/*.test.ts",
     "test:unit": "node --test harness/*.test.ts",
     "coverage:gate": "python3 coverage_gate.py",

--- a/tests/e2e-prod/package.json
+++ b/tests/e2e-prod/package.json
@@ -6,6 +6,7 @@
     "smoke": "node smoke.ts",
     "pretest": "rm -rf reports/coverage reports/mcp-coverage reports/event-coverage",
     "test": "node --test --test-concurrency=1 --test-reporter=spec suites/*.test.ts",
+    "test:prod": "node --test --test-concurrency=1 --test-reporter=spec suites/*.test.ts suites/prod/*.test.ts",
     "test:unit": "node --test harness/*.test.ts",
     "coverage:gate": "python3 coverage_gate.py",
     "coverage:gate:mcp": "python3 mcp_coverage_gate.py",

--- a/tests/e2e-prod/suites/prod/30-inbound-mx.test.ts
+++ b/tests/e2e-prod/suites/prod/30-inbound-mx.test.ts
@@ -1,0 +1,293 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { ApiClient } from "../../harness/client.ts";
+import { uniqueSlug, uniqueSubject } from "../../harness/fixtures.ts";
+import { writeReport, info } from "../../harness/report.ts";
+
+// PRODUCTION-ONLY: a genuine agent-to-agent send over the REAL wire — SES
+// egress, a real external MX hop back into e2a's own inbound SMTP listener —
+// as opposed to the internal loopback shortcut (internal/loopback/, taken
+// only when IsSelfSend(req, agentEmail) is true: a single To recipient that
+// IS the sender's own address, no Cc/Bcc). Staging cannot exercise this at
+// all: a distinct agent→agent send there egresses via SES and fails (no
+// external MX for agents-staging.e2a.dev to route back through) — see this
+// directory's README. Production's agents.e2a.dev has a live MX
+// (_dc-mx.<hex>.agents.e2a.dev, INFRASTRUCTURE.md) that resolves back to the
+// same VM's real SMTP listener, so a distinct-agent send genuinely round-trips
+// through SES and back in, and is the only way to black-box prove the wire
+// path (as opposed to the loopback's internal short-circuit) actually works.
+//
+// Distinguishing the two paths: loopback unconditionally hardcodes
+// envelope_from=nil and authentication=nil on every event it builds
+// (internal/loopback/screening_events.go; internal/agent/selfsend.go sets
+// EnvelopeFrom: nil explicitly) — it never touches the SMTP listener. A real
+// wire delivery's envelope_from is populated from the actual SMTP MAIL FROM
+// the inbound listener observed (internal/relay/server.go: Mail(from) →
+// extractEmail → EmailReceivedData.EnvelopeFrom). For a SHARED-domain agent
+// (agents.e2a.dev, not a customer's own sending-verified domain), sender.go's
+// useOwnAddressFrom is false, so e2a itself composes the header From address
+// as the e2a-owned relay address (agent@send.e2a.dev in prod), NOT the
+// sending agent's own address (live-probed 2026-07-25 — this initially
+// surprised an assumption that header_from would be the agent's own address,
+// which only holds for a customer's sending-verified domain). SES then
+// separately rewrites the wire envelope Return-Path under its OWN
+// custom-MAIL-FROM subdomain (mail.send.e2a.dev) to a VERP-style bounce
+// token distinct from what e2a submitted. So header_from and envelope_from
+// differ from EACH OTHER, but both are non-null and both are categorically
+// different from the sending agent's address — a combination loopback can
+// never produce (its header_from IS the agent's own address, and its
+// envelope_from is always null) — which is exactly what this suite asserts.
+//
+// Webhook delivery is proved to the same bar suites/21-webhook-events.test.ts
+// established: event-scoped fanout (delivery_status.matched_webhooks>=1) AND
+// webhook-scoped delivery attempts>=1 (our fresh webhook's HTTP leg actually
+// fired — the delivery worker signs the payload per internal/webhook/
+// subscriber_deliverer.go's X-E2A-Signature: t=<unix>,v1=<hmac-sha256> scheme
+// before dispatch). This suite does not itself decode that header — doing so
+// black-box would require an internet-reachable HTTPS capture endpoint this
+// harness does not provision (attempting to stand one up against a
+// convenience third-party capture service was refused by this environment's
+// own network policy; deploying dedicated capture infra is a bigger, separate
+// decision than writing this test) — so "HMAC verified" here means what it
+// means everywhere else in this suite: a real signed delivery attempt ran,
+// proved the same dual-assertion way. Flagged explicitly rather than silently
+// assumed; a follow-up with a real capture endpoint would tighten this to an
+// actual byte-level signature check.
+const SUITE = "prod/30-inbound-mx";
+const client = new ApiClient();
+
+const EVENT_COVERAGE_DIR = fileURLToPath(new URL("../../reports/event-coverage/", import.meta.url));
+const verifiedEventTypes = new Set<string>();
+
+interface EventView {
+  id: string;
+  type: string;
+  schema_version: string;
+  created_at: string;
+  status: string;
+  data: Record<string, unknown>;
+  agent_email?: string;
+  message_id?: string;
+  delivery_status?: { matched_webhooks?: number };
+}
+interface PageEventView {
+  items: EventView[];
+  next_cursor: string | null;
+}
+interface WebhookDeliveryView {
+  id: string;
+  type: string;
+  status: string;
+  attempts: number;
+}
+interface PageWebhookDeliveryView {
+  items: WebhookDeliveryView[];
+  next_cursor: string | null;
+}
+interface CreateWebhookResponse {
+  id: string;
+  url: string;
+  events: string[];
+  signing_secret: string;
+}
+interface SendResult {
+  status?: string;
+  message_id?: string;
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const sinceNow = () => new Date(Date.now() - 5000).toISOString();
+
+async function createAgent(label: string): Promise<string> {
+  const slug = uniqueSlug(label);
+  const c = await client.post<{ email: string }>("/v1/agents", {
+    body: { email: `${slug}@${client.env.sharedDomain}`, name: `inbound-mx ${label}` },
+  });
+  if (c.status !== 201 || !c.body?.email) {
+    throw new Error(`create agent failed: ${c.status} ${c.raw.slice(0, 200)}`);
+  }
+  return c.body.email;
+}
+async function delAgent(email: string): Promise<void> {
+  await client.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE`);
+}
+async function createHook(events: string[]): Promise<CreateWebhookResponse> {
+  const r = await client.post<CreateWebhookResponse>("/v1/webhooks", {
+    body: { url: "https://example.com/e2e-prod-inbound-mx", events, description: `e2e-prod ${uniqueSlug("whmx")}` },
+  });
+  assert.equal(r.status, 201, `create webhook expected 201, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  return r.body!;
+}
+async function delHook(id: string): Promise<void> {
+  await client.delete(`/v1/webhooks/${encodeURIComponent(id)}?confirm=DELETE`);
+}
+
+async function pollEvent(
+  params: { type: string; agentId: string; since: string },
+  match: (e: EventView) => boolean,
+  timeoutMs = 30000,
+): Promise<EventView | null> {
+  const deadline = Date.now() + timeoutMs;
+  let delay = 500;
+  while (Date.now() < deadline) {
+    const r = await client.get<PageEventView>("/v1/events", {
+      query: { type: params.type, agent_email: params.agentId, since: params.since, limit: 50 },
+    });
+    if (r.status === 200 && r.body?.items) {
+      const found = r.body.items.find(match);
+      if (found) return found;
+    }
+    await sleep(delay);
+    delay = Math.min(Math.floor(delay * 1.5), 3000);
+  }
+  return null;
+}
+async function pollEventFanout(eventId: string, timeoutMs = 20000): Promise<number | null> {
+  const deadline = Date.now() + timeoutMs;
+  let delay = 500;
+  while (Date.now() < deadline) {
+    const r = await client.get<EventView>(`/v1/events/${eventId}`);
+    const n = r.body?.delivery_status?.matched_webhooks ?? 0;
+    if (r.status === 200 && n >= 1) return n;
+    await sleep(delay);
+    delay = Math.min(Math.floor(delay * 1.5), 3000);
+  }
+  return null;
+}
+async function pollDelivery(webhookId: string, eventType: string, timeoutMs = 20000): Promise<WebhookDeliveryView | null> {
+  const deadline = Date.now() + timeoutMs;
+  let delay = 500;
+  while (Date.now() < deadline) {
+    const r = await client.get<PageWebhookDeliveryView>(`/v1/webhooks/${webhookId}/deliveries`);
+    if (r.status === 200 && r.body?.items) {
+      const found = r.body.items.find((d) => d.type === eventType && d.attempts >= 1);
+      if (found) return found;
+    }
+    await sleep(delay);
+    delay = Math.min(Math.floor(delay * 1.5), 3000);
+  }
+  return null;
+}
+
+test("real wire round trip: agent A → agent B egresses via SES and re-enters over the real inbound MX", async () => {
+  const agentA = await createAgent("mxa");
+  const agentB = await createAgent("mxb");
+  const hook = await createHook(["email.sent", "email.received"]);
+  const since = sinceNow();
+  try {
+    const subject = uniqueSubject("real wire round trip");
+    const send = await client.post<SendResult>(`/v1/agents/${encodeURIComponent(agentA)}/messages`, {
+      body: { to: [agentB], subject, text: "genuine agent-to-agent send over the real inbound MX" },
+    });
+    // Distinct recipient (agentB != agentA) → NOT a self-send: this is a real
+    // external send, accepted for async delivery (202), not the loopback's
+    // synchronous 200.
+    assert.equal(send.status, 202, `distinct-agent send expected 202 accepted, got ${send.status}: ${send.raw.slice(0, 200)}`);
+    assert.equal(send.body?.status, "accepted", "a real (non-loopback) send is accepted for async delivery");
+    const sentMessageId = send.body!.message_id!;
+    assert.ok(sentMessageId?.startsWith("msg_"), "send returns a msg_ id");
+
+    // ---- Leg 1: the message actually egresses via SES (email.sent on A) ----
+    const sentEv = await pollEvent({ type: "email.sent", agentId: agentA, since }, (e) =>
+      e.message_id === sentMessageId || e.data.message_id === sentMessageId,
+    );
+    assert.ok(sentEv, `email.sent event for ${sentMessageId} must appear within 30s (proves SES egress)`);
+    const sentFanout = await pollEventFanout(sentEv!.id);
+    assert.ok(sentFanout, `email.sent event ${sentEv!.id} must fan out to >=1 webhook`);
+    const sentDel = await pollDelivery(hook.id, "email.sent");
+    assert.ok(sentDel, "a delivery attempt for email.sent must appear on our webhook");
+    info(SUITE, "email.sent", `egress confirmed: evt=${sentEv!.id} fanned to ${sentFanout} webhook(s), whd=${sentDel!.id} attempts=${sentDel!.attempts}`);
+    verifiedEventTypes.add("email.sent");
+
+    // ---- Leg 2: the message re-enters via the REAL inbound MX (email.received on B) ----
+    // Correlated by the unique subject (the inbound copy's message_id is
+    // distinct from the outbound send's, same as the self-send tests in
+    // 21-webhook-events.test.ts).
+    const receivedEv = await pollEvent({ type: "email.received", agentId: agentB, since }, (e) => e.data.subject === subject);
+    assert.ok(receivedEv, `email.received event for subject ${JSON.stringify(subject)} must appear within 30s (proves the real MX round trip)`);
+    assert.equal(receivedEv!.data.direction, "inbound", "received payload carries direction=inbound");
+    assert.equal(receivedEv!.data.delivered_to, agentB, "received payload's delivered_to is agent B");
+
+    // THE distinguishing assertion: loopback unconditionally nils both
+    // envelope_from and authentication (screening_events.go / selfsend.go).
+    // A real wire delivery populates both from the actual inbound SMTP
+    // session the listener observed.
+    //
+    // Empirically (live-probed 2026-07-25, production): for a SHARED-domain
+    // agent (not a customer's own sending-verified domain), sender.go's
+    // useOwnAddressFrom is false, so the header From address falls back to
+    // the e2a-owned relay address e2a itself composed
+    // (`agent@<outbound_smtp.from_domain>` — prod: agent@send.e2a.dev) — NOT
+    // the sending agent's own address (an initial assumption that the header
+    // From stays the agent's own address was wrong; it only holds for a
+    // customer's sending-verified domain). SES then independently rewrites
+    // the wire envelope Return-Path under its OWN custom-MAIL-FROM subdomain
+    // (INFRASTRUCTURE.md: "custom MAIL FROM at mail.send.e2a.dev") to a
+    // VERP-style bounce token, e.g.
+    // `010f...@mail.send.e2a.dev` — SES's own generated address, distinct
+    // from what e2a submitted. So header_from and envelope_from are NOT
+    // equal to each other on the wire, but BOTH are non-null and BOTH are
+    // categorically different from the sending agent's own address — a
+    // combination loopback can never produce (its header_from IS the
+    // agent's own address, and its envelope_from is always null).
+    const envelopeFrom = receivedEv!.data.envelope_from;
+    const headerFrom = receivedEv!.data.header_from;
+    assert.ok(
+      typeof envelopeFrom === "string" && envelopeFrom.length > 0,
+      `envelope_from must be populated for a real wire delivery (loopback always nils it); got ${JSON.stringify(envelopeFrom)}`,
+    );
+    assert.ok(
+      typeof headerFrom === "string" && headerFrom.length > 0,
+      `header_from must be populated; got ${JSON.stringify(headerFrom)}`,
+    );
+    assert.notEqual(
+      String(envelopeFrom).toLowerCase(),
+      agentA.toLowerCase(),
+      "envelope_from is SES's own return-path, not the sending agent's address — proves this transited SES, not the loopback shortcut",
+    );
+    assert.notEqual(
+      String(headerFrom).toLowerCase(),
+      agentA.toLowerCase(),
+      "header_from is e2a's own relay address for a shared-domain send, not the sending agent's own address (that equality only holds for a customer's sending-verified domain)",
+    );
+    assert.ok(
+      String(envelopeFrom).toLowerCase().endsWith("send.e2a.dev"),
+      `envelope_from is expected under the outbound relay's own domain (send.e2a.dev, or SES's custom MAIL FROM subdomain mail.send.e2a.dev), got ${JSON.stringify(envelopeFrom)}`,
+    );
+    assert.ok(
+      String(headerFrom).toLowerCase().endsWith("send.e2a.dev"),
+      `header_from is expected under the outbound relay's own domain (send.e2a.dev), got ${JSON.stringify(headerFrom)}`,
+    );
+    assert.notEqual(
+      receivedEv!.data.authentication,
+      null,
+      "authentication must be populated for a real inbound SMTP delivery (loopback always nils it)",
+    );
+    info(
+      SUITE,
+      "email.received",
+      `real wire round trip confirmed: envelope_from=${String(envelopeFrom)} header_from=${String(headerFrom)}`,
+    );
+
+    const receivedFanout = await pollEventFanout(receivedEv!.id);
+    assert.ok(receivedFanout, `email.received event ${receivedEv!.id} must fan out to >=1 webhook`);
+    const receivedDel = await pollDelivery(hook.id, "email.received");
+    assert.ok(receivedDel, "a delivery attempt for email.received must appear on our webhook");
+    info(SUITE, "email.received", `evt=${receivedEv!.id} fanned to ${receivedFanout} webhook(s), whd=${receivedDel!.id} attempts=${receivedDel!.attempts}`);
+    verifiedEventTypes.add("email.received");
+  } finally {
+    await delHook(hook.id);
+    await delAgent(agentA);
+    await delAgent(agentB);
+  }
+});
+
+after(async () => {
+  await writeReport(`./reports/${SUITE.replace("/", "-")}.json`);
+  if (verifiedEventTypes.size > 0) {
+    mkdirSync(EVENT_COVERAGE_DIR, { recursive: true });
+    writeFileSync(`${EVENT_COVERAGE_DIR}${process.pid}.json`, JSON.stringify([...verifiedEventTypes]));
+  }
+});

--- a/tests/e2e-prod/suites/prod/31-ses-feedback.test.ts
+++ b/tests/e2e-prod/suites/prod/31-ses-feedback.test.ts
@@ -1,0 +1,383 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { ApiClient } from "../../harness/client.ts";
+import { uniqueSlug, uniqueSubject } from "../../harness/fixtures.ts";
+import { writeReport, info } from "../../harness/report.ts";
+
+// PRODUCTION-ONLY: real Amazon SES delivery feedback (SES → SNS →
+// /webhooks/ses), which staging's e2a-staging-smtp IAM policy blocks by
+// denying ses:SendRawEmail to the mailbox-simulator's bounce@/complaint@
+// addresses (see this directory's README and event_coverage_gate.py's
+// STAGING_ONLY_ALLOWLIST). This suite is EXPLICITLY authorized to send real
+// mail to the AWS-purpose-built simulator addresses
+// (success@/bounce@/complaint@simulator.amazonses.com) — they exist for
+// exactly this, and do not touch sender reputation.
+//
+// internal/delivery/ses.go's ParseSESNotification classifies what each
+// simulator address produces:
+//   success@simulator.amazonses.com  → Delivery                (email.delivered)
+//   bounce@simulator.amazonses.com   → Bounce, type=Permanent   (email.bounced,
+//                                       hard=true → auto-suppressed)
+//   complaint@simulator.amazonses.com → Complaint               (email.complained,
+//                                       always Suppress=true)
+// Only a PERMANENT bounce or a complaint auto-suppresses
+// (internal/delivery/consumer.go); both fire domain.suppression_added
+// (account-scoped despite the event-name prefix — EventSuppressionAdded is
+// literal "domain.suppression_added" in that file). This is the ONLY
+// black-box way to create a real account suppression (no createSuppression
+// API), which is what makes deleteSuppression's happy path exercisable here
+// for the first time — see coverage_gate.py's STAGING_ONLY_ALLOWLIST entry,
+// retired from the always-allowlisted set by this suite.
+//
+// agent.suppression_added is a DIFFERENT mechanism entirely — read
+// internal/delivery/consumer.go closely and it NEVER fires that event; only
+// the manual createAgentSuppression API and the unsubscribe-token flow do
+// (internal/agent/events_api.go's AgentSuppressionAddedHook, called from
+// internal/httpapi/agent_suppressions.go and internal/httpapi/unsubscribe.go
+// only). It was allowlisted in event_coverage_gate.py under the same
+// blanket "needs a real bounce" reasoning as domain.suppression_added, which
+// doesn't actually apply to it — a real bounce/complaint NEVER produces an
+// agent-scoped suppression, on staging OR production. It's verified here via
+// the manual-create path (already black-box testable anywhere, per
+// suites/24-agent-suppressions.test.ts) rather than a real bounce, so this
+// one test would pass unchanged on staging too; it lives here because no
+// staging suite currently wires a webhook to it (see event_coverage_gate.py's
+// entry for the full note) — a reasonable follow-up left for later so this
+// change stays scoped to what a prod-only differential suite is for.
+//
+// Verification is the same dual assertion suites/21-webhook-events.test.ts
+// established: event-scoped fanout (delivery_status.matched_webhooks>=1) AND
+// webhook-scoped delivery attempts>=1 on our own fresh webhook.
+//
+// Feedback is ASYNCHRONOUS (SES → SNS → our webhook endpoint) and can take
+// tens of seconds; polls below use a generous budget (2 minutes) with capped
+// backoff. A timeout is a hard assertion failure, never a skip.
+const SUITE = "prod/31-ses-feedback";
+const client = new ApiClient();
+
+const EVENT_COVERAGE_DIR = fileURLToPath(new URL("../../reports/event-coverage/", import.meta.url));
+const verifiedEventTypes = new Set<string>();
+
+interface EventView {
+  id: string;
+  type: string;
+  schema_version: string;
+  created_at: string;
+  status: string;
+  data: Record<string, unknown>;
+  agent_email?: string;
+  message_id?: string;
+  delivery_status?: { matched_webhooks?: number };
+}
+interface PageEventView {
+  items: EventView[];
+  next_cursor: string | null;
+}
+interface WebhookDeliveryView {
+  id: string;
+  type: string;
+  status: string;
+  attempts: number;
+}
+interface PageWebhookDeliveryView {
+  items: WebhookDeliveryView[];
+  next_cursor: string | null;
+}
+interface CreateWebhookResponse {
+  id: string;
+  url: string;
+  events: string[];
+  signing_secret: string;
+}
+interface SendResult {
+  status?: string;
+  message_id?: string;
+}
+interface SuppressionView {
+  address: string;
+  source: string;
+  created_at: string;
+  reason?: string;
+}
+interface PageSuppressionView {
+  items: SuppressionView[];
+  next_cursor: string | null;
+}
+interface DeleteSuppressionResult {
+  deleted: boolean;
+  address: string;
+}
+interface AgentSuppressionView {
+  agent_email: string;
+  address: string;
+  source: string;
+  created_at: string;
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const sinceNow = () => new Date(Date.now() - 5000).toISOString();
+
+const SUCCESS_SIM = "success@simulator.amazonses.com";
+const BOUNCE_SIM = "bounce@simulator.amazonses.com";
+const COMPLAINT_SIM = "complaint@simulator.amazonses.com";
+
+async function createAgent(label: string): Promise<string> {
+  const slug = uniqueSlug(label);
+  const c = await client.post<{ email: string }>("/v1/agents", {
+    body: { email: `${slug}@${client.env.sharedDomain}`, name: `ses-feedback ${label}` },
+  });
+  if (c.status !== 201 || !c.body?.email) {
+    throw new Error(`create agent failed: ${c.status} ${c.raw.slice(0, 200)}`);
+  }
+  return c.body.email;
+}
+async function delAgent(email: string): Promise<void> {
+  await client.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE`);
+}
+async function createHook(events: string[]): Promise<CreateWebhookResponse> {
+  const r = await client.post<CreateWebhookResponse>("/v1/webhooks", {
+    body: { url: "https://example.com/e2e-prod-ses-feedback", events, description: `e2e-prod ${uniqueSlug("whsf")}` },
+  });
+  assert.equal(r.status, 201, `create webhook expected 201, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  return r.body!;
+}
+async function delHook(id: string): Promise<void> {
+  await client.delete(`/v1/webhooks/${encodeURIComponent(id)}?confirm=DELETE`);
+}
+
+// Generous async budget: SES → SNS → /webhooks/ses feedback has no
+// documented SLA and observably takes anywhere from a few seconds to over a
+// minute. A timeout returns null, which every caller turns into a hard
+// assert.ok(..., "... must appear within Nms") failure — never a skip.
+async function pollEvent(
+  params: { type: string; agentId?: string; since: string },
+  match: (e: EventView) => boolean,
+  timeoutMs = 120000,
+): Promise<EventView | null> {
+  const deadline = Date.now() + timeoutMs;
+  let delay = 1000;
+  while (Date.now() < deadline) {
+    const r = await client.get<PageEventView>("/v1/events", {
+      query: { type: params.type, agent_email: params.agentId, since: params.since, limit: 50 },
+    });
+    if (r.status === 200 && r.body?.items) {
+      const found = r.body.items.find(match);
+      if (found) return found;
+    }
+    await sleep(delay);
+    delay = Math.min(Math.floor(delay * 1.5), 5000);
+  }
+  return null;
+}
+async function pollEventFanout(eventId: string, timeoutMs = 30000): Promise<number | null> {
+  const deadline = Date.now() + timeoutMs;
+  let delay = 500;
+  while (Date.now() < deadline) {
+    const r = await client.get<EventView>(`/v1/events/${eventId}`);
+    const n = r.body?.delivery_status?.matched_webhooks ?? 0;
+    if (r.status === 200 && n >= 1) return n;
+    await sleep(delay);
+    delay = Math.min(Math.floor(delay * 1.5), 3000);
+  }
+  return null;
+}
+async function pollDelivery(webhookId: string, eventType: string, timeoutMs = 30000): Promise<WebhookDeliveryView | null> {
+  const deadline = Date.now() + timeoutMs;
+  let delay = 500;
+  while (Date.now() < deadline) {
+    const r = await client.get<PageWebhookDeliveryView>(`/v1/webhooks/${webhookId}/deliveries`);
+    if (r.status === 200 && r.body?.items) {
+      const found = r.body.items.find((d) => d.type === eventType && d.attempts >= 1);
+      if (found) return found;
+    }
+    await sleep(delay);
+    delay = Math.min(Math.floor(delay * 1.5), 3000);
+  }
+  return null;
+}
+
+async function assertDualDelivery(hookId: string, eventType: string, ev: EventView): Promise<void> {
+  const fanout = await pollEventFanout(ev.id);
+  assert.ok(fanout, `event ${ev.id} (${eventType}) must fan out (matched_webhooks>=1) within 30s`);
+  const del = await pollDelivery(hookId, eventType);
+  assert.ok(del, `a delivery attempt for ${eventType} must appear on webhook ${hookId}`);
+  assert.ok(del!.attempts >= 1, `delivery attempted (attempts=${del!.attempts})`);
+  info(SUITE, eventType, `evt=${ev.id} fanned to ${fanout} webhook(s); whd=${del!.id} attempts=${del!.attempts}`);
+  verifiedEventTypes.add(eventType);
+}
+
+// ---- email.delivered: a real send to the SES success simulator ----
+test("emit: email.delivered — a real delivery-confirmed send emits the event and attempts a delivery", async () => {
+  const email = await createAgent("delivered");
+  const hook = await createHook(["email.delivered"]);
+  const since = sinceNow();
+  try {
+    const send = await client.post<SendResult>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
+      body: { to: [SUCCESS_SIM], subject: uniqueSubject("emit delivered"), text: "real send for delivery confirmation" },
+    });
+    assert.equal(send.status, 202, `real send expected 202 accepted, got ${send.status}: ${send.raw.slice(0, 200)}`);
+    const messageId = send.body!.message_id!;
+
+    const ev = await pollEvent({ type: "email.delivered", agentId: email, since }, (e) =>
+      e.message_id === messageId || e.data.message_id === messageId,
+    );
+    assert.ok(ev, `email.delivered event for ${messageId} must appear within 120s (real SES→SNS feedback)`);
+    assert.equal(ev!.data.direction, "outbound", "delivered payload carries direction=outbound");
+    assert.equal(ev!.data.delivered_to, SUCCESS_SIM, "delivered payload's delivered_to is the simulator recipient");
+    assert.equal(ev!.data.agent_email, email, "delivered payload's agent_email is the sending agent");
+
+    await assertDualDelivery(hook.id, "email.delivered", ev!);
+  } finally {
+    await delHook(hook.id);
+    await delAgent(email);
+  }
+});
+
+// ---- email.bounced + domain.suppression_added: a real hard bounce ----
+test("emit: email.bounced — a real permanent bounce emits the event, auto-suppresses, and is deletable", async () => {
+  const email = await createAgent("bounced");
+  const hook = await createHook(["email.bounced", "domain.suppression_added"]);
+  const since = sinceNow();
+  try {
+    const send = await client.post<SendResult>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
+      body: { to: [BOUNCE_SIM], subject: uniqueSubject("emit bounced"), text: "real send to trigger a hard bounce" },
+    });
+    assert.equal(send.status, 202, `real send expected 202 accepted, got ${send.status}: ${send.raw.slice(0, 200)}`);
+    const messageId = send.body!.message_id!;
+
+    // ---- email.bounced ----
+    const bouncedEv = await pollEvent({ type: "email.bounced", agentId: email, since }, (e) =>
+      e.message_id === messageId || e.data.message_id === messageId,
+    );
+    assert.ok(bouncedEv, `email.bounced event for ${messageId} must appear within 120s (real SES→SNS feedback)`);
+    assert.equal(bouncedEv!.data.direction, "outbound", "bounced payload carries direction=outbound");
+    assert.equal(bouncedEv!.data.delivered_to, BOUNCE_SIM, "bounced payload's delivered_to is the simulator recipient");
+    assert.equal(bouncedEv!.data.bounce_type, "permanent", "the mailbox simulator's bounce@ address produces a PERMANENT (hard) bounce");
+    await assertDualDelivery(hook.id, "email.bounced", bouncedEv!);
+
+    // ---- domain.suppression_added (account-scoped; a hard bounce auto-suppresses) ----
+    // Account-scoped events carry no agent_email (internal/delivery/consumer.go
+    // leaves AgentID empty for the suppression FiredEvent), so correlate by the
+    // triggering message_id instead of an agent_email filter.
+    const suppEv = await pollEvent({ type: "domain.suppression_added", since }, (e) => e.data.message_id === messageId, 30000);
+    assert.ok(suppEv, `domain.suppression_added event for ${messageId} must appear within 30s of the bounce`);
+    assert.equal(suppEv!.data.address, BOUNCE_SIM, "suppression payload's address is the bounced recipient");
+    assert.equal(suppEv!.data.source, "bounce", "suppression payload's source is bounce");
+    await assertDualDelivery(hook.id, "domain.suppression_added", suppEv!);
+
+    // ---- listSuppressions shows it ----
+    const list = await client.get<PageSuppressionView>("/v1/account/suppressions", { query: { limit: 100 } });
+    assert.equal(list.status, 200, `listSuppressions expected 200, got ${list.status}`);
+    const listed = list.body!.items.find((s) => s.address === BOUNCE_SIM);
+    assert.ok(listed, `${BOUNCE_SIM} must appear in listSuppressions after the real bounce`);
+    assert.equal(listed!.source, "bounce", "listed suppression's source is bounce");
+
+    // ---- deleteSuppression: previously allowlisted in coverage_gate.py as
+    // "no happy path black-box" — a real bounce is exactly what makes this
+    // exercisable. Clean up so the shared simulator address isn't left
+    // suppressed on this account. ----
+    const del = await client.delete<DeleteSuppressionResult>(
+      `/v1/account/suppressions/${encodeURIComponent(BOUNCE_SIM)}?confirm=DELETE`,
+    );
+    assert.equal(del.status, 200, `deleteSuppression expected 200, got ${del.status}: ${del.raw.slice(0, 200)}`);
+    assert.equal(del.body?.deleted, true, "deletion object has deleted:true");
+    assert.equal(del.body?.address, BOUNCE_SIM, "deletion object echoes the un-suppressed address");
+
+    const afterDel = await client.get<PageSuppressionView>("/v1/account/suppressions", { query: { limit: 100 } });
+    assert.ok(
+      !afterDel.body!.items.some((s) => s.address === BOUNCE_SIM),
+      `${BOUNCE_SIM} must no longer be suppressed after cleanup`,
+    );
+    info(SUITE, "deleteSuppression", `real bounce suppression created and deleted cleanly for ${BOUNCE_SIM}`);
+  } finally {
+    await delHook(hook.id);
+    await delAgent(email);
+  }
+});
+
+// ---- email.complained + domain.suppression_added: a real complaint ----
+test("emit: email.complained — a real complaint emits the event, auto-suppresses, and is deletable", async () => {
+  const email = await createAgent("complained");
+  const hook = await createHook(["email.complained", "domain.suppression_added"]);
+  const since = sinceNow();
+  try {
+    const send = await client.post<SendResult>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
+      body: { to: [COMPLAINT_SIM], subject: uniqueSubject("emit complained"), text: "real send to trigger a complaint" },
+    });
+    assert.equal(send.status, 202, `real send expected 202 accepted, got ${send.status}: ${send.raw.slice(0, 200)}`);
+    const messageId = send.body!.message_id!;
+
+    // ---- email.complained ----
+    const complainedEv = await pollEvent({ type: "email.complained", agentId: email, since }, (e) =>
+      e.message_id === messageId || e.data.message_id === messageId,
+    );
+    assert.ok(complainedEv, `email.complained event for ${messageId} must appear within 120s (real SES→SNS feedback)`);
+    assert.equal(complainedEv!.data.direction, "outbound", "complained payload carries direction=outbound");
+    assert.equal(complainedEv!.data.delivered_to, COMPLAINT_SIM, "complained payload's delivered_to is the simulator recipient");
+    await assertDualDelivery(hook.id, "email.complained", complainedEv!);
+
+    // ---- domain.suppression_added (a complaint ALWAYS auto-suppresses) ----
+    const suppEv = await pollEvent({ type: "domain.suppression_added", since }, (e) => e.data.message_id === messageId, 30000);
+    assert.ok(suppEv, `domain.suppression_added event for ${messageId} must appear within 30s of the complaint`);
+    assert.equal(suppEv!.data.address, COMPLAINT_SIM, "suppression payload's address is the complained recipient");
+    assert.equal(suppEv!.data.source, "complaint", "suppression payload's source is complaint");
+    await assertDualDelivery(hook.id, "domain.suppression_added", suppEv!);
+
+    // ---- clean up: un-suppress so the shared simulator address is left usable ----
+    const del = await client.delete<DeleteSuppressionResult>(
+      `/v1/account/suppressions/${encodeURIComponent(COMPLAINT_SIM)}?confirm=DELETE`,
+    );
+    assert.equal(del.status, 200, `deleteSuppression expected 200, got ${del.status}: ${del.raw.slice(0, 200)}`);
+    assert.equal(del.body?.deleted, true, "deletion object has deleted:true");
+
+    const afterDel = await client.get<PageSuppressionView>("/v1/account/suppressions", { query: { limit: 100 } });
+    assert.ok(
+      !afterDel.body!.items.some((s) => s.address === COMPLAINT_SIM),
+      `${COMPLAINT_SIM} must no longer be suppressed after cleanup`,
+    );
+    info(SUITE, "deleteSuppression", `real complaint suppression created and deleted cleanly for ${COMPLAINT_SIM}`);
+  } finally {
+    await delHook(hook.id);
+    await delAgent(email);
+  }
+});
+
+// ---- agent.suppression_added: manual create (NOT a real-bounce artifact — see module doc) ----
+test("emit: agent.suppression_added — a manual agent-scoped block emits the event and attempts a delivery", async () => {
+  const email = await createAgent("agentsupp");
+  const hook = await createHook(["agent.suppression_added"]);
+  const since = sinceNow();
+  const address = `blocked-${uniqueSlug("rcpt")}@example.com`;
+  try {
+    const create = await client.post<AgentSuppressionView>(`/v1/agents/${encodeURIComponent(email)}/suppressions`, {
+      body: { address, reason: "e2e-prod agent.suppression_added emission" },
+    });
+    assert.equal(create.status, 200, `createAgentSuppression expected 200, got ${create.status}: ${create.raw.slice(0, 200)}`);
+    assert.equal(create.body?.source, "manual", "API-created block has source=manual");
+
+    const ev = await pollEvent({ type: "agent.suppression_added", agentId: email, since }, (e) => e.data.address === address, 30000);
+    assert.ok(ev, `agent.suppression_added event for ${address} must appear within 30s`);
+    assert.equal(ev!.data.agent_email, email, "agent-suppression payload's agent_email is the owning agent");
+    assert.equal(ev!.data.address, address, "agent-suppression payload's address is the blocked recipient");
+    assert.equal(ev!.data.source, "manual", "agent-suppression payload's source is manual");
+    await assertDualDelivery(hook.id, "agent.suppression_added", ev!);
+
+    // Clean up the agent-scoped block (API-allowed; cf. deleteAgentSuppression
+    // in suites/24-agent-suppressions.test.ts).
+    const del = await client.delete(`/v1/agents/${encodeURIComponent(email)}/suppressions/${encodeURIComponent(address)}?confirm=DELETE`);
+    assert.equal(del.status, 200, `deleteAgentSuppression expected 200, got ${del.status}: ${del.raw.slice(0, 200)}`);
+  } finally {
+    await delHook(hook.id);
+    await delAgent(email);
+  }
+});
+
+after(async () => {
+  await writeReport(`./reports/${SUITE.replace("/", "-")}.json`);
+  if (verifiedEventTypes.size > 0) {
+    mkdirSync(EVENT_COVERAGE_DIR, { recursive: true });
+    writeFileSync(`${EVENT_COVERAGE_DIR}${process.pid}.json`, JSON.stringify([...verifiedEventTypes]));
+  }
+});

--- a/tests/e2e-prod/suites/prod/README.md
+++ b/tests/e2e-prod/suites/prod/README.md
@@ -1,0 +1,53 @@
+# Prod-only suites
+
+Suites here verify behavior that **staging structurally cannot produce**, so they
+run only when the target is production.
+
+## Why a directory, not a runtime skip
+
+The obvious implementation is a guard at the top of each test — "if not prod,
+`return`". Do not do that. A test that silently returns is indistinguishable
+from a test that passed, and this repo has already been bitten by exactly that:
+`get_message`'s happy path used to `return` when the inbox was empty, so the
+suite reported 18/18 green while never once exercising the tool.
+
+Selection is therefore by **file glob**, not by runtime branch:
+
+| Script | Runs | Target |
+|---|---|---|
+| `npm test` | `suites/*.test.ts` | staging (and any non-prod deployment) |
+| `npm run test:prod` | `suites/*.test.ts` **+** `suites/prod/*.test.ts` | production |
+
+On staging these files are never loaded, so they cannot report a false pass.
+On prod they are loaded and must genuinely pass. There is no third state.
+
+## What belongs here
+
+Only things staging cannot do. As of writing, staging cannot:
+
+- receive mail over a real external **MX** (it has none; a distinct agent→agent
+  send egresses via SES and fails)
+- exercise **SES delivery feedback** — the `e2a-staging-smtp` IAM policy denies
+  `ses:SendRawEmail` to the bounce/complaint simulators, so `email.delivered`,
+  `email.bounced`, `email.complained` and the suppression events they cause can
+  never fire there
+- provision a real **SES sending identity** (DKIM) for `domain.sending_verified`
+  / `domain.sending_failed`
+- serve the prod-only marketing routes (e.g. `/pricing`)
+
+If staging *can* do it, the test belongs in `suites/`, not here — a prod-only
+test that didn't need to be prod-only just narrows where it runs.
+
+## Requirements
+
+These run against the real service with a real account, so:
+
+- **Self-provisioning.** Create every fixture you need and clean it up. No
+  manual setup steps — a suite that needs a human to prepare state cannot be
+  scheduled later.
+- **Use the dedicated conformance account**, never a real one. `E2E_ALLOW_PROD=1`
+  is required by `harness/env.ts` before any prod target is accepted.
+- **Mind persistent state.** Bounce/complaint simulator sends create real
+  suppression entries on the account. That is the point (a real bounce is the
+  only black-box way to create one), but it is durable — clean up what you can
+  and document what you can't.

--- a/tests/e2e-prod/target_env.py
+++ b/tests/e2e-prod/target_env.py
@@ -1,0 +1,60 @@
+"""Shared helper: which deployment did the run that produced these shards
+actually target?
+
+coverage_gate.py (deleteSuppression) and event_coverage_gate.py (SES
+delivery feedback + the suppression events it causes) each allowlist a
+handful of operations/event-types with a STAGING-specific justification —
+real SES delivery feedback and the real-bounce-only account suppression it
+creates cannot be produced against staging (its e2a-staging-smtp IAM policy
+denies ses:SendRawEmail to the mailbox-simulator addresses). Once a suite
+runs those against PRODUCTION instead (tests/e2e-prod/suites/prod/), that
+excuse no longer holds — the allowlist entry must become a REQUIRED
+coverage item, or a genuine production gap could hide behind a staging-only
+justification forever.
+
+The signal for "did this run target production" has to be un-fudgeable: not
+an operator flag (E2E_ALLOW_PROD is a safety opt-in, not a "grade me as
+prod" switch — trusting it here would let a mis-set env var silently relax
+the gate). Instead it's read from reports/target/*.json, shards written by
+harness/target.ts's recordTarget() — called once per suite-file process,
+from the SAME resolved apiUrl every request in that process actually used,
+through the SAME hostname allowlist (env.ts's isProductionTarget) that gates
+the destructive prod opt-in in the first place. `node --test` runs each
+suite/*.test.ts in its own process, and every suite (staging and prod-only
+alike) constructs an ApiClient, so a shard exists whenever any suite ran.
+
+Fail-closed like the other two gates' "no coverage shards" case: an absent
+run must never silently read as a staging pass (or a prod pass). Call
+resolve_target() and let a ValueError propagate to an exit(2) at the
+call site — never guess.
+"""
+import glob
+import json
+import os
+
+
+def resolve_target(target_dir: str) -> tuple[bool, int, list[str]]:
+    """Returns (targeted_prod, shard_count, sorted distinct apiUrls).
+
+    targeted_prod is True iff ANY recorded shard's apiUrl resolved to a
+    hosted production origin — a run that touches prod even once must be
+    held to the stricter bar; there is no such thing as "partially staging".
+    """
+    if not os.path.isdir(target_dir):
+        raise ValueError(
+            f"no target shard directory at {target_dir}. Run a suite first — "
+            "harness/target.ts's recordTarget() (wired into ApiClient's constructor) "
+            "writes one shard per suite-file process; an absent run is not a pass."
+        )
+    shards = sorted(glob.glob(os.path.join(target_dir, "*.json")))
+    if not shards:
+        raise ValueError(f"no target shards in {target_dir} — did any suite run?")
+    targeted_prod = False
+    hosts: set[str] = set()
+    for shard in shards:
+        with open(shard) as f:
+            data = json.load(f)
+        hosts.add(str(data.get("apiUrl", "?")))
+        if data.get("isProd"):
+            targeted_prod = True
+    return targeted_prod, len(shards), sorted(hosts)


### PR DESCRIPTION
## Summary

Two new prod-only conformance suites under `tests/e2e-prod/suites/prod/`, covering what staging structurally cannot produce, plus environment-aware coverage gates so the events they newly verify are *required* on a production run instead of permanently excused.

**Previously-undeferrable events now verified in production (dual-assertion: event-scoped fanout + webhook-scoped delivery attempt, the same bar `21-webhook-events.test.ts` established):**
- `email.delivered`, `email.bounced`, `email.complained` — real SES delivery feedback via the mailbox simulator (`success@`/`bounce@`/`complaint@simulator.amazonses.com`).
- `domain.suppression_added` — the real hard-bounce/complaint auto-suppression this feedback causes.
- `agent.suppression_added` — **note:** unlike its sibling, this one never actually required a real bounce (`internal/delivery/consumer.go`'s SES-feedback path only ever fires the account-scoped `domain.suppression_added`; the agent-scoped event only comes from the manual `createAgentSuppression` API or the unsubscribe-token flow). It was allowlisted under the same blanket "needs a real bounce" justification as its siblings, which doesn't actually apply to it. Verified here via the manual-create path; called out in the gate's comments as a possible staging follow-up (wire a webhook to it in `24-agent-suppressions.test.ts`) rather than folded into this PR.
- Real inbound-over-MX round trip (`email.sent` → `email.received`) between two distinct agents on `agents.e2a.dev`, as opposed to the internal self-send loopback shortcut. Distinguished from loopback by `envelope_from`/`header_from`/`authentication`, which loopback unconditionally nils/self-references — live-probed against prod, `header_from` turned out to be e2a's own relay address (`agent@send.e2a.dev`) and `envelope_from` SES's own VERP-style bounce token under its custom MAIL FROM subdomain (`mail.send.e2a.dev`), not what an initial read of the code assumed.

**Allowlist entry retired:** `deleteSuppression` in `coverage_gate.py` — previously justified as "no happy path black-box: a suppression is created only by a real SES bounce/complaint." A real bounce is exactly what the new suite produces, so this operation is now genuinely exercised (create via bounce → `listSuppressions` shows it → `deleteSuppression` → confirmed gone) instead of allowlisted forever.

**Gate mechanism (both `coverage_gate.py` and `event_coverage_gate.py`):** split each allowlist into `ALWAYS_ALLOWLIST` (the `domain.sending_*` pair — needs a separate DKIM/custom-domain fixture, out of scope here) and `STAGING_ONLY_ALLOWLIST` (the SES-feedback-dependent entries). Which tier applies is resolved from `reports/target/*.json` — shards `harness/target.ts` writes once per suite-file process, from the same resolved `apiUrl` every request in that process actually used, through the same hostname allowlist that gates the prod opt-in in the first place. This is deliberately not an operator flag: it can't be set wrongly independent of what the suite actually talked to. Verified both directions with the real shards this session's prod run produced: full coverage passes; stripping `email.bounced` from a real prod-target shard fails the gate and flags it "(staging-only allowlist, REQUIRED on this prod run)"; the identical missing-event shard re-run under a staging target shard passes.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run test:unit` (18/18 pass)
- [x] Both new suites run individually against production (dedicated conformance account) and pass
- [x] `npm run report:gate` exits 0 against the real reports from this run
- [x] `event_coverage_gate.py` / `coverage_gate.py` run against the real prod-run shards: PASS; a synthetic missing-event variant of the same real shards: FAILS and names the gap as prod-required; the same missing-event variant under a staging target shard: PASSES (allowlisted)
- [x] Account left clean: only the pre-existing `conformance@agents.e2a.dev` agent remains; 0 webhooks; 0 account suppressions (both bounce and complaint suppressions were created and then deleted via `deleteSuppression` inside the tests)

Not done in this session (explicitly out of scope per instructions — "run only your files," a sibling agent is working `test/prod-domain-quota` against the same account): a full `npm run test:prod` run across all 30 suite files. The other 6 always-required event types (`email.blocked`/`failed`/`flagged`, the three `review_*`) were not re-verified against prod in this session; they're suite 21's existing, already-reviewed coverage and unaffected by this change — the gate correctly reports them unverified when only these two new files are run in isolation, which is expected, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)