### PR TITLE
docs(sdk): fix contradictory AuthVerdict migration guidance in changelogs

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -84,14 +84,14 @@ in this release, so read those three sections together when upgrading from 4.x.
   ``event_json`` → ``event_view``), ``PageEventJSON`` → ``PageEventView``,
   ``Suppression`` → ``SuppressionView``, ``PageSuppression`` →
   ``PageSuppressionView``; the duplicate ``Result`` collapsed into the
-  existing ``AuthVerdict``, and the duplicate ``AttachmentMeta`` collapsed
+  existing ``Authentication``, and the duplicate ``AttachmentMeta`` collapsed
   into the canonical ``AttachmentMetaView`` (one attachment-metadata shape for
   REST responses, stable event payloads, and the account export — the
   hand-written webhook payload TypedDict in ``webhook_signature.py`` follows
   the same rename). The wire JSON is unchanged — field names, optionality, and
   values are identical; only the exported type names changed. Migrate:
   ``EventJSON`` → ``EventView``, ``Suppression`` → ``SuppressionView``,
-  ``Result`` → ``AuthVerdict``, ``AttachmentMeta`` → ``AttachmentMetaView``.
+  ``Result`` → ``Authentication``, ``AttachmentMeta`` → ``AttachmentMetaView``.
 
 - **The reserved-word wire field `from` is exposed as `from_` (PEP 8 trailing
   underscore) where a sender is still projected** (was the generator-mangled

--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -80,14 +80,14 @@ in this release, so read those three sections together when upgrading from 4.x.
   Generated types: `EventJSON` → `EventView`, `PageEventJSON` →
   `PageEventView`, `Suppression` → `SuppressionView`, `PageSuppression` →
   `PageSuppressionView`; the duplicate `Result` collapsed into the existing
-  `AuthVerdict`, and the duplicate `AttachmentMeta` collapsed into the
+  `Authentication`, and the duplicate `AttachmentMeta` collapsed into the
   canonical `AttachmentMetaView` (one attachment-metadata shape for REST
   responses, stable event payloads, and the account export — the hand-written
   webhook payload interface in `webhook-signature.ts` follows the same
   rename). The wire JSON is unchanged — field names, optionality, and values
   are identical; only the exported type names changed. Migrate:
   `EventJSON` → `EventView`, `Suppression` → `SuppressionView`,
-  `Result` → `AuthVerdict`, `AttachmentMeta` → `AttachmentMetaView`.
+  `Result` → `Authentication`, `AttachmentMeta` → `AttachmentMetaView`.
 
 - **The reserved-word wire field `from` is exposed as `from_` where a sender is
   still projected** (was the private-looking `_from`, an OpenAPI Generator


### PR DESCRIPTION
## Summary

The 5.2.0 entries in both `sdks/typescript/CHANGELOG.md` and `sdks/python/CHANGELOG.md` contradict themselves: one bullet in the "Breaking (pre-GA)" section says `AuthVerdict` was removed and replaced by `Authentication`, while the very next bullet in the same release says the duplicate `Result` schema "collapsed into the existing `AuthVerdict`" and tells readers to migrate `Result` → `AuthVerdict`.

Verified against the current generated SDKs: neither `AuthVerdict` nor a bare `Result` type exists anywhere in `sdks/typescript/src/v1/generated/` or `sdks/python/src/e2a/v1/generated/`. The type that actually ships is `Authentication`. This PR corrects the stale migration guidance to point at `Authentication` instead of the already-removed `AuthVerdict`, in both changelogs.

This is a docs-only fix (changelog text); no code, generated types, or public API surface changed.

## Test plan

- [x] Grepped `sdks/typescript/src/v1/generated/` and `sdks/python/src/e2a/v1/generated/` to confirm `AuthVerdict`/`Result` don't exist and `Authentication` does.
- [x] Reviewed the diff for correctness in both changelog files.

---
_Generated by [Claude Code](https://claude.ai/code/session_011G8YjefvRCnfwHU7wE2yg3)_