### PR TITLE
test(e2e-prod): give the prod-only suites unique, ordered numbers

### DIFF
--- a/tests/e2e-prod/event_coverage_gate.py
+++ b/tests/e2e-prod/event_coverage_gate.py
@@ -55,7 +55,7 @@ ENVIRONMENT-AWARE ALLOWLIST: two tiers.
     genuine prod gap hide behind a staging-only excuse.
 
     domain.sending_verified is in this tier for a different reason worth
-    knowing: suites/prod/33-domain-sending-identity.test.ts verifies it for
+    knowing: suites/prod/35-domain-sending-identity.test.ts verifies it for
     real, but that suite lives in suites/prod/ and so runs only under
     `npm run test:prod`. On a staging run it never executes, and staging has
     no real SES sending identity to produce the event anyway — so requiring

--- a/tests/e2e-prod/suites/prod/32-loopback-inbound-protection.test.ts
+++ b/tests/e2e-prod/suites/prod/32-loopback-inbound-protection.test.ts
@@ -47,7 +47,7 @@ import { fail, info, writeReport } from "../../harness/report.ts";
 // run the identical scenario) — it belongs here because it is a direct,
 // deliberate live-prod verification of a fix that reached prod unverified
 // against this exact posture; see the task brief that requested it.
-const SUITE = "32-loopback-inbound-protection";
+const SUITE = "prod/32-loopback-inbound-protection";
 const client = new ApiClient();
 
 interface SendResult {

--- a/tests/e2e-prod/suites/prod/33-quota-enforcement.test.ts
+++ b/tests/e2e-prod/suites/prod/33-quota-enforcement.test.ts
@@ -26,7 +26,7 @@ import { fail, info, writeReport } from "../../harness/report.ts";
 // second consecutive run starts from the same empty baseline. Do not leave
 // the account AT its cap — the whole point of the cleanup discipline is that
 // this suite can run indefinitely without manual intervention.
-const SUITE = "30-quota-enforcement";
+const SUITE = "prod/33-quota-enforcement";
 const base = new ApiClient();
 
 if (!base.env.quotaApiKey) {

--- a/tests/e2e-prod/suites/prod/34-billing-plan.test.ts
+++ b/tests/e2e-prod/suites/prod/34-billing-plan.test.ts
@@ -28,7 +28,7 @@ import { info, writeReport } from "../../harness/report.ts";
 // request with 401 — the same negative-space CSRF/authn discipline
 // 13-billing-surface.test.ts already applies to /api/billing/checkout and
 // /api/billing/portal.
-const SUITE = "31-billing-plan";
+const SUITE = "prod/34-billing-plan";
 const client = new ApiClient();
 const siteClient = new ApiClient(client.env, undefined, client.env.siteUrl);
 

--- a/tests/e2e-prod/suites/prod/35-domain-sending-identity.test.ts
+++ b/tests/e2e-prod/suites/prod/35-domain-sending-identity.test.ts
@@ -46,7 +46,7 @@ import { writeReport, info, warn, fail } from "../../harness/report.ts";
 //   6. create a custom-domain agent, confirming domain_verified=true.
 //   7. teardown: agent BEFORE domain (domain_has_agents guard), then all 5
 //      Cloudflare records unconditionally.
-const SUITE = "33-domain-sending-identity";
+const SUITE = "prod/35-domain-sending-identity";
 const client = new ApiClient();
 
 // Event-type coverage recorder for event_coverage_gate.py, same shard


### PR DESCRIPTION
Housekeeping on the Phase 2 suites, found while auditing `main`.

## The collision

Two agents built the prod-only suites in parallel and independently picked the
same prefixes:

```
30-inbound-mx     /  30-quota-enforcement
31-billing-plan   /  31-ses-feedback
```

The numeric prefix exists to make execution order deterministic. With a
collision it silently falls back to full-string alphabetical — so
`30-inbound-mx` ran before `30-quota-enforcement` by accident, not intent.
These suites share a **single production conformance account**, so ordering
isn't purely cosmetic.

## New order — deliberate, not just unique

Core paths first, external dependencies last, so a slow third-party wait can't
delay the assertions that matter most:

| | Suite | Why here |
|---|---|---|
| 30 | `inbound-mx` | real MX round trip |
| 31 | `ses-feedback` | SES delivery feedback + suppressions |
| 32 | `loopback-inbound-protection` | the 1.3.0 regression |
| 33 | `quota-enforcement` | separate quota account |
| 34 | `billing-plan` | read-only |
| 35 | `domain-sending-identity` | real DNS + async AWS DKIM — slowest, most external |

## Also fixed: the `SUITE` constants

They were stale after the rename **and** already inconsistent — four lacked the
`prod/` prefix the other two used. `SUITE` is the name that appears in findings
reports, so a stale value points a reader at the wrong file. All six now match
their filename.

`event_coverage_gate.py`'s cross-reference updated for the `33 → 35`
domain-sending-identity move.

## Verification

Re-ran the renamed suites against **production**:

| Suite | Result |
|---|---|
| `33-quota-enforcement` | 3/3 — cleanup still leaves the quota account off-cap |
| `34-billing-plan` | 3/3 |
| `32-loopback-inbound-protection` | 1/1 |

`tsc --noEmit` clean. Pure rename + constant/reference sync — no assertion or
behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)