### PR TITLE
fix(delivery): re-fire domain.suppression_added on a genuine re-suppression

### DIFF
--- a/internal/delivery/consumer.go
+++ b/internal/delivery/consumer.go
@@ -65,7 +65,10 @@ type Store interface {
 	// a duplicate/older event is a no-op.
 	RecordDeliveryOutcomeTx(ctx context.Context, tx pgx.Tx, messageID, address string, status Status, detail string) (applied bool, err error)
 	// AddSuppression idempotently inserts a (user, address) suppression.
-	// added=false when it already existed (so the event fires at most once).
+	// added=false when it already existed, so an upsert no-op fires no event.
+	// This is per-INSERT, not once-per-address-forever: if the caller deletes a
+	// suppression and the address is suppressed again later, that is a genuine
+	// new insert and does fire.
 	AddSuppressionTx(ctx context.Context, tx pgx.Tx, userID, address, reason, source, sourceMessageID string) (suppressionID string, added bool, err error)
 	AppendLifecycleTx(ctx context.Context, tx pgx.Tx, input messagelifecycle.AppendInput) (messagelifecycle.MessageLifecycleTransition, error)
 }
@@ -275,7 +278,31 @@ func (c *Consumer) Process(ctx context.Context, ev *Event) error {
 						return err
 					}
 					if c.fire != nil {
-						event := FiredEvent{UserID: m.UserID, Type: EventSuppressionAdded, Data: eventpayload.DomainSuppressionAddedData{Address: r.Address, Source: source, Reason: r.Detail, MessageID: m.MessageID, LifecycleTransitions: []messagelifecycle.MessageLifecycleTransition{suppressionTransition}}, DedupKey: EventSuppressionAdded + "|" + m.UserID + "|" + r.Address, OccurredAt: ev.OccurredAt}
+						// Dedup on the PROVIDER NOTIFICATION, not on (user, address).
+						//
+						// The old key was EventSuppressionAdded|userID|address, which
+						// fired the event at most once per address for the lifetime of
+						// the account. That guarded against nothing: once an address is
+						// suppressed, a send to it is refused with 422
+						// recipient_suppressed BEFORE it reaches the provider (see
+						// internal/agent/api.go), so no second bounce can occur and
+						// there is no repeat-event stream to protect anyone from.
+						//
+						// The only route to a second suppression is the remediation the
+						// docs prescribe — DELETE /v1/account/suppressions/{address},
+						// then send again. That is a deliberate act on the belief that
+						// the address is fixed, and if it bounces again that belief was
+						// wrong. Staying silent there left the caller's webhook-driven
+						// state saying "deliverable" while e2a said "suppressed", with
+						// every later send failing for a reason they could not see.
+						//
+						// Keying on ProviderEventID matches the sibling delivery events
+						// (feedbackDedupeKey below): a REDELIVERED SNS notification —
+						// the duplicate that actually happens — still dedups, while a
+						// genuinely new suppression notifies. AddSuppressionTx's `added`
+						// flag remains the guard that this is a real insert, not an
+						// upsert no-op.
+						event := FiredEvent{UserID: m.UserID, Type: EventSuppressionAdded, Data: eventpayload.DomainSuppressionAddedData{Address: r.Address, Source: source, Reason: r.Detail, MessageID: m.MessageID, LifecycleTransitions: []messagelifecycle.MessageLifecycleTransition{suppressionTransition}}, DedupKey: "provider-feedback:" + ev.ProviderEventID + ":" + r.Address + ":" + EventSuppressionAdded, OccurredAt: ev.OccurredAt}
 						suppressionEvent = &event
 					}
 				}

