### PR TITLE
docs(examples): fix broken HMAC verification anchor link

### DIFF
--- a/examples/adk-cloud-webhook/README.md
+++ b/examples/adk-cloud-webhook/README.md
@@ -133,7 +133,7 @@ signed request bytes through a 1 MiB limit before signature verification, so a
 chunked request cannot bypass the bound or allocate an unbounded body.
 
 See [webhook.py](webhook.py) for the implementation, including
-[HMAC signature verification](https://github.com/tokencanopy/e2a/blob/main/sdks/python/README.md#quick-start)
+[HMAC signature verification](https://github.com/tokencanopy/e2a/blob/main/sdks/python/README.md#verify-a-webhook)
 which you should *always* do on a public webhook before trusting any
 field on the parsed payload.
 


### PR DESCRIPTION
## Summary

`examples/adk-cloud-webhook/README.md` links to the Python SDK's webhook-signature docs at `sdks/python/README.md#quick-start`, but that section is just sync/async client usage examples — it has no signature-verification content. The actual HMAC verification material (`construct_event`, `X-E2A-Signature`, replay protection, `E2AWebhookSignatureError`) lives in the `### Verify a webhook` section, anchor `#verify-a-webhook`. This PR retargets the link.

Docs-only fix, no code changes.

## Test plan

- [x] Confirmed `sdks/python/README.md`'s `## Quick Start` (line 106) contains no HMAC verification content, and `### Verify a webhook` (line 247) does.

---
_Generated by [Claude Code](https://claude.ai/code/session_011G8YjefvRCnfwHU7wE2yg3)_