### PR TITLE
docs: fix stale MCP tool counts, undocumented contacts feature, retired OAuth scope

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
   "plugins": [
     {
       "name": "e2a",
-      "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 60 MCP tools over hosted streamable HTTP with OAuth.",
+      "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 71 MCP tools over hosted streamable HTTP with OAuth.",
       "category": "productivity",
       "source": "./plugins/e2a",
       "homepage": "https://e2a.dev"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,7 +277,7 @@ manually on every API change even though the template won't remind you.
   definite configuration failure). Add new codes, never renumber.
 - **MCP server** (`mcp/`): inbox tools over the REST API; hosted HTTP
   transport (image `ghcr.io/tokencanopy/e2a-mcp-http`). **npm publishing is
-  retired** (`@e2a/mcp-server` frozen at 0.4.0) — do not configure a trusted
+  retired** (`@e2a/mcp-server` frozen at 0.5.0) — do not configure a trusted
   publisher.
 - **Web** (`web/`): Next.js 16 static export; dev rewrites `/api/*` to
   :8080; consumes `@e2a/ui` via a `file:` dep, so `design-system/dist/` is

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Authenticate either with **OAuth 2.1** (add e2a as a connector and authorize in 
 
 The toolset covers the full agent loop — inbox (`list_messages`, `get_message`, `get_attachment`, `list_conversations`, `get_conversation`, `update_message_labels`), outbound (`send_message`, `reply_to_message`, `forward_message`), HITL review (`list_reviews`, `get_review`, `approve_review`, `reject_review`), plus agent/domain/webhook management. Inbound is consumed by polling (`list_messages`) or a `create_webhook` subscription.
 
-The hosted server is the primary path; npm publishing of `@e2a/mcp-server` is retired (frozen at `0.4.0`). See [mcp/README.md](mcp/README.md) for per-framework setup and the full tool reference.
+The hosted server is the primary path; npm publishing of `@e2a/mcp-server` is retired (frozen at `0.5.0`). See [mcp/README.md](mcp/README.md) for per-framework setup and the full tool reference.
 
 ## CLI
 
@@ -251,7 +251,7 @@ domains/webhooks in the **web dashboard**.
 | `e2a agents list\|create\|get` | Manage inboxes (requires an account-scoped key) |
 | `e2a keys create\|list\|delete` | Mint, list, and revoke API keys (requires an account-scoped key) |
 | `e2a protection get\|set` | Show or update an agent's HITL screening/review config |
-| `e2a contacts list\|get\|create\|update\|delete\|import\|outreach ...` | Manage account contacts, suppression, and per-agent outreach state |
+| `e2a contacts list\|get\|create\|update\|delete\|import\|outreach ...` | Manage account contacts and per-agent outreach state, with suppression visibility |
 | `e2a send` / `e2a reply` | Send an email as the agent, or reply in-thread |
 | `e2a messages list\|get` | List or fetch messages for an agent |
 | `e2a listen --agent <email>` | Stream inbound email for an agent over WebSocket (real-time; `--json` for raw, `--forward <url>` to bridge to a local HTTP handler) |

--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ domains/webhooks in the **web dashboard**.
 | `e2a agents list\|create\|get` | Manage inboxes (requires an account-scoped key) |
 | `e2a keys create\|list\|delete` | Mint, list, and revoke API keys (requires an account-scoped key) |
 | `e2a protection get\|set` | Show or update an agent's HITL screening/review config |
+| `e2a contacts list\|get\|create\|update\|delete\|import\|outreach ...` | Manage account contacts, suppression, and per-agent outreach state |
 | `e2a send` / `e2a reply` | Send an email as the agent, or reply in-thread |
 | `e2a messages list\|get` | List or fetch messages for an agent |
 | `e2a listen --agent <email>` | Stream inbound email for an agent over WebSocket (real-time; `--json` for raw, `--forward <url>` to bridge to a local HTTP handler) |

--- a/cli/README.md
+++ b/cli/README.md
@@ -235,6 +235,35 @@ a message's observed lifecycle transitions; flags: `--cursor` (continue from a
 prior page), `--limit` (page size, 1–100), `--agent`, `--json` (print the
 canonical lifecycle page as JSON).
 
+### `e2a contacts`
+
+Manage account-level contacts (identity + suppression) and per-agent outreach
+state (requires an account-scoped key, except `outreach`, which is agent-scoped).
+
+```bash
+e2a contacts list --source import --limit 50 --json
+e2a contacts get alice@example.com
+e2a contacts create alice@example.com --idempotency-key <uuid>
+e2a contacts update alice@example.com --metadata '{"tier":"gold"}' --if-match <etag>
+e2a contacts delete alice@example.com
+e2a contacts import contacts.csv --agent bot@acme.com --stage new --on-conflict merge
+e2a contacts imports delete <import-batch-id>
+e2a contacts outreach list --agent bot@acme.com --stage new --replied false
+e2a contacts outreach get alice@example.com --agent bot@acme.com
+e2a contacts outreach set alice@example.com --agent bot@acme.com --stage replied --next-action clear
+e2a contacts outreach delete alice@example.com --agent bot@acme.com
+```
+
+`list`/`outreach list` flags: `--source` (`import`/`manual`/`inbound`),
+`--import-batch`, `--created-after`/`--created-before` (list) or
+`--stage`/`--replied`/`--suppressed`/`--next-action-before`/
+`--last-outbound-before` (outreach list), `--limit`, `--json` (NDJSON instead
+of TSV). `create`/`import` accept `--idempotency-key` to safely replay a
+timed-out request. `update`/`outreach set` accept `--if-match <etag>` to
+reject a stale edit. `import` reads an RFC 4180 CSV (`--email-column`,
+`--name-column`, `--on-conflict merge|skip`, `--dry-run` to preview without
+writing); `imports delete` reverses one import batch.
+
 ### `e2a listen`
 
 Stream inbound email for an agent over WebSocket in real time. The connection is

--- a/cli/README.md
+++ b/cli/README.md
@@ -237,8 +237,9 @@ canonical lifecycle page as JSON).
 
 ### `e2a contacts`
 
