### PR TITLE
fix: close agent-enumeration oracles on consent and dashboard

### DIFF
--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -918,18 +918,6 @@ func (a *API) WWWAuthenticateChallenge(r *http.Request) string {
 	return a.authChallenge(r, err)
 }
 
-// resolveAgentForUser loads an agent by email address and verifies the user owns it.
-func (a *API) resolveAgentForUser(r *http.Request, email string, user *identity.User) (*identity.AgentIdentity, error) {
-	agent, err := a.store.GetAgentByEmail(r.Context(), email)
-	if err != nil {
-		return nil, fmt.Errorf("agent not found")
-	}
-	if agent.UserID != user.ID {
-		return nil, fmt.Errorf("forbidden")
-	}
-	return agent, nil
-}
-
 // --- Domain Management ---
 
 // dnsRecordCheck holds the per-record probe results for the verify

--- a/internal/agent/oauth_consent_test.go
+++ b/internal/agent/oauth_consent_test.go
@@ -3,6 +3,7 @@ package agent_test
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -493,8 +494,12 @@ func TestHTTP_Consent_Allow_Existing(t *testing.T) {
 	}
 }
 
-// TestHTTP_Consent_Allow_Existing_NotOwned — picking an agent owned
-// by a different user is forbidden.
+// TestHTTP_Consent_Allow_Existing_NotOwned — picking an agent owned by a
+// different user is refused with the generic, non-revealing error. It must
+// NOT be a 403 "you do not own that agent": that told any logged-in user
+// which arbitrary addresses are live agents on other accounts
+// (GHSA-jh7v-7hx6-2mc2). See the anti-enumeration comment in
+// handleOAuthConsent.
 func TestHTTP_Consent_Allow_Existing_NotOwned(t *testing.T) {
 	f := newConsentFixture(t)
 	ctx := context.Background()
@@ -515,8 +520,73 @@ func TestHTTP_Consent_Allow_Existing_NotOwned(t *testing.T) {
 
 	resp := f.consentPOST(t, form)
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusForbidden {
-		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (must not distinguish not-owned from nonexistent)", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Exact match, not a substring check: the message must be the generic
+	// one shared with the nonexistent-agent case, and nothing about
+	// ownership or existence may leak into it.
+	if got := strings.TrimSpace(string(body)); got != consentUnknownAgentMsg {
+		t.Errorf("body = %q, want the generic %q (must not reveal that the agent exists but belongs to another account)", got, consentUnknownAgentMsg)
+	}
+}
+
+// consentUnknownAgentMsg is the single response body both the "no such
+// agent" and "not your agent" paths must return — see the anti-enumeration
+// comment in handleOAuthConsent.
+const consentUnknownAgentMsg = "unknown or inaccessible agent"
+
+// TestHTTP_Consent_Allow_Existing_NotEnumerable is the actual regression
+// guard for GHSA-jh7v-7hx6-2mc2: probing a real agent owned by another
+// account and probing an address that does not exist at all must produce
+// byte-identical responses, so the endpoint cannot be used as an existence
+// oracle. Asserting each case's status separately would not catch a future
+// change that keeps both at 400 but reintroduces distinct bodies.
+func TestHTTP_Consent_Allow_Existing_NotEnumerable(t *testing.T) {
+	f := newConsentFixture(t)
+	ctx := context.Background()
+	store := identity.NewStore(f.pool)
+	other, err := store.CreateOrGetUser(ctx, "other-"+randHex8(t)+"@example.com", "Other", "google-other-"+randHex8(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A real agent on another account, and — deliberately — one on a domain
+	// that is NOT verified, which the SMTP edge hides behind the same 550 it
+	// uses for unknown recipients. This surface must hide it too.
+	if _, err := store.CreateAgent(ctx, "realvictim@agents.e2a.dev", "agents.e2a.dev", "", "", "local", other.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	probe := func(t *testing.T, address string) (int, string) {
+		t.Helper()
+		_, challenge := newPKCE(t)
+		form := authorizeParams(challenge, f.clientID, "s1s1s1s1s1s1s1s1")
+		form.Set("action", "allow")
+		form.Set("agent_choice", "existing:"+address)
+		resp := f.consentPOST(t, form)
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return resp.StatusCode, string(body)
+	}
+
+	existsStatus, existsBody := probe(t, "realvictim@agents.e2a.dev")
+	missingStatus, missingBody := probe(t, "no-such-agent-"+randHex8(t)+"@agents.e2a.dev")
+
+	if existsStatus != missingStatus {
+		t.Errorf("status leaks existence: exists=%d missing=%d", existsStatus, missingStatus)
+	}
+	if existsBody != missingBody {
+		t.Errorf("body leaks existence:\n exists  = %q\n missing = %q", existsBody, missingBody)
+	}
+	if existsStatus != http.StatusBadRequest {
+		t.Errorf("both cases should be 400, got %d", existsStatus)
 	}
 }
 

--- a/internal/agent/oauth_consent_test.go
+++ b/internal/agent/oauth_consent_test.go
@@ -554,9 +554,14 @@ func TestHTTP_Consent_Allow_Existing_NotEnumerable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// A real agent on another account, and — deliberately — one on a domain
-	// that is NOT verified, which the SMTP edge hides behind the same 550 it
-	// uses for unknown recipients. This surface must hide it too.
+	// A real agent on another account, on the shared domain (which the
+	// fixture seeds verified via EnsureSharedDomain). Domain verification is
+	// not what this test turns on: handleOAuthConsent never consults
+	// DomainVerified, so the invariant it pins — existence must not be
+	// observable — holds for verified and unverified domains alike. That
+	// matters because the SMTP edge hides unverified-domain agents behind the
+	// same 550 it uses for unknown recipients (internal/relay/server.go), so
+	// this surface must not be the one that discloses them.
 	if _, err := store.CreateAgent(ctx, "realvictim@agents.e2a.dev", "agents.e2a.dev", "", "", "local", other.ID); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/agent/oauth_handlers.go
+++ b/internal/agent/oauth_handlers.go
@@ -1033,13 +1033,34 @@ func (a *API) handleOAuthConsent(w http.ResponseWriter, r *http.Request) {
 	switch {
 	case strings.HasPrefix(agentChoice, "existing:"):
 		email := identity.NormalizeEmail(strings.TrimPrefix(agentChoice, "existing:"))
+		// ANTI-ENUMERATION INVARIANT: "no such agent" and "exists but owned
+		// by another account" MUST be indistinguishable — same status, same
+		// body. Reaching this line needs only a logged-in session (checked
+		// above) plus any self-registered OAuth client, and agent_choice is
+		// an arbitrary caller-supplied address, so a distinguishable error
+		// turns this endpoint into an existence oracle for other accounts'
+		// inboxes. It would leak strictly more than the SMTP edge does:
+		// session.Rcpt returns the SAME 550 for an unknown recipient and for
+		// a real agent on an unverified domain (internal/relay/server.go), so
+		// unverified-domain agents are invisible over mail and must stay
+		// invisible here. The consent page only ever offers the user their
+		// own agents, so nothing legitimate needs the distinction.
+		//
+		// Same invariant as resolveOwnedAgent (internal/httpapi/operations.go)
+		// and the WebSocket surface, expressed as a 400 rather than their 404
+		// because this is a form POST inside the consent flow, not a REST
+		// resource lookup. A store error collapses in here too: the caller
+		// learns nothing either way and the operator gets the detail from the
+		// log line below.
 		agent, err := a.store.GetAgentByEmail(ctx, email)
-		if err != nil {
-			http.Error(w, "chosen agent does not exist", http.StatusBadRequest)
-			return
+		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+			// Deliberately omits the address: this is an unresolved,
+			// attacker-chosen string that may name a third party, and it
+			// must not reach shipped logs (same rule as relay.Rcpt).
+			log.Printf("[oauth] /consent agent lookup failed: request_id=%s err=%v", reqID, err)
 		}
-		if agent.UserID != user.ID {
-			http.Error(w, "you do not own that agent", http.StatusForbidden)
+		if err != nil || agent.UserID != user.ID {
+			http.Error(w, "unknown or inaccessible agent", http.StatusBadRequest)
 			return
 		}
 		// No agent creation needed — drop straight into the code-

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -19,6 +19,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/tokencanopy/e2a/internal/config"
 	"github.com/tokencanopy/e2a/internal/identity"
 	"golang.org/x/oauth2"
@@ -647,6 +648,14 @@ func (ua *UserAuth) HandleDeleteAgent(w http.ResponseWriter, r *http.Request) {
 	// HandleAgentActivity below; GetAgentByEmail is NOT user-scoped, so the
 	// ownership check has to be explicit here.
 	agent, err := ua.store.GetAgentByEmail(r.Context(), email)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		// A store failure collapses into the same 404 as every other case —
+		// the caller must not learn the difference — but it must not vanish:
+		// without this, a database outage presents as "every agent 404s",
+		// including the caller's own, with nothing in the logs. Omits the
+		// address, which is caller-supplied and may name a third party.
+		log.Printf("[dashboard] agent lookup failed (delete): %v", err)
+	}
 	if err != nil || agent.UserID != user.ID {
 		http.Error(w, "agent not found", http.StatusNotFound)
 		return
@@ -706,6 +715,11 @@ func (ua *UserAuth) HandleUpdateAgent(w http.ResponseWriter, r *http.Request) {
 	// recognized fields" 400 while a nonexistent one 404s, which is the same
 	// oracle by a different route.
 	agnt, err := ua.store.GetAgentByEmail(r.Context(), email)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		// See HandleDeleteAgent: collapse for the caller, but stay visible
+		// to the operator. Address deliberately omitted.
+		log.Printf("[dashboard] agent lookup failed (update): %v", err)
+	}
 	if err != nil || agnt.UserID != user.ID {
 		http.Error(w, "agent not found", http.StatusNotFound)
 		return
@@ -736,11 +750,18 @@ func (ua *UserAuth) HandleUpdateAgent(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if err := ua.store.UpdateAgentHITL(r.Context(), agnt.ID, user.ID, ttl, action); err != nil {
-			// Past validation, the remaining cases are a store failure or a
-			// zero-row update (a lost race — the agent was removed between
-			// the ownership check and the write). Never echo err.Error():
-			// the zero-row message is "agent not found or not owned by
-			// user", which would leak the distinction the check above hides.
+			// Past validation, the remaining cases are a zero-row update and
+			// a store failure. Zero rows is a lost race — the agent went away
+			// between the ownership check and the write — which is a 404, not
+			// a server fault; mapping it to 500 would page on ordinary
+			// concurrency. Matches HandleDeleteAgent above.
+			if errors.Is(err, identity.ErrAgentNotFound) {
+				http.Error(w, "agent not found", http.StatusNotFound)
+				return
+			}
+			// Never echo err.Error() on the remaining path: the store's
+			// zero-row text names the ownership distinction the check above
+			// exists to hide.
 			log.Printf("[dashboard] update agent HITL failed: %v", err)
 			http.Error(w, "failed to update agent", http.StatusInternalServerError)
 			return

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -638,14 +638,33 @@ func (ua *UserAuth) HandleDeleteAgent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// ANTI-ENUMERATION INVARIANT: a missing agent and one owned by another
+	// account MUST be indistinguishable — same status, same body. This route
+	// needs only a dashboard session, and the address comes from the URL, so
+	// a split response lets any signed-up user probe arbitrary addresses and
+	// map other accounts' inboxes. Same invariant as resolveOwnedAgent
+	// (internal/httpapi/operations.go), the WebSocket handshake, and
+	// HandleAgentActivity below; GetAgentByEmail is NOT user-scoped, so the
+	// ownership check has to be explicit here.
 	agent, err := ua.store.GetAgentByEmail(r.Context(), email)
-	if err != nil {
+	if err != nil || agent.UserID != user.ID {
 		http.Error(w, "agent not found", http.StatusNotFound)
 		return
 	}
 
 	if err := ua.store.SoftDeleteAgent(r.Context(), agent.ID, user.ID); err != nil {
-		http.Error(w, err.Error(), http.StatusForbidden)
+		// Ownership is already established above, so this is not an
+		// enumeration path — but never echo err.Error() here: the store's
+		// message names the ownership distinction ("agent not found or not
+		// owned by user") and would reintroduce the leak verbatim.
+		// ErrAgentNotFound at this point means a lost race (the agent was
+		// trashed between the read and the write), which is a genuine 404.
+		if errors.Is(err, identity.ErrAgentNotFound) {
+			http.Error(w, "agent not found", http.StatusNotFound)
+			return
+		}
+		log.Printf("[dashboard] soft-delete agent failed: %v", err)
+		http.Error(w, "failed to delete agent", http.StatusInternalServerError)
 		return
 	}
 
@@ -680,8 +699,14 @@ func (ua *UserAuth) HandleUpdateAgent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// ANTI-ENUMERATION INVARIANT: see HandleDeleteAgent above — a missing
+	// agent and one owned by another account must be indistinguishable. The
+	// check has to sit here, before the field-parsing branches: an empty PUT
+	// against a foreign agent would otherwise fall through to the "no
+	// recognized fields" 400 while a nonexistent one 404s, which is the same
+	// oracle by a different route.
 	agnt, err := ua.store.GetAgentByEmail(r.Context(), email)
-	if err != nil {
+	if err != nil || agnt.UserID != user.ID {
 		http.Error(w, "agent not found", http.StatusNotFound)
 		return
 	}
@@ -701,8 +726,23 @@ func (ua *UserAuth) HandleUpdateAgent(w http.ResponseWriter, r *http.Request) {
 		if req.HITLExpirationAction != nil {
 			action = *req.HITLExpirationAction
 		}
-		if err := ua.store.UpdateAgentHITL(r.Context(), agnt.ID, user.ID, ttl, action); err != nil {
+		// Validate up front so the three error classes UpdateAgentHITL folds
+		// into one return value stay distinguishable HERE, where they map to
+		// different statuses. A config problem is the caller's fault (400)
+		// and its message is safe to echo — it describes the TTL/action, not
+		// ownership.
+		if err := identity.ValidateHITLConfig(ttl, action); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if err := ua.store.UpdateAgentHITL(r.Context(), agnt.ID, user.ID, ttl, action); err != nil {
+			// Past validation, the remaining cases are a store failure or a
+			// zero-row update (a lost race — the agent was removed between
+			// the ownership check and the write). Never echo err.Error():
+			// the zero-row message is "agent not found or not owned by
+			// user", which would leak the distinction the check above hides.
+			log.Printf("[dashboard] update agent HITL failed: %v", err)
+			http.Error(w, "failed to update agent", http.StatusInternalServerError)
 			return
 		}
 		touched = true

--- a/internal/auth/handlers_extra_test.go
+++ b/internal/auth/handlers_extra_test.go
@@ -294,7 +294,14 @@ func TestHandleUpdateAgent_NotEnumerable(t *testing.T) {
 		return w.Code, w.Body.String()
 	}
 
-	for _, body := range []string{`{}`, `{"hitl_ttl_seconds":3600}`} {
+	// The invalid-config body is the one that pins the ownership check's
+	// PLACEMENT. With the check above ValidateHITLConfig (correct), a foreign
+	// agent 404s like a nonexistent one. Move the check below validation — a
+	// plausible "validate input early" refactor — and this body alone
+	// reopens the oracle: the foreign agent returns 400 with the validation
+	// message while the nonexistent one still 404s. The two valid bodies
+	// cannot tell those orderings apart.
+	for _, body := range []string{`{}`, `{"hitl_ttl_seconds":3600}`, `{"hitl_ttl_seconds":-1}`} {
 		existsStatus, existsBody := probe("agent%40upd-enum-foreign.example.com", body)
 		missingStatus, missingBody := probe("agent%40upd-enum-nowhere.example.com", body)
 

--- a/internal/auth/handlers_extra_test.go
+++ b/internal/auth/handlers_extra_test.go
@@ -215,6 +215,10 @@ func TestHandleDeleteAgent_NotFound(t *testing.T) {
 	}
 }
 
+// TestHandleDeleteAgent_NotOwned — an agent owned by another account is
+// refused as if it did not exist. It must NOT be a 403: that told any
+// signed-up user which arbitrary addresses are live agents on other
+// accounts. Same class as GHSA-jh7v-7hx6-2mc2 on the consent endpoint.
 func TestHandleDeleteAgent_NotOwned(t *testing.T) {
 	ua, store, token := setupUserAuth(t)
 	ctx := context.Background()
@@ -227,8 +231,80 @@ func TestHandleDeleteAgent_NotOwned(t *testing.T) {
 	w := httptest.NewRecorder()
 	ua.HandleDeleteAgent(w, req)
 
-	if w.Code != http.StatusForbidden {
-		t.Errorf("status = %d, want 403 for an agent owned by another user", w.Code)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 (must not distinguish not-owned from nonexistent)", w.Code)
+	}
+	// The store's own message names the distinction ("agent not found or not
+	// owned by user"); echoing it would leak just as loudly as the status.
+	if strings.Contains(w.Body.String(), "not owned") {
+		t.Errorf("body must not reveal the ownership distinction: %q", w.Body.String())
+	}
+}
+
+// TestHandleDeleteAgent_NotEnumerable is the regression guard: a real agent
+// on another account and an address that does not exist at all must produce
+// byte-identical responses. Asserting each case's status separately would
+// not catch a change that keeps both at 404 but reintroduces distinct bodies.
+func TestHandleDeleteAgent_NotEnumerable(t *testing.T) {
+	ua, store, token := setupUserAuth(t)
+	ctx := context.Background()
+
+	other, _ := store.CreateOrGetUser(ctx, "other@del-enum.example.com", "Other", "google-other-del-enum")
+	store.ClaimOrCreateDomain(ctx, "del-enum-foreign.example.com", other.ID)
+	store.CreateAgent(ctx, "agent@del-enum-foreign.example.com", "del-enum-foreign.example.com", "", "https://example.com/webhook", "", other.ID)
+
+	probe := func(path string) (int, string) {
+		req := authedRequest("DELETE", "/api/dashboard/agents/"+path, token)
+		w := httptest.NewRecorder()
+		ua.HandleDeleteAgent(w, req)
+		return w.Code, w.Body.String()
+	}
+
+	existsStatus, existsBody := probe("agent%40del-enum-foreign.example.com")
+	missingStatus, missingBody := probe("agent%40del-enum-nowhere.example.com")
+
+	if existsStatus != missingStatus {
+		t.Errorf("status leaks existence: exists=%d missing=%d", existsStatus, missingStatus)
+	}
+	if existsBody != missingBody {
+		t.Errorf("body leaks existence:\n exists  = %q\n missing = %q", existsBody, missingBody)
+	}
+	if existsStatus != http.StatusNotFound {
+		t.Errorf("both cases should be 404, got %d", existsStatus)
+	}
+}
+
+// TestHandleUpdateAgent_NotEnumerable pins the same invariant on the update
+// route. The empty body is deliberate: the ownership check has to run before
+// the field-parsing branches, or a foreign agent falls through to the "no
+// recognized fields" 400 while a nonexistent one 404s — the same oracle by a
+// different route.
+func TestHandleUpdateAgent_NotEnumerable(t *testing.T) {
+	ua, store, token := setupUserAuth(t)
+	ctx := context.Background()
+
+	other, _ := store.CreateOrGetUser(ctx, "other@upd-enum.example.com", "Other", "google-other-upd-enum")
+	store.ClaimOrCreateDomain(ctx, "upd-enum-foreign.example.com", other.ID)
+	store.CreateAgent(ctx, "agent@upd-enum-foreign.example.com", "upd-enum-foreign.example.com", "", "https://example.com/webhook", "", other.ID)
+
+	probe := func(path, body string) (int, string) {
+		req := authedJSON("PUT", "/api/dashboard/agents/"+path, token, body)
+		w := httptest.NewRecorder()
+		ua.HandleUpdateAgent(w, req)
+		return w.Code, w.Body.String()
+	}
+
+	for _, body := range []string{`{}`, `{"hitl_ttl_seconds":3600}`} {
+		existsStatus, existsBody := probe("agent%40upd-enum-foreign.example.com", body)
+		missingStatus, missingBody := probe("agent%40upd-enum-nowhere.example.com", body)
+
+		if existsStatus != missingStatus || existsBody != missingBody {
+			t.Errorf("body %s leaks existence: exists=(%d,%q) missing=(%d,%q)",
+				body, existsStatus, existsBody, missingStatus, missingBody)
+		}
+		if existsStatus != http.StatusNotFound {
+			t.Errorf("body %s: both cases should be 404, got %d", body, existsStatus)
+		}
 	}
 }
 

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -1567,7 +1567,10 @@ func (s *Store) UpdateAgentHITL(ctx context.Context, agentID, userID string, ttl
 		return err
 	}
 	if tag.RowsAffected() == 0 {
-		return fmt.Errorf("agent not found or not owned by user")
+		// Sentinel, not a fresh error with the same text: handlers map this
+		// to 404 (a lost race against the caller's own agent) rather than a
+		// 500, and they can only do that if it's matchable with errors.Is.
+		return ErrAgentNotFound
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Closes an agent-existence enumeration oracle on three session-authenticated endpoints. Each one returned a distinguishable response for "no such agent" versus "that agent exists but belongs to another account", so any user who can sign up could probe arbitrary addresses and map other accounts' inboxes one at a time.

Originally reported against `/oauth2/consent` by @rajnisht7 via **GHSA-jh7v-7hx6-2mc2**. Reviewing that fix surfaced the identical bug class on two dashboard routes; all three are fixed here. Exploit details stay in the private advisory — this description stays at the level needed to review the change.

| Endpoint | Was | Now |
|---|---|---|
| `POST /oauth2/consent` (`existing:` branch) | 400 vs 403 | identical `400 "unknown or inaccessible agent"` |
| `DELETE /api/dashboard/agents/{email}` | 404 vs 403 + `"…or not owned by user"` | identical `404 "agent not found"` |
| `PUT /api/dashboard/agents/{email}` | 404 vs 400 + `"…or not owned by user"` | identical `404 "agent not found"` |

`resolveOwnedAgent` (`internal/httpapi/operations.go:189-190`), the WebSocket handshake, and `HandleAgentActivity` (`internal/auth/auth.go:736-744`) already held this invariant with explicit comments. These three were the surfaces that didn't.

**Severity: medium** (CVSS 3.1 base 4.3, `AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N`). Existence-only disclosure — no message content, credentials, or agent access. Tempering it: running an email service already reveals which addresses accept mail. Sharpening it: `session.Rcpt` returns the *same* 550 for an unknown recipient and for a real agent on an unverified domain (`internal/relay/server.go:273,280`), so agents on unverified and custom domains are invisible over SMTP — and all three endpoints exposed them. Probing was silent (no mail, no bounce) and unrated: `/oauth2/consent` has no rate limit and dynamic client registration is anonymous, so one self-registered client enabled unbounded probing.

## What changed

**`/oauth2/consent`** (`internal/agent/oauth_handlers.go`) — both failure cases collapse into one `http.Error` call. A store error collapses in too; the operator gets the detail from a new log line that deliberately omits the address, since `agent_choice` is an unresolved caller-supplied string that may name a third party (same rule as `relay.Rcpt`).

**Dashboard delete/update** (`internal/auth/auth.go`) — `GetAgentByEmail` is not user-scoped, so the ownership check has to be explicit. Added immediately after the lookup on both handlers, returning the same 404 as the missing case.

On update it must precede the field-parsing branches: an empty `PUT` against a foreign agent otherwise reached `"no recognized fields"` (400) while a nonexistent one 404'd — the same oracle by a different route. That second path is covered by a test.

Both routes also stop echoing store errors. The zero-row message is literally `"agent not found or not owned by user"`, so passing it through leaked as loudly as the status did. HITL config is now validated in the handler, which keeps the three error classes `UpdateAgentHITL` folds into a single return value mapped to distinct statuses — config problems stay a 400 with their own message, a lost race is a 404, and a genuine store failure is a logged 500.

**Dead code** — deleted `resolveAgentForUser` (`internal/agent/api.go`), zero call sites, returned `"agent not found"` vs `"forbidden"`. Same shape, waiting to be wired up.

## Client surface checklist

- [x] Go handlers + integration tests
- [ ] ~~Migration~~ — no schema change
- [x] OpenAPI spec — `make spec-check` clean; neither `/oauth2/*` nor `/api/dashboard/*` is on the `/v1` Huma surface, so neither is in the spec and no regeneration applies
- [ ] ~~TypeScript SDK~~ / ~~Python SDK~~ / ~~CLI~~ / ~~MCP tool~~ — not applicable, see below
- [x] Tests at each surface that applies (positive + negative-path regression)

**Intentionally skipped:** these are browser-facing routes — an OAuth consent form POST and two dashboard endpoints. None is part of `/v1`, none appears in the OpenAPI spec, and no SDK, CLI, or MCP tool calls them, so there is nothing to regenerate or mirror. The contract-scenario rule in AGENTS.md targets public `/v1` API features and doesn't reach them.

**Web dashboard** (the surface the template doesn't list, checked manually): no change needed. The consent page (`web/src/app/oauth/consent/page.tsx:401-412`) builds its inbox radios from the user's own agents, and the dashboard only issues delete/update against inboxes it already lists for the signed-in user. Legitimate flows never hit the changed responses; they're reachable only by hand-crafting the request.

## Operational risk

Low. No schema change, no migration, no feature flag, no background job. Every legitimate flow is unchanged: consenting to your own inbox still 303s to the client `redirect_uri`, and deleting or updating your own agent still returns 200.

Two deliberate widenings, both on paths that previously returned a leaky 4xx:

- A store error during the consent lookup now returns the same 400 rather than a distinct outcome. The caller must not be able to distinguish it either. Known gap: that branch logs but increments no metric, so a Postgres outage would surface to consenting users as a misleading 400 with no 5xx-based alert. The WebSocket precedent does split the reason for its SLI. Worth one counter in a follow-up observability pass.
- Dashboard write failures now return a logged 500 instead of echoing the store's message at 4xx. Ownership is already established by then, so this isn't an enumeration path — it's about not leaking internal text. A zero-row write (the agent went away mid-request) stays a 404 on both routes rather than paging as a server fault.

Rollback is a plain revert.

## Test plan

Against Postgres on :5433:

- [x] `go test ./internal/auth/ ./internal/agent/ -tags integration` — both packages pass
- [x] `go test ./internal/httpapi/ ./internal/ws/ ./internal/oauth/ -tags integration` — passes
- [x] `make spec-check` — no drift
- [x] `go build ./...` clean; `go vet` clean for every touched file

Guards added, one per surface, each asserting the two probes are **byte-identical** in status and body — a per-case status assertion would not catch a change that keeps both statuses equal but reintroduces distinct messages:

- `TestHTTP_Consent_Allow_Existing_NotEnumerable`
- `TestHandleDeleteAgent_NotEnumerable`
- `TestHandleUpdateAgent_NotEnumerable` — runs three bodies: empty, a valid field update, and an invalid config. The last one pins the ownership check's *placement* above validation; the two valid bodies can't distinguish that ordering.

`TestHandleDeleteAgent_NotOwned` and `TestHTTP_Consent_Allow_Existing_NotOwned` flip from asserting the leaky status to asserting the conflated one.

**Verified the guards are real:** reverted `internal/auth/auth.go` and re-ran them against the pre-fix handlers — all three fail, reporting `exists=403 missing=404`, the leaked `"agent not found or not owned by user"` body, and the empty-`PUT` 400-vs-404 split. They pass only against the fix.

## Deliberately not fixed: the `create_new` 409

`issueOAuthCodeWithNewAgent` (`internal/agent/oauth_handlers.go`) returns `409 "that slug is already taken"` for a slug owned by another user versus a 303 when it's free — structurally the same oracle.

Leaving it, because the asymmetry that justifies fixing the others doesn't apply. The shared domain is verified by definition, so `session.Rcpt` accepts mail to any existing shared-domain agent — SMTP is already a free, unauthenticated existence oracle for exactly the slug set the 409 reveals. Closing it would hide nothing the mail edge doesn't disclose by design, while breaking load-bearing signup UX (a user who picks a taken slug has to be told). Probing is also self-limiting: every free slug probed actually creates an agent in the attacker's own account.

Leaks strictly more than SMTP → fix. Leaks strictly the same → accept. That line is what put the three fixed endpoints on one side and this one on the other. Recording it as a decision rather than an oversight; happy to document it in `SECURITY.md` if preferred.

## Addressed in review

A second review pass over the dashboard commit found three gaps, all fixed in `7ad18062`:

- **The update route's guard didn't pin the ownership check's placement.** It probed only bodies that pass HITL validation, so it couldn't distinguish the correct ordering from a "validate input early" refactor that moves the check below `ValidateHITLConfig` — under which a foreign agent returns 400 with the validation message while a nonexistent one 404s. Added an invalid-config probe and verified it fails against a simulated reordering.
- **Lost races mapped inconsistently.** `UpdateAgentHITL` returned a fresh `fmt.Errorf` whose text duplicated `ErrAgentNotFound`, so the handler couldn't match the zero-row case and sent a 500 — paging on ordinary concurrency, and inconsistent with the delete handler's 404. Now returns the sentinel, and the handler mirrors the 404 branch.
- **Store lookup failures were silent.** Both handlers folded `GetAgentByEmail` errors into the conflated 404 with no log, so a database outage would have looked like "every agent 404s" with nothing for an operator to see. Now logged (address omitted) while the response stays identical, matching the consent handler.

## Follow-ups, not in this PR

- ~~Sentinel for `UpdateAgentHITL`~~ — done above. Still outstanding for `UpdateAgentInboundPolicy` and `UpdateAgentName`, which return the same formatted string naming the ownership distinction.
- `HandleDeleteAPIKey` echoes raw store errors with a 404. Not an oracle — the zero-row case is a constant with no ownership split — but a genuine DB error's text reaches the client. Pre-existing.
- Add the missing metric on the consent store-error branch.

> **Correction.** An earlier version of this section pointed at "domain handlers" in `internal/auth/auth.go` around lines 286/295/416/424. That was wrong on both counts: there are no domain handlers in that file (domain management lives in `internal/httpapi/domains.go` behind `/v1`), and those lines are `HandleLogin`/`HandleCallback` validators echoing errors about the caller's *own* `cli_callback` and `return_to` input. No cross-tenant data, not oracles. Noting it so nobody audits handlers that don't exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