--- a/internal/delivery/suppression_refire_test.go
+++ b/internal/delivery/suppression_refire_test.go
@@ -1,0 +1,116 @@
+package delivery
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// A suppression that is deleted and later re-created must fire
+// domain.suppression_added again.
+//
+// The event used to dedup on (type, userID, address), so it fired at most once
+// per address for the lifetime of an account. That guarded against nothing:
+// once an address is suppressed, a send to it is refused with 422
+// recipient_suppressed BEFORE it reaches the provider, so no second bounce can
+// occur and there is no repeat-event stream to protect anyone from.
+//
+// The only route to a second suppression is the remediation the docs prescribe
+// — DELETE /v1/account/suppressions/{address}, then send again. That is a
+// deliberate act on the belief the address is fixed; if it bounces again, that
+// belief was wrong, and staying silent left the caller's webhook-driven state
+// saying "deliverable" while e2a said "suppressed".
+//
+// Found by the first production conformance run: the suppression rows were
+// created with timestamps matching their email.bounced / email.complained
+// siblings, but no domain.suppression_added accompanied them.
+func TestSuppressionAddedRefiresAfterDeleteAndReBounce(t *testing.T) {
+	ctx := context.Background()
+	const user, addr = "u_1", "bounce@x.com"
+
+	fireOnce := func(providerEventID string) []firedEvent {
+		store := newFakeConsumerStore()
+		store.corr["ses-1"] = &CorrelatedMessage{MessageID: "msg_1", UserID: user, AgentID: "bot@x.com"}
+		fire, events := recordingFirer()
+		c := NewConsumer(store, fire)
+		err := c.Process(ctx, &Event{
+			ProviderEventID: providerEventID, OccurredAt: testFeedbackOccurredAt,
+			Kind: KindBounce, SESMessageID: "ses-1",
+			Recipients: []RecipientOutcome{{Address: addr, Status: StatusBounced, Detail: "550 user unknown", Suppress: true}},
+		})
+		if err != nil {
+			t.Fatalf("Process(%s): %v", providerEventID, err)
+		}
+		return *events
+	}
+
+	suppressionKeys := func(evs []firedEvent) []string {
+		var keys []string
+		for _, e := range evs {
+			if e.eventType == EventSuppressionAdded {
+				keys = append(keys, e.dedupKey)
+			}
+		}
+		return keys
+	}
+
+	// First bounce — a fresh store means the suppression is genuinely inserted.
+	first := suppressionKeys(fireOnce("sns-bounce-1"))
+	if len(first) != 1 {
+		t.Fatalf("first bounce fired %d %s events, want 1", len(first), EventSuppressionAdded)
+	}
+
+	// The caller deletes the suppression and sends again; the address bounces a
+	// second time, arriving as a DIFFERENT provider notification. A fresh store
+	// models the post-delete state — the row is gone, so this is a real insert.
+	second := suppressionKeys(fireOnce("sns-bounce-2"))
+	if len(second) != 1 {
+		t.Fatalf("re-bounce after delete fired %d %s events, want 1 — a genuinely new suppression must notify, or the caller's webhook state silently desyncs", len(second), EventSuppressionAdded)
+	}
+
+	// The keys must differ, or the publisher dedups the second one away. This is
+	// the assertion that actually catches the regression: both events are
+	// constructed either way, but identical keys mean only one is ever delivered.
+	if first[0] == second[0] {
+		t.Fatalf("dedup key is identical across two distinct provider notifications (%q) — the second event would be deduped away, which is the bug", first[0])
+	}
+
+	// And the key must be derived from the provider notification, matching the
+	// sibling delivery events, so that a REDELIVERED notification still dedups.
+	for _, k := range []string{first[0], second[0]} {
+		if !strings.HasPrefix(k, "provider-feedback:") {
+			t.Fatalf("dedup key %q should be derived from the provider notification (provider-feedback:<ProviderEventID>:...), matching feedbackDedupeKey, so redeliveries still dedup", k)
+		}
+	}
+}
+
+// The same provider notification arriving twice — the duplicate that actually
+// happens with SNS at-least-once delivery — must still dedup to one event.
+func TestSuppressionAddedDedupsARedeliveredNotification(t *testing.T) {
+	ctx := context.Background()
+
+	run := func() string {
+		store := newFakeConsumerStore()
+		store.corr["ses-1"] = &CorrelatedMessage{MessageID: "msg_1", UserID: "u_1", AgentID: "bot@x.com"}
+		fire, events := recordingFirer()
+		c := NewConsumer(store, fire)
+		if err := c.Process(ctx, &Event{
+			ProviderEventID: "sns-redelivered", OccurredAt: testFeedbackOccurredAt,
+			Kind: KindBounce, SESMessageID: "ses-1",
+			Recipients: []RecipientOutcome{{Address: "bounce@x.com", Status: StatusBounced, Detail: "550 user unknown", Suppress: true}},
+		}); err != nil {
+			t.Fatalf("Process: %v", err)
+		}
+		for _, e := range *events {
+			if e.eventType == EventSuppressionAdded {
+				return e.dedupKey
+			}
+		}
+		t.Fatal("no suppression event fired")
+		return ""
+	}
+
+	if a, b := run(), run(); a != b {
+		t.Fatalf("the SAME provider notification produced different dedup keys (%q vs %q) — a redelivered SNS message would fire twice", a, b)
+	}
+}