-Manage account-level contacts (identity + suppression) and per-agent outreach
-state (requires an account-scoped key, except `outreach`, which is agent-scoped).
+Manage account-level contact identity and per-agent outreach state, with
+suppression visibility. Contact identity operations require account scope;
+`outreach` also supports an agent-scoped credential for its bound inbox.
 
 ```bash
 e2a contacts list --source import --limit 50 --json
@@ -253,6 +254,9 @@ e2a contacts outreach get alice@example.com --agent bot@acme.com
 e2a contacts outreach set alice@example.com --agent bot@acme.com --stage replied --next-action clear
 e2a contacts outreach delete alice@example.com --agent bot@acme.com
 ```
+
+`contacts delete` removes the account contact and all of its per-agent outreach
+rows; suppression and consent records survive.
 
 `list`/`outreach list` flags: `--source` (`import`/`manual`/`inbound`),
 `--import-batch`, `--created-after`/`--created-before` (list) or

--- a/docs/runbooks/mcp-server.md
+++ b/docs/runbooks/mcp-server.md
@@ -116,7 +116,7 @@ design.
 
 - **Symptoms**: requests succeed, but the credential is served at
   least-privilege **agent scope**: account-scoped callers see the tool list
-  shrink from 60 tools to the 16 runtime tools, and the per-request default
+  shrink from 71 tools to the 20 runtime tools, and the per-request default
   agent is unset (explicit `email` required).
 - **Detection**: `auth_resolution` WARNING `whoami probe failed; serving
   least-privilege fallback`; `mcp_auth_resolutions_total{result="fallback"}`.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -121,15 +121,15 @@ Hosts that support OAuth connectors can instead add `https://api.e2a.dev/mcp` as
 
 ## Tools
 
-The server exposes up to **60** tools spanning agents, messages, human-in-the-loop
-approval, attachments, domains, events, webhooks, API keys, and email templates
-(beta).
+The server exposes up to **71** tools spanning agents, messages, human-in-the-loop
+approval, attachments, domains, events, webhooks, API keys, contacts/outreach,
+and email templates (beta).
 **The visible set depends on your credential's scope:** an **agent**-scoped
