### PR TITLE
feat(agent): link the approved message from the HITL result page

### DIFF
--- a/internal/agent/hitl_magic_api.go
+++ b/internal/agent/hitl_magic_api.go
@@ -6,6 +6,7 @@ import (
 	"html"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -273,8 +274,9 @@ func (a *API) magicApprove(w http.ResponseWriter, r *http.Request, messageID, us
 	if handled {
 		log.Printf("[mail:%s] dir=outbound type=%s status=%s agent=%s to_count=%d to_domains=%v approved=magic-link:user:%s delivery=async",
 			sent.ID, sent.Type, sent.Status, agent.EmailAddress(), len(sent.ToRecipients), logredact.AddressDomains(sent.ToRecipients), userID)
-		writeMagicMessage(w, http.StatusOK, "Approved",
-			fmt.Sprintf("Your message to %s has been queued for delivery.", html.EscapeString(firstRecipient(sent.ToRecipients))))
+		writeMagicResult(w, http.StatusOK, "Approved",
+			fmt.Sprintf("Your message to %s has been queued for delivery.", html.EscapeString(firstRecipient(sent.ToRecipients))),
+			viewMessageCTA(agent.EmailAddress(), sent.ID))
 		return
 	}
 
@@ -308,9 +310,10 @@ func (a *API) magicApprove(w http.ResponseWriter, r *http.Request, messageID, us
 	log.Printf("[mail:%s] dir=outbound type=%s status=%s agent=%s to_count=%d to_domains=%v approved=magic-link:user:%s",
 		sent.ID, sent.Type, sent.Status, agent.EmailAddress(), len(sent.ToRecipients), logredact.AddressDomains(sent.ToRecipients), userID)
 
-	writeMagicMessage(w, http.StatusOK,
+	writeMagicResult(w, http.StatusOK,
 		"Approved",
-		fmt.Sprintf("Your message to %s has been sent.", html.EscapeString(firstRecipient(sent.ToRecipients))))
+		fmt.Sprintf("Your message to %s has been sent.", html.EscapeString(firstRecipient(sent.ToRecipients))),
+		viewMessageCTA(agent.EmailAddress(), sent.ID))
 }
 
 // writeMagicApproveError renders the magic-link HTML error page for an async
@@ -728,17 +731,55 @@ func setMagicHeaders(w http.ResponseWriter, status int) {
 	w.WriteHeader(status)
 }
 
-// writeMagicMessage renders the post-action / error page. Cream surface,
-// inline brand mark up top, big editorial-italic title, ember CTA back
-// to the dashboard.
+// magicCTA is the single call-to-action button at the foot of the result
+// page.
+type magicCTA struct {
+	Label string
+	Href  string
+}
+
+// dashboardCTA is the fallback CTA: every error, reject, and
+// already-resolved page lands the reviewer on the dashboard because there
+// is no one message worth deep-linking to.
+var dashboardCTA = magicCTA{Label: "Open the dashboard", Href: "/dashboard"}
+
+// viewMessageCTA deep-links the dashboard's single-message focus view so an
+// approving reviewer lands on the message they just approved instead of the
+// dashboard root. The href is relative on purpose — these pages are served
+// by the same origin as the dashboard, so this works under any public URL.
+// Both identifiers are required by the focus view (it resolves the message
+// through the agent-scoped detail endpoint); if either is missing there is
+// nothing to link to, so fall back to the dashboard.
+func viewMessageCTA(agentEmail, messageID string) magicCTA {
+	if agentEmail == "" || messageID == "" {
+		return dashboardCTA
+	}
+	return magicCTA{
+		Label: "View message",
+		// direction=outbound selects the outbound projection on the focus
+		// page; a held message resolved through this flow is always outbound.
+		Href: "/inboxes/messages/view?email=" + url.QueryEscape(agentEmail) +
+			"&id=" + url.QueryEscape(messageID) + "&direction=outbound",
+	}
+}
+
+// writeMagicMessage renders the post-action / error page with the default
+// dashboard CTA.
 func writeMagicMessage(w http.ResponseWriter, status int, title, body string) {
+	writeMagicResult(w, status, title, body, dashboardCTA)
+}
+
+// writeMagicResult renders the post-action / error page. Cream surface,
+// inline brand mark up top, big editorial-italic title, ember CTA at the
+// foot.
+func writeMagicResult(w http.ResponseWriter, status int, title, body string, cta magicCTA) {
 	setMagicHeaders(w, status)
 	writeLoftHead(w, title)
 	fmt.Fprintf(w, `<div class="result">
 <span class="eyebrow">%s</span>
 <h1>%s</h1>
 <p>%s</p>
-<p><a class="btn btn-primary" href="/dashboard">Open the dashboard</a></p>
+<p><a class="btn btn-primary" href="%s">%s</a></p>
 </div>
 </div>
 </body>
@@ -750,6 +791,8 @@ func writeMagicMessage(w http.ResponseWriter, status int, title, body string) {
 		// path runs html.EscapeString itself before calling us). Don't
 		// double-escape.
 		body,
+		html.EscapeString(cta.Href),
+		html.EscapeString(cta.Label),
 	)
 }
 

--- a/internal/agent/hitl_magic_api_test.go
+++ b/internal/agent/hitl_magic_api_test.go
@@ -317,6 +317,7 @@ func TestMagicApprovePOSTQueues(t *testing.T) {
 	if !strings.Contains(body, "Approved") {
 		t.Errorf("expected 'Approved' in body, got: %s", body)
 	}
+	assertViewMessageCTA(t, body, a.EmailAddress(), msg.ID)
 
 	if msgs := smtpDone(); len(msgs) != 0 {
 		t.Fatalf("approval submitted %d SMTP messages inline, want zero", len(msgs))
@@ -361,6 +362,8 @@ func TestMagicApprovePOSTSelfSendDeliversViaLoopback(t *testing.T) {
 	}
 	if body := readBody(t, resp); !strings.Contains(body, "Approved") {
 		t.Errorf("expected 'Approved' on the result page, got: %s", body)
+	} else {
+		assertViewMessageCTA(t, body, a.EmailAddress(), held.ID)
 	}
 
 	if msgs := smtpDone(); len(msgs) != 0 {
@@ -391,6 +394,27 @@ func TestMagicApprovePOSTSelfSendDeliversViaLoopback(t *testing.T) {
 	}
 }
 
+// assertViewMessageCTA pins the approve result page's call to action: a
+// deep link to the dashboard's single-message focus view for the message
+// that was just approved, NOT the generic dashboard root. Both query params
+// matter — the focus view resolves the message through the agent-scoped
+// detail endpoint (?email=) and picks its outbound projection from
+// ?direction=. `&` arrives HTML-escaped in the href attribute.
+func assertViewMessageCTA(t *testing.T, body, agentEmail, messageID string) {
+	t.Helper()
+	want := "/inboxes/messages/view?email=" + url.QueryEscape(agentEmail) +
+		"&amp;id=" + url.QueryEscape(messageID) + "&amp;direction=outbound"
+	if !strings.Contains(body, `href="`+want+`"`) {
+		t.Errorf("result page missing view-message href %q, got: %s", want, body)
+	}
+	if !strings.Contains(body, ">View message</a>") {
+		t.Errorf("result page missing 'View message' button label, got: %s", body)
+	}
+	if strings.Contains(body, "Open the dashboard") {
+		t.Errorf("approve result page should not fall back to the dashboard CTA, got: %s", body)
+	}
+}
+
 // subjectsOf is a small helper to keep error messages readable when an
 // inbox-shape assertion fails.
 func subjectsOf(msgs []identity.Message) []string {
@@ -414,6 +438,11 @@ func TestMagicRejectPOSTWithReason(t *testing.T) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("POST reject: status = %d", resp.StatusCode)
+	}
+	// Only approve deep-links the message; a rejected draft is discarded, so
+	// reject keeps the generic dashboard CTA.
+	if body := readBody(t, resp); !strings.Contains(body, "Open the dashboard") {
+		t.Errorf("reject result page should keep the dashboard CTA, got: %s", body)
 	}
 
 	if msgs := smtpDone(); len(msgs) != 0 {


### PR DESCRIPTION
## Summary

After approving a held message from the HITL magic link, the result page's only CTA was `Open the dashboard` — the reviewer landed on the dashboard root and had to go find the message they had just approved. This deep-links the dashboard's single-message focus view instead, behind a **View message** button.

The href is `/inboxes/messages/view?email=<agent>&id=<msg_id>&direction=outbound` — the same URL shape the inbox list uses to open a message. Relative on purpose: these pages are served from the same origin as the dashboard, so it works under any `public_url` (same precedent as the existing `/dashboard/pending` link in the approval email itself).

Both approve-success paths get it — the async/River-queued path and the loopback self-send path. Rejects, errors, expired links, and already-resolved pages keep the dashboard CTA: a rejected draft is discarded, so there is nothing worth deep-linking to.

## Client surface checklist

Not an API change — no handler, spec, schema, or client-surface change. This only touches the HTML the Go binary serves for the magic-link result page (`internal/agent/hitl_magic_api.go`), so every row below is intentionally skipped and the section is left in place only to make that explicit.

> No `/v1` surface touched: no OpenAPI drift (`make spec-check` unaffected), no SDK/CLI/MCP/web change, no migration.

## Operational risk

Low. Presentation-only change to a page served after the state change has already committed — nothing about approve/reject behavior, tokens, or delivery moves.

- The destination requires an authenticated owner session. A reviewer approving from a phone without an active session bounces through login first, and the login redirect may drop the query params — the old dashboard link had the same gate but a less specific destination. Preserving the return URL through login is a web-side follow-up, not in this PR.
- `viewMessageCTA` falls back to the dashboard CTA if either identifier is empty, so a missing agent email or message id degrades to today's behavior rather than emitting a broken link.
- The href is HTML-escaped in the attribute (`&` → `&amp;`); the message id and agent address are both server-owned values.

## Test plan

- [x] `go test ./internal/agent/ -tags integration -count=1` — full package green (53s)
- [x] New `assertViewMessageCTA` helper pins the exact href, the `View message` label, and the *absence* of the dashboard fallback; wired into both approve tests (`TestMagicApprovePOSTQueues`, `TestMagicApprovePOSTSelfSendDeliversViaLoopback`)
- [x] Negative-path regression: `TestMagicRejectPOSTWithReason` now asserts reject still renders `Open the dashboard`, so a future change can't silently give rejects a message deep-link
- [x] `go build ./...` clean
- [ ] After merge: click a real approval link end-to-end on a deployed instance and confirm the button lands on the sent message (static export resolves `/inboxes/messages/view` → `view.html`, same as the already-working `/dashboard/pending`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
