### PR TITLE
docs: correct data-handling.md log-redaction claims

### DIFF
--- a/docs/data-handling.md
+++ b/docs/data-handling.md
@@ -23,7 +23,7 @@ For vulnerability reporting and the security model, see [SECURITY.md](../SECURIT
 
 ## What's logged
 
-- The SMTP relay logs envelope metadata on every inbound message: sender address, recipient list, byte count, the SPF/DKIM verdict. This is standard MTA practice (Postfix and other relays log the same), but it does mean **PII (sender + recipient addresses) appears in application logs** and inherits whatever retention your log pipeline has. Operators in privacy-strict environments should plan for redaction in their log forwarder.
+- The SMTP relay logs envelope metadata on every inbound message: sender/recipient domains, byte count, the SPF/DKIM verdict. Addresses are redacted before they reach a log line (`internal/logredact`): an unresolved or external address is reduced to its domain (`AddressDomain` / `AddressDomains`), and client IPs are truncated to their network prefix (`IPNetwork`, `/24` for IPv4, `/48` for IPv6). Once a recipient resolves to one of the deployment's own agents, its full address is logged as the tracing key — that's e2a's own namespace, not third-party PII. Message subject lines are never logged in full, only `subject_len`. Operators in privacy-strict environments who also want resolved agent addresses redacted, or who need to bound retention of the domain-only remnants, should still plan for that in their log forwarder.
 - HITL state transitions log message IDs and agent IDs but not bodies.
 - Webhook delivery attempts log the destination URL and status code.
 
@@ -45,5 +45,5 @@ Things e2a doesn't (and can't) handle for you:
 - **Database backups.** Take them, encrypt them, set retention policy. e2a doesn't ship a backup story; use whatever your Postgres provider gives you.
 - **TLS termination** for the API and SMTP. Production mode enforces HTTPS for webhook delivery; the operator's reverse proxy / ingress terminates TLS for inbound API traffic and the SMTP relay's `tls_cert` / `tls_key` config covers `:2525`.
 - **At-rest encryption.** Disk-level / volume-level encryption is the operator's responsibility (Postgres TDE, EBS encryption, GCP CMEK, …). e2a does not currently encrypt message bodies or attachments at the application layer; if your threat model includes a privileged DBA, you'll want to add column-level encryption.
-- **Log redaction.** If your environment can't tolerate sender/recipient addresses in application logs, redact in your log forwarder — e2a does not currently offer a built-in structured-log toggle.
+- **Log redaction.** e2a already redacts unresolved/external addresses to domain-only and truncates client IPs before they reach `log.Printf` (`internal/logredact`); resolved agent addresses (your own users) are logged in full as the tracing key. If your environment can't tolerate that — or the domain-only remnants — redact further in your log forwarder; e2a doesn't expose a config toggle to suppress its own log lines.
 - **Compliance attestations** (SOC 2, HIPAA, ISO 27001) — those are deployment-level, not code-level.


### PR DESCRIPTION
## Summary

- `docs/data-handling.md` claimed the SMTP relay logs full sender/recipient addresses and that "e2a does not currently offer a built-in structured-log toggle" for redaction.
- That's stale: `internal/logredact` already exists and is used throughout `internal/relay/server.go` to reduce unresolved/external addresses to domain-only (`AddressDomain`/`AddressDomains`) and truncate client IPs to their network prefix (`IPNetwork`) before any `log.Printf` call. Message subjects are never logged in full either (`subject_len` only). Full addresses only appear in logs once a recipient has resolved to one of the deployment's own agents — intentional, since that's e2a's own tracing key, not third-party PII (see the invariant comment at `internal/relay/server.go:256`).
- Updated the "What's logged" and "Log redaction" sections in `docs/data-handling.md` to describe the actual (already-shipped) redaction behavior instead of telling operators they're on their own.

This is a docs-only change; deleted the "Client surface checklist" section per the PR template's own instructions for non-API changes.

## Test plan

- [x] Read `internal/logredact/logredact.go` and its usage in `internal/relay/server.go` to confirm the described behavior (domain-only redaction, IP truncation, subject-length-only logging, full address only after agent resolution).
- [ ] Docs-only change; no build/test required.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XnxFnX66s6eyaQWDC3c358)_