### PR TITLE
docs(readme): credit Token Canopy

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 Receive inbound over **webhook · WebSocket · REST · MCP**. Send through an **HTTP API**. Every sender — human or agent — **identity-verified**.
 
+<sub>A [Token Canopy](https://tokencanopy.com) product</sub>
+
 [![Tests](https://github.com/tokencanopy/e2a/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/tokencanopy/e2a/actions/workflows/test.yml)
 [![Build image](https://github.com/tokencanopy/e2a/actions/workflows/build-image.yml/badge.svg?branch=main)](https://github.com/tokencanopy/e2a/actions/workflows/build-image.yml)
 [![License](https://img.shields.io/github/license/tokencanopy/e2a)](LICENSE)

--- a/docs/superpowers/specs/2026-07-28-readme-token-canopy-branding-design.md
+++ b/docs/superpowers/specs/2026-07-28-readme-token-canopy-branding-design.md
@@ -1,0 +1,21 @@
+# README Token Canopy Branding
+
+## Goal
+
+Identify e2a as a Token Canopy product in the repository's top-level README
+without weakening e2a's product identity or adding visual clutter to its hero.
+
+## Design
+
+Add a single centered line reading **A Token Canopy product** immediately below
+the existing e2a tagline and product summary. Link “Token Canopy” to
+`https://tokencanopy.com`.
+
+The endorsement will use ordinary Markdown inside the README's existing
+centered HTML container. It will not add a second logo, change the e2a
+wordmark, alter the navigation, or repeat the parent brand elsewhere.
+
+## Verification
+
+Confirm that the README renders the endorsement in the centered hero, that the
+link target is correct, and that no unrelated README content changes.


### PR DESCRIPTION
## Summary

- Add a centered “A Token Canopy product” endorsement beneath the e2a README hero copy.
- Link the Token Canopy name to https://tokencanopy.com.
- Record the approved placement and scope in a short design note.

This makes e2a’s relationship to Token Canopy explicit without competing with e2a’s primary product identity. Documentation and branding only; no runtime, API, or dependency changes.

## Operational risk

None. README-only branding and documentation.

## Test plan

- [x] `git diff --check`
- [x] `scripts/check-repository-text-integrity.sh`