### PR TITLE
docs(runbooks): disambiguate migration reference in sending-ramp exemptions

### DIFF
--- a/docs/runbooks/sending-ramp.md
+++ b/docs/runbooks/sending-ramp.md
@@ -22,8 +22,8 @@ sustained over-cap admission or a ramp-store incident.
 
 ## Exemptions
 
-Migration 067 exempts domains that were already sending-verified when the
-feature shipped. A verified domain that sends while `sending_ramp.enabled` is
+Migration `067_domain_sending_ramp.sql` exempts domains that were already
+sending-verified when the feature shipped. A verified domain that sends while `sending_ramp.enabled` is
 false is also persistently exempt. Enabling the feature later does not revoke
 those exemptions. This prevents a rollout from unexpectedly throttling an
 established sender.


### PR DESCRIPTION
## Summary

`docs/runbooks/sending-ramp.md`'s "Exemptions" section refers to "Migration 067," but `migrations/` currently has two files sharing that number: `067_agent_registered_domain.sql` and `067_domain_sending_ramp.sql`. The sending-ramp exemption logic actually lives in `067_domain_sending_ramp.sql` (confirmed by its `UPDATE domains SET sending_ramp_status = 'exempt' WHERE sending_status = 'verified' ...`). This PR names the specific file so the reference is unambiguous.

Docs-only fix; no migration files changed or renumbered.

## Test plan

- [x] Confirmed `067_domain_sending_ramp.sql` contains the exemption UPDATE described in the runbook.

---
_Generated by [Claude Code](https://claude.ai/code/session_011G8YjefvRCnfwHU7wE2yg3)_