### PR TITLE
docs: document contact.due event and internal/contactdue package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,7 +211,10 @@ Key packages, grouped (name — a few words each):
 - Webhooks & jobs: `webhook`/`webhookdelivery`/`webhookpub` subscriptions,
   durable fan-out, SSRF-guarded HTTP POST delivery+retry; `eventpayload`
   typed webhook `data` payloads; `jobs` River-backed durable job runtime
-  (Postgres mandatory); `janitor` periodic TTL sweeps (trash, expired holds).
+  (Postgres mandatory); `janitor` periodic TTL sweeps (trash, expired holds);
+  `contactdue` outreach wake-up sweep — emits `contact.due` for engagements
+  past `next_action_at`, on its own River queue/interval, deliberately
+  separate from the janitor's cleanup cadence.
 - Send guards & accounting: `idempotency` `Idempotency-Key` storage+replay;
   `unsubscribe` opaque per-recipient unsubscribe tokens/URLs
   (List-Unsubscribe); `usage`/`limits` usage metering + plan/account
@@ -291,8 +294,8 @@ manually on every API change even though the template won't remind you.
   runs everything with `-tags integration -p 4` (safe: per-package test DBs). CI additionally race-checks
   `./internal/sendramp` and `./internal/outboundsend` with `-race`.
 - **Coverage ratchet**: `.testcoverage.yml` sets per-package floors (currently
-  webhook, webhookpub, webhookdelivery, httpapi, outboundsend, sendramp,
-  inboundprocess, jobs, auth, apiserver, loopback, inboundscreen).
+  webhook, webhookpub, webhookdelivery, httpapi, contactdue, outboundsend,
+  sendramp, inboundprocess, jobs, auth, apiserver, loopback, inboundscreen).
   Ratchet floors UP, never down. `make cover-check` runs the same gate CI
   runs (`vladopajic/go-test-coverage`).
 - **Contract tests**: TS and Python SDK contract tests run against

--- a/docs/api.md
+++ b/docs/api.md
@@ -748,9 +748,8 @@ own **per-webhook signing secret** that signs the payloads sent to it.
 
 Agent-scoped suppression management is beta. The authenticated list, create,
 and delete operations and their request/response schemas may change before
-they are declared stable. `agent.suppression_added`, `contact.due` is a beta event emitted
-once when a new exact-agent
-block is created. Its current payload is
+they are declared stable. `agent.suppression_added` is a beta event emitted
+once when a new exact-agent block is created. Its current payload is
 `{agent_email, address, source}`, where `source` is `unsubscribe` or `manual`.
 Consumers must tolerate additive or other beta payload changes. The existing
 stable `domain.suppression_added` event remains account-scoped and unchanged.

--- a/docs/events.md
+++ b/docs/events.md
@@ -70,8 +70,9 @@ async with AsyncE2AClient(api_key=os.environ["E2A_API_KEY"]) as client:
 | `agent.suppression_added` | A recipient was suppressed for one exact sending agent through managed unsubscribe or the management API | Best-effort; **beta** |
 | `domain.sending_verified` | A domain's async SES sending identity reached the verified terminal state | Best-effort |
 | `domain.sending_failed` | A domain's async SES sending identity reached a failed terminal state | Best-effort |
+| `contact.due` | An outreach engagement's `next_action_at` passed, waking an agent that is not running | **At-least-once**; **beta** |
 
-The review-hold + screening events (`email.flagged`, `email.blocked`, `email.review_requested`, `email.review_approved`, `email.review_rejected`) and `agent.suppression_added` are **beta** — their payloads may change before they are declared stable.
+The review-hold + screening events (`email.flagged`, `email.blocked`, `email.review_requested`, `email.review_approved`, `email.review_rejected`), `agent.suppression_added`, and `contact.due` are **beta** — their payloads may change before they are declared stable.
 
 One `email.blocked` asymmetry to know: an **outbound** gate-block refuses the send outright, so no message row exists — its `data.message_id` is a stable rowless soft-ref (`msgblk_…`), the event's top-level `message_id` is absent, and `GET /v1/events?message_id=…` cannot match it (filter by `type` + `agent_email`, or by `conversation_id`, instead). **Inbound** blocks are accept-then-quarantine, reference a real message, and filter normally.
 
@@ -164,6 +165,7 @@ beta event types must still parse. The stable mapping is:
 | `domain.sending_failed` | `DomainSendingFailedData` | `domain`, `sending_status` | `reason` |
 | `domain.suppression_added` | `DomainSuppressionAddedData` | `address`, `source` (`bounce` \| `complaint`) | `reason`, `message_id` |
 | `agent.suppression_added` (**beta**) | `AgentSuppressionAddedData` | `agent_email`, `address`, `source` (`unsubscribe` \| `manual`) | — |
+| `contact.due` (**beta**) | — (untyped, built in `internal/contactdue`) | `agent_email`, `address`, `stage`, `next_action_at`, `replied`, `outbound_count`, `contact` (`address`, `display_name`, `metadata`) | `last_outbound_at`, `last_conversation_id` |
 
 Notes:
 


### PR DESCRIPTION
## Summary

Scheduled documentation audit found the `contact.due` webhook event (shipped with the contacts/outreach feature) was undocumented, and `AGENTS.md`'s backend package inventory never picked up `internal/contactdue`.

- **`docs/api.md`**: the webhooks section had a garbled sentence — `contact.due` had been accidentally merged into the description of the unrelated `agent.suppression_added` event (wrong payload implied: `contact.due` does not carry `{agent_email, address, source}`). Split back into a clean, correct `agent.suppression_added` description.
- **`docs/events.md`**: `contact.due` was completely missing from the event-types table, the beta-events list, and the payload-schema table, even though it's a shipped, tested event (`internal/contactdue`, `webhookpub.EventContactDue`, `e2a_contact_due_events_total` metric). Added it as **at-least-once** (published via `webhookpub.PublishTx` in the same transaction as the schedule claim, per `internal/contactdue/publisher.go`) and **beta** (listed in `webhookpub.ExperimentalEventTypes`).
- **`AGENTS.md`**: added `contactdue` to the "Webhooks & jobs" package group (it was missing from the `internal/` package inventory entirely) and to the coverage-ratchet package list — `.testcoverage.yml` already gates it at a 75% floor, but the prose list of gated packages stopped at 12 instead of 13.

Verified each claim against `internal/webhookpub/event.go`, `internal/contactdue/publisher.go`, `.testcoverage.yml`, and `docs/design/2026-07-24-contacts-and-outreach-state.md` (which documents `contact.due` as durable at-least-once fan-out through the standard outbox).

Docs-only change — no API/behavior change, so the client-surface checklist doesn't apply.

## Test plan

- [x] Read-only doc verification against current Go source (`internal/webhookpub`, `internal/contactdue`, `.testcoverage.yml`) — no code changes made.
- [ ] Reviewer sanity-check of wording/tone.

---

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01ReXoZCexw8ARdjhYh6x7eT

---
_Generated by [Claude Code](https://claude.ai/code/session_01ReXoZCexw8ARdjhYh6x7eT)_