### PR DESCRIPTION
Found by the **first production conformance run**. The suppression rows were
created with timestamps matching their `email.bounced` / `email.complained`
siblings exactly — `06:11:33.061679Z` and `06:12:16.173533Z` — but no
`domain.suppression_added` accompanied them.

## The bug

The event deduped on `(type, userID, address)`:

```go
DedupKey: EventSuppressionAdded + "|" + m.UserID + "|" + r.Address
```

No event id, no message, no time — so it fires **at most once per address for
the lifetime of an account**.

## Why that guard protects nothing

Once an address is suppressed, a send to it is refused with `422
recipient_suppressed` **before it reaches the provider**
(`internal/agent/api.go:1200`). No second bounce can occur, so there is no
repeat-event stream to dedup.

The only route to a second suppression is the remediation the docs prescribe:

> remove the suppression (`DELETE /v1/account/suppressions/{address}`) and approve again

That's a deliberate act on the belief the address is fixed. If it bounces again,
that belief was wrong — and that is the **worst possible moment to go silent**.
The caller's webhook-driven state now says *deliverable* while e2a says
*suppressed*, and every later send fails for a reason they cannot see.

Cost of re-firing: effectively zero noise, since reaching it requires a
deliberate delete. Cost of staying silent: a permanent, invisible desync.

## The fix

Key on the provider notification, matching the sibling delivery events
(`feedbackDedupeKey`):

```go
DedupKey: "provider-feedback:" + ev.ProviderEventID + ":" + r.Address + ":" + EventSuppressionAdded
```

A **redelivered** SNS message — the duplicate that actually happens under
at-least-once delivery — still dedups. A genuinely new suppression notifies.

`AddSuppressionTx`'s `added` flag is untouched and still guards that this is a
real INSERT rather than an upsert no-op. Its doc comment claimed "the event
fires at most once", which described the old key rather than that flag's actual
per-insert semantics; corrected.

## The tests catch the bug, not the fix

Written to fail against the original code, and verified. With the old key
restored:

```
--- FAIL: TestSuppressionAddedRefiresAfterDeleteAndReBounce
    dedup key is identical across two distinct provider notifications
    ("domain.suppression_added|u_1|bounce@x.com") — the second event would be
    deduped away, which is the bug
```

The second test pins the property that must **not** change: the same provider
notification arriving twice still produces exactly one event.

`internal/delivery` and `internal/identity` green; build and `go vet` clean.

## Note

This also makes the prod SES-feedback suite re-runnable, which it wasn't — but
that's a consequence, not the goal. Had the answer been "fire once", the right
move would have been to fix the test instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)