### PR TITLE
docs: remove phantom template_variables field reference

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -40,7 +40,7 @@ loops, no conditionals, no partials:
 Missing variables render as **empty strings**. Variable names match
 `[A-Za-z_][A-Za-z0-9_.]*`-style identifiers (e.g. `order_id`, `items_html`) —
 a dot path (e.g. `{{user.name}}`) resolves into a nested object, matching how
-`template_data`/`template_variables` are passed as nested JSON.
+`template_data` is passed as nested JSON.
 
 **Reserved-section note:** anything that is not a `{{…}}` / `{{{…}}}` slot is
 literal template text and is emitted verbatim — including `{` and `}`


### PR DESCRIPTION
## Summary

`docs/templates.md` said dot-path variable resolution matches how `template_data`/`template_variables` are passed as nested JSON. `template_variables` doesn't exist anywhere in the codebase — not in `internal/httpapi/templates.go`, `internal/httpapi/outbound.go`, `api/openapi.yaml`, the MCP tools, or either SDK. The only real field is `template_data`. This appears to be a stale leftover from an earlier/renamed field name; the synced `plugins/e2a/docs/templates.md` / `web/public/templates.md` variant never mentioned it. Removing the phantom name.

Docs-only fix; no code changes.

## Test plan

- [x] Grepped the whole repo for `template_variables` — the only hit was this line in `docs/templates.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_011G8YjefvRCnfwHU7wE2yg3)_