### PR TITLE
test(selftest): eliminate WebSocket registration flake

### DIFF
--- a/internal/selftest/ws_scenario_test.go
+++ b/internal/selftest/ws_scenario_test.go
@@ -25,13 +25,15 @@ import (
 // and DELETE …/messages/{id} (recorded into deleted, so tests can pin the
 // scenario's residue cleanup against the actual response shape).
 type wsStubState struct {
-	mu        sync.Mutex
-	conn      *websocket.Conn
-	connReady chan struct{} // closed once conn is safe for the POST handler
-	readyOnce sync.Once
-	deleted   []string
-	closeSeen chan struct{} // closed once the stub reads a normal-closure frame
-	closeOnce sync.Once
+	mu          sync.Mutex
+	conn        *websocket.Conn
+	connReady   chan struct{} // closed once conn is safe for the POST handler
+	readyOnce   sync.Once
+	postStarted chan struct{} // closed once POST /messages enters the handler
+	postOnce    sync.Once
+	deleted     []string
+	closeSeen   chan struct{} // closed once the stub reads a normal-closure frame
+	closeOnce   sync.Once
 }
 
 // noteCloseFrame records that the stub read the client's normal-closure frame.
@@ -77,8 +79,9 @@ func wsStub(t *testing.T) (*httptest.Server, *wsStubState) {
 func wsStubWithRegistrationDelay(t *testing.T, registrationDelay time.Duration) (*httptest.Server, *wsStubState) {
 	t.Helper()
 	st := &wsStubState{
-		connReady: make(chan struct{}),
-		closeSeen: make(chan struct{}),
+		connReady:   make(chan struct{}),
+		postStarted: make(chan struct{}),
+		closeSeen:   make(chan struct{}),
 	}
 
 	mux := http.NewServeMux()
@@ -94,6 +97,12 @@ func wsStubWithRegistrationDelay(t *testing.T, registrationDelay time.Duration) 
 				return
 			}
 			if registrationDelay > 0 {
+				select {
+				case <-st.postStarted:
+				case <-time.After(2 * time.Second):
+					c.Close(websocket.StatusInternalError, "POST did not start")
+					return
+				}
 				time.Sleep(registrationDelay)
 			}
 			st.mu.Lock()
@@ -131,6 +140,7 @@ func wsStubWithRegistrationDelay(t *testing.T, registrationDelay time.Duration) 
 			st.mu.Unlock()
 			w.WriteHeader(http.StatusOK)
 		case strings.HasSuffix(r.URL.Path, "/messages") && r.Method == http.MethodPost:
+			st.postOnce.Do(func() { close(st.postStarted) })
 			readyCtx, cancelReady := context.WithTimeout(r.Context(), 2*time.Second)
 			defer cancelReady()
 			select {

--- a/internal/selftest/ws_scenario_test.go
+++ b/internal/selftest/ws_scenario_test.go
@@ -27,6 +27,8 @@ import (
 type wsStubState struct {
 	mu        sync.Mutex
 	conn      *websocket.Conn
+	connReady chan struct{} // closed once conn is safe for the POST handler
+	readyOnce sync.Once
 	deleted   []string
 	closeSeen chan struct{} // closed once the stub reads a normal-closure frame
 	closeOnce sync.Once
@@ -69,8 +71,15 @@ func (st *wsStubState) deletedIDs() []string {
 }
 
 func wsStub(t *testing.T) (*httptest.Server, *wsStubState) {
+	return wsStubWithRegistrationDelay(t, 0)
+}
+
+func wsStubWithRegistrationDelay(t *testing.T, registrationDelay time.Duration) (*httptest.Server, *wsStubState) {
 	t.Helper()
-	st := &wsStubState{closeSeen: make(chan struct{})}
+	st := &wsStubState{
+		connReady: make(chan struct{}),
+		closeSeen: make(chan struct{}),
+	}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
@@ -84,9 +93,13 @@ func wsStub(t *testing.T) (*httptest.Server, *wsStubState) {
 			if err != nil {
 				return
 			}
+			if registrationDelay > 0 {
+				time.Sleep(registrationDelay)
+			}
 			st.mu.Lock()
 			st.conn = c
 			st.mu.Unlock()
+			st.readyOnce.Do(func() { close(st.connReady) })
 			// Read loop mirroring the real handler (internal/ws/handler.go:377).
 			// Control frames are only processed while something reads, so a stub
 			// that never reads never answers the client's close frame — and the
@@ -118,6 +131,14 @@ func wsStub(t *testing.T) (*httptest.Server, *wsStubState) {
 			st.mu.Unlock()
 			w.WriteHeader(http.StatusOK)
 		case strings.HasSuffix(r.URL.Path, "/messages") && r.Method == http.MethodPost:
+			readyCtx, cancelReady := context.WithTimeout(r.Context(), 2*time.Second)
+			defer cancelReady()
+			select {
+			case <-st.connReady:
+			case <-readyCtx.Done():
+				http.Error(w, "websocket registration timeout", http.StatusGatewayTimeout)
+				return
+			}
 			raw, _ := io.ReadAll(io.LimitReader(r.Body, 1<<20))
 			var in struct {
 				Subject string `json:"subject"`
@@ -144,7 +165,9 @@ func wsStub(t *testing.T) (*httptest.Server, *wsStubState) {
 }
 
 func TestScenarioWebSocketRoundTrip(t *testing.T) {
-	srv, st := wsStub(t)
+	// Widen the real post-upgrade window: websocket.Accept can flush HTTP 101
+	// before the handler stores the connection, so Dial may return first.
+	srv, st := wsStubWithRegistrationDelay(t, 50*time.Millisecond)
 	defer srv.Close()
 	p := failProbe(srv.URL, "", nil)
 	if r := scenarioWebSocketRoundTrip(context.Background(), p); r.Status != StatusPass {


### PR DESCRIPTION
## Summary

Eliminate the `TestScenarioWebSocketRoundTrip` coverage flake by synchronizing
the test stub's self-send handler with WebSocket connection registration.

`websocket.Accept` can flush HTTP 101 before the server goroutine stores the
accepted connection. The client can therefore finish `Dial`, immediately POST
the self-send, and make the stub observe `conn == nil`; the stub silently
dropped the push and the scenario timed out.

The stub now closes a readiness channel after storing the connection, and its
POST path waits on that channel with a bounded context. The happy-path test
uses a phase barrier to prove POST has entered, then deliberately delays
registration by 50 ms so the readiness handoff is exercised.

## Scope

Test infrastructure only. Production WebSocket behavior and API contracts are
unchanged.

## Test plan

- [x] RED: delayed registration reproduced the missing push, missing inbound
  cleanup, and close-handshake cascade before the readiness handoff
- [x] `go test -covermode=atomic ./internal/selftest -run '^TestScenarioWebSocketRoundTrip$' -count=20`
- [x] `go test ./internal/selftest -count=1`
- [x] `make cover`
- [x] `go run github.com/vladopajic/go-test-coverage/v2@v2.14.3 --config=.testcoverage.yml`

Full coverage completed successfully: `internal/selftest` 87.5%, total 78.1%.
