### PR TITLE
test(selftest): fix close-frame assertion race in WS round-trip test

### DIFF
--- a/internal/selftest/ws_scenario_test.go
+++ b/internal/selftest/ws_scenario_test.go
@@ -25,20 +25,41 @@ import (
 // and DELETE …/messages/{id} (recorded into deleted, so tests can pin the
 // scenario's residue cleanup against the actual response shape).
 type wsStubState struct {
-	mu       sync.Mutex
-	conn     *websocket.Conn
-	deleted  []string
-	sawClose bool
+	mu        sync.Mutex
+	conn      *websocket.Conn
+	deleted   []string
+	closeSeen chan struct{} // closed once the stub reads a normal-closure frame
+	closeOnce sync.Once
 }
 
-// sawCloseFrame reports whether the stub read a normal-closure frame from the
-// client. This is the DETERMINISTIC signal that the close handshake completed:
-// conn.Close blocks until the peer answers (or its 5s timeout expires), so if
-// this is false by the time the scenario returns, the handshake did not happen.
-func (st *wsStubState) sawCloseFrame() bool {
-	st.mu.Lock()
-	defer st.mu.Unlock()
-	return st.sawClose
+// noteCloseFrame records that the stub read the client's normal-closure frame.
+// Safe to call more than once.
+func (st *wsStubState) noteCloseFrame() {
+	st.closeOnce.Do(func() { close(st.closeSeen) })
+}
+
+// awaitCloseFrame reports whether the stub read a normal-closure frame from the
+// client, waiting up to d for the stub's read goroutine to record it.
+//
+// The wait is NOT a wall-clock budget on the handshake — it is the missing
+// happens-before edge. The library echoes the close frame from inside
+// handleControl BEFORE the error propagates out of the stub's c.Read, so
+// conn.Close can return (and the scenario with it) while the stub goroutine
+// has not yet been scheduled to record what it saw. Measured margin on an idle
+// machine is ~6µs, so any deschedule longer than that flipped this assertion —
+// which is exactly what a loaded, coverage-instrumented CI runner does.
+//
+// The contract this pins is unchanged: if the handshake genuinely does not
+// complete, the frame is never read, closeSeen is never closed, and this
+// returns false. A non-reading stub also makes conn.Close burn its full 5s
+// timeout first, so d is only ever paid on an already-failing test.
+func (st *wsStubState) awaitCloseFrame(d time.Duration) bool {
+	select {
+	case <-st.closeSeen:
+		return true
+	case <-time.After(d):
+		return false
+	}
 }
 
 func (st *wsStubState) deletedIDs() []string {
@@ -49,7 +70,7 @@ func (st *wsStubState) deletedIDs() []string {
 
 func wsStub(t *testing.T) (*httptest.Server, *wsStubState) {
 	t.Helper()
-	st := &wsStubState{}
+	st := &wsStubState{closeSeen: make(chan struct{})}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
@@ -84,9 +105,7 @@ func wsStub(t *testing.T) (*httptest.Server, *wsStubState) {
 				for {
 					if _, _, err := c.Read(context.Background()); err != nil {
 						if websocket.CloseStatus(err) == websocket.StatusNormalClosure {
-							st.mu.Lock()
-							st.sawClose = true
-							st.mu.Unlock()
+							st.noteCloseFrame()
 						}
 						return
 					}
@@ -150,9 +169,10 @@ func TestScenarioWebSocketRoundTrip(t *testing.T) {
 	// Close-handshake contract. conn.Close waits for the peer's close frame and
 	// gives up after 5s, so a stub that does not read makes EVERY invocation of
 	// this scenario cost 5s of pure waiting. Asserting the stub observed the
-	// frame pins that deterministically — without a wall-clock budget, which is
-	// the flake pattern this suite already got bitten by.
-	if !st.sawCloseFrame() {
+	// frame pins that — without a wall-clock budget, which is the flake pattern
+	// this suite already got bitten by. See awaitCloseFrame for why the wait is
+	// a happens-before edge rather than a timing budget.
+	if !st.awaitCloseFrame(2 * time.Second) {
 		t.Error("stub never observed the client's close frame: the close handshake " +
 			"did not complete, so conn.Close burned the library's full 5s timeout")
 	}


### PR DESCRIPTION
## Summary

Fixes the intermittent `Go coverage gate` failure in `internal/selftest`:

```
--- FAIL: TestScenarioWebSocketRoundTrip
    ws_scenario_test.go:156: stub never observed the client's close frame:
    the close handshake did not complete, so conn.Close burned the library's
    full 5s timeout
```

Most recently seen on #711 (a dependabot `actions/setup-python` bump that
touches no Go code); a plain re-run went green.

**Root cause is the assertion, not the product code or the scenario.** The test
read the stub's `sawClose` flag immediately after the scenario returned, but
that flag is written by the stub's *read goroutine* with no happens-before edge
to the assertion:

- `nhooyr.io/websocket@v1.8.17` `read.go:337` — the server echoes the peer's
  close frame from inside `handleControl`, **before** the error propagates out
  of the stub's `c.Read`.
- `close.go:174` — the client's `Close()` returns the moment that echo arrives.

So the handshake is complete and `Close` has returned while the stub goroutine
still has to be scheduled to record what it saw.

**Confirmed empirically.** An instrumented harness distinguished "flag arrived
late" from "flag never arrived" at the exact instant the assertion reads it.
Over 800 `-race` iterations:

```
in-time=797   LATE=3   never=0   worst-lateness=62.875µs
```

`never=0` rules out a genuinely broken handshake — in every case that would have
failed, the handshake *had* completed and the flag merely landed up to 62.9µs
late. A loaded, coverage-instrumented CI runner is exactly where that window
opens, which is where it fired.

The fix replaces the bool with a channel the read goroutine closes and has the
test wait on it — supplying the missing happens-before edge, not a timing budget.

I also checked and cleared a plausible alternative: `cancelRead()` runs before
`conn.Close()` in the LIFO defer order (`ws_scenario.go:100` vs `:63`), but
`readFramePayload` resets the registered ctx to `context.Background()` after a
successful read, so it cannot trip `timeoutLoop`'s `c.close()`.

## Operational risk

None — test-only change, single file, no product code touched.

## Test plan

- [x] `-count=300 -race`, 10 batches on **original** code: **4/10 batches failed**
      with the exact CI message (flake reproduced locally)
- [x] Same amplification with the fix: **0 failures across ~6,900 iterations**
- [x] Mutation test — stub's read loop disabled so the handshake genuinely does
      not complete: assertion **still fails**, in 7.01s (the library's 5s
      close-handshake burn + the 2s wait). The contract from ccd06c15 is intact.
- [x] `gofmt`, `go vet`, full `./internal/selftest/ -race` clean
- [ ] CI green on this PR

## Note

The 2s wait is only ever paid on an already-failing test: if the handshake
genuinely does not complete, `conn.Close` has already burned its own 5s first.
The happy path resolves in microseconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)