-credential sees the 16 runtime/inbox tools (read, send, reply, restore messages);
-an **account**-scoped credential also sees the 44 admin/setup
-tools (agent/domain/webhook/event/template/API-key management — **and HITL
-review discovery plus approve/reject, which is an account-owner action, never
-agent self-approval**) — all 60.
+credential sees the 20 runtime/inbox tools (read, send, reply, restore
+messages, per-agent outreach); an **account**-scoped credential also sees the
+51 admin/setup tools (agent/domain/webhook/event/template/API-key/contact
+management — **and HITL review discovery plus approve/reject, which is an
+account-owner action, never agent self-approval**) — all 71.
 Every tool carries MCP annotations (`readOnlyHint`/`destructiveHint`/
 `idempotentHint`) so hosts can auto-approve reads and flag destructive actions.
 The tables below highlight the most commonly used ones — your MCP host's tool list
@@ -206,6 +206,25 @@ dashboard or the raw API, where a human is in the loop.
 | `list_api_keys` | List the account's API keys — metadata only (secrets are shown once, at creation). |
 | `create_api_key` | Mint a new agent-scoped key bound to an inbox; returns the plaintext key ONCE — store it immediately. |
 | `delete_api_key` | Revoke a key permanently (requires `confirm: true`). |
+
+### Contacts (beta)
+
+The people an account corresponds with (`list_contacts` / `get_contact` /
+`create_contact` / `update_contact` / `delete_contact`, admin/account-scoped)
+and one agent's per-contact outreach state — stage, next action, reply/
+suppression facts (`list_outreach_contacts` / `get_outreach_contact` /
+`set_outreach_contact` / `delete_outreach_contact`, agent-scoped). Import is
+inert — it records identity and enrolls outreach without sending anything.
+
+| Tool | Description |
+| --- | --- |
+| `list_contacts` / `get_contact` | List account contacts (filter by provenance/import batch/creation window) or fetch one by address. |
+| `create_contact` / `update_contact` / `delete_contact` | Create, partially update (`etag`-guarded via `if_match`), or delete a contact's identity. Deleting a contact does not remove suppressions. |
+| `import_contacts` | Bulk-import contacts from rows, optionally enrolling them into an agent's outreach. |
+| `delete_contact_import` | Reverse an import batch, removing untouched contacts and the enrolments it created. |
+| `list_outreach_contacts` / `get_outreach_contact` | List or fetch the contacts an agent is working, with server-derived reply/delivery facts. |
+| `set_outreach_contact` | Enroll a contact in an agent's outreach, or update the agent-owned fields (stage, next action). |
+| `delete_outreach_contact` | Un-enroll a contact from an agent's outreach; the contact and its suppressions survive. |
 
 ### Templates (beta)
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -213,8 +213,9 @@ The people an account corresponds with (`list_contacts` / `get_contact` /
 `create_contact` / `update_contact` / `delete_contact`, admin/account-scoped)
 and one agent's per-contact outreach state — stage, next action, reply/
 suppression facts (`list_outreach_contacts` / `get_outreach_contact` /
-`set_outreach_contact` / `delete_outreach_contact`, agent-scoped). Import is
-inert — it records identity and enrolls outreach without sending anything.
+`set_outreach_contact` / `delete_outreach_contact`, available to account scope
+or an agent-scoped credential for its bound inbox). Import is inert — it
+records identity and enrolls outreach without sending anything.
 
 | Tool | Description |
 | --- | --- |

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -219,7 +219,7 @@ inert — it records identity and enrolls outreach without sending anything.
 | Tool | Description |
 | --- | --- |
 | `list_contacts` / `get_contact` | List account contacts (filter by provenance/import batch/creation window) or fetch one by address. |
-| `create_contact` / `update_contact` / `delete_contact` | Create, partially update (`etag`-guarded via `if_match`), or delete a contact's identity. Deleting a contact does not remove suppressions. |
+| `create_contact` / `update_contact` / `delete_contact` | Create, partially update (`etag`-guarded via `if_match`), or delete a contact's identity and all of its per-agent outreach rows. Deleting a contact does not remove suppressions. |
 | `import_contacts` | Bulk-import contacts from rows, optionally enrolling them into an agent's outreach. |
 | `delete_contact_import` | Reverse an import batch, removing untouched contacts and the enrolments it created. |
 | `list_outreach_contacts` / `get_outreach_contact` | List or fetch the contacts an agent is working, with server-derived reply/delivery facts. |

