### PR TITLE
fix(dkim): N+1 oversign present headers to detect prepended duplicates

### DIFF
--- a/internal/dkim/dkim.go
+++ b/internal/dkim/dkim.go
@@ -146,7 +146,7 @@ var signedHeaderCandidates = []string{
 // the dangerous direction. Composed messages never take these paths;
 // headerWriter emits "Key: value" and strips CR/LF.
 func signedHeaderKeys(message []byte) []string {
-	present := map[string]bool{}
+	count := map[string]int{}
 	hdr, err := textproto.NewReader(bufio.NewReader(bytes.NewReader(message))).ReadMIMEHeader()
 	if err != nil && len(hdr) == 0 {
 		// Unparseable header block: fall back to the full candidate list
@@ -154,13 +154,28 @@ func signedHeaderKeys(message []byte) []string {
 		// caller sends unsigned, which is the existing behavior.
 		return signedHeaderCandidates
 	}
-	for k := range hdr {
-		present[k] = true
+	for k, values := range hdr {
+		count[k] = len(values)
 	}
 
-	keys := make([]string, 0, len(signedHeaderCandidates))
+	keys := make([]string, 0, 2*len(signedHeaderCandidates))
 	for _, k := range signedHeaderCandidates {
-		if k == "From" || present[textproto.CanonicalMIMEHeaderKey(k)] {
+		n := count[textproto.CanonicalMIMEHeaderKey(k)]
+		if n == 0 {
+			// From must be covered even when absent (RFC 6376 § 5.4).
+			if k == "From" {
+				keys = append(keys, k)
+			}
+			continue
+		}
+		// N+1 oversigning: list a present header once more than it
+		// occurs. A verifier binds each listed instance from the bottom
+		// up, so the extra entry asserts "there is no further instance".
+		// Without it, a hop can PREPEND a second Subject: the verifier
+		// still matches the original and reports pass, while the MUA
+		// displays the attacker's copy. Confirmed both ways — listing
+		// once accepts the spoof, listing n+1 times rejects it.
+		for i := 0; i < n+1; i++ {
 			keys = append(keys, k)
 		}
 	}

--- a/internal/dkim/sign_headers_test.go
+++ b/internal/dkim/sign_headers_test.go
@@ -213,6 +213,76 @@ func TestSign_TamperingWithASignedHeaderIsDetected(t *testing.T) {
 	}
 }
 
+// The attack N+1 oversigning exists to stop. A hop prepends a second
+// Subject; a verifier binds header instances from the bottom up, so with
+// the header listed only once it matches the original and reports pass —
+// while the MUA displays the attacker's copy at the top.
+func TestSign_PrependedDuplicateHeaderIsDetected(t *testing.T) {
+	kp, err := GenerateKeypair()
+	if err != nil {
+		t.Fatalf("GenerateKeypair: %v", err)
+	}
+
+	spoofs := map[string]string{
+		"Subject":    "Subject: YOU HAVE WON",
+		"From":       "From: ceo@example.com",
+		"To":         "To: mallory@evil.test",
+		"Reply-To":   "Reply-To: mallory@evil.test",
+		"Message-ID": "Message-ID: <spoof@evil.test>",
+	}
+
+	// Message carries every header the spoofs target, so each is a
+	// duplicate rather than a fresh addition.
+	msg := "From: bot@example.com\r\n" +
+		"To: alice@elsewhere.test\r\n" +
+		"Reply-To: bot@example.com\r\n" +
+		"Subject: real subject\r\n" +
+		"Message-ID: <real@example.com>\r\n" +
+		"Date: Fri, 22 May 2026 12:00:00 +0000\r\n\r\nbody\r\n"
+
+	signed, err := Sign([]byte(msg), "example.com", kp.Selector, kp.PrivateKeyDER)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if v := verifySigned(t, signed, "example.com", kp.Selector, kp.PublicKeyDNS); v[0].Err != nil {
+		t.Fatalf("control: unmutated signature must verify: %v", v[0].Err)
+	}
+
+	for header, spoof := range spoofs {
+		t.Run(header, func(t *testing.T) {
+			mutated := append([]byte(spoof+"\r\n"), signed...)
+			v := verifySigned(t, mutated, "example.com", kp.Selector, kp.PublicKeyDNS)
+			if len(v) == 1 && v[0].Err == nil {
+				t.Errorf("a prepended duplicate %s went undetected", header)
+			}
+		})
+	}
+}
+
+// N+1 must not come at the cost of the fix it builds on: an ABSENT
+// candidate is still omitted entirely, so a relay adding one for the
+// first time (SES and Message-ID) still verifies.
+func TestSign_NPlusOneDoesNotResurrectOversigning(t *testing.T) {
+	kp, err := GenerateKeypair()
+	if err != nil {
+		t.Fatalf("GenerateKeypair: %v", err)
+	}
+
+	signed, err := Sign([]byte(composerShapedMessage), "example.com", kp.Selector, kp.PrivateKeyDER)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if h := signedHTag(t, signed); hasHeader(h, "message-id") {
+		t.Fatalf("h= claims an absent Message-ID: %v", h)
+	}
+
+	delivered := append([]byte(sesMessageIDHeader), signed...)
+	v := verifySigned(t, delivered, "example.com", kp.Selector, kp.PublicKeyDNS)
+	if len(v) != 1 || v[0].Err != nil {
+		t.Errorf("SES stamping Message-ID broke the signature again: %+v", v)
+	}
+}
+
 func TestSign_CoversOnlyStablePresentHeaders(t *testing.T) {
 	kp, err := GenerateKeypair()
 	if err != nil {
@@ -269,24 +339,40 @@ func TestSignedHeaderKeys(t *testing.T) {
 		want    []string
 	}{
 		{
+			// Each present header appears n+1 times: N+1 oversigning, so
+			// a relay cannot append another instance unnoticed.
 			name:    "composer shape drops absent headers",
 			message: composerShapedMessage,
-			want:    []string{"From", "To", "Subject", "MIME-Version", "Content-Type"},
+			want: []string{
+				"From", "From", "To", "To", "Subject", "Subject",
+				"MIME-Version", "MIME-Version", "Content-Type", "Content-Type",
+			},
 		},
 		{
 			name:    "unsubscribe headers covered when set",
 			message: "From: a@b.test\r\nList-Unsubscribe: <https://x/u>\r\nList-Unsubscribe-Post: List-Unsubscribe=One-Click\r\n\r\nbody",
-			want:    []string{"From", "List-Unsubscribe", "List-Unsubscribe-Post"},
+			want: []string{
+				"From", "From", "List-Unsubscribe", "List-Unsubscribe",
+				"List-Unsubscribe-Post", "List-Unsubscribe-Post",
+			},
 		},
 		{
+			// Absent From is listed exactly once: RFC 6376 § 5.4 requires
+			// it in h=, and there is no instance to count.
 			name:    "From always covered even when missing",
 			message: "Subject: no from here\r\n\r\nbody",
-			want:    []string{"From", "Subject"},
+			want:    []string{"From", "Subject", "Subject"},
 		},
 		{
 			name:    "case-insensitive header match",
 			message: "from: a@b.test\r\nCONTENT-TYPE: text/plain\r\n\r\nbody",
-			want:    []string{"From", "Content-Type"},
+			want:    []string{"From", "From", "Content-Type", "Content-Type"},
+		},
+		{
+			// Already duplicated in the source message: listed n+1 = 3.
+			name:    "a header present twice is listed three times",
+			message: "From: a@b.test\r\nSubject: one\r\nSubject: two\r\n\r\nbody",
+			want:    []string{"From", "From", "Subject", "Subject", "Subject"},
 		},
 	}
 

--- a/internal/dkim/sign_headers_test.go
+++ b/internal/dkim/sign_headers_test.go
@@ -261,7 +261,7 @@ func TestSign_PrependedDuplicateHeaderIsDetected(t *testing.T) {
 
 // N+1 must not come at the cost of the fix it builds on: an ABSENT
 // candidate is still omitted entirely, so a relay adding one for the
-// first time (SES and Message-ID) still verifies.
+// first time still verifies, and provider-owned Date remains unsigned.
 func TestSign_NPlusOneDoesNotResurrectOversigning(t *testing.T) {
 	kp, err := GenerateKeypair()
 	if err != nil {
@@ -276,10 +276,19 @@ func TestSign_NPlusOneDoesNotResurrectOversigning(t *testing.T) {
 		t.Fatalf("h= claims an absent Message-ID: %v", h)
 	}
 
-	delivered := append([]byte(sesMessageIDHeader), signed...)
+	delivered := bytes.Replace(
+		signed,
+		[]byte("Date: Fri, 22 May 2026 12:00:00 +0000"),
+		[]byte("Date: Fri, 22 May 2026 12:00:01 +0000"),
+		1,
+	)
+	if bytes.Equal(delivered, signed) {
+		t.Fatal("Date replacement target not found — test is inert")
+	}
+	delivered = append([]byte(sesMessageIDHeader), delivered...)
 	v := verifySigned(t, delivered, "example.com", kp.Selector, kp.PublicKeyDNS)
 	if len(v) != 1 || v[0].Err != nil {
-		t.Errorf("SES stamping Message-ID broke the signature again: %+v", v)
+		t.Errorf("SES rewriting Message-ID/Date broke the signature again: %+v", v)
 	}
 }
 


### PR DESCRIPTION
## Summary

Listing each present header **once** in `h=` leaves header-duplication spoofing open. A DKIM verifier binds listed header instances from the bottom up, so a hop that *prepends* a second `Subject` still matches the original and reports **pass** — while the recipient's MUA displays the attacker's copy at the top.

Present headers are now listed **n+1** times. The extra entry asserts "there is no further instance."

Raised during adversarial review of #746, which correctly noted the weakness predates that PR — the old static list also passed each candidate once.

## Confirmed both ways against the signer

Not argued from the RFC — measured:

| `h=` listing | Prepended spoof `Subject: YOU HAVE WON` |
|---|---|
| `From:Subject` (before) | **verifies clean** — spoof succeeds |
| `From:From:Subject:Subject` (after) | **fails** — spoof detected |

Same result for `From`, `To`, `Reply-To`, and `Message-ID`.

Mutation-verified in reverse too: reverting to single listing fails `TestSign_PrependedDuplicateHeaderIsDetected` with *"a prepended duplicate Subject went undetected"* on every case.

## This must not undo #746

The two interact directly, so there's a dedicated test for it. **Absent** candidates are still omitted from `h=` entirely — that's what keeps SES stamping its own `Message-ID` from breaking the signature. N+1 applies only to headers the message actually carries.

`TestSign_NPlusOneDoesNotResurrectOversigning` asserts the composer-shaped message still verifies after SES adds `Message-ID`, so this hardening cannot silently reintroduce the bug it builds on.

## Trade-off

A relay that *legitimately* adds a duplicate of a header we already set would now break the signature. Accepted: no relay in this path does so, and the candidate list is narrow. The alternative is silently accepting a spoofed display value, which is the worse failure — a signature that says "verified" over content the user never sees.

## Client surface checklist

Not applicable — internal signing behavior. No API surface, schema, or migration; `make generate` untouched.

## Merge order

**Builds on #746** (`fix/dkim-sign-present-headers`) and is branched from it, since it modifies the function that PR introduces. Merge after #746.

## Test plan

- [x] `go test ./internal/dkim/` — green
- [x] `make test-unit` — full unit suite, 0 failures
- [x] `gofmt` / `go vet` clean
- [x] Prepended-duplicate detection across `Subject`, `From`, `To`, `Reply-To`, `Message-ID`, with an unmutated control asserted first
- [x] `signedHeaderKeys` table extended: present headers listed n+1, an already-duplicated header listed 3 times, absent `From` still listed exactly once per RFC 6376 § 5.4
- [x] Mutation-verified: reverting to single listing fails every spoof case

🤖 Generated with [Claude Code](https://claude.com/claude-code)