### PR TITLE
chore(mcp): add glama.json to claim the Glama server listing

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": [
+    "jiashuoz"
+  ]
+}


### PR DESCRIPTION
Glama now lists this repo at [glama.ai/mcp/servers/tokencanopy/e2a](https://glama.ai/mcp/servers/tokencanopy/e2a).

Claiming a server owned by an **organization** requires a `glama.json` at the repository root naming the GitHub accounts permitted to maintain the listing. The claim is completed afterwards by signing in to Glama with one of those accounts.

## Why claim it

- Correct the listing description (Glama generated its own from the repo).
- Receive notifications of reviews.
- **Prerequisite for the awesome-mcp-servers entry** — that list requires an inline Glama score badge, and PR punkpeye/awesome-mcp-servers#6741 was auto-closed for not having one.

## Contents

Only field the [schema](https://glama.ai/mcp/schemas/server.json) defines is `maintainers` (array of GitHub usernames, required):

```json
{
  "$schema": "https://glama.ai/mcp/schemas/server.json",
  "maintainers": ["jiashuoz"]
}
```

No secrets, no runtime effect — it is read by Glama from the public repo. Add more usernames here if other maintainers should be able to edit the listing.