### PR TITLE
chore(mcp): move registry identity to dev.e2a/mcp-server

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -2,7 +2,7 @@
   "name": "@e2a/mcp-server",
   "version": "0.5.0",
   "description": "MCP server for e2a — email for AI agents",
-  "mcpName": "io.github.Mnexa-AI/mcp-server",
+  "mcpName": "dev.e2a/mcp-server",
   "type": "module",
   "main": "./dist/bin/http.js",
   "files": [

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.Mnexa-AI/mcp-server",
+  "name": "dev.e2a/mcp-server",
   "title": "e2a — email for AI agents",
   "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verified.",
   "websiteUrl": "https://e2a.dev",


### PR DESCRIPTION
## What

Two string changes — `mcp/server.json:3` and `mcp/package.json:5`:

```
io.github.Mnexa-AI/mcp-server  →  dev.e2a/mcp-server
```

## Why not `io.github.tokencanopy/mcp-server`

The first version of this PR did exactly that, and publishing it failed:

```
403 Forbidden — You have permission to publish: io.github.jiashuoz/*.
Attempting to publish: io.github.tokencanopy/mcp-server.
```

The registry **tightened its org rule**: publishing under `io.github.<org>/*` now requires Owner role *and* the registry's OAuth app to be approved for that org under third-party application access restrictions. That change is also why the old `io.github.Mnexa-AI/*` grant silently vanished from our token — it was present back in #103.

We could approve the app and carry on, but that leaves the identity welded to a GitHub org slug that already changed once, with no rename operation to recover. So this moves the authority to a domain we control.

## Why `dev.e2a`

`e2a.dev` is the product domain, already `websiteUrl`, already serving `api.e2a.dev/mcp`, and it isn't going to be renamed. Reverse-DNS gives the `dev.e2a` namespace. Domain auth needs no org role and no OAuth app approval, so two settings that can silently change stop being load-bearing.

## Why this needs no npm release

The registry normally verifies a name against the live npm manifest's `mcpName`. `@e2a/mcp-server@0.4.0` on npm carries the old value and npm publishing is retired (frozen, no trusted publisher), so that path is closed. `server.json` here is **remote-only** — no `packages[]` — so the publish authenticates against the domain alone.

## Also fixes the stale published entry

The live listing has drifted well past the name:

| field | published | this repo |
|---|---|---|
| `version` | 0.3.2 | 1.0.0 |
| `repository.url` | `github.com/Mnexa-AI/e2a` | `github.com/tokencanopy/e2a` |
| `remotes[].url` | `mcp.e2a.dev/mcp` | `api.e2a.dev/mcp` |
| `packages[]` | npm `@e2a/mcp-server@0.3.2` (stdio) | absent — hosted-only |

Both endpoints answer today (401 to an unauthenticated `initialize`), so nothing is broken for users — but the listing still advertises a stdio npm install that contradicts hosted-only.

## Maintainer steps after merge

```bash
# 1. proof record at the APEX of e2a.dev (not a selector — SPF-style placement)
#    e2a.dev. IN TXT "v=MCPv1; k=ed25519; p=<pubkey>"

# 2. publish
mcp-publisher login dns --domain e2a.dev --private-key <hex>
cd mcp && mcp-publisher publish
```

## Separate follow-up: retire the old entry

Domain auth grants `dev.e2a/*` only — it cannot touch `io.github.Mnexa-AI/mcp-server`. Deprecating that entry needs GitHub auth as a **Mnexa-AI Owner** with the registry OAuth app approved for the org:

```bash
mcp-publisher status --status deprecated --all-versions \
  --message "Moved to dev.e2a/mcp-server" io.github.Mnexa-AI/mcp-server
```

**Keep the reserved `Mnexa-AI` org held until that is done, and afterwards.** Registry publish rights key on the org slug, and the old listing carries a Bearer `Authorization` header marked `isSecret` — if the slug were released and claimed, its next owner could publish over the entry, repoint `remotes[].url`, and collect e2a API keys through every catalog that syncs the registry.

## Verification

- `mcp-publisher validate` passes on the new `server.json`
- `dev.e2a` confirmed unclaimed on the registry (0 entries)
- `e2a.dev` apex has SPF but no existing `MCPv1` record — no conflict
- No source, test, or lockfile reference to `mcpName` or the old slug; these two lines are the only occurrences repo-wide

## Follow-up

#755 (MCP Toplist badge) hardcodes the old slug in its link and should wait until the catalog resyncs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)