### PR TITLE
fix(cli): isolate live doctor release gate

### DIFF
--- a/cli/test/e2e.test.ts
+++ b/cli/test/e2e.test.ts
@@ -84,22 +84,36 @@ function runAsync(args: string[], extra: Record<string, string> = {}): Promise<R
 const sleep = (ms: number) => new Promise((res) => setTimeout(res, ms));
 
 // The CLI can't delete agents; clean up created inboxes over the API.
-async function apiDeleteAgent(email: string): Promise<void> {
-  await fetch(`${URL_}/v1/agents/${encodeURIComponent(email)}?confirm=DELETE`, {
-    method: "DELETE",
-    headers: { Authorization: `Bearer ${KEY}` },
-  }).catch(() => {});
+async function apiDeleteAgent(email: string): Promise<string | undefined> {
+  try {
+    const res = await fetch(`${URL_}/v1/agents/${encodeURIComponent(email)}?confirm=DELETE`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${KEY}` },
+    });
+    if (res.ok) return undefined;
+    return `${email}: HTTP ${res.status} ${res.statusText}: ${(await res.text()).slice(0, 200)}`;
+  } catch (err) {
+    return `${email}: ${err instanceof Error ? err.message : String(err)}`;
+  }
 }
 
 const createdAgents: string[] = [];
 afterAll(async () => {
-  for (const a of createdAgents) await apiDeleteAgent(a);
-  // Explicit flush: this suite runs inside a vitest worker, whose 'exit'
-  // lifecycle (the recorder's best-effort fallback) is not guaranteed to
-  // line up with the outer vitest process — see cli-coverage.ts. Calling
-  // this here, unconditionally, is what actually gets the shard written for
-  // `npm run coverage:gate:cli` to read.
-  flushCliCoverage();
+  const cleanupFailures: string[] = [];
+  try {
+    for (const a of createdAgents) {
+      const failure = await apiDeleteAgent(a);
+      if (failure) cleanupFailures.push(failure);
+    }
+  } finally {
+    // Explicit flush: this suite runs inside a vitest worker, whose 'exit'
+    // lifecycle (the recorder's best-effort fallback) is not guaranteed to
+    // line up with the outer vitest process — see cli-coverage.ts. Calling
+    // this here, unconditionally, is what actually gets the shard written for
+    // `npm run coverage:gate:cli` to read.
+    flushCliCoverage();
+  }
+  expect(cleanupFailures, cleanupFailures.join("\n")).toEqual([]);
 });
 
 describe.skipIf(!live)("cli live parity", () => {
@@ -286,6 +300,7 @@ describe.skipIf(!live)("cli live parity", () => {
     createdAgents.push(doctorAgent);
 
     let keyId = "";
+    let primaryError: unknown;
     try {
       const createdKey = run([
         "keys",
@@ -300,7 +315,10 @@ describe.skipIf(!live)("cli live parity", () => {
       const key = JSON.parse(createdKey.stdout);
       keyId = key.id ?? key.keyId;
       expect(keyId).toBeTruthy();
-      expect(key.key).toMatch(/^e2a_agt_/);
+      expect(
+        typeof key.key === "string" && key.key.startsWith("e2a_agt_"),
+        "agent-scoped key response must contain an e2a_agt_ secret",
+      ).toBe(true);
       const isolated = {
         E2A_API_KEY: key.key,
         E2A_AGENT_EMAIL: doctorAgent,
@@ -312,8 +330,17 @@ describe.skipIf(!live)("cli live parity", () => {
       expect(healthy.code, JSON.stringify(healthyReport, null, 2)).toBe(0);
       expect(healthyReport.schema).toBe("e2a.doctor/v1");
       expect(healthyReport.status).toBe("healthy");
+      const authCheck = healthyReport.checks.find((c: { id: string }) => c.id === "api.auth");
+      expect(authCheck?.evidence?.scope).toBe("agent");
+      expect(authCheck?.evidence?.bound_agent).toBe(doctorAgent);
       const agentCheck = healthyReport.checks.find((c: { id: string }) => c.id === "agent.access");
       expect(agentCheck?.status).toBe("pass");
+      expect(agentCheck?.evidence?.email).toBe(doctorAgent);
+      for (const id of ["domain.registered", "webhook.config"]) {
+        const scopedSkip = healthyReport.checks.find((c: { id: string }) => c.id === id);
+        expect(scopedSkip?.status, `${id} must skip for an agent-scoped key`).toBe("skip");
+        expect(scopedSkip?.reason_code).toBe("requires_account_scope");
+      }
 
       // Warnings-only (8): force the ONE warn-producing, side-effect-free
       // client-side condition doctor has — a partially-configured
@@ -345,8 +372,20 @@ describe.skipIf(!live)("cli live parity", () => {
       expect(failedCheck?.reason_code).toBe("agent_not_found");
 
       recordCovered("doctor");
+    } catch (err) {
+      primaryError = err;
+      throw err;
     } finally {
-      if (keyId) run(["keys", "delete", keyId]);
+      if (keyId) {
+        const revoked = run(["keys", "delete", keyId]);
+        if (revoked.code !== 0) {
+          if (primaryError) {
+            console.warn(`failed to revoke temporary doctor key ${keyId}: ${revoked.stderr}`);
+          } else {
+            expect(revoked.code, revoked.stderr).toBe(0);
+          }
+        }
+      }
     }
   });
 

--- a/cli/test/e2e.test.ts
+++ b/cli/test/e2e.test.ts
@@ -274,45 +274,80 @@ describe.skipIf(!live)("cli live parity", () => {
   });
 
   it("doctor: healthy (0), warnings-only (8), and config failure (9) exit codes", () => {
-    // Healthy: valid creds, a real agent, no custom domains/webhooks
-    // registered on this dedicated account → every check is pass or a
-    // benign skip, no warn/fail anywhere.
-    const healthy = run(["doctor", "--json"]);
-    const healthyReport = JSON.parse(healthy.stdout);
-    expect(healthy.code, healthy.stderr).toBe(healthyReport.exit_code);
-    expect(healthy.code, JSON.stringify(healthyReport, null, 2)).toBe(0);
-    expect(healthyReport.schema).toBe("e2a.doctor/v1");
-    expect(healthyReport.status).toBe("healthy");
-    const agentCheck = healthyReport.checks.find((c: { id: string }) => c.id === "agent.access");
-    expect(agentCheck?.status).toBe("pass");
+    // The account-scoped conformance credential is deliberately shared with
+    // suites that create custom-domain fixtures. Doctor correctly diagnoses
+    // their missing DNS, so that mutable account can never be a deterministic
+    // "healthy" fixture. Mint a short-lived agent-scoped key instead: domain
+    // and webhook checks then skip by contract, while the real API, auth,
+    // agent-access, SMTP, report, and exit-code paths still run live.
+    const doctorAgent = `cli-live-doctor-${Date.now().toString(36)}@${DOMAIN}`;
+    const createdAgent = run(["agents", "create", doctorAgent, "--name", "cli live doctor e2e", "--json"]);
+    expect(createdAgent.code, createdAgent.stderr).toBe(0);
+    createdAgents.push(doctorAgent);
 
-    // Warnings-only (8): force the ONE warn-producing, side-effect-free
-    // client-side condition doctor has — a partially-configured
-    // E2A_OUTBOUND_SMTP_* environment (host without from_domain) — with
-    // nothing else in a fail/auth/config state, so the exit-code priority
-    // (auth > config > transient > warn) lands on WARN.
-    const warn = run(["doctor", "--json"], { E2A_OUTBOUND_SMTP_HOST: "smtp.example.com" });
-    const warnReport = JSON.parse(warn.stdout);
-    expect(warn.code, warn.stderr).toBe(8);
-    expect(warnReport.exit_code).toBe(8);
-    expect(warnReport.status).toBe("warnings");
-    const smtpCheck = warnReport.checks.find((c: { id: string }) => c.id === "smtp.config");
-    expect(smtpCheck?.status).toBe("warn");
-    expect(smtpCheck?.reason_code).toBe("smtp_partial");
+    let keyId = "";
+    try {
+      const createdKey = run([
+        "keys",
+        "create",
+        "--agent",
+        doctorAgent,
+        "--name",
+        "cli-live-doctor-isolated",
+        "--json",
+      ]);
+      expect(createdKey.code, createdKey.stderr).toBe(0);
+      const key = JSON.parse(createdKey.stdout);
+      keyId = key.id ?? key.keyId;
+      expect(keyId).toBeTruthy();
+      expect(key.key).toMatch(/^e2a_agt_/);
+      const isolated = {
+        E2A_API_KEY: key.key,
+        E2A_AGENT_EMAIL: doctorAgent,
+      };
 
-    // Definite configuration failure (9): a nonexistent agent is a config
-    // problem, not a network one — read-only (GET only), no fixture needed.
-    const bogusAgent = `cli-live-doctor-missing-${Date.now().toString(36)}@${DOMAIN}`;
-    const fail = run(["doctor", "--agent", bogusAgent, "--json"]);
-    const failReport = JSON.parse(fail.stdout);
-    expect(fail.code, fail.stderr).toBe(9);
-    expect(failReport.exit_code).toBe(9);
-    expect(failReport.status).toBe("failed");
-    const failedCheck = failReport.checks.find((c: { id: string }) => c.id === "agent.access");
-    expect(failedCheck?.status).toBe("fail");
-    expect(failedCheck?.reason_code).toBe("agent_not_found");
+      const healthy = run(["doctor", "--json"], isolated);
+      const healthyReport = JSON.parse(healthy.stdout);
+      expect(healthy.code, healthy.stderr).toBe(healthyReport.exit_code);
+      expect(healthy.code, JSON.stringify(healthyReport, null, 2)).toBe(0);
+      expect(healthyReport.schema).toBe("e2a.doctor/v1");
+      expect(healthyReport.status).toBe("healthy");
+      const agentCheck = healthyReport.checks.find((c: { id: string }) => c.id === "agent.access");
+      expect(agentCheck?.status).toBe("pass");
 
-    recordCovered("doctor");
+      // Warnings-only (8): force the ONE warn-producing, side-effect-free
+      // client-side condition doctor has — a partially-configured
+      // E2A_OUTBOUND_SMTP_* environment (host without from_domain) — with
+      // nothing else in a fail/auth/config state, so the exit-code priority
+      // (auth > config > transient > warn) lands on WARN.
+      const warn = run(["doctor", "--json"], {
+        ...isolated,
+        E2A_OUTBOUND_SMTP_HOST: "smtp.example.com",
+      });
+      const warnReport = JSON.parse(warn.stdout);
+      expect(warn.code, warn.stderr).toBe(8);
+      expect(warnReport.exit_code).toBe(8);
+      expect(warnReport.status).toBe("warnings");
+      const smtpCheck = warnReport.checks.find((c: { id: string }) => c.id === "smtp.config");
+      expect(smtpCheck?.status).toBe("warn");
+      expect(smtpCheck?.reason_code).toBe("smtp_partial");
+
+      // Definite configuration failure (9): a nonexistent agent is a config
+      // problem, not a network one — read-only (GET only), no fixture needed.
+      const bogusAgent = `cli-live-doctor-missing-${Date.now().toString(36)}@${DOMAIN}`;
+      const fail = run(["doctor", "--agent", bogusAgent, "--json"], isolated);
+      const failReport = JSON.parse(fail.stdout);
+      expect(fail.code, fail.stderr).toBe(9);
+      expect(failReport.exit_code).toBe(9);
+      expect(failReport.status).toBe("failed");
+      const failedCheck = failReport.checks.find((c: { id: string }) => c.id === "agent.access");
+      expect(failedCheck?.status).toBe("fail");
+      expect(failedCheck?.reason_code).toBe("agent_not_found");
+
+      recordCovered("doctor");
+    } finally {
+      if (keyId) run(["keys", "delete", keyId]);
+    }
   });
 
   it("config: list/get/set round-trip against an isolated HOME", () => {


### PR DESCRIPTION
## Summary

- create a throwaway agent for the live CLI doctor scenario
- mint a temporary agent-scoped key and use it for healthy/warning/failure checks
- revoke the key in `finally` and retain the existing throwaway-agent cleanup

## Root cause

Release run 30218811198 used the shared account-scoped conformance key for the supposed healthy doctor check. The conformance account contains custom-domain fixtures with intentionally missing DNS, so doctor correctly returned configuration failure 9 instead of healthy 0. The test depended on mutable account-wide state.

Agent scope preserves the real live API, authentication, agent-access, SMTP-warning, report-schema, and exit-code checks while domain and webhook checks skip by contract.

## Verification

- TypeScript SDK build
- CLI TypeScript build
- 244 CLI unit tests
- live-suite compilation/collection (11 tests skip locally without staging credentials)
- `git diff --check`

The fix must receive its final verification from the staging release pipeline because the failing scenario requires the protected staging credential.