--- a/mcp/examples/README.md
+++ b/mcp/examples/README.md
@@ -12,7 +12,7 @@ End-to-end demos showing how to wire the e2a MCP surface into popular agent fram
 
 ## One hosted endpoint, same tool surface
 
-Each example exercises the same e2a tool surface (60 tools; the visible set depends on your key's scope) against the hosted MCP server. The Python framework examples ship an `agent.py` script; the Codex example ships a TOML block (Codex is itself the agent, so you configure it instead of writing a script).
+Each example exercises the same e2a tool surface (71 tools; the visible set depends on your key's scope) against the hosted MCP server. The Python framework examples ship an `agent.py` script; the Codex example ships a TOML block (Codex is itself the agent, so you configure it instead of writing a script).
 
 Every example connects to `https://api.e2a.dev/mcp` over Streamable HTTP with an
 agent-scoped API key in the `Authorization` header. Set `E2A_MCP_URL` to point

--- a/mcp/examples/codex/README.md
+++ b/mcp/examples/codex/README.md
@@ -2,7 +2,7 @@
 
 [Codex CLI](https://github.com/openai/codex) is OpenAI's terminal coding agent (peer to Claude Code). It speaks MCP natively — you declare servers in `~/.codex/config.toml` and Codex connects to them at session start, then surfaces their tools to whatever model you're running.
 
-Unlike the [LangChain](../langchain/), [CrewAI](../crewai/), [Google ADK](../adk/), and [OpenAI Agents SDK](../openai-agents/) examples — which are Python scripts you run — Codex is itself the agent. The "example" here is the TOML you paste into your Codex config to add e2a's MCP tools (60 total; the visible set depends on your key's scope).
+Unlike the [LangChain](../langchain/), [CrewAI](../crewai/), [Google ADK](../adk/), and [OpenAI Agents SDK](../openai-agents/) examples — which are Python scripts you run — Codex is itself the agent. The "example" here is the TOML you paste into your Codex config to add e2a's MCP tools (71 total; the visible set depends on your key's scope).
 
 Codex opens a Streamable HTTP session to the hosted endpoint at `https://api.e2a.dev/mcp` with your API key in the `Authorization: Bearer …` header — no Node toolchain on the host (works on CI runners, dev containers, remote app servers, etc.).
 

--- a/plugins/e2a/.claude-plugin/plugin.json
+++ b/plugins/e2a/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "e2a",
   "displayName": "e2a",
   "version": "0.5.0",
-  "description": "Authenticated email gateway for AI agents — per-agent inboxes, SPF/DKIM verification, and a queryable, replayable event log. 60 MCP tools over hosted streamable HTTP with OAuth.",
+  "description": "Authenticated email gateway for AI agents — per-agent inboxes, SPF/DKIM verification, and a queryable, replayable event log. 71 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "TokenCanopy",
     "url": "https://e2a.dev"

--- a/plugins/e2a/.codex-plugin/plugin.json
+++ b/plugins/e2a/.codex-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "e2a",
   "displayName": "e2a",
   "version": "0.5.0",
-  "description": "Authenticated email gateway for AI agents — per-agent inboxes, SPF/DKIM verification, and a queryable, replayable event log. 60 MCP tools over hosted streamable HTTP with OAuth.",
+  "description": "Authenticated email gateway for AI agents — per-agent inboxes, SPF/DKIM verification, and a queryable, replayable event log. 71 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "TokenCanopy"
   },

--- a/plugins/e2a/.cursor-plugin/plugin.json
+++ b/plugins/e2a/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "e2a",
   "displayName": "e2a",
   "version": "0.5.0",
-  "description": "Authenticated email gateway for AI agents — per-agent inboxes, SPF/DKIM verification, and a queryable, replayable event log. 60 MCP tools over hosted streamable HTTP with OAuth.",
+  "description": "Authenticated email gateway for AI agents — per-agent inboxes, SPF/DKIM verification, and a queryable, replayable event log. 71 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "TokenCanopy",
     "url": "https://e2a.dev"

