### PR TITLE
test(e2e-prod): stop a failed SES-feedback run from wedging the suite

### DIFF
--- a/tests/e2e-prod/suites/prod/31-ses-feedback.test.ts
+++ b/tests/e2e-prod/suites/prod/31-ses-feedback.test.ts
@@ -147,6 +147,31 @@ async function delHook(id: string): Promise<void> {
   await client.delete(`/v1/webhooks/${encodeURIComponent(id)}?confirm=DELETE`);
 }
 
+// Best-effort un-suppress. Unlike the ASSERTED deleteSuppression call inside
+// each test (which is real coverage of that operation's happy path), this
+// swallows every outcome — a 404 just means the address wasn't suppressed.
+//
+// It runs BOTH before the send and in the finally, and that pairing is the
+// point. These simulator addresses are shared, account-scoped state: once
+// suppressed, every later send to them is refused with 422
+// recipient_suppressed. A failure anywhere between the send and the asserted
+// delete used to leak the suppression, and because the very next run then
+// failed at its own send — before reaching any cleanup — the leak re-armed
+// itself. One red run permanently wedged the suite until someone deleted the
+// suppression by hand. Observed on the 2026-07-26 production run: bounce@ and
+// complaint@ were still suppressed from the previous night's failed run.
+//
+// The finally sweep stops a failure from leaking; the pre-send clear lets an
+// already-wedged account heal on its own next run. Neither alone is enough.
+async function clearSuppression(address: string): Promise<void> {
+  try {
+    await client.delete(`/v1/account/suppressions/${encodeURIComponent(address)}?confirm=DELETE`);
+  } catch {
+    // Network/transport failure during best-effort cleanup — never mask the
+    // real test failure this finally block is unwinding from.
+  }
+}
+
 // Generous async budget: SES → SNS → /webhooks/ses feedback has no
 // documented SLA and observably takes anywhere from a few seconds to over a
 // minute. A timeout returns null, which every caller turns into a hard
@@ -241,6 +266,9 @@ test("emit: email.bounced — a real permanent bounce emits the event, auto-supp
   const hook = await createHook(["email.bounced", "domain.suppression_added"]);
   const since = sinceNow();
   try {
+    // Heal a suppression leaked by an earlier failed run before it refuses
+    // this send with 422 recipient_suppressed. See clearSuppression's note.
+    await clearSuppression(BOUNCE_SIM);
     const send = await client.post<SendResult>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
       body: { to: [BOUNCE_SIM], subject: uniqueSubject("emit bounced"), text: "real send to trigger a hard bounce" },
     });
@@ -292,6 +320,7 @@ test("emit: email.bounced — a real permanent bounce emits the event, auto-supp
     );
     info(SUITE, "deleteSuppression", `real bounce suppression created and deleted cleanly for ${BOUNCE_SIM}`);
   } finally {
+    await clearSuppression(BOUNCE_SIM);
     await delHook(hook.id);
     await delAgent(email);
   }
@@ -303,6 +332,9 @@ test("emit: email.complained — a real complaint emits the event, auto-suppress
   const hook = await createHook(["email.complained", "domain.suppression_added"]);
   const since = sinceNow();
   try {
+    // Heal a suppression leaked by an earlier failed run before it refuses
+    // this send with 422 recipient_suppressed. See clearSuppression's note.
+    await clearSuppression(COMPLAINT_SIM);
     const send = await client.post<SendResult>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
       body: { to: [COMPLAINT_SIM], subject: uniqueSubject("emit complained"), text: "real send to trigger a complaint" },
     });
@@ -339,6 +371,7 @@ test("emit: email.complained — a real complaint emits the event, auto-suppress
     );
     info(SUITE, "deleteSuppression", `real complaint suppression created and deleted cleanly for ${COMPLAINT_SIM}`);
   } finally {
+    await clearSuppression(COMPLAINT_SIM);
     await delHook(hook.id);
     await delAgent(email);
   }


### PR DESCRIPTION
## The failure mode

`deleteSuppression` sat inside the `try` in `31-ses-feedback.test.ts`; the `finally` only cleaned up the webhook and the agent. So any failure between the send and that delete leaked an **account-scoped** suppression on a **shared** simulator address (`bounce@` / `complaint@`).

That leak is self-perpetuating. Once the address is suppressed, the next run's send is refused with `422 recipient_suppressed` — which happens *before* the test reaches any cleanup — so it leaks again. **One red run wedges the suite permanently** until someone deletes the suppression by hand.

Not hypothetical: on the 2026-07-26 production run both `bounce@` and `complaint@` were still suppressed from the previous night's failed run, and both tests failed at their send.

## The fix

A best-effort `clearSuppression()` helper, called on **both** sides:

- in the `finally` — so a failure cannot leak in the first place
- **before** the send — so an already-wedged account heals on its own next run

Neither half alone is sufficient. The sweep prevents new leaks; the pre-clear recovers from existing ones. It swallows every outcome (a 404 just means the address wasn't suppressed) and never masks the real failure the `finally` is unwinding from.

The **asserted** `deleteSuppression` call stays inside the `try` — it's genuine coverage of that operation's happy path, and is what closed the `deleteSuppression` allowlist entry in `coverage_gate.py`.

## Verification against production

Before: both tests failed at the send with `422 recipient_suppressed`.
After: both sends succeed, `email.bounced` and `email.complained` fire and fan out to the webhook (`attempts=1`), and the account is left at **0 suppressions** — confirming the sweep works.

Both tests still fail one assertion later, on `domain.suppression_added` — but that is a **separate, already-fixed defect**, not this one. Prod runs v1.3.0, whose dedup key is `EventSuppressionAdded|userID|address`, so the event fires at most once per address for the lifetime of the account. #727 (`d5e650cb`) re-keys it on the provider notification and is on `main` but not in any release tag yet. The production event log matches exactly: three `domain.suppression_added` events ever, one per distinct address, each the first time that address was suppressed.

So this change is complete for what it targets; the residual failures clear when a release carrying #727 reaches prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)