### PR TITLE
docs: fix stale coverage-floor list and MCP tool-count claims

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
   "plugins": [
     {
       "name": "e2a",
-      "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 50 MCP tools over hosted streamable HTTP with OAuth.",
+      "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 60 MCP tools over hosted streamable HTTP with OAuth.",
       "category": "productivity",
       "source": "./plugins/e2a",
       "homepage": "https://e2a.dev"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,7 +292,7 @@ manually on every API change even though the template won't remind you.
   `./internal/sendramp` and `./internal/outboundsend` with `-race`.
 - **Coverage ratchet**: `.testcoverage.yml` sets per-package floors (currently
   webhook, webhookpub, webhookdelivery, httpapi, outboundsend, sendramp,
-  inboundprocess, jobs, auth, apiserver, loopback).
+  inboundprocess, jobs, auth, apiserver, loopback, inboundscreen).
   Ratchet floors UP, never down. `make cover-check` runs the same gate CI
   runs (`vladopajic/go-test-coverage`).
 - **Contract tests**: TS and Python SDK contract tests run against

--- a/plugins/e2a/.claude-plugin/plugin.json
+++ b/plugins/e2a/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "e2a",
   "displayName": "e2a",
   "version": "0.5.0",
-  "description": "Authenticated email gateway for AI agents — per-agent inboxes, SPF/DKIM verification, and a queryable, replayable event log. 50 MCP tools over hosted streamable HTTP with OAuth.",
+  "description": "Authenticated email gateway for AI agents — per-agent inboxes, SPF/DKIM verification, and a queryable, replayable event log. 60 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "TokenCanopy",
     "url": "https://e2a.dev"

--- a/plugins/e2a/.codex-plugin/plugin.json
+++ b/plugins/e2a/.codex-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "e2a",
   "displayName": "e2a",
   "version": "0.5.0",
-  "description": "Authenticated email gateway for AI agents — per-agent inboxes, SPF/DKIM verification, and a queryable, replayable event log. 50 MCP tools over hosted streamable HTTP with OAuth.",
+  "description": "Authenticated email gateway for AI agents — per-agent inboxes, SPF/DKIM verification, and a queryable, replayable event log. 60 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "TokenCanopy"
   },

--- a/plugins/e2a/.cursor-plugin/plugin.json
+++ b/plugins/e2a/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "e2a",
   "displayName": "e2a",
   "version": "0.5.0",
-  "description": "Authenticated email gateway for AI agents — per-agent inboxes, SPF/DKIM verification, and a queryable, replayable event log. 50 MCP tools over hosted streamable HTTP with OAuth.",
+  "description": "Authenticated email gateway for AI agents — per-agent inboxes, SPF/DKIM verification, and a queryable, replayable event log. 60 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "TokenCanopy",
     "url": "https://e2a.dev"


### PR DESCRIPTION
## Summary

Scheduled documentation audit across all `.md` files in the repo (READMEs, `docs/`, examples, plugin/skill docs, plugin manifests). Every claim below was verified against the current code before being changed. `docs/design/**` and `docs/superpowers/**` (dated design docs/plans) were intentionally excluded as out of scope.

## What was outdated → what changed

- **`AGENTS.md`** — the "Coverage ratchet" package list (`.testcoverage.yml` per-package floors) omitted `internal/inboundscreen`. Verified: `.testcoverage.yml:63` gates `^internal/inboundscreen$` at 88% (it's the shared screening core for both the SMTP and loopback self-send paths), alongside the 11 packages already listed. Added it.

- **Plugin manifest tool-count** (`plugins/e2a/.claude-plugin/plugin.json`, `plugins/e2a/.codex-plugin/plugin.json`, `plugins/e2a/.cursor-plugin/plugin.json`, root `.claude-plugin/marketplace.json`) — all four still advertised "50 MCP tools" in their description field. The actual MCP surface is **60 tools** (16 runtime + 44 admin, per `mcp/src/tools/tiers.ts`'s `RUNTIME_TOOLS`/`ADMIN_TOOLS`), which `plugins/e2a/skills/e2a/SKILL.md` already states correctly. Two prior fix passes (#645 and a follow-up commit) corrected this figure everywhere it appeared in `mcp/README.md`, the example READMEs, and the skill doc, but never touched these four manifests, which carry a separate description string. Updated all four to 60.

Confirmed `node scripts/validate-plugin.mjs` still reports manifests in sync, and `bash scripts/check-repository-text-integrity.sh` passes.

Everything else audited (root docs, `docs/`, CLI/SDK docs, MCP + example docs, web/plugin docs, `tests/*` READMEs) checked out against current code — no other high-confidence issues found.

## Test plan
- [x] `node scripts/validate-plugin.mjs` — manifests in sync
- [x] `bash scripts/check-repository-text-integrity.sh` — passes
- [x] Both changed claims cross-checked against cited source (`.testcoverage.yml`, `mcp/src/tools/tiers.ts`)
- [ ] Reviewer sanity-check of wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Ue9MZ8tqe4V6E2nhbvggK

---
_Generated by [Claude Code](https://claude.ai/code/session_012Ue9MZ8tqe4V6E2nhbvggK)_