--- a/plugins/e2a/docs/auth.md
+++ b/plugins/e2a/docs/auth.md
@@ -36,9 +36,9 @@ Both are presented as `Authorization: Bearer <credential>`.
 
 If you are an MCP client, you do not need an API key. Run the standard discovery + DCR + authorization-code flow:
 
-1. **Discover** — `GET https://api.e2a.dev/.well-known/oauth-authorization-server`. Read `registration_endpoint`, `authorization_endpoint`, `token_endpoint`. Scope to request: `agent` (add `account` for workspace-admin access).
-2. **Register** — `POST` your client metadata to `registration_endpoint` (RFC 7591). You'll receive a `client_id`. Token endpoint auth method is `none` — you are a public client.
-3. **Authorize** — redirect the user to `authorization_endpoint` with `response_type=code`, your `client_id`, `redirect_uri`, `scope=agent`, and PKCE S256 (`code_challenge`, `code_challenge_method=S256`). The user logs in to e2a and consents.
+1. **Discover** — `GET https://api.e2a.dev/.well-known/oauth-authorization-server`. Read `registration_endpoint`, `authorization_endpoint`, `token_endpoint`, and `scopes_supported` (`agent` and `account`).
+2. **Register** — `POST` your client metadata to `registration_endpoint` (RFC 7591), including `scope: "agent"` for agent-only access or `scope: "agent account"` to make workspace-admin consent eligible. Account scope is eligible only when every registered redirect URI is HTTPS or an HTTP loopback URI. Omitting `scope` registers the full ceiling the redirect URIs allow. You'll receive a `client_id`; token endpoint auth method is `none` because you are a public client.
+3. **Authorize** — redirect the user to `authorization_endpoint` with `response_type=code`, your `client_id`, `redirect_uri`, a space-delimited scope matching the registered access (`scope=agent` or `scope=agent account`, query-encoded), and PKCE S256 (`code_challenge`, `code_challenge_method=S256`). The user logs in and chooses the exact grant.
 4. **Token exchange** — `POST` `code` + `code_verifier` to `token_endpoint`. You receive `access_token` (prefix `ate2a_…`) and `refresh_token`.
 5. **Use** — present the access token as a bearer; refresh with the refresh token before `expires_in`.
 

--- a/plugins/e2a/docs/auth.md
+++ b/plugins/e2a/docs/auth.md
@@ -36,9 +36,9 @@ Both are presented as `Authorization: Bearer <credential>`.
 
 If you are an MCP client, you do not need an API key. Run the standard discovery + DCR + authorization-code flow:
 
-1. **Discover** — `GET https://api.e2a.dev/.well-known/oauth-authorization-server`. Read `registration_endpoint`, `authorization_endpoint`, `token_endpoint`. Scope to request: `mcp`.
+1. **Discover** — `GET https://api.e2a.dev/.well-known/oauth-authorization-server`. Read `registration_endpoint`, `authorization_endpoint`, `token_endpoint`. Scope to request: `agent` (add `account` for workspace-admin access).
 2. **Register** — `POST` your client metadata to `registration_endpoint` (RFC 7591). You'll receive a `client_id`. Token endpoint auth method is `none` — you are a public client.
-3. **Authorize** — redirect the user to `authorization_endpoint` with `response_type=code`, your `client_id`, `redirect_uri`, `scope=mcp`, and PKCE S256 (`code_challenge`, `code_challenge_method=S256`). The user logs in to e2a and consents.
+3. **Authorize** — redirect the user to `authorization_endpoint` with `response_type=code`, your `client_id`, `redirect_uri`, `scope=agent`, and PKCE S256 (`code_challenge`, `code_challenge_method=S256`). The user logs in to e2a and consents.
 4. **Token exchange** — `POST` `code` + `code_verifier` to `token_endpoint`. You receive `access_token` (prefix `ate2a_…`) and `refresh_token`.
 5. **Use** — present the access token as a bearer; refresh with the refresh token before `expires_in`.
 
@@ -166,7 +166,7 @@ No code reading, no copy-paste, no transcript leakage. This is uniquely possible
 
 What e2a publishes today:
 
-- **RFC 8414 authorization-server metadata** at [`https://api.e2a.dev/.well-known/oauth-authorization-server`](https://api.e2a.dev/.well-known/oauth-authorization-server) — advertises `authorization_endpoint`, `token_endpoint`, `registration_endpoint`, `revocation_endpoint`, supported grants (`authorization_code`, `refresh_token`), PKCE (`S256`), and the RFC 9207 `iss` parameter. Request the `mcp` scope.
+- **RFC 8414 authorization-server metadata** at [`https://api.e2a.dev/.well-known/oauth-authorization-server`](https://api.e2a.dev/.well-known/oauth-authorization-server) — advertises `authorization_endpoint`, `token_endpoint`, `registration_endpoint`, `revocation_endpoint`, supported grants (`authorization_code`, `refresh_token`), PKCE (`S256`), and the RFC 9207 `iss` parameter. Request the `agent` scope (`account` for workspace-admin access).
 - **RFC 6750 Bearer challenges** on every 401 from `/v1/...` — `WWW-Authenticate: Bearer realm="e2a"` for unknown/missing credentials, plus RFC 6750 §3.1 error params for OAuth-bearer failures.
 
 What e2a publishes for the autonomous-agent path today (gated behind an opt-in signing-key config; see [Agent identity](#agent-identity)):

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -346,7 +346,7 @@ referenced from `messages.send` via `template_id`/`template_alias`.
 `client.contacts` manages the people an account corresponds with:
 `list`/`get`/`get_with_etag`/`create`/`update`/`delete` (account-scoped,
 optimistic concurrency via `if_match`), plus `import_`/`delete_import` for
-CSV-driven bulk upload. `client.contacts.outreach(email, ...)` and its
+structured-row bulk imports. `client.contacts.outreach(email, ...)` and its
 `get_outreach`/`get_outreach_with_etag`/`set_outreach`/`delete_outreach`
 counterparts track one agent's per-contact engagement (stage, next action,
 reply/suppression state) and may be driven by an agent-scoped credential.

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -343,6 +343,14 @@ alone via `list`/`get`/`approve`/`reject`; and `client.templates` (beta) —
 reusable `{{variable}}` email templates plus the read-only starter catalog,
 referenced from `messages.send` via `template_id`/`template_alias`.
 
+`client.contacts` manages the people an account corresponds with:
+`list`/`get`/`get_with_etag`/`create`/`update`/`delete` (account-scoped,
+optimistic concurrency via `if_match`), plus `import_`/`delete_import` for
+CSV-driven bulk upload. `client.contacts.outreach(email, ...)` and its
+`get_outreach`/`get_outreach_with_etag`/`set_outreach`/`delete_outreach`
+counterparts track one agent's per-contact engagement (stage, next action,
+reply/suppression state) and may be driven by an agent-scoped credential.
+
 The sync `E2AClient` exposes the **same resource tree** — drop the `await`.
 It mirrors the async client dynamically (every async method is bridged, not
 re-implemented), so the two surfaces are identical by construction.

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -296,10 +296,10 @@ referenced from `messages.send` via `template_id`/`template_alias`.
 `client.contacts` manages the people an account corresponds with:
 `list`/`get`/`getWithETag`/`create`/`update`/`delete` (account-scoped,
 optimistic concurrency via `ifMatch`), plus `import`/`deleteImport` for
-CSV-driven bulk upload. `client.contacts.outreach(address, params)` and its
-`get`/`set`/`delete` counterparts track one agent's per-contact engagement
-(stage, next action, reply/suppression state) and may be driven by an
-agent-scoped credential.
+structured-row bulk imports. `client.contacts.outreach(email, params)` and its
+`getOutreach`/`getOutreachWithETag`/`setOutreach`/`deleteOutreach` counterparts
+track one agent's per-contact engagement (stage, next action,
+reply/suppression state) and may be driven by an agent-scoped credential.
 
 ### `new E2AClient(options?)`
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -293,6 +293,14 @@ alone via `list`/`get`/`approve`/`reject`; and `client.templates` (beta) —
 reusable `{{variable}}` email templates plus the read-only starter catalog,
 referenced from `messages.send` via `template_id`/`template_alias`.
 
+`client.contacts` manages the people an account corresponds with:
+`list`/`get`/`getWithETag`/`create`/`update`/`delete` (account-scoped,
+optimistic concurrency via `ifMatch`), plus `import`/`deleteImport` for
+CSV-driven bulk upload. `client.contacts.outreach(address, params)` and its
+`get`/`set`/`delete` counterparts track one agent's per-contact engagement
+(stage, next action, reply/suppression state) and may be driven by an
+agent-scoped credential.
+
 ### `new E2AClient(options?)`
 
 | Option         | Type     | Default                 | Description                              |

--- a/web/public/auth.md
+++ b/web/public/auth.md
@@ -36,9 +36,9 @@ Both are presented as `Authorization: Bearer <credential>`.
 
 If you are an MCP client, you do not need an API key. Run the standard discovery + DCR + authorization-code flow:
 
-1. **Discover** — `GET https://api.e2a.dev/.well-known/oauth-authorization-server`. Read `registration_endpoint`, `authorization_endpoint`, `token_endpoint`. Scope to request: `agent` (add `account` for workspace-admin access).
-2. **Register** — `POST` your client metadata to `registration_endpoint` (RFC 7591). You'll receive a `client_id`. Token endpoint auth method is `none` — you are a public client.
-3. **Authorize** — redirect the user to `authorization_endpoint` with `response_type=code`, your `client_id`, `redirect_uri`, `scope=agent`, and PKCE S256 (`code_challenge`, `code_challenge_method=S256`). The user logs in to e2a and consents.
+1. **Discover** — `GET https://api.e2a.dev/.well-known/oauth-authorization-server`. Read `registration_endpoint`, `authorization_endpoint`, `token_endpoint`, and `scopes_supported` (`agent` and `account`).
+2. **Register** — `POST` your client metadata to `registration_endpoint` (RFC 7591), including `scope: "agent"` for agent-only access or `scope: "agent account"` to make workspace-admin consent eligible. Account scope is eligible only when every registered redirect URI is HTTPS or an HTTP loopback URI. Omitting `scope` registers the full ceiling the redirect URIs allow. You'll receive a `client_id`; token endpoint auth method is `none` because you are a public client.
+3. **Authorize** — redirect the user to `authorization_endpoint` with `response_type=code`, your `client_id`, `redirect_uri`, a space-delimited scope matching the registered access (`scope=agent` or `scope=agent account`, query-encoded), and PKCE S256 (`code_challenge`, `code_challenge_method=S256`). The user logs in and chooses the exact grant.
 4. **Token exchange** — `POST` `code` + `code_verifier` to `token_endpoint`. You receive `access_token` (prefix `ate2a_…`) and `refresh_token`.
 5. **Use** — present the access token as a bearer; refresh with the refresh token before `expires_in`.
 

--- a/web/public/auth.md
+++ b/web/public/auth.md
@@ -36,9 +36,9 @@ Both are presented as `Authorization: Bearer <credential>`.
 
 If you are an MCP client, you do not need an API key. Run the standard discovery + DCR + authorization-code flow:
 
-1. **Discover** — `GET https://api.e2a.dev/.well-known/oauth-authorization-server`. Read `registration_endpoint`, `authorization_endpoint`, `token_endpoint`. Scope to request: `mcp`.
+1. **Discover** — `GET https://api.e2a.dev/.well-known/oauth-authorization-server`. Read `registration_endpoint`, `authorization_endpoint`, `token_endpoint`. Scope to request: `agent` (add `account` for workspace-admin access).
 2. **Register** — `POST` your client metadata to `registration_endpoint` (RFC 7591). You'll receive a `client_id`. Token endpoint auth method is `none` — you are a public client.
-3. **Authorize** — redirect the user to `authorization_endpoint` with `response_type=code`, your `client_id`, `redirect_uri`, `scope=mcp`, and PKCE S256 (`code_challenge`, `code_challenge_method=S256`). The user logs in to e2a and consents.
+3. **Authorize** — redirect the user to `authorization_endpoint` with `response_type=code`, your `client_id`, `redirect_uri`, `scope=agent`, and PKCE S256 (`code_challenge`, `code_challenge_method=S256`). The user logs in to e2a and consents.
 4. **Token exchange** — `POST` `code` + `code_verifier` to `token_endpoint`. You receive `access_token` (prefix `ate2a_…`) and `refresh_token`.
 5. **Use** — present the access token as a bearer; refresh with the refresh token before `expires_in`.
 
@@ -166,7 +166,7 @@ No code reading, no copy-paste, no transcript leakage. This is uniquely possible
 
 What e2a publishes today:
 
-- **RFC 8414 authorization-server metadata** at [`https://api.e2a.dev/.well-known/oauth-authorization-server`](https://api.e2a.dev/.well-known/oauth-authorization-server) — advertises `authorization_endpoint`, `token_endpoint`, `registration_endpoint`, `revocation_endpoint`, supported grants (`authorization_code`, `refresh_token`), PKCE (`S256`), and the RFC 9207 `iss` parameter. Request the `mcp` scope.
+- **RFC 8414 authorization-server metadata** at [`https://api.e2a.dev/.well-known/oauth-authorization-server`](https://api.e2a.dev/.well-known/oauth-authorization-server) — advertises `authorization_endpoint`, `token_endpoint`, `registration_endpoint`, `revocation_endpoint`, supported grants (`authorization_code`, `refresh_token`), PKCE (`S256`), and the RFC 9207 `iss` parameter. Request the `agent` scope (`account` for workspace-admin access).
 - **RFC 6750 Bearer challenges** on every 401 from `/v1/...` — `WWW-Authenticate: Bearer realm="e2a"` for unknown/missing credentials, plus RFC 6750 §3.1 error params for OAuth-bearer failures.
 
 What e2a publishes for the autonomous-agent path today (gated behind an opt-in signing-key config; see [Agent identity](#agent-identity)):


### PR DESCRIPTION
## Summary

Scheduled documentation audit of every Markdown file in the repo, cross-checked against current code. Docs-only change; three verified drifts:

- **Undocumented `contacts`/outreach feature** (shipped in #754): `README.md`'s CLI table, `cli/README.md`, and both SDK READMEs' Resources lists never mentioned it, even though it's fully implemented and already surfaced in the CLI's own `--help` text and both SDK clients (`ContactsResource` in TS/Python). Added a `### e2a contacts` section to `cli/README.md`, a table row to `README.md`, and Resources-list paragraphs to `sdks/typescript/README.md` / `sdks/python/README.md`.
- **Stale MCP tool counts**: the contacts feature added 11 MCP tools (4 runtime + 7 admin), but every doc that quotes a tool count still said "60" (16 runtime / 44 admin) instead of the current 71 (20 runtime / 51 admin) — verified against `mcp/src/tools/tiers.ts` and every `registerTool()` call site. Fixed in `mcp/README.md` (also added a missing "Contacts" tools section there), `mcp/examples/README.md`, `mcp/examples/codex/README.md`, `docs/runbooks/mcp-server.md`, and all four plugin manifests (`.claude-plugin/marketplace.json` + the three `plugins/e2a/.*-plugin/plugin.json`).
- **Retired OAuth scope reference**: `plugins/e2a/docs/auth.md` told MCP clients to request the `mcp` OAuth scope, which was retired in favor of `agent`/`account` (`internal/agent/oauth_handlers.go`). Fixed the canonical doc and re-ran `node scripts/sync-agent-docs.mjs` to refresh the `web/public/auth.md` mirror.
- Also corrected `AGENTS.md`'s "`@e2a/mcp-server` frozen at 0.4.0" claim, which no longer matched `mcp/package.json` (`0.5.0`).

No code changes. Verified: `node scripts/validate-plugin.mjs`, `node scripts/sync-agent-docs.mjs --check`, and `bash scripts/check-repository-text-integrity.sh` all pass.

## Test plan

- [x] `node scripts/validate-plugin.mjs` — plugin manifests valid and in sync
- [x] `node scripts/sync-agent-docs.mjs --check` — mirrors in sync
- [x] `bash scripts/check-repository-text-integrity.sh` — passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01WnaFHKiNcPgPtRpAKWSyA8)_