### PR TITLE
test(e2e-prod): the inbound-MX round trip runs on staging too

### DIFF
--- a/tests/e2e-prod/suites/29-inbound-mx.test.ts
+++ b/tests/e2e-prod/suites/29-inbound-mx.test.ts
@@ -2,9 +2,9 @@ import { test, after } from "node:test";
 import assert from "node:assert/strict";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { ApiClient } from "../../harness/client.ts";
-import { uniqueSlug, uniqueSubject } from "../../harness/fixtures.ts";
-import { writeReport, info } from "../../harness/report.ts";
+import { ApiClient } from "../harness/client.ts";
+import { uniqueSlug, uniqueSubject } from "../harness/fixtures.ts";
+import { writeReport, info } from "../harness/report.ts";
 
 // PRODUCTION-ONLY: a genuine agent-to-agent send over the REAL wire — SES
 // egress, a real external MX hop back into e2a's own inbound SMTP listener —
@@ -55,7 +55,7 @@ import { writeReport, info } from "../../harness/report.ts";
 // proved the same dual-assertion way. Flagged explicitly rather than silently
 // assumed; a follow-up with a real capture endpoint would tighten this to an
 // actual byte-level signature check.
-const SUITE = "prod/30-inbound-mx";
+const SUITE = "29-inbound-mx";
 const client = new ApiClient();
 
 const EVENT_COVERAGE_DIR = fileURLToPath(new URL("../../reports/event-coverage/", import.meta.url));
@@ -252,13 +252,30 @@ test("real wire round trip: agent A → agent B egresses via SES and re-enters o
       agentA.toLowerCase(),
       "header_from is e2a's own relay address for a shared-domain send, not the sending agent's own address (that equality only holds for a customer's sending-verified domain)",
     );
-    assert.ok(
-      String(envelopeFrom).toLowerCase().endsWith("send.e2a.dev"),
-      `envelope_from is expected under the outbound relay's own domain (send.e2a.dev, or SES's custom MAIL FROM subdomain mail.send.e2a.dev), got ${JSON.stringify(envelopeFrom)}`,
+    // Assert the SHAPE, not a literal domain. What proves the wire path is that
+    // envelope_from is a VERP bounce token under SES's custom MAIL FROM
+    // subdomain — NOT that the domain is the production one. Hardcoding
+    // send.e2a.dev made this suite fail on staging purely because its relay is
+    // send-staging.e2a.dev, even though the round trip completed correctly.
+    //   prod:    ...@mail.send.e2a.dev
+    //   staging: ...@mail.send-staging.e2a.dev
+    // The distinguishing property against a loopback short-circuit is the same
+    // either way: a loopback never leaves e2a, so envelope_from would be the
+    // agent's own address rather than a provider-generated return-path.
+    assert.match(
+      String(envelopeFrom).toLowerCase(),
+      /^[^@]+@mail\.send(-[a-z0-9-]+)?\.e2a\.dev$/,
+      `envelope_from should be SES's VERP return-path under the deployment's custom MAIL FROM subdomain (mail.send.e2a.dev on prod, mail.send-staging.e2a.dev on staging) — that is what proves the message left via SES and re-entered over the MX rather than short-circuiting through loopback. Got ${JSON.stringify(envelopeFrom)}`,
     );
-    assert.ok(
-      String(headerFrom).toLowerCase().endsWith("send.e2a.dev"),
-      `header_from is expected under the outbound relay's own domain (send.e2a.dev), got ${JSON.stringify(headerFrom)}`,
+    // Shape, not a literal domain — same reasoning as envelope_from above. The
+    // relay's from_domain is deployment-specific (send.e2a.dev on prod,
+    // send-staging.e2a.dev on staging); what matters is that header_from is the
+    // RELAY's address and not the sending agent's, which the assert.equal above
+    // already pins.
+    assert.match(
+      String(headerFrom).toLowerCase(),
+      /^[^@]+@send(-[a-z0-9-]+)?\.e2a\.dev$/,
+      `header_from should be the deployment's own outbound relay address (agent@send.e2a.dev on prod, agent@send-staging.e2a.dev on staging), got ${JSON.stringify(headerFrom)}`,
     );
     assert.notEqual(
       receivedEv!.data.authentication,

--- a/tests/reports/event-coverage/10945.json
+++ b/tests/reports/event-coverage/10945.json
@@ -1,0 +1,1 @@
+["email.sent"]

--- a/tests/reports/event-coverage/12446.json
+++ b/tests/reports/event-coverage/12446.json
@@ -1,0 +1,1 @@
+["email.sent"]

--- a/tests/reports/event-coverage/12789.json
+++ b/tests/reports/event-coverage/12789.json
@@ -1,0 +1,1 @@
+["email.sent","email.received"]

--- a/tests/reports/event-coverage/13397.json
+++ b/tests/reports/event-coverage/13397.json
@@ -1,0 +1,1 @@
+["email.sent"]

--- a/tests/reports/event-coverage/15033.json
+++ b/tests/reports/event-coverage/15033.json
@@ -1,0 +1,1 @@
+["email.sent","email.received"]

--- a/tests/reports/event-coverage/15362.json
+++ b/tests/reports/event-coverage/15362.json
@@ -1,0 +1,1 @@
+["email.sent","email.received"]


### PR DESCRIPTION
Written as prod-only on the strength of an `AGENTS.md` claim that turned out to
be false.

## The claim

> a distinct agent→agent send on the shared domain egresses via SES and fails
> **(staging has no external MX)**

Both halves are wrong:

```
dig MX agents-staging.e2a.dev  →  mx-staging.e2a.dev  →  34.45.86.55
```

and a live send between two distinct agents on the staging shared domain is
**delivered in ~10s** over that MX. Corrected in ops `AGENTS.md` separately.

## Why the location mattered

`suites/prod/` only runs under `npm run test:prod`. Left there, **staging never
exercised the real wire path at all** — a coverage loss for no reason, and
exactly what that directory's own README warns against:

> If staging *can* do it, the test belongs in `suites/`, not here.

## Two assertions hardcoded prod's domain

| | prod | staging |
|---|---|---|
| `envelope_from` | `…@mail.send.e2a.dev` | `…@mail.send-staging.e2a.dev` |
| `header_from` | `agent@send.e2a.dev` | `agent@send-staging.e2a.dev` |

Both now match a pattern instead of a literal. **This is stronger, not weaker.**
What distinguishes the real wire path from the `IsSelfSend` loopback
short-circuit is that `envelope_from` is a *provider-generated VERP
return-path* rather than the agent's own address — a property, not a particular
domain. The suite was asserting the deployment it happened to be written
against.

## Verification

Run against **both** environments, which is the actual proof it never needed to
be prod-only:

```
staging:     1/1
production:  1/1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)