### PR TITLE
fix(oauth): include issuer in authorization errors

### DIFF
--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -568,7 +568,7 @@ func main() {
 	} else {
 		// Issuer = api_url (defaults to public_url). fosite stamps it into
 		// token `iss` and the RFC 9207 response, so it must match what
-		// discovery advertises and what agentAuthIssuer signs/verifies.
+		// discovery advertises and what oauthIssuer signs/verifies.
 		oauthProvider, err := oauth.NewProvider(oauthStorage, cfg.HTTP.APIURL, []byte(cfg.Signing.HMACSecret))
 		if err != nil {
 			log.Fatalf("[oauth] provider wiring failed: %v", err)

--- a/internal/agent/agent_identity.go
+++ b/internal/agent/agent_identity.go
@@ -30,13 +30,6 @@ import (
 // falling through to fosite's authorization_code/refresh_token handling.
 const jwtBearerGrantType = "urn:ietf:params:oauth:grant-type:jwt-bearer"
 
-// agentAuthIssuer is the iss/aud bound into every minted token — the API base
-// URL (apiURL, which defaults to publicURL), trailing slash trimmed so it's
-// byte-stable with the discovery doc's issuer. It signs AND verifies, so a
-// deployment that changes api_url re-keys its token audience: tokens minted
-// under the old issuer stop validating and clients must re-auth.
-func (a *API) agentAuthIssuer() string { return strings.TrimRight(a.apiURL, "/") }
-
 // agentAuthReady reports whether the agent-identity surface is usable: a signing
 // key AND a public URL (needed for iss/aud) must both be configured.
 func (a *API) agentAuthReady() bool {
@@ -83,7 +76,7 @@ func (a *API) handleAgentIdentity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	assertion, exp, err := a.signer.SignIdentityAssertion(ag.ID, identity.ScopeAgent, ag.AssertionVersion, a.agentAuthIssuer())
+	assertion, exp, err := a.signer.SignIdentityAssertion(ag.ID, identity.ScopeAgent, ag.AssertionVersion, a.oauthIssuer())
 	if err != nil {
 		writeOAuthError(w, r, http.StatusInternalServerError, "server_error", "failed to mint identity assertion")
 		return
@@ -120,7 +113,7 @@ func (a *API) handleJWTBearerGrant(w http.ResponseWriter, r *http.Request) {
 		writeOAuthError(w, r, http.StatusBadRequest, "invalid_request", "assertion is required")
 		return
 	}
-	claims, err := a.signer.VerifyToken(assertion, agentauth.TypIdentityAssertion, a.agentAuthIssuer())
+	claims, err := a.signer.VerifyToken(assertion, agentauth.TypIdentityAssertion, a.oauthIssuer())
 	if err != nil {
 		writeOAuthError(w, r, http.StatusBadRequest, "invalid_grant", "identity assertion is invalid or expired")
 		return
@@ -137,7 +130,7 @@ func (a *API) handleJWTBearerGrant(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	token, exp, err := a.signer.SignAccessToken(ag.ID, identity.ScopeAgent, ag.AssertionVersion, a.agentAuthIssuer())
+	token, exp, err := a.signer.SignAccessToken(ag.ID, identity.ScopeAgent, ag.AssertionVersion, a.oauthIssuer())
 	if err != nil {
 		writeOAuthError(w, r, http.StatusInternalServerError, "server_error", "failed to mint access token")
 		return
@@ -160,7 +153,7 @@ func (a *API) resolveAgentAccessToken(r *http.Request, bearer string) (*identity
 	if !a.agentAuthReady() || !looksLikeJWT(bearer) {
 		return nil, false, nil
 	}
-	claims, err := a.signer.VerifyToken(bearer, agentauth.TypAccessToken, a.agentAuthIssuer())
+	claims, err := a.signer.VerifyToken(bearer, agentauth.TypAccessToken, a.oauthIssuer())
 	if err != nil {
 		// It parses as a JWT but isn't a valid e2a access token — reject
 		// rather than fall through (a tampered/expired token is a 401, not an

--- a/internal/agent/oauth_consent_test.go
+++ b/internal/agent/oauth_consent_test.go
@@ -284,6 +284,39 @@ func TestHTTP_Authorize_InvalidClient(t *testing.T) {
 			t.Errorf("unknown client should NOT redirect to consent; Location=%q", loc)
 		}
 	}
+	if loc := resp.Header.Get("Location"); loc != "" {
+		t.Errorf("unknown client must not redirect to an untrusted redirect_uri; Location=%q", loc)
+	}
+}
+
+// TestHTTP_Authorize_InvalidScope_RedirectIncludesIssuer covers an authorize
+// error after fosite has verified the client and redirect_uri. RFC 9207
+// requires the redirect to identify the authorization server just like a
+// successful code response does.
+func TestHTTP_Authorize_InvalidScope_RedirectIncludesIssuer(t *testing.T) {
+	f := newConsentFixture(t)
+	_, challenge := newPKCE(t)
+	q := authorizeParams(challenge, f.clientID, "s1s1s1s1s1s1s1s1")
+	q.Set("scope", "agent unknown")
+
+	resp := f.authorizeRequest(t, q, true)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusFound && resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 302/303 redirect-with-error", resp.StatusCode)
+	}
+	loc, err := url.Parse(resp.Header.Get("Location"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := loc.Query().Get("error"); got != "invalid_scope" {
+		t.Errorf("error = %q, want invalid_scope", got)
+	}
+	if got := loc.Query().Get("state"); got != "s1s1s1s1s1s1s1s1" {
+		t.Errorf("state = %q, want s1s1s1s1s1s1s1s1", got)
+	}
+	if got := loc.Query().Get("iss"); got != "https://test.e2a.dev" {
+		t.Errorf("RFC 9207 iss = %q, want https://test.e2a.dev", got)
+	}
 }
 
 // ──────────────────────── /consent ────────────────────────
@@ -401,8 +434,8 @@ func TestHTTP_Consent_Deny(t *testing.T) {
 
 	resp := f.consentPOST(t, form)
 	defer resp.Body.Close()
-	// fosite's WriteAuthorizeError emits 302 for redirect-uri-bound
-	// errors.
+	// Redirect-uri-bound authorization errors remain 302/303 after the
+	// RFC 9207 issuer is added.
 	if resp.StatusCode != http.StatusFound && resp.StatusCode != http.StatusSeeOther {
 		t.Fatalf("status = %d, want 302/303 redirect-with-error", resp.StatusCode)
 	}
@@ -415,6 +448,12 @@ func TestHTTP_Consent_Deny(t *testing.T) {
 	}
 	if got := loc.Query().Get("error"); got != "access_denied" {
 		t.Errorf("error = %q, want access_denied", got)
+	}
+	if got := loc.Query().Get("state"); got != "s1s1s1s1s1s1s1s1" {
+		t.Errorf("state = %q, want s1s1s1s1s1s1s1s1", got)
+	}
+	if got := loc.Query().Get("iss"); got != "https://test.e2a.dev" {
+		t.Errorf("RFC 9207 iss = %q, want https://test.e2a.dev", got)
 	}
 }
 

--- a/internal/agent/oauth_consent_test.go
+++ b/internal/agent/oauth_consent_test.go
@@ -41,10 +41,12 @@ type consentFixture struct {
 	sessionToken string
 	userID       string
 	clientID     string
+	issuer       string
 }
 
 func newConsentFixture(t *testing.T) *consentFixture {
 	t.Helper()
+	const issuer = "https://test.e2a.dev"
 	pool := testutil.TestDB(t)
 	store := identity.NewStore(pool)
 	smtpRelay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{})
@@ -60,11 +62,11 @@ func newConsentFixture(t *testing.T) *consentFixture {
 	}, store, false)
 
 	api := agent.NewAPI(store, sender, smtpRelay, userAuth, usage.NewNoopUsageTracker(),
-		"e2a.dev", "test.e2a.dev", "agents.e2a.dev", "https://test.e2a.dev", false)
+		"e2a.dev", "test.e2a.dev", "agents.e2a.dev", issuer, false)
 
 	secret := []byte("test-secret-test-secret-test-sec")
 	storage := oauth.NewStorage(pool)
-	provider, err := oauth.NewProvider(storage, "https://test.e2a.dev", secret)
+	provider, err := oauth.NewProvider(storage, issuer, secret)
 	if err != nil {
 		t.Fatalf("NewProvider: %v", err)
 	}
@@ -97,7 +99,7 @@ func newConsentFixture(t *testing.T) *consentFixture {
 		API: api, Store: store, Enforcer: enforcer, UsageStore: usageStore,
 		SubscriberStore: subscriberStore, Idempotency: idempotencyStore, Pool: pool,
 		SMTPDomain: "test.e2a.dev", SharedDomain: "agents.e2a.dev",
-		PublicURL: "https://test.e2a.dev", Production: false,
+		PublicURL: issuer, Production: false,
 		Legacy: router, WSHandle: wsHandler.ServeWithEmail,
 	})
 	server := httptest.NewServer(v1)
@@ -145,6 +147,7 @@ func newConsentFixture(t *testing.T) *consentFixture {
 		sessionToken: sessionToken,
 		userID:       user.ID,
 		clientID:     clientID,
+		issuer:       issuer,
 	}
 }
 
@@ -299,15 +302,8 @@ func TestHTTP_Authorize_InvalidClient(t *testing.T) {
 	q := authorizeParams(challenge, "mcp_unknown_client", "s1s1s1s1s1s1s1s1")
 	resp := f.authorizeRequest(t, q, true)
 	defer resp.Body.Close()
-	// fosite emits a non-2xx, non-302 response for invalid_client at
-	// /authorize (since the redirect_uri isn't trusted). Status code
-	// can be 400 or 401 depending on fosite version; we just want it
-	// to NOT be a successful redirect to our consent UI.
-	if resp.StatusCode == http.StatusFound {
-		loc := resp.Header.Get("Location")
-		if strings.Contains(loc, "/oauth/consent") {
-			t.Errorf("unknown client should NOT redirect to consent; Location=%q", loc)
-		}
+	if resp.StatusCode < 400 || resp.StatusCode >= 500 {
+		t.Errorf("status = %d, want direct 4xx", resp.StatusCode)
 	}
 	if loc := resp.Header.Get("Location"); loc != "" {
 		t.Errorf("unknown client must not redirect to an untrusted redirect_uri; Location=%q", loc)
@@ -339,8 +335,44 @@ func TestHTTP_Authorize_InvalidScope_RedirectIncludesIssuer(t *testing.T) {
 	if got := loc.Query().Get("state"); got != "s1s1s1s1s1s1s1s1" {
 		t.Errorf("state = %q, want s1s1s1s1s1s1s1s1", got)
 	}
-	if got := loc.Query().Get("iss"); got != "https://test.e2a.dev" {
-		t.Errorf("RFC 9207 iss = %q, want https://test.e2a.dev", got)
+	if got := loc.Query().Get("iss"); got != f.issuer {
+		t.Errorf("RFC 9207 iss = %q, want %q", got, f.issuer)
+	}
+}
+
+// TestHTTP_Authorize_DangerousStoredRedirectDoesNotRedirect covers the
+// defense-in-depth boundary for client rows inserted outside DCR validation.
+// Even when fosite exact-matches the stored redirect_uri, the server must not
+// emit an executable Location header on an authorization error.
+func TestHTTP_Authorize_DangerousStoredRedirectDoesNotRedirect(t *testing.T) {
+	f := newConsentFixture(t)
+	ctx := context.Background()
+	clientID := "mcp_dangerous_" + randHex8(t)
+	const redirectURI = "javascript:alert(1)"
+	if _, err := f.pool.Exec(ctx, `
+		INSERT INTO oauth_clients
+		    (client_id, client_name, redirect_uris, grant_types,
+		     response_types, scopes, audiences, token_endpoint_auth_method,
+		     public, created_via)
+		VALUES ($1, 'dangerous redirect fixture', ARRAY[$2],
+		        ARRAY['authorization_code','refresh_token'], ARRAY['code'],
+		        ARRAY['agent'], ARRAY[]::TEXT[], 'none', TRUE, 'admin')
+	`, clientID, redirectURI); err != nil {
+		t.Fatalf("seed dangerous client: %v", err)
+	}
+
+	_, challenge := newPKCE(t)
+	q := authorizeParams(challenge, clientID, "s1s1s1s1s1s1s1s1")
+	q.Set("redirect_uri", redirectURI)
+	q.Set("scope", "agent unknown")
+	resp := f.authorizeRequest(t, q, true)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+	if loc := resp.Header.Get("Location"); loc != "" {
+		t.Errorf("dangerous redirect must not emit Location; got %q", loc)
 	}
 }
 
@@ -376,8 +408,8 @@ func TestHTTP_Authorize_ErrorUsesAdvertisedQueryMode(t *testing.T) {
 			if got := loc.Query().Get("state"); got != "s1s1s1s1s1s1s1s1" {
 				t.Errorf("state = %q, want s1s1s1s1s1s1s1s1", got)
 			}
-			if got := loc.Query().Get("iss"); got != "https://test.e2a.dev" {
-				t.Errorf("RFC 9207 iss = %q, want https://test.e2a.dev", got)
+			if got := loc.Query().Get("iss"); got != f.issuer {
+				t.Errorf("RFC 9207 iss = %q, want %q", got, f.issuer)
 			}
 		})
 	}
@@ -418,8 +450,8 @@ func TestHTTP_Consent_Allow_CreateNew(t *testing.T) {
 	if got := loc.Query().Get("state"); got != "s1s1s1s1s1s1s1s1" {
 		t.Errorf("state round-trip: got %q, want s1s1s1s1s1s1s1s1", got)
 	}
-	if got := loc.Query().Get("iss"); got != "https://test.e2a.dev" {
-		t.Errorf("RFC 9207 iss missing/wrong: got %q, want https://test.e2a.dev", got)
+	if got := loc.Query().Get("iss"); got != f.issuer {
+		t.Errorf("RFC 9207 iss missing/wrong: got %q, want %q", got, f.issuer)
 	}
 
 	// Verify the agent was actually created on the shared domain.
@@ -516,8 +548,8 @@ func TestHTTP_Consent_Deny(t *testing.T) {
 	if got := loc.Query().Get("state"); got != "s1s1s1s1s1s1s1s1" {
 		t.Errorf("state = %q, want s1s1s1s1s1s1s1s1", got)
 	}
-	if got := loc.Query().Get("iss"); got != "https://test.e2a.dev" {
-		t.Errorf("RFC 9207 iss = %q, want https://test.e2a.dev", got)
+	if got := loc.Query().Get("iss"); got != f.issuer {
+		t.Errorf("RFC 9207 iss = %q, want %q", got, f.issuer)
 	}
 }
 
@@ -610,8 +642,8 @@ func TestHTTP_FullE2E_AuthorizeConsentToken(t *testing.T) {
 	if code == "" {
 		t.Fatal("step 2: missing code")
 	}
-	if got := loc.Query().Get("iss"); got != "https://test.e2a.dev" {
-		t.Errorf("step 2: iss = %q, want https://test.e2a.dev", got)
+	if got := loc.Query().Get("iss"); got != f.issuer {
+		t.Errorf("step 2: iss = %q, want %q", got, f.issuer)
 	}
 
 	// Step 3: exchange the code at /token.

--- a/internal/agent/oauth_consent_test.go
+++ b/internal/agent/oauth_consent_test.go
@@ -264,6 +264,31 @@ func TestHTTP_Authorize_WithSession(t *testing.T) {
 	}
 }
 
+// TestHTTP_Authorize_ExplicitQueryMode verifies that a client may explicitly
+// request the sole response mode advertised in OAuth discovery.
+func TestHTTP_Authorize_ExplicitQueryMode(t *testing.T) {
+	f := newConsentFixture(t)
+	_, challenge := newPKCE(t)
+	q := authorizeParams(challenge, f.clientID, "s1s1s1s1s1s1s1s1")
+	q.Set("response_mode", "query")
+
+	resp := f.authorizeRequest(t, q, true)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("status = %d, want 302 consent redirect", resp.StatusCode)
+	}
+	loc, err := url.Parse(resp.Header.Get("Location"))
+	if err != nil {
+		t.Fatalf("Location parse: %v", err)
+	}
+	if !strings.HasSuffix(loc.Path, "/oauth/consent") {
+		t.Errorf("Location path = %q, want /oauth/consent", loc.Path)
+	}
+	if got := loc.Query().Get("response_mode"); got != "query" {
+		t.Errorf("response_mode = %q, want query", got)
+	}
+}
+
 // TestHTTP_Authorize_InvalidClient — fosite rejects before we get a
 // chance to check the session. The response is a fosite-emitted
 // direct error (not a redirect to redirect_uri, since redirect_uri

--- a/internal/agent/oauth_consent_test.go
+++ b/internal/agent/oauth_consent_test.go
@@ -319,6 +319,45 @@ func TestHTTP_Authorize_InvalidScope_RedirectIncludesIssuer(t *testing.T) {
 	}
 }
 
+// TestHTTP_Authorize_ErrorUsesAdvertisedQueryMode verifies that an invalid
+// request cannot move the error parameters away from the server's sole
+// advertised response mode. In particular, fosite otherwise honors an
+// unsupported response_mode while writing an error, putting the error in a
+// fragment or an HTML form where RFC 9207's iss decorator cannot accompany it.
+func TestHTTP_Authorize_ErrorUsesAdvertisedQueryMode(t *testing.T) {
+	for _, responseMode := range []string{"fragment", "form_post"} {
+		t.Run(responseMode, func(t *testing.T) {
+			f := newConsentFixture(t)
+			_, challenge := newPKCE(t)
+			q := authorizeParams(challenge, f.clientID, "s1s1s1s1s1s1s1s1")
+			q.Set("scope", "agent unknown")
+			q.Set("response_mode", responseMode)
+
+			resp := f.authorizeRequest(t, q, true)
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusFound && resp.StatusCode != http.StatusSeeOther {
+				t.Fatalf("status = %d, want 302/303 redirect-with-error", resp.StatusCode)
+			}
+			loc, err := url.Parse(resp.Header.Get("Location"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if loc.Fragment != "" {
+				t.Errorf("fragment = %q, want empty because only query mode is supported", loc.Fragment)
+			}
+			if got := loc.Query().Get("error"); got != "invalid_scope" {
+				t.Errorf("error = %q, want invalid_scope", got)
+			}
+			if got := loc.Query().Get("state"); got != "s1s1s1s1s1s1s1s1" {
+				t.Errorf("state = %q, want s1s1s1s1s1s1s1s1", got)
+			}
+			if got := loc.Query().Get("iss"); got != "https://test.e2a.dev" {
+				t.Errorf("RFC 9207 iss = %q, want https://test.e2a.dev", got)
+			}
+		})
+	}
+}
+
 // ──────────────────────── /consent ────────────────────────
 
 // TestHTTP_Consent_Allow_CreateNew is the happy path: user picks

--- a/internal/agent/oauth_handlers.go
+++ b/internal/agent/oauth_handlers.go
@@ -1054,6 +1054,17 @@ func (a *API) handleOAuthConsent(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// queryModeAuthorizeRequester makes error responses follow the only response
+// mode this server advertises. fosite otherwise uses a requested but unsupported
+// fragment or form_post mode while reporting an earlier validation error.
+type queryModeAuthorizeRequester struct {
+	fosite.AuthorizeRequester
+}
+
+func (queryModeAuthorizeRequester) GetResponseMode() fosite.ResponseModeType {
+	return fosite.ResponseModeQuery
+}
+
 // authorizeErrorResponseWriter decorates redirecting authorization errors
 // with the RFC 9207 issuer identifier. fosite v0.49.0 owns the validation,
 // status code, and error parameters but has no native RFC 9207 support, so we
@@ -1064,6 +1075,10 @@ type authorizeErrorResponseWriter struct {
 	http.ResponseWriter
 	issuer      string
 	wroteHeader bool
+}
+
+func (w *authorizeErrorResponseWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
 }
 
 func (w *authorizeErrorResponseWriter) WriteHeader(statusCode int) {
@@ -1101,7 +1116,7 @@ func (a *API) writeAuthorizeError(ctx context.Context, w http.ResponseWriter, ar
 	a.oauthProvider.WriteAuthorizeError(ctx, &authorizeErrorResponseWriter{
 		ResponseWriter: w,
 		issuer:         strings.TrimRight(a.apiURL, "/"),
-	}, ar, err)
+	}, queryModeAuthorizeRequester{AuthorizeRequester: ar}, err)
 }
 
 // issueOAuthCode is the no-new-agent path. fosite mints the code via

--- a/internal/agent/oauth_handlers.go
+++ b/internal/agent/oauth_handlers.go
@@ -865,7 +865,7 @@ func (a *API) handleOAuthAuthorize(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		// fosite writes the right response shape (redirect-with-error
 		// when the URI was verified, direct error otherwise).
-		a.oauthProvider.WriteAuthorizeError(ctx, w, ar, err)
+		a.writeAuthorizeError(ctx, w, ar, err)
 		return
 	}
 
@@ -951,7 +951,7 @@ func (a *API) handleOAuthConsent(w http.ResponseWriter, r *http.Request) {
 	authReq.URL.RawQuery = r.PostForm.Encode()
 	ar, err := a.oauthProvider.NewAuthorizeRequest(ctx, authReq)
 	if err != nil {
-		a.oauthProvider.WriteAuthorizeError(ctx, w, ar, err)
+		a.writeAuthorizeError(ctx, w, ar, err)
 		return
 	}
 
@@ -964,9 +964,9 @@ func (a *API) handleOAuthConsent(w http.ResponseWriter, r *http.Request) {
 	action := r.PostFormValue("action")
 	if action == "deny" {
 		// RFC 6749 §4.1.2.1: redirect back with error=access_denied.
-		// fosite's WriteAuthorizeError emits the redirect for us when
-		// the error is shaped right.
-		a.oauthProvider.WriteAuthorizeError(ctx, w, ar,
+		// writeAuthorizeError delegates the error shape to fosite and
+		// adds the RFC 9207 issuer when fosite emits a redirect.
+		a.writeAuthorizeError(ctx, w, ar,
 			fosite.ErrAccessDenied.WithHint("user denied consent"))
 		return
 	}
@@ -987,7 +987,7 @@ func (a *API) handleOAuthConsent(w http.ResponseWriter, r *http.Request) {
 	switch scopeChoice {
 	case identity.ScopeAccount:
 		if !accountEligibleRedirect(ar.GetRedirectURI().String()) {
-			a.oauthProvider.WriteAuthorizeError(ctx, w, ar,
+			a.writeAuthorizeError(ctx, w, ar,
 				fosite.ErrInvalidScope.WithHint(
 					"account scope may only be granted to a client with a loopback or https redirect_uri"))
 			return
@@ -997,7 +997,7 @@ func (a *API) handleOAuthConsent(w http.ResponseWriter, r *http.Request) {
 		// exactly like an e2a_acct_ key; any agent_choice is ignored.
 		if err := a.issueOAuthCode(ctx, w, r, ar, user.ID, "", identity.ScopeAccount); err != nil {
 			log.Printf("[oauth] /consent issue (account) failed: request_id=%s err=%v", reqID, err)
-			a.oauthProvider.WriteAuthorizeError(ctx, w, ar, err)
+			a.writeAuthorizeError(ctx, w, ar, err)
 		}
 		return
 	case identity.ScopeAgent:
@@ -1027,7 +1027,7 @@ func (a *API) handleOAuthConsent(w http.ResponseWriter, r *http.Request) {
 		// issue path with the resolved email on the session.
 		if err := a.issueOAuthCode(ctx, w, r, ar, user.ID, email, identity.ScopeAgent); err != nil {
 			log.Printf("[oauth] /consent issue (existing agent) failed: request_id=%s err=%v", reqID, err)
-			a.oauthProvider.WriteAuthorizeError(ctx, w, ar, err)
+			a.writeAuthorizeError(ctx, w, ar, err)
 		}
 
 	case agentChoice == "create_new":
@@ -1046,12 +1046,62 @@ func (a *API) handleOAuthConsent(w http.ResponseWriter, r *http.Request) {
 		agentEmail := slug + "@" + a.sharedDomain
 		if err := a.issueOAuthCodeWithNewAgent(ctx, w, r, ar, user.ID, agentEmail, identity.ScopeAgent); err != nil {
 			log.Printf("[oauth] /consent issue (new agent) failed: request_id=%s err=%v", reqID, err)
-			a.oauthProvider.WriteAuthorizeError(ctx, w, ar, err)
+			a.writeAuthorizeError(ctx, w, ar, err)
 		}
 
 	default:
 		http.Error(w, "agent_choice must be 'existing:<email>' or 'create_new'", http.StatusBadRequest)
 	}
+}
+
+// authorizeErrorResponseWriter decorates redirecting authorization errors
+// with the RFC 9207 issuer identifier. fosite v0.49.0 owns the validation,
+// status code, and error parameters but has no native RFC 9207 support, so we
+// amend only a Location header it has already decided is safe to emit. Direct
+// error responses (for example, an unknown client or untrusted redirect_uri)
+// have no Location and pass through unchanged.
+type authorizeErrorResponseWriter struct {
+	http.ResponseWriter
+	issuer      string
+	wroteHeader bool
+}
+
+func (w *authorizeErrorResponseWriter) WriteHeader(statusCode int) {
+	if w.wroteHeader {
+		return
+	}
+	w.appendIssuer()
+	w.wroteHeader = true
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *authorizeErrorResponseWriter) Write(p []byte) (int, error) {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.ResponseWriter.Write(p)
+}
+
+func (w *authorizeErrorResponseWriter) appendIssuer() {
+	location := w.Header().Get("Location")
+	if location == "" {
+		return
+	}
+	redirect, err := url.Parse(location)
+	if err != nil {
+		return
+	}
+	q := redirect.Query()
+	q.Set("iss", w.issuer)
+	redirect.RawQuery = q.Encode()
+	w.Header().Set("Location", redirect.String())
+}
+
+func (a *API) writeAuthorizeError(ctx context.Context, w http.ResponseWriter, ar fosite.AuthorizeRequester, err error) {
+	a.oauthProvider.WriteAuthorizeError(ctx, &authorizeErrorResponseWriter{
+		ResponseWriter: w,
+		issuer:         strings.TrimRight(a.apiURL, "/"),
+	}, ar, err)
 }
 
 // issueOAuthCode is the no-new-agent path. fosite mints the code via

--- a/internal/agent/oauth_handlers.go
+++ b/internal/agent/oauth_handlers.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ory/fosite"
 	"github.com/tokencanopy/e2a/internal/identity"
 	"github.com/tokencanopy/e2a/internal/oauth"
+	"golang.org/x/text/language"
 )
 
 // handleOAuthToken is the /oauth2/token endpoint. Thin wrapper
@@ -262,6 +263,15 @@ func isLoopbackRedirect(raw string) bool {
 	return isLoopbackHost(u.Hostname())
 }
 
+func isDangerousOAuthRedirectScheme(scheme string) bool {
+	switch strings.ToLower(scheme) {
+	case "javascript", "data", "file", "vbscript", "blob", "about":
+		return true
+	default:
+		return false
+	}
+}
+
 // accountEligibleRedirect reports whether a redirect_uri may be granted
 // account (workspace-admin) scope.
 //
@@ -327,8 +337,7 @@ func validateRedirectURI(raw string) error {
 		// prevent these from being reached, http.Redirect writes the
 		// Location header verbatim regardless of scheme — see
 		// writeAuthorizeRedirect for the matching defense-in-depth check.
-		switch u.Scheme {
-		case "javascript", "data", "file", "vbscript", "blob", "about":
+		if isDangerousOAuthRedirectScheme(u.Scheme) {
 			return errors.New("redirect_uri scheme not permitted")
 		}
 		// RFC 8252 §7.1: private-use URI schemes MUST be in reverse-
@@ -685,6 +694,12 @@ type OAuthMetadata struct {
 	AuthorizationResponseIssParameterSupported bool `json:"authorization_response_iss_parameter_supported,omitempty"`
 }
 
+// oauthIssuer returns the canonical authorization-server issuer used by
+// discovery, authorization responses, and agent-auth tokens.
+func (a *API) oauthIssuer() string {
+	return strings.TrimRight(a.apiURL, "/")
+}
+
 // agentAuthMetadata is the auth.md `agent_auth` discovery block (Slice 5b-2).
 // Advertised only when the agent-identity surface is live.
 type agentAuthMetadata struct {
@@ -724,7 +739,11 @@ func (a *API) handleOAuthDiscovery(w http.ResponseWriter, r *http.Request) {
 	// browser-facing authorization_endpoint — it stays on the web app
 	// (publicURL) where the login/consent UI lives. When api_url is unset
 	// the two are identical (single-host), preserving historical behaviour.
-	apiBase := strings.TrimRight(a.apiURL, "/")
+	apiBase := a.oauthIssuer()
+	if apiBase == "" {
+		http.NotFound(w, r)
+		return
+	}
 	webBase := strings.TrimRight(a.publicURL, "/")
 	meta := OAuthMetadata{
 		Issuer:                 apiBase,
@@ -1057,6 +1076,8 @@ func (a *API) handleOAuthConsent(w http.ResponseWriter, r *http.Request) {
 // queryModeAuthorizeRequester makes error responses follow the only response
 // mode this server advertises. fosite otherwise uses a requested but unsupported
 // fragment or form_post mode while reporting an earlier validation error.
+// Correctness also depends on the provider using fosite's default response
+// mode handler; e2a does not configure a ResponseModeHandlerExtension.
 type queryModeAuthorizeRequester struct {
 	fosite.AuthorizeRequester
 }
@@ -1064,6 +1085,15 @@ type queryModeAuthorizeRequester struct {
 func (queryModeAuthorizeRequester) GetResponseMode() fosite.ResponseModeType {
 	return fosite.ResponseModeQuery
 }
+
+func (r queryModeAuthorizeRequester) GetLang() language.Tag {
+	if ctx, ok := r.AuthorizeRequester.(fosite.G11NContext); ok {
+		return ctx.GetLang()
+	}
+	return language.English
+}
+
+var _ fosite.G11NContext = queryModeAuthorizeRequester{}
 
 // authorizeErrorResponseWriter decorates redirecting authorization errors
 // with the RFC 9207 issuer identifier. fosite v0.49.0 owns the validation,
@@ -1085,7 +1115,12 @@ func (w *authorizeErrorResponseWriter) WriteHeader(statusCode int) {
 	if w.wroteHeader {
 		return
 	}
-	w.appendIssuer()
+	if err := w.appendIssuer(); err != nil {
+		w.Header().Del("Location")
+		w.wroteHeader = true
+		http.Error(w.ResponseWriter, err.Error(), http.StatusBadRequest)
+		return
+	}
 	w.wroteHeader = true
 	w.ResponseWriter.WriteHeader(statusCode)
 }
@@ -1097,25 +1132,32 @@ func (w *authorizeErrorResponseWriter) Write(p []byte) (int, error) {
 	return w.ResponseWriter.Write(p)
 }
 
-func (w *authorizeErrorResponseWriter) appendIssuer() {
+func (w *authorizeErrorResponseWriter) appendIssuer() error {
 	location := w.Header().Get("Location")
 	if location == "" {
-		return
+		return nil
 	}
 	redirect, err := url.Parse(location)
 	if err != nil {
-		return
+		return errors.New("invalid redirect_uri")
+	}
+	if isDangerousOAuthRedirectScheme(redirect.Scheme) {
+		return errors.New("invalid redirect_uri scheme")
+	}
+	if w.issuer == "" {
+		return nil
 	}
 	q := redirect.Query()
 	q.Set("iss", w.issuer)
 	redirect.RawQuery = q.Encode()
 	w.Header().Set("Location", redirect.String())
+	return nil
 }
 
 func (a *API) writeAuthorizeError(ctx context.Context, w http.ResponseWriter, ar fosite.AuthorizeRequester, err error) {
 	a.oauthProvider.WriteAuthorizeError(ctx, &authorizeErrorResponseWriter{
 		ResponseWriter: w,
-		issuer:         strings.TrimRight(a.apiURL, "/"),
+		issuer:         a.oauthIssuer(),
 	}, queryModeAuthorizeRequester{AuthorizeRequester: ar}, err)
 }
 
@@ -1223,8 +1265,7 @@ func (a *API) writeAuthorizeRedirect(w http.ResponseWriter, r *http.Request, ar 
 	// against dangerous schemes, but if a row was inserted by some
 	// other path (operator script, future endpoint, migration replay
 	// of legacy data), refuse to emit Location: javascript:… here.
-	switch strings.ToLower(redirect.Scheme) {
-	case "javascript", "data", "file", "vbscript", "blob", "about":
+	if isDangerousOAuthRedirectScheme(redirect.Scheme) {
 		http.Error(w, "invalid redirect_uri scheme", http.StatusBadRequest)
 		return
 	}
@@ -1236,7 +1277,9 @@ func (a *API) writeAuthorizeRedirect(w http.ResponseWriter, r *http.Request, ar 
 	}
 	// RFC 9207 §2 — tell mix-up-aware clients which AS produced this
 	// response. Must byte-match the `issuer` discovery advertises (apiURL).
-	q.Set("iss", strings.TrimRight(a.apiURL, "/"))
+	if issuer := a.oauthIssuer(); issuer != "" {
+		q.Set("iss", issuer)
+	}
 	redirect.RawQuery = q.Encode()
 	http.Redirect(w, r, redirect.String(), http.StatusSeeOther)
 }

--- a/internal/agent/oauth_handlers_internal_test.go
+++ b/internal/agent/oauth_handlers_internal_test.go
@@ -1,0 +1,56 @@
+package agent
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/ory/fosite"
+	"golang.org/x/text/language"
+)
+
+func TestAuthorizeErrorResponseWriterOmitsEmptyIssuer(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := &authorizeErrorResponseWriter{ResponseWriter: rec}
+	w.Header().Set("Location", "https://client.example/callback?error=invalid_scope")
+
+	w.WriteHeader(http.StatusSeeOther)
+
+	location, err := url.Parse(rec.Header().Get("Location"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if location.Query().Has("iss") {
+		t.Errorf("empty issuer must be omitted; Location=%q", location.String())
+	}
+}
+
+func TestQueryModeAuthorizeRequesterPreservesLanguage(t *testing.T) {
+	original := fosite.NewAuthorizeRequest()
+	original.Lang = language.French
+
+	wrapped := queryModeAuthorizeRequester{AuthorizeRequester: original}
+
+	if got := wrapped.GetLang(); got != language.French {
+		t.Errorf("GetLang() = %v, want %v", got, language.French)
+	}
+}
+
+func TestOAuthIssuerCanonicalizesAPIURL(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		apiURL string
+		want   string
+	}{
+		{name: "trailing slashes", apiURL: "https://api.e2a.dev///", want: "https://api.e2a.dev"},
+		{name: "empty", apiURL: "", want: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			api := &API{apiURL: tc.apiURL}
+			if got := api.oauthIssuer(); got != tc.want {
+				t.Errorf("oauthIssuer() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/agent/oauth_handlers_internal_test.go
+++ b/internal/agent/oauth_handlers_internal_test.go
@@ -24,6 +24,12 @@ func TestAuthorizeErrorResponseWriterOmitsEmptyIssuer(t *testing.T) {
 	if location.Query().Has("iss") {
 		t.Errorf("empty issuer must be omitted; Location=%q", location.String())
 	}
+	if got := location.Query().Get("error"); got != "invalid_scope" {
+		t.Errorf("error = %q, want invalid_scope; Location=%q", got, location.String())
+	}
+	if got := location.String(); got != "https://client.example/callback?error=invalid_scope" {
+		t.Errorf("Location = %q, want original redirect preserved", got)
+	}
 }
 
 func TestQueryModeAuthorizeRequesterPreservesLanguage(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -512,6 +512,12 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("config: signing.hmac_secret is %d bytes; production requires at least %d (run `openssl rand -hex 32` to generate)", len(c.Signing.HMACSecret), minHMACSecretBytes)
 		}
 	}
+	if c.HTTP.APIURL != "" {
+		apiURL, err := absoluteHTTPURL(c.HTTP.APIURL)
+		if err != nil || apiURL.RawQuery != "" || apiURL.Fragment != "" {
+			return errors.New("config: http.api_url must be an absolute http(s) URL without userinfo, query, or fragment")
+		}
+	}
 	if c.Trash.RetentionDays < 1 {
 		return fmt.Errorf("config: trash.retention_days must be at least 1 (got %d) — the stable API promises soft-deleted resources stay restorable", c.Trash.RetentionDays)
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -208,6 +208,44 @@ signing:
 	}
 }
 
+func TestValidateAPIURL(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		apiURL  string
+		wantErr bool
+	}{
+		{name: "empty disables issuer-dependent features", apiURL: ""},
+		{name: "https origin", apiURL: "https://api.e2a.dev"},
+		{name: "http loopback development", apiURL: "http://localhost:8080"},
+		{name: "issuer path", apiURL: "https://example.com/e2a"},
+		{name: "relative", apiURL: "/", wantErr: true},
+		{name: "dangerous scheme", apiURL: "javascript:alert(1)", wantErr: true},
+		{name: "userinfo", apiURL: "https://user@example.com", wantErr: true},
+		{name: "query", apiURL: "https://api.e2a.dev?tenant=one", wantErr: true},
+		{name: "fragment", apiURL: "https://api.e2a.dev#issuer", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{
+				HTTP:  HTTPConfig{APIURL: tc.apiURL},
+				Trash: TrashConfig{RetentionDays: 1},
+			}
+			err := cfg.Validate()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("Validate() accepted invalid http.api_url %q", tc.apiURL)
+				}
+				if !strings.Contains(err.Error(), "http.api_url") {
+					t.Errorf("error = %q, want http.api_url context", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Validate() rejected http.api_url %q: %v", tc.apiURL, err)
+			}
+		})
+	}
+}
+
 func TestLoadConfigOIDCDefaultsDisabled(t *testing.T) {
 	dir := t.TempDir()
 	cfgPath := filepath.Join(dir, "config.yaml")

--- a/internal/oauth/client.go
+++ b/internal/oauth/client.go
@@ -27,19 +27,25 @@ type Client struct {
 	CreatedByUserID          string
 }
 
-// fosite.Client interface methods. We satisfy the minimal Client
-// interface; richer subtypes (e.g. ResponseModeClient, OpenIDConnect-
-// Client) are deliberately not implemented because we don't support
-// those flows.
+// fosite.Client interface methods. We also implement ResponseModeClient
+// because OAuth discovery advertises explicit query-mode support. Richer
+// subtypes such as OpenIDConnectClient remain deliberately unsupported.
 
 func (c *Client) GetID() string                      { return c.ID }
-func (c *Client) GetHashedSecret() []byte             { return c.SecretHash }
-func (c *Client) GetRedirectURIs() []string           { return c.RedirectURIs }
-func (c *Client) GetGrantTypes() fosite.Arguments     { return fosite.Arguments(c.GrantTypeStrings) }
-func (c *Client) GetResponseTypes() fosite.Arguments  { return fosite.Arguments(c.ResponseTypeStrings) }
-func (c *Client) GetScopes() fosite.Arguments         { return fosite.Arguments(c.ScopeStrings) }
-func (c *Client) IsPublic() bool                      { return c.Public }
-func (c *Client) GetAudience() fosite.Arguments       { return fosite.Arguments(c.AudienceStrings) }
+func (c *Client) GetHashedSecret() []byte            { return c.SecretHash }
+func (c *Client) GetRedirectURIs() []string          { return c.RedirectURIs }
+func (c *Client) GetGrantTypes() fosite.Arguments    { return fosite.Arguments(c.GrantTypeStrings) }
+func (c *Client) GetResponseTypes() fosite.Arguments { return fosite.Arguments(c.ResponseTypeStrings) }
+func (c *Client) GetScopes() fosite.Arguments        { return fosite.Arguments(c.ScopeStrings) }
+func (c *Client) IsPublic() bool                     { return c.Public }
+func (c *Client) GetAudience() fosite.Arguments      { return fosite.Arguments(c.AudienceStrings) }
+
+// GetResponseModes returns the authorization response modes accepted from
+// every registered client. The server supports authorization code flow only,
+// whose default and sole explicit response mode is query.
+func (c *Client) GetResponseModes() []fosite.ResponseModeType {
+	return []fosite.ResponseModeType{fosite.ResponseModeDefault, fosite.ResponseModeQuery}
+}
 
 // GetTokenEndpointAuthMethod returns the registered auth method.
 // fosite reads this opportunistically via a runtime type-assert on
@@ -54,3 +60,4 @@ func (c *Client) GetTokenEndpointAuthMethod() string { return c.TokenEndpointAut
 // assertion. Until then, the minimal fosite.Client surface is enough
 // for auth_code + PKCE + refresh + revoke.
 var _ fosite.Client = (*Client)(nil)
+var _ fosite.ResponseModeClient = (*Client)(nil)


### PR DESCRIPTION
## Summary

- append the RFC 9207 `iss` parameter to redirecting OAuth authorization errors
- accept explicit `response_mode=query`, matching authorization-server discovery
- normalize unsupported fragment/form-post error responses to the server's sole advertised query mode
- preserve fosite as the authority for request validation, OAuth error parameters, and redirect matching
- fail closed when a non-DCR client row contains a dangerous redirect scheme
- reject malformed OAuth issuer/API URLs during configuration validation
- leave direct errors for unknown clients or untrusted redirect URIs unchanged

## Root cause

e2a's authorization-server metadata advertised two capabilities that the implementation honored only partially:

1. `authorization_response_iss_parameter_supported: true`, while only successful authorization responses included `iss`.
2. `response_modes_supported: ["query"]`, while clients that explicitly requested `response_mode=query` were rejected because the stored client type did not implement fosite's response-mode interface.

This PR aligns authorization behavior with discovery. It does **not** claim to resolve the separate Codex MCP login failure: the pinned Codex client ignores `iss` and does not send `response_mode`, so that issue remains open for request-level diagnosis.

## Verification

- RED: denied-consent and invalid-scope redirects omitted `iss`
- RED: explicit `response_mode=query` returned `unsupported_response_mode`
- RED: fragment split `iss` from `error`/`state`; form-post returned HTML without `iss`
- RED: a database-seeded `javascript:` redirect emitted an executable `Location`
- RED: malformed `http.api_url` values were accepted during startup validation
- focused OAuth/config regression and control tests passed
- isolated `E2A_TEST_DATABASE_URL=... make test` passed across all Go packages
- real binary startup rejected an invalid `/` API URL before service initialization
- real local service:
  - explicit query mode returned `302` to login with `response_mode=query` preserved
  - a database-seeded dangerous redirect returned `400` with no `Location`
  - unsupported fragment/form-post errors returned `303` query redirects containing `error`, `state`, and `iss`
  - unknown client remained a direct `401` without a redirect
