### PR TITLE
test(e2e-prod): email.failed is staging-triggerable, not prod-triggerable

### DIFF
--- a/tests/e2e-prod/event_coverage_gate.py
+++ b/tests/e2e-prod/event_coverage_gate.py
@@ -48,6 +48,11 @@ ENVIRONMENT-AWARE ALLOWLIST: two tiers.
     domain.sending_failed now — it needs a real AWS-classified sending-identity
     FAILURE, and no suite has induced one anywhere; prod-vs-staging does not
     unlock it.
+  - PROD_ONLY_ALLOWLIST: the INVERSE — allowlisted only on a production run,
+    REQUIRED on staging. email.failed lives here because its deterministic
+    trigger is manufactured by staging's narrow SES IAM scope, which production
+    deliberately lacks. Tiering is therefore not "prod can do more": each
+    environment can do things the other cannot.
   - STAGING_ONLY_ALLOWLIST: allowlisted ONLY when this run did not target
     production. Most trace back to the real-SES-feedback blocker staging's
     e2a-staging-smtp IAM policy imposes; production has no such block, so a
@@ -130,6 +135,27 @@ STAGING_ONLY_ALLOWLIST = {
 }
 
 
+# Allowlisted ONLY on a PRODUCTION run — REQUIRED on staging. The inverse of the
+# tier above, and it exists because one trigger is manufactured by staging's
+# DELIBERATELY NARROW SES IAM scope, which production does not have.
+PROD_ONLY_ALLOWLIST = {
+    "email.failed": "the only deterministic trigger is a SYNCHRONOUS provider "
+    "refusal, which staging manufactures by scoping ses:SendRawEmail to a small "
+    "recipient allowlist — a send outside it gets an SMTP 554 and the outbound "
+    "worker terminally fails the message. Production's sending identity is "
+    "deliberately NOT recipient-scoped, so the identical send is accepted and the "
+    "unroutable recipient bounces asynchronously instead (live-probed 2026-07-26: "
+    "only email.sent appeared). There is no safe production equivalent: a genuine "
+    "SES Reject needs a virus payload, which is inappropriate to send from a real "
+    "sending identity and counts against reputation; and the other terminal path "
+    "— every recipient suppressed at send time — is unreachable because the API "
+    "pre-checks suppression and returns 422 before the message is queued. "
+    "suites/21-webhook-events.test.ts asserts production's real outcome (the send "
+    "IS accepted) rather than skipping, so neither environment reports a vacuous "
+    "pass.",
+}
+
+
 def load_event_types(openapi_path):
     try:
         import yaml
@@ -170,7 +196,7 @@ def main():
 
     # An allowlist entry that no longer names a real event type is a silent hole
     # (e.g. the type was renamed) — fail loudly so either tier can't drift stale.
-    stale = (set(ALWAYS_ALLOWLIST) | set(STAGING_ONLY_ALLOWLIST)) - all_types
+    stale = (set(ALWAYS_ALLOWLIST) | set(STAGING_ONLY_ALLOWLIST) | set(PROD_ONLY_ALLOWLIST)) - all_types
     if stale:
         print(
             f"event_coverage_gate: allowlist entries not in the spec (renamed/removed?): {sorted(stale)}",
@@ -187,6 +213,7 @@ def main():
     allowlist = dict(ALWAYS_ALLOWLIST)
     if targeted_prod:
         env_label = "PRODUCTION"
+        allowlist.update(PROD_ONLY_ALLOWLIST)
     else:
         env_label = "non-production (staging/self-hosted)"
         allowlist.update(STAGING_ONLY_ALLOWLIST)

--- a/tests/e2e-prod/suites/21-webhook-events.test.ts
+++ b/tests/e2e-prod/suites/21-webhook-events.test.ts
@@ -4,6 +4,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { ApiClient } from "../harness/client.ts";
 import { isEventsLogDisabled } from "../harness/event-capability.ts";
+import { isProductionTarget } from "../harness/env.ts";
 import { uniqueSlug, uniqueSubject, holdAllOutbound } from "../harness/fixtures.ts";
 import { writeReport, info } from "../harness/report.ts";
 
@@ -665,7 +666,30 @@ test("emit: email.flagged — an inbound gate the self-sender doesn't satisfy em
 // deliberately scoped for safety rather than by a bad mailbox. The recipient
 // uses the RFC 2606 `.invalid` TLD so it stays unroutable even if that IAM
 // scope ever widens.
+// ON PRODUCTION THIS TRIGGER DOES NOT APPLY, and that is the point.
+//
+// The refusal above is manufactured by staging's DELIBERATELY NARROW SES IAM
+// scope. Production's sending identity is not scoped that way — it may send to
+// any recipient — so the identical request is ACCEPTED, `email.sent` fires, and
+// the unroutable .invalid domain produces an asynchronous BOUNCE instead of a
+// synchronous submission rejection. Confirmed by live-probing production
+// 2026-07-26: the send returned accepted and only email.sent appeared.
+//
+// This inverts the usual tiering. Normally production can exercise what staging
+// cannot; here staging's *restrictive* IAM policy is itself the test fixture,
+// and production deliberately lacks it. There is no safe production equivalent:
+// a genuine SES Reject needs a virus payload (inappropriate to send from a real
+// sending identity, and it counts against reputation), and the other terminal
+// path — every recipient suppressed at send time — is unreachable because the
+// API pre-checks suppression and returns 422 before the message is ever queued.
+//
+// So each environment asserts the outcome that is REAL for it. Neither branch
+// skips: a skip here would let the suite report green while verifying nothing,
+// which is the exact failure mode this repo has already been bitten by.
+// email.failed is correspondingly allowlisted on production in
+// event_coverage_gate.py's PROD_ONLY_ALLOWLIST, and required on staging.
 const UNAUTHORIZED_RECIPIENT = "emit-failed-probe@nonexistent-e2e-events.invalid";
+const TARGET_IS_PROD = isProductionTarget(client.env.apiUrl);
 test("emit: email.failed — a provider-refused send emits the event and attempts a delivery", { skip }, async () => {
   const email = await createAgent("failed");
   const hook = await createHook(["email.failed"]);
@@ -674,6 +698,22 @@ test("emit: email.failed — a provider-refused send emits the event and attempt
     const send = await client.post<SendResult>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
       body: { to: [UNAUTHORIZED_RECIPIENT], subject: uniqueSubject("emit failed"), text: "provider-refused send" },
     });
+
+    if (TARGET_IS_PROD) {
+      // Production accepts the send — its identity is not recipient-scoped.
+      // Assert that real outcome rather than skipping: the request is accepted
+      // and the message is durably queued with an id.
+      assert.equal(send.status, 202, `send expected 202 accepted, got ${send.status}: ${send.raw.slice(0, 200)}`);
+      assert.equal(send.body?.status, "accepted", "production accepts the send — its sending identity is not recipient-scoped like staging's");
+      assert.ok(send.body?.message_id, "an accepted send carries a message id");
+      info(
+        SUITE,
+        "email.failed-not-triggerable-on-prod",
+        `production accepted the send to ${UNAUTHORIZED_RECIPIENT} (msg=${send.body!.message_id}) — staging's narrow ses:SendRawEmail scope is what manufactures the synchronous refusal, and prod deliberately lacks it. email.failed is allowlisted for prod in event_coverage_gate.py; it stays REQUIRED on staging.`,
+      );
+      return;
+    }
+
     // The async pipeline always accepts first; the terminal failure arrives
     // via the email.failed event (or GET .../messages/{id}), not the HTTP status.
     assert.equal(send.status, 202, `send expected 202 accepted, got ${send.status}: ${send.raw.slice(0, 200)}`);


### PR DESCRIPTION
The second of two failures from the first production conformance run.
(The first was a genuine product defect — [#727](https://github.com/tokencanopy/e2a/pull/727).) This one is
environmental, and the direction is the interesting part.

## Why it failed on prod

`email.failed`'s trigger is manufactured by **staging's deliberately narrow SES
IAM scope**: a send outside its recipient allowlist gets a synchronous SMTP
`554 Access denied`, and the outbound worker terminally fails the message.

Production's sending identity is **not** recipient-scoped, so the identical send
is accepted. Live-probed 2026-07-26 — only `email.sent` appeared, and the
unroutable `.invalid` recipient bounces asynchronously instead of being refused
at submission.

## This inverts the usual tiering

Normally production exercises what staging cannot. Here **staging's restrictive
policy is itself the test fixture**, and production deliberately lacks it.

There's no safe production equivalent:

- a genuine SES **Reject** needs a virus payload — inappropriate to send from a
  real sending identity, and it counts against reputation
- the other terminal path, *every recipient suppressed at send time*, is
  unreachable because the API pre-checks suppression and returns `422` before
  the message is ever queued

## The fix: each environment asserts what's real for it

| | Assertion |
|---|---|
| **staging** | unchanged — the 554, `email.failed` with `reason_code=submission.provider_rejected`, fanout, delivery attempt |
| **production** | the send **is accepted** with a message id, and records why the event cannot follow |

**Neither branch skips.** A skip would let the suite report green while
verifying nothing — the exact failure mode this repo has already been bitten by
(`12-mcp-extended`'s `get_message` returned early on an empty inbox while
reporting 18/18).

## Gate: a third tier

`event_coverage_gate.py` gains `PROD_ONLY_ALLOWLIST`, the inverse of
`STAGING_ONLY_ALLOWLIST`. The stale-entry check now covers all three tiers, so a
renamed event still can't rot in any of them.

Verified in all three directions:

```
prod,    no email.failed  -> 0   (allowlisted there)
staging, no email.failed  -> 1   (REQUIRED there)
staging, with it          -> 0
```

And both branches run green against their live environments — staging still gets
the real `554 Access denied ... user/e2a-staging` and emits the event;
production accepts the send.

🤖 Generated with [Claude Code](https://claude.com/claude-code)