### PR TITLE
test(e2e-prod): staging conformance coverage for contacts, MCP tools, and contact.due

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,12 @@ jobs:
       # Network-free unit tests only — the e2e-prod suites against a live
       # deployment stay manual. No npm ci needed: node --test type-strips.
       - run: node --test tests/e2e-prod/harness/*.test.ts
+      # Offline unit tests for the three coverage gates (synthetic shards,
+      # red-without-contacts / green-when-complete). pyyaml is what the gates
+      # themselves need to parse api/openapi.yaml.
+      - run: |
+          pip install pyyaml
+          cd tests/e2e-prod && python3 -m unittest test_gates -v
       # monitor.py imports the Python SDK (from e2a.v1 import ...) — install
       # the repo's SDK so the gate tests this tree, not a published release.
       - run: |

--- a/cli/test/e2e.test.ts
+++ b/cli/test/e2e.test.ts
@@ -19,6 +19,7 @@
  */
 import { describe, it, expect, afterAll } from "vitest";
 import { spawnSync, spawn } from "node:child_process";
+import { writeFileSync, rmSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { parseHelpCommands, recordAdvertised, recordCovered, flushCliCoverage } from "./harness/cli-coverage.js";
 
@@ -133,6 +134,7 @@ describe.skipIf(!live)("cli live parity", () => {
     expect(commands).toEqual([
       "agents",
       "config",
+      "contacts",
       "doctor",
       "keys",
       "listen",
@@ -286,6 +288,106 @@ describe.skipIf(!live)("cli live parity", () => {
     expect(setOff.code, setOff.stderr).toBe(0);
     recordCovered("protection");
   });
+
+  it("contacts: create/get/list/update/delete + import/imports delete + outreach tree", () => {
+    const slug = Date.now().toString(36);
+    const addr = `cli-live-contacts-${slug}@example.com`;
+    const importAddr1 = `cli-live-contacts-import-a-${slug}@example.com`;
+    const importAddr2 = `cli-live-contacts-import-b-${slug}@example.com`;
+    const csvPath = `/tmp/e2a-cli-e2e-contacts-${slug}.csv`;
+    writeFileSync(
+      csvPath,
+      `email,name,company\n${importAddr1},Import One,Acme\n${importAddr2},Import Two,Acme\n`,
+    );
+
+    try {
+      // Identity CRUD.
+      const created = run([
+        "contacts", "create", addr,
+        "--name", "CLI Live", "--metadata", '{"origin":"cli-e2e"}', "--json",
+      ]);
+      expect(created.code, created.stderr).toBe(0);
+      expect(JSON.parse(created.stdout).address).toBe(addr);
+
+      const got = run(["contacts", "get", addr]);
+      expect(got.code, got.stderr).toBe(0);
+      const etag = got.stdout.match(/^etag:\s+(\S+)$/m)?.[1];
+      expect(etag, `contacts get must print an etag line:\n${got.stdout}`).toBeTruthy();
+
+      const list = run(["contacts", "list", "--json"]);
+      expect(list.code, list.stderr).toBe(0);
+      expect(list.stdout).toContain(addr);
+
+      const updated = run([
+        "contacts", "update", addr, "--name", "CLI Live Updated", "--if-match", etag!, "--json",
+      ]);
+      expect(updated.code, updated.stderr).toBe(0);
+      expect(JSON.parse(updated.stdout).displayName).toBe("CLI Live Updated");
+
+      // CSV import: --dry-run previews without writing, the real run writes,
+      // imports delete reverses the batch.
+      const dryRun = run(["contacts", "import", csvPath, "--dry-run", "--json"]);
+      expect(dryRun.code, dryRun.stderr).toBe(0);
+      expect(JSON.parse(dryRun.stdout).rows).toBe(2);
+      // Preview must not have created anything.
+      expect(run(["contacts", "get", importAddr1]).code).not.toBe(0);
+
+      const imported = run(["contacts", "import", csvPath, "--json"]);
+      expect(imported.code, imported.stderr).toBe(0);
+      const importResult = JSON.parse(imported.stdout);
+      expect(importResult.batchId).toBeTruthy();
+      expect(importResult.created).toBe(2);
+
+      const reversed = run(["contacts", "imports", "delete", importResult.batchId, "--json"]);
+      expect(reversed.code, reversed.stderr).toBe(0);
+      expect(JSON.parse(reversed.stdout).deleted).toBe(true);
+      expect(run(["contacts", "get", importAddr1]).code).not.toBe(0);
+
+      // Outreach tree against a fresh (throwaway) agent.
+      const bot = `cli-live-outreach-${slug}@${DOMAIN}`;
+      const createdAgent = run(["agents", "create", bot, "--name", "cli live contacts e2e", "--json"]);
+      expect(createdAgent.code, createdAgent.stderr).toBe(0);
+      createdAgents.push(bot);
+
+      const nextAction = new Date(Date.now() + 86_400_000).toISOString();
+      const enrolled = run([
+        "contacts", "outreach", "set", addr,
+        "--agent", bot, "--stage", "prospect", "--next-action", nextAction, "--json",
+      ]);
+      expect(enrolled.code, enrolled.stderr).toBe(0);
+      expect(JSON.parse(enrolled.stdout).stage).toBe("prospect");
+
+      const outreach = run(["contacts", "outreach", "get", addr, "--agent", bot]);
+      expect(outreach.code, outreach.stderr).toBe(0);
+      // TSV: address \t stage \t nextActionAt \t etag
+      const fields = outreach.stdout.trim().split("\t");
+      expect(fields[0]).toBe(addr);
+      expect(fields[1]).toBe("prospect");
+      expect(fields[3], `outreach get must end with an etag field:\n${outreach.stdout}`).toBeTruthy();
+
+      const outreachList = run([
+        "contacts", "outreach", "list", "--agent", bot, "--stage", "prospect", "--json",
+      ]);
+      expect(outreachList.code, outreachList.stderr).toBe(0);
+      expect(outreachList.stdout).toContain(addr);
+
+      const unenrolled = run(["contacts", "outreach", "delete", addr, "--agent", bot, "--json"]);
+      expect(unenrolled.code, unenrolled.stderr).toBe(0);
+      expect(run(["contacts", "outreach", "get", addr, "--agent", bot]).code).not.toBe(0);
+
+      // Deleting the identity removes the contact (suppression survives server-side).
+      const deleted = run(["contacts", "delete", addr, "--json"]);
+      expect(deleted.code, deleted.stderr).toBe(0);
+      expect(JSON.parse(deleted.stdout).address).toBe(addr);
+      expect(run(["contacts", "get", addr]).code).not.toBe(0);
+
+      recordCovered("contacts");
+    } finally {
+      // Tolerate non-zero: the happy path already deleted these.
+      for (const a of [addr, importAddr1, importAddr2]) run(["contacts", "delete", a]);
+      rmSync(csvPath, { force: true });
+    }
+  }, 60_000);
 
   it("doctor: healthy (0), warnings-only (8), and config failure (9) exit codes", () => {
     // The account-scoped conformance credential is deliberately shared with

--- a/cli/test/harness/cli-coverage.test.ts
+++ b/cli/test/harness/cli-coverage.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Pure unit test for parseHelpCommands — no live gating, no creds, no
+ * binary spawn. Lives under test/** so it runs with vitest.e2e.config.ts
+ * (offline-safe: passes with or without staging env); the default unit
+ * config (src/**) never picks it up.
+ */
+import { describe, it, expect } from "vitest";
+import { parseHelpCommands } from "./cli-coverage.js";
+
+// Mirrors the real USAGE layout (cli/src/bin/e2a.ts): genuine top-level
+// command lines are indented by exactly two spaces; option/continuation
+// lines sit deeper, and prose mentions of `e2a` never lead a line.
+const SAMPLE_HELP = [
+  "e2a — email for AI agents",
+  "",
+  "Usage:",
+  "  e2a login                         Log in via browser (account-scoped key)",
+  "  e2a whoami [--json]               Show key identity: user, scope, bound agent, plan",
+  "  e2a agents list                   List owned inboxes (account key)",
+  "  e2a agents create <email> [--name <n>]   Create an inbox (account key)",
+  "  e2a agents get <email>            Show one inbox",
+  "  e2a contacts list [options]        List account contacts",
+  "        --source import|manual|inbound   Filter by provenance",
+  "  e2a contacts get <address>         Show one contact",
+  "  e2a contacts create <address>      Create one contact",
+  "  e2a contacts update <address>      Update --name/--clear-name and/or --metadata",
+  "  e2a contacts delete <address>      Delete identity (suppression survives)",
+  "  e2a contacts import <csv>          Preview or import an RFC 4180 CSV",
+  "        --dry-run                    Parse and preview without writing",
+  "  e2a contacts imports delete <id>   Reverse an import batch",
+  "  e2a contacts outreach list         List one agent's outreach",
+  "  e2a contacts outreach get <address>",
+  "  e2a contacts outreach set <address>",
+  "        --stage <s>|--clear-stage --next-action <ISO|clear> --metadata <json>",
+  "  e2a contacts outreach delete <address>",
+  "  e2a send [options]                Send an email as the agent",
+  "  e2a reply <message-id> [options]  Reply in-thread (same body options as send)",
+  "        --agent <email>            Sending inbox (or config agent_email)",
+  "",
+  "Options:",
+  "  -h, --help                        Show help",
+  "",
+  "Exit codes:",
+  "  0 ok · 1 transient · 2 usage — run e2a send -h for per-command help",
+  "",
+].join("\n");
+
+describe("parseHelpCommands", () => {
+  it("extracts the deduped top-level catalog — contacts included, no subcommand leakage", () => {
+    // `contacts` appears on 11 lines (list/get/create/update/delete/import/
+    // imports delete/outreach ×4); it must collapse to ONE token, and the
+    // subcommand words (list, outreach, imports, …) must never surface.
+    expect(parseHelpCommands(SAMPLE_HELP)).toEqual([
+      "agents",
+      "contacts",
+      "login",
+      "reply",
+      "send",
+      "whoami",
+    ]);
+  });
+
+  it("ignores lines not indented by exactly two spaces", () => {
+    const text = [
+      "e2a nosep <id>              no indent",
+      "    e2a deep <id>           four-space indent",
+      "        e2a option <id>     eight-space indent",
+      "  e2a real <id>             genuine entry",
+    ].join("\n");
+    expect(parseHelpCommands(text)).toEqual(["real"]);
+  });
+
+  it("returns an empty catalog when no command lines are present", () => {
+    expect(parseHelpCommands("Usage: e2a <command> [options]\n")).toEqual([]);
+  });
+});

--- a/cli/vitest.config.ts
+++ b/cli/vitest.config.ts
@@ -2,7 +2,10 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["src/**/*.test.ts"],
+    // test/harness holds the offline unit tests for the e2e coverage harness
+    // itself (e.g. the --help parser); the live binary-spawn suites under
+    // test/*.test.ts stay on vitest.e2e.config.ts.
+    include: ["src/**/*.test.ts", "test/harness/*.test.ts"],
     coverage: {
       provider: "v8",
       include: ["src/**/*.ts"],

--- a/sdks/python/tests/test_e2e_resources.py
+++ b/sdks/python/tests/test_e2e_resources.py
@@ -603,11 +603,13 @@ async def test_contacts_account_level_crud_list_and_import():
                 try:
                     await client.contacts.delete(address)
                 except E2ANotFoundError:
+                    # Best-effort cleanup: the happy path already deleted it.
                     pass
             if batch_id:
                 try:
                     await client.contacts.delete_import(batch_id)
                 except E2ANotFoundError:
+                    # Best-effort cleanup: the happy path already deleted it.
                     pass
 
 
@@ -667,6 +669,7 @@ async def test_contacts_outreach_full_surface():
                 try:
                     await client.contacts.delete(address)
                 except E2ANotFoundError:
+                    # Best-effort cleanup: the happy path already deleted it.
                     pass
         finally:
             await client.agents.delete(email)

--- a/sdks/python/tests/test_e2e_resources.py
+++ b/sdks/python/tests/test_e2e_resources.py
@@ -5,10 +5,11 @@ and the full scope/design writeup).
 ``tests/test_e2e.py`` already exercises 7 methods (``info``, ``agents.create``,
 ``agents.delete``, ``messages.send``, ``messages.list``, ``messages.get``,
 ``messages.reply``) as part of its self-loopback round trip and now calls
-``mark_covered`` for each. This module fills in the rest of the 64 methods
-runtime introspection finds on ``AsyncE2AClient``
-(``tests/resource_coverage_lib/discovery.py``), minus the two destructive/
-no-happy-path entries allowlisted in the gate (``account.delete``,
+``mark_covered`` for each. This module fills in the rest of the methods
+runtime introspection finds on ``AsyncE2AClient`` (the live count is owned by
+``tests/resource_coverage_lib/discovery.py`` — 77 at time of writing — so it
+is deliberately not restated here), minus the two destructive/no-happy-path
+entries allowlisted in the gate (``account.delete``,
 ``account.suppressions.delete``) and ``listen`` (allowlisted — see the gate
 for why).
 
@@ -35,7 +36,7 @@ import time
 
 import pytest
 
-from e2a import AsyncE2AClient
+from e2a import AsyncE2AClient, E2ANotFoundError
 
 from .resource_coverage_lib.tracker import mark_covered
 
@@ -509,4 +510,163 @@ async def test_webhooks_and_events_full_surface():
             deleted_hook = await client.webhooks.delete(hook.id)
             assert deleted_hook.deleted is True
             mark_covered("webhooks.delete")
+            await client.agents.delete(email)
+
+
+# ── contacts: account-level CRUD, list, and bulk import ─────────────
+
+
+async def test_contacts_account_level_crud_list_and_import():
+    async with _client() as client:
+        slug = _slug("ct")
+        addr_a = f"{slug}-a@example.com"
+        addr_b = f"{slug}-b@example.com"
+        addr_c = f"{slug}-c@example.com"
+        addr_d = f"{slug}-d@example.com"
+        import_a = f"{slug}-imp-a@example.com"
+        import_b = f"{slug}-imp-b@example.com"
+        batch_id = ""  # set once the import lands so finally can reverse it on failure
+        try:
+            # create canonicalizes the address: a display-name form with an
+            # uppercased domain resolves to the lowercase canonical key.
+            created = await client.contacts.create(
+                {"address": f"Py Cov A <{slug}-a@EXAMPLE.COM>", "display_name": "Py Cov A"}
+            )
+            assert created.address == addr_a
+            assert created.display_name == "Py Cov A"
+            assert created.source == "manual"
+            mark_covered("contacts.create")
+
+            got = await client.contacts.get(addr_a)
+            assert got.address == addr_a
+            assert got.display_name == "Py Cov A"
+            mark_covered("contacts.get")
+
+            item, etag = await client.contacts.get_with_etag(addr_a)
+            assert item.address == addr_a
+            assert isinstance(etag, str) and etag
+            mark_covered("contacts.get_with_etag")
+
+            updated = await client.contacts.update(addr_a, {"display_name": "Py Cov A renamed"}, if_match=etag)
+            assert updated.address == addr_a
+            assert updated.display_name == "Py Cov A renamed"
+            mark_covered("contacts.update")
+
+            await client.contacts.create({"address": addr_b})
+            await client.contacts.create({"address": addr_c})
+
+            # Page size 1 on purpose: with three of our own contacts newest-first,
+            # finding all three proves the AutoPager really walked next_cursor
+            # instead of stopping after the first page.
+            listed = await client.contacts.list(limit=1).to_list(limit=200)
+            assert {addr_a, addr_b, addr_c} <= {c.address for c in listed}
+            manual = await client.contacts.list(source="manual", limit=100).to_list(limit=200)
+            assert {addr_a, addr_b, addr_c} <= {c.address for c in manual}
+            assert all(c.source == "manual" for c in manual)
+            mark_covered("contacts.list")
+
+            # Three fresh rows where the third duplicates the first in-batch:
+            # the upload itself still succeeds, with one outcome per row.
+            imported = await client.contacts.import_(
+                {"contacts": [{"address": import_a}, {"address": import_b}, {"address": import_a}]}
+            )
+            assert imported.batch_id
+            assert imported.created == 2
+            assert imported.skipped == 1
+            assert imported.failed == 0
+            assert [r.status for r in imported.results] == ["created", "created", "skipped"]
+            assert imported.results[2].code == "duplicate_in_batch"
+            batch_id = imported.batch_id
+            mark_covered("contacts.import_")
+
+            # Freshly imported contacts have no correspondence history, so the
+            # reversal removes both of them (nothing retained).
+            reversed_batch = await client.contacts.delete_import(batch_id)
+            assert reversed_batch.deleted is True
+            assert reversed_batch.batch_id == batch_id
+            assert reversed_batch.contacts_deleted == 2
+            batch_id = ""  # reversed — nothing left for finally to undo
+            mark_covered("contacts.delete_import")
+            with pytest.raises(E2ANotFoundError):
+                await client.contacts.get(import_a)
+
+            created_d = await client.contacts.create({"address": addr_d})
+            assert created_d.address == addr_d
+            deleted = await client.contacts.delete(addr_d)
+            assert deleted.deleted is True
+            assert deleted.address == addr_d
+            mark_covered("contacts.delete")
+            with pytest.raises(E2ANotFoundError):
+                await client.contacts.get(addr_d)
+        finally:
+            for address in (addr_a, addr_b, addr_c, addr_d, import_a, import_b):
+                try:
+                    await client.contacts.delete(address)
+                except E2ANotFoundError:
+                    pass
+            if batch_id:
+                try:
+                    await client.contacts.delete_import(batch_id)
+                except E2ANotFoundError:
+                    pass
+
+
+# ── contacts: per-agent outreach (engagements) ───────────────────────
+
+
+async def test_contacts_outreach_full_surface():
+    async with _client() as client:
+        email = _bot("outreach")
+        address = f"{_slug('out')}@example.com"
+        await client.agents.create({"email": email, "name": "cov outreach"})
+        try:
+            await client.contacts.create({"address": address, "display_name": "Py Cov Outreach"})
+            try:
+                # The first set_outreach on an (agent, contact) pair CREATES the
+                # engagement; stage and next_action_at are caller-owned fields.
+                enrolled = await client.contacts.set_outreach(
+                    email, address, {"stage": "touch1", "next_action_at": "2099-01-01T00:00:00Z"}
+                )
+                assert enrolled.agent_email == email
+                assert enrolled.address == address
+                assert enrolled.stage == "touch1"
+                assert enrolled.next_action_at is not None
+                mark_covered("contacts.set_outreach")
+
+                got = await client.contacts.get_outreach(email, address)
+                assert got.agent_email == email
+                assert got.address == address
+                assert got.stage == "touch1"
+                mark_covered("contacts.get_outreach")
+
+                item, etag = await client.contacts.get_outreach_with_etag(email, address)
+                assert item.stage == "touch1"
+                assert isinstance(etag, str) and etag
+                mark_covered("contacts.get_outreach_with_etag")
+
+                # The update half of the upsert: guarded by the ETag above.
+                advanced = await client.contacts.set_outreach(email, address, {"stage": "touch2"}, if_match=etag)
+                assert advanced.stage == "touch2"
+
+                # Fresh agent ⇒ its outreach list holds exactly this engagement;
+                # the stage filter must return it, a mismatched stage must not.
+                working = await client.contacts.outreach(email, stage="touch2").to_list(limit=20)
+                assert any(e.address == address for e in working)
+                assert all(e.stage == "touch2" for e in working)
+                other = await client.contacts.outreach(email, stage="no-such-stage").to_list(limit=20)
+                assert not any(e.address == address for e in other)
+                mark_covered("contacts.outreach")
+
+                removed = await client.contacts.delete_outreach(email, address)
+                assert removed.deleted is True
+                assert removed.address == address
+                mark_covered("contacts.delete_outreach")
+                with pytest.raises(E2ANotFoundError):
+                    await client.contacts.get_outreach(email, address)
+            finally:
+                try:
+                    await client.contacts.delete(address)
+                except E2ANotFoundError:
+                    pass
+        finally:
             await client.agents.delete(email)

--- a/sdks/python/tests/test_resource_coverage_discovery.py
+++ b/sdks/python/tests/test_resource_coverage_discovery.py
@@ -1,0 +1,73 @@
+"""Offline regression net for the resource-coverage gate's DENOMINATOR.
+
+``tests/resource_coverage_gate.py`` fails when a method runtime introspection
+finds on ``AsyncE2AClient`` has no live ``mark_covered`` call — but that only
+protects the facade if introspection actually SEES every resource. A discovery
+regression (e.g. a heuristic change that stops descending into a resource
+namespace) would shrink the denominator and let the gate pass while whole
+resources went untested live. These tests pin three properties of the
+discovered set:
+
+  1. it contains the full ``contacts.*`` surface (13 methods — the surface the
+     live contacts section in ``tests/test_e2e_resources.py`` exists to cover,
+     so a discovery miss here demonstrably turns the gate red for the wrong
+     reason or, worse, green for the wrong reason);
+  2. it still contains long-standing methods (``agents.create``,
+     ``messages.send``) — a canary against the walk breaking wholesale;
+  3. it excludes private names and lifecycle plumbing (``aclose``), which have
+     no request/response surface for a coverage gate to be accountable for.
+
+Needs no credentials, no network, and writes no coverage shards:
+``discover_client_methods`` builds a throwaway client whose constructor
+performs no I/O (see its docstring), and nothing here imports the tracker.
+"""
+
+from __future__ import annotations
+
+from .resource_coverage_lib.discovery import discover_client_methods
+
+# The 13 contacts.* ids the live suite in test_e2e_resources.py covers. Kept
+# as an explicit set (not derived from the resource class) precisely so the
+# test and discovery can disagree — that disagreement is the signal.
+CONTACTS_METHODS = frozenset(
+    {
+        "contacts.create",
+        "contacts.delete",
+        "contacts.delete_import",
+        "contacts.delete_outreach",
+        "contacts.get",
+        "contacts.get_outreach",
+        "contacts.get_outreach_with_etag",
+        "contacts.get_with_etag",
+        "contacts.import_",
+        "contacts.list",
+        "contacts.outreach",
+        "contacts.set_outreach",
+        "contacts.update",
+    }
+)
+
+LONGSTANDING_METHODS = frozenset({"agents.create", "messages.send"})
+
+
+def test_discovery_finds_the_full_contacts_surface():
+    discovered = discover_client_methods()
+    missing = CONTACTS_METHODS - discovered.keys()
+    assert not missing, (
+        f"discover_client_methods no longer sees {sorted(missing)} — the gate's "
+        "denominator shrank, so absent live coverage would pass silently"
+    )
+
+
+def test_discovery_still_finds_longstanding_methods():
+    discovered = discover_client_methods()
+    missing = LONGSTANDING_METHODS - discovered.keys()
+    assert not missing, f"discovery walk looks broken: missing {sorted(missing)}"
+
+
+def test_discovery_excludes_private_and_lifecycle_names():
+    discovered = discover_client_methods()
+    assert "aclose" not in discovered
+    for name in discovered:
+        for part in name.split("."):
+            assert not part.startswith("_"), f"private name leaked into the denominator: {name}"

--- a/sdks/typescript/test/e2e-contacts.test.ts
+++ b/sdks/typescript/test/e2e-contacts.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Live ergonomic coverage: client.contacts.* — account-level contacts plus the
+ * per-agent outreach surface. See test/e2e.test.ts's header for the
+ * coverage-gate contract this suite participates in.
+ *
+ * This file owns: contacts.create, contacts.get, contacts.getWithETag,
+ * contacts.update, contacts.list, contacts.import, contacts.deleteImport,
+ * contacts.delete, contacts.setOutreach, contacts.getOutreach,
+ * contacts.getOutreachWithETag, contacts.outreach, contacts.deleteOutreach.
+ *
+ * Contact fixtures are unique <slug>@example.com addresses per run, cleaned up
+ * in afterAll (a suppression surviving its contact's delete is by design —
+ * per-run uniqueness makes that harmless).
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { E2AClient, E2ANotFoundError } from "../src/v1/index.js";
+import { walkErgonomicSurface } from "./coverage/introspect.js";
+import { recordSurface, recordCovered, flushCoverage } from "./coverage/recorder.js";
+import { loadLiveEnv, uniqueSlug } from "./coverage/helpers.js";
+
+const env = loadLiveEnv();
+
+describe.skipIf(!env)("ts sdk live e2e: contacts", () => {
+  let client: E2AClient;
+  const cleanup: Array<() => Promise<unknown>> = [];
+
+  const contactAddress = (prefix: string) => `${uniqueSlug(prefix)}@example.com`;
+  const trackContact = (address: string) => cleanup.push(() => client.contacts.delete(address));
+
+  beforeAll(() => {
+    client = new E2AClient({ apiKey: env!.apiKey, baseUrl: env!.baseUrl });
+    recordSurface(walkErgonomicSurface(client));
+  });
+
+  afterAll(async () => {
+    for (const fn of cleanup.splice(0)) {
+      await fn().catch(() => {});
+    }
+    flushCoverage();
+  });
+
+  it("create / get / getWithETag / update round-trip on a fresh contact", async () => {
+    const address = contactAddress("ctc");
+    trackContact(address);
+
+    const created = await client.contacts.create({
+      address: `Coverage Contact <${address}>`,
+      displayName: "Coverage Contact",
+      metadata: { suite: "contacts" },
+    });
+    // The address is canonicalized: the display-name form resolves to the bare address.
+    expect(created.address).toBe(address);
+    expect(created.displayName).toBe("Coverage Contact");
+    expect(created.metadata.suite).toBe("contacts");
+    recordCovered("contacts.create");
+
+    const got = await client.contacts.get(address);
+    expect(got.address).toBe(address);
+    expect(got.displayName).toBe("Coverage Contact");
+    recordCovered("contacts.get");
+
+    const withETag = await client.contacts.getWithETag(address);
+    expect(withETag.data.address).toBe(address);
+    expect(typeof withETag.etag).toBe("string");
+    expect(withETag.etag!.length).toBeGreaterThan(0);
+    recordCovered("contacts.getWithETag");
+
+    const renamed = `coverage renamed ${Date.now()}`;
+    const updated = await client.contacts.update(
+      address,
+      { displayName: renamed },
+      { ifMatch: withETag.etag },
+    );
+    expect(updated.address).toBe(address);
+    expect(updated.displayName).toBe(renamed);
+    recordCovered("contacts.update");
+
+    // Confirm the rename actually persisted (not just echoed back).
+    const reread = await client.contacts.get(address);
+    expect(reread.displayName).toBe(renamed);
+  });
+
+  it("list paginates at limit 2 and filters by source", async () => {
+    const addresses = [contactAddress("lst"), contactAddress("lst"), contactAddress("lst")];
+    for (const address of addresses) {
+      await client.contacts.create({ address });
+      trackContact(address);
+    }
+
+    // Three fresh contacts at limit 2 forces at least one cursor hop — walk the
+    // pages manually until every fixture address has been seen.
+    const seen = new Set<string>();
+    let cursor: string | undefined;
+    let pages = 0;
+    const pager = client.contacts.list({ limit: 2 });
+    while (seen.size < addresses.length && pages < 50) {
+      const page = await pager.page(cursor);
+      pages += 1;
+      for (const contact of page.items) {
+        if (addresses.includes(contact.address)) seen.add(contact.address);
+      }
+      if (!page.next_cursor) break;
+      cursor = page.next_cursor;
+    }
+    expect(pages).toBeGreaterThan(1);
+    expect(seen.size).toBe(addresses.length);
+
+    // The source filter narrows by provenance: manual creates are source=manual.
+    const manual = await client.contacts.list({ source: "manual", limit: 50 }).toArray({ limit: 50 });
+    for (const address of addresses) {
+      expect(
+        manual.some((contact) => contact.address === address),
+        `${address} must appear under source=manual`,
+      ).toBe(true);
+    }
+    recordCovered("contacts.list");
+  });
+
+  it("import records a batch (with an in-batch duplicate) and deleteImport reverses it", async () => {
+    const first = contactAddress("imp");
+    const second = contactAddress("imp");
+    trackContact(first);
+    trackContact(second);
+
+    const result = await client.contacts.import({
+      contacts: [
+        { address: first, displayName: "Import One" },
+        { address: second, displayName: "Import Two" },
+        { address: first }, // in-batch duplicate of row 0
+      ],
+    });
+    expect(result.batchId).toBeTruthy();
+    expect(result.results.length).toBe(3);
+    expect(result.created).toBe(2);
+    expect(result.skipped).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(result.results[2].status).toBe("skipped");
+    recordCovered("contacts.import");
+
+    const imported = await client.contacts.get(first);
+    expect(imported.source).toBe("import");
+    expect(imported.importBatchId).toBe(result.batchId);
+
+    const reversed = await client.contacts.deleteImport(result.batchId);
+    expect(reversed.deleted).toBe(true);
+    expect(reversed.batchId).toBe(result.batchId);
+    expect(reversed.contactsDeleted).toBe(2);
+    recordCovered("contacts.deleteImport");
+
+    // The reversal removed the contacts — a follow-up read is a typed not-found.
+    await expect(client.contacts.get(first)).rejects.toBeInstanceOf(E2ANotFoundError);
+  });
+
+  it("delete removes a contact; a follow-up get is a typed not-found", async () => {
+    const address = contactAddress("del");
+    await client.contacts.create({ address });
+    trackContact(address);
+
+    const deleted = await client.contacts.delete(address);
+    expect(deleted.deleted).toBe(true);
+    expect(deleted.address).toBe(address);
+    recordCovered("contacts.delete");
+
+    await expect(client.contacts.get(address)).rejects.toBeInstanceOf(E2ANotFoundError);
+  });
+
+  it("setOutreach / getOutreach / getOutreachWithETag / outreach / deleteOutreach round-trip", async () => {
+    const agent = `${uniqueSlug("outcov")}@${env!.sharedDomain}`;
+    await client.agents.create({ email: agent, name: "coverage outreach" });
+    cleanup.push(() => client.agents.delete(agent));
+
+    const address = contactAddress("out");
+    await client.contacts.create({ address });
+    trackContact(address);
+
+    // First setOutreach enrols: stage + a next-action schedule.
+    const stage = uniqueSlug("stage");
+    const nextActionAt = new Date(Date.now() + 3_600_000);
+    const enrolled = await client.contacts.setOutreach(agent, address, { stage, nextActionAt });
+    expect(enrolled.agentEmail).toBe(agent);
+    expect(enrolled.address).toBe(address);
+    expect(enrolled.stage).toBe(stage);
+    expect(enrolled.nextActionAt).toBeTruthy();
+    recordCovered("contacts.setOutreach");
+
+    const fetched = await client.contacts.getOutreach(agent, address);
+    expect(fetched.agentEmail).toBe(agent);
+    expect(fetched.address).toBe(address);
+    expect(fetched.stage).toBe(stage);
+    recordCovered("contacts.getOutreach");
+
+    const withETag = await client.contacts.getOutreachWithETag(agent, address);
+    expect(withETag.data.address).toBe(address);
+    expect(withETag.data.stage).toBe(stage);
+    expect(typeof withETag.etag).toBe("string");
+    expect(withETag.etag!.length).toBeGreaterThan(0);
+    recordCovered("contacts.getOutreachWithETag");
+
+    // Guarded read-modify-write: advance the stage with the validator just read;
+    // the omitted schedule must survive (setOutreach is partial).
+    const advancedStage = `${stage}-advanced`;
+    const advanced = await client.contacts.setOutreach(
+      agent,
+      address,
+      { stage: advancedStage },
+      { ifMatch: withETag.etag },
+    );
+    expect(advanced.stage).toBe(advancedStage);
+    expect(advanced.nextActionAt).toBeTruthy();
+
+    // The stage-filtered list surfaces the engagement, and the AutoPager yields it.
+    const listed = await client.contacts.outreach(agent, { stage: advancedStage, limit: 20 }).toArray({ limit: 20 });
+    const mine = listed.find((e) => e.address === address);
+    expect(mine, `engagement for ${address} must appear under stage=${advancedStage}`).toBeTruthy();
+    expect(mine!.stage).toBe(advancedStage);
+    recordCovered("contacts.outreach");
+
+    let yielded: string | undefined;
+    for await (const engagement of client.contacts.outreach(agent, { stage: advancedStage })) {
+      if (engagement.address === address) {
+        yielded = engagement.address;
+        break;
+      }
+    }
+    expect(yielded).toBe(address);
+
+    const unenrolled = await client.contacts.deleteOutreach(agent, address);
+    expect(unenrolled.deleted).toBe(true);
+    expect(unenrolled.address).toBe(address);
+    recordCovered("contacts.deleteOutreach");
+
+    // The contact itself survives un-enrolment; only the engagement is gone.
+    await expect(client.contacts.getOutreach(agent, address)).rejects.toBeInstanceOf(E2ANotFoundError);
+  });
+});

--- a/sdks/typescript/test/v1/introspect.test.ts
+++ b/sdks/typescript/test/v1/introspect.test.ts
@@ -1,0 +1,61 @@
+// Unit test for the coverage-gate denominator walker, test/coverage/introspect.ts.
+// Runs offline in the default `npm test` (test:unit globs test/v1): the
+// E2AClient constructor only wires generated transport handles — it performs no
+// I/O — so walking a dummy-configured client is pure reflection.
+//
+// This is the "missing coverage demonstrably fails" regression net: the walker
+// must SEE every ergonomic method (contacts.* included), because whatever it
+// advertises becomes the denominator gate.mjs demands coverage for.
+import { describe, it, expect } from "vitest";
+import { E2AClient } from "../../src/v1/index.js";
+import { walkErgonomicSurface } from "../coverage/introspect.js";
+
+const CONTACTS_IDS = [
+  "contacts.create",
+  "contacts.get",
+  "contacts.getWithETag",
+  "contacts.update",
+  "contacts.list",
+  "contacts.import",
+  "contacts.deleteImport",
+  "contacts.delete",
+  "contacts.setOutreach",
+  "contacts.getOutreach",
+  "contacts.getOutreachWithETag",
+  "contacts.outreach",
+  "contacts.deleteOutreach",
+];
+
+describe("walkErgonomicSurface", () => {
+  const client = new E2AClient({ apiKey: "test-key", baseUrl: "http://localhost" });
+  const ids = walkErgonomicSurface(client);
+
+  it("advertises the full contacts.* surface (so the gate demands coverage for it)", () => {
+    for (const id of CONTACTS_IDS) {
+      expect(ids, `walker must advertise ${id}`).toContain(id);
+    }
+  });
+
+  it("advertises known pre-existing ergonomic ids", () => {
+    for (const id of ["info", "agents.create", "messages.send", "account.apiKeys.create"]) {
+      expect(ids, `walker must advertise ${id}`).toContain(id);
+    }
+  });
+
+  it("never double-counts (aliased resources resolve to the same instance)", () => {
+    // client.messages / client.inbound's facade / client.webhooks share one
+    // MessagesResource instance; the visited-set must keep ids unique.
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("excludes the generated transport layer (Promise<Tag>Api internals)", () => {
+    // client.meta (a raw PromiseMetaApi) and every resource's private `.api`
+    // handle are the generated layer — internal by construction, excluded from
+    // the denominator rather than allowlisted. Nothing reachable only through
+    // them (e.g. getInfo, *WithHttpInfo) may surface.
+    expect(ids.some((id) => id === "meta" || id.startsWith("meta."))).toBe(false);
+    expect(ids.some((id) => id.split(".").some((seg) => /^Promise[A-Za-z0-9]*Api$/.test(seg)))).toBe(false);
+    expect(ids.some((id) => id === "api" || id.includes(".api."))).toBe(false);
+    expect(ids.some((id) => id.endsWith("WithHttpInfo"))).toBe(false);
+  });
+});

--- a/tests/e2e-prod/README.md
+++ b/tests/e2e-prod/README.md
@@ -40,4 +40,20 @@ Do not commit credentials or print secret values in reports or logs.
 npm test              # run all suites (suites/*.test.ts)
 npm run smoke          # quick smoke check (smoke.ts)
 npm run coverage       # run all suites, then the coverage gate
+npm run test:unit      # harness unit tests (node --test harness/*.test.ts)
+npm run test:unit:gates  # gate unit tests (python3 -m unittest test_gates -v)
 ```
+
+`test:unit:gates` is deliberately NOT chained into `test:unit`: the harness
+tests are pure Node, while the gate tests drive the three Python coverage
+gates (`coverage_gate.py`, `event_coverage_gate.py`, `mcp_coverage_gate.py`)
+as subprocesses against synthetic shard directories, and need `python3` +
+PyYAML. Run both in environments that have them.
+
+The three gates fail closed on uncovered surface: every /v1 operationId
+(coverage_gate.py), every webhook event type (event_coverage_gate.py), and
+every advertised MCP tool (mcp_coverage_gate.py) must be exercised by a live
+run. Suite `30-contacts-outreach.test.ts` owns the contacts/outreach surface
+for all three: the 11 contacts operationIds (REST), the 11 contact MCP
+tools, and the `contact.due` event (dual-assertion emission, same bar as
+`21-webhook-events.test.ts`).

--- a/tests/e2e-prod/package.json
+++ b/tests/e2e-prod/package.json
@@ -9,6 +9,7 @@
     "pretest:prod": "rm -rf reports/coverage reports/mcp-coverage reports/event-coverage reports/target",
     "test:prod": "node --test --test-concurrency=1 --test-reporter=spec suites/*.test.ts suites/prod/*.test.ts",
     "test:unit": "node --test harness/*.test.ts",
+    "test:unit:gates": "python3 -m unittest test_gates -v",
     "coverage:gate": "python3 coverage_gate.py",
     "coverage:gate:mcp": "python3 mcp_coverage_gate.py",
     "coverage:gate:events": "python3 event_coverage_gate.py",

--- a/tests/e2e-prod/suites/30-contacts-outreach.test.ts
+++ b/tests/e2e-prod/suites/30-contacts-outreach.test.ts
@@ -771,12 +771,22 @@ test("emit: contact.due — a past-due engagement emits the event and attempts a
     info(SUITE, "contact.due", `emitted evt=${ev!.id} fanned to ${fanout!.matched_webhooks} webhook(s); our webhook whd=${del!.id} attempts=${del!.attempts} last_status=${del!.last_status_code}`);
     verifiedEventTypes.add("contact.due");
   } finally {
-    trackedHooks.delete(hook.id);
-    await client.delete(`/v1/webhooks/${encodeURIComponent(hook.id)}?confirm=DELETE`);
-    untrackEngagement(agent, address);
-    await client.delete(`/v1/agents/${encodeURIComponent(agent)}/contacts/${encodeURIComponent(address)}?confirm=DELETE`);
-    trackedContacts.delete(address);
-    await client.delete(`/v1/contacts/${encodeURIComponent(address)}?confirm=DELETE`);
+    // Each delete is individually guarded and the resource is untracked only
+    // AFTER its delete succeeds: a throw here must neither skip the remaining
+    // deletes nor strand the resource for the `after` fallback (whose
+    // 404-tolerance makes a double-delete harmless).
+    try {
+      await client.delete(`/v1/webhooks/${encodeURIComponent(hook.id)}?confirm=DELETE`);
+      trackedHooks.delete(hook.id);
+    } catch { /* after() retries via trackedHooks */ }
+    try {
+      await client.delete(`/v1/agents/${encodeURIComponent(agent)}/contacts/${encodeURIComponent(address)}?confirm=DELETE`);
+      untrackEngagement(agent, address);
+    } catch { /* after() retries via trackedEngagements */ }
+    try {
+      await client.delete(`/v1/contacts/${encodeURIComponent(address)}?confirm=DELETE`);
+      trackedContacts.delete(address);
+    } catch { /* after() retries via trackedContacts */ }
   }
 });
 

--- a/tests/e2e-prod/suites/30-contacts-outreach.test.ts
+++ b/tests/e2e-prod/suites/30-contacts-outreach.test.ts
@@ -1,0 +1,836 @@
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { ApiClient, type RawResponse } from "../harness/client.ts";
+import { isEventsLogDisabled } from "../harness/event-capability.ts";
+import { uniqueSlug } from "../harness/fixtures.ts";
+import { track, cleanup } from "../harness/cleanup.ts";
+import { HttpMcpClient, callTool } from "../harness/mcp.ts";
+import { writeReport, info, warn } from "../harness/report.ts";
+
+// Contacts + outreach (beta) conformance — the live coverage owner for the 11
+// contacts operationIds, the 11 contacts MCP tools, and the contact.due event,
+// none of which any other suite exercises. Shapes verified against
+// api/openapi.yaml (the drift-gated SSOT) before these assertions were written.
+//
+// Section 1 — REST (account key), all 11 operationIds on their 2xx paths:
+//   createContact (201 + Location; duplicate → 409 conflict),
+//   getContact (ETag header, "…32-hex…" strong validator), updateContact
+//   (If-Match 200 → new ETag; stale If-Match → 412 precondition_failed),
+//   listContacts (cursor pagination with no overlap; source=manual filter;
+//   bogus source → 400 invalid_filter), importContacts (batch_id + per-row
+//   statuses incl. duplicate_in_batch; import_batch_id list filter),
+//   deleteImportBatch (contacts_deleted/contacts_retained counts; batch
+//   contact then 404s), deleteContact (200; get → 404 contact_not_found),
+//   and the per-agent engagement quad listEngagements / getEngagement /
+//   upsertEngagement (201 enrol + ETag, If-Match 200 update) /
+//   deleteEngagement (200; engagement 404s, the account-level CONTACT
+//   survives). Per-agent scoping is asserted by upserting the SAME contact
+//   address under two agents and showing the stages stay independent.
+//   Scoping probe: an agent-scoped API key (minted via POST
+//   /v1/account/api-keys, scope=agent — the pattern 19-account establishes)
+//   is 403 forbidden on the account-level contacts surface.
+//
+// Section 2 — MCP. All 11 contact tools called successfully (isError !==
+// true is what mcp_coverage_gate.py counts) with FRESH addresses disjoint
+// from section 1, asserting on the parsed tool-result content, not merely
+// the absence of an error.
+//
+// Section 3 — contact.due. A fresh engagement with next_action_at in the
+// PAST is picked up by the deployment's contactdue sweep (River periodic,
+// 5-minute interval + RunOnStart, internal/contactdue/contactdue.go), which
+// emits one contact.due event per due engagement. Proved to the same
+// dual-assertion bar 21-webhook-events established: (1) the event's own
+// delivery_status.matched_webhooks >= 1 AND (2) OUR fresh webhook's
+// deliveries list an entry for contact.due with attempts >= 1 (the
+// example.com sink 405s the POST — an ATTEMPT is asserted, never delivery
+// success). The listEvents poll budget is ~8 minutes to straddle two sweep
+// intervals. IMPORTANT: contact.due is a wake-up signal delivered to
+// subscribed webhooks so an EXTERNAL agent runtime can act on it — this
+// suite asserts the signal is emitted and fanned out; it does NOT claim the
+// event launches an agent runtime.
+//
+// Cleanup: agents go through the shared harness (track/cleanup); contacts,
+// engagements, import batches and webhooks are tracked in local sets/arrays
+// and deleted best-effort in `after` — each delete individually wrapped so
+// one failure (or a mid-section test abort) can't strand the rest, and
+// 404/403 count as success (already gone). Coverage recording is automatic:
+// ApiClient records each 2xx for coverage_gate.py, HttpMcpClient records
+// each successful tools/call for mcp_coverage_gate.py, and the verified
+// contact.due type is flushed to reports/event-coverage/<pid>.json below —
+// the same inline shard pattern as 21-webhook-events (deliberately not
+// harness infra; see that suite's module doc for why).
+const SUITE = "30-contacts-outreach";
+const client = new ApiClient();
+const mcp = new HttpMcpClient(client.env.mcpUrl, client.env.apiKey);
+
+const EVENT_COVERAGE_DIR = fileURLToPath(new URL("../reports/event-coverage/", import.meta.url));
+const verifiedEventTypes = new Set<string>();
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+// A `since` filter with slack for host/server clock skew (same reasoning as
+// 21-webhook-events): a `since` AFTER the event's server-side created_at
+// would hide a just-emitted event → false RED.
+const sinceNow = () => new Date(Date.now() - 5000).toISOString();
+
+// ---------------------------------------------------------------------------
+// Wire types (subset of api/openapi.yaml schemas the assertions read).
+// ---------------------------------------------------------------------------
+interface ErrorEnvelope {
+  error?: { code?: string; message?: string };
+}
+interface ContactView {
+  address: string;
+  display_name: string;
+  metadata: Record<string, unknown>;
+  source: string;
+  import_batch_id?: string;
+  created_at: string;
+  updated_at: string;
+}
+interface PageContactView {
+  items: ContactView[];
+  next_cursor: string | null;
+}
+interface ContactEngagementView {
+  agent_email: string;
+  address: string;
+  stage: string;
+  next_action_at: string | null;
+  metadata: Record<string, unknown>;
+  replied: boolean;
+  suppressed: boolean;
+  contact: { address: string; display_name: string; metadata: Record<string, unknown> };
+  created_at: string;
+  updated_at: string;
+}
+interface PageContactEngagementView {
+  items: ContactEngagementView[];
+  next_cursor: string | null;
+}
+interface ContactImportResult {
+  batch_id: string;
+  created: number;
+  updated: number;
+  skipped: number;
+  failed: number;
+  results: Array<{ index: number; status: string; code?: string; address?: string }>;
+}
+interface DeleteImportBatchResult {
+  deleted: boolean;
+  batch_id: string;
+  contacts_deleted: number;
+  contacts_retained: number;
+  engagements_deleted: number;
+}
+interface EventView {
+  id: string;
+  type: string;
+  schema_version: string;
+  created_at: string;
+  status: string;
+  data: Record<string, unknown>;
+  agent_email?: string;
+  delivery_status?: { matched_webhooks?: number; delivered?: number; pending?: number; failed?: number };
+}
+interface PageEventView {
+  items: EventView[];
+  next_cursor: string | null;
+}
+interface WebhookDeliveryView {
+  id: string;
+  type: string;
+  status: string;
+  attempts: number;
+  last_status_code?: number;
+}
+interface PageWebhookDeliveryView {
+  items: WebhookDeliveryView[];
+  next_cursor: string | null;
+}
+interface CreateWebhookResponse {
+  id: string;
+  url: string;
+  events: string[];
+  signing_secret: string;
+}
+
+// ETags on this surface are strong validators: a quoted 32-hex digest
+// (internal/httpapi/contacts.go contactETag / engagements.go engagementETag —
+// sha256 truncated to 16 bytes, hex-encoded, quoted).
+const ETAG_RE = /^"[0-9a-f]{32}"$/;
+
+// ---------------------------------------------------------------------------
+// Local resource tracking. The shared harness cleanup only knows agents and
+// domains, so contacts/engagements/batches/webhooks are tracked here and
+// deleted best-effort in `after`. Every address comes from uniqueSlug(), so
+// nothing collides across runs even when a prior run's cleanup failed.
+// ---------------------------------------------------------------------------
+const trackedContacts = new Set<string>();
+const trackedBatches = new Set<string>();
+const trackedHooks = new Set<string>();
+const trackedEngagements = new Set<string>(); // "<agent>\n<address>"
+
+function trackEngagement(agent: string, address: string): void {
+  trackedEngagements.add(`${agent}\n${address}`);
+  // An upsert auto-creates the account-level contact when absent, so the
+  // address always needs contact cleanup too.
+  trackedContacts.add(address);
+}
+function untrackEngagement(agent: string, address: string): void {
+  trackedEngagements.delete(`${agent}\n${address}`);
+}
+
+async function freshAgent(label: string): Promise<string> {
+  const email = `${uniqueSlug(label)}@${client.env.sharedDomain}`;
+  const r = await client.post<{ email: string }>("/v1/agents", {
+    body: { email, name: `contacts ${label}` },
+    expect: 201,
+  });
+  track("agent", email);
+  return r.body!.email;
+}
+
+async function createContact(address: string, displayName?: string): Promise<void> {
+  const r = await client.post<ContactView>("/v1/contacts", {
+    body: { address, ...(displayName ? { display_name: displayName } : {}) },
+    expect: 201,
+  });
+  trackedContacts.add(r.body!.address);
+}
+
+// ---------------------------------------------------------------------------
+// Section 1 — REST contacts + engagements (account key).
+// ---------------------------------------------------------------------------
+
+test("createContact: 201 + Location; a duplicate create → 409 conflict", async () => {
+  const address = `${uniqueSlug("ctdup")}@example.com`;
+  const r = await client.post<ContactView>("/v1/contacts", {
+    body: { address, display_name: "Coverage Contact", metadata: { origin: "suite-30" } },
+  });
+  assert.equal(r.status, 201, `createContact expected 201, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  trackedContacts.add(r.body!.address);
+  assert.equal(r.body?.address, address, "ContactView echoes the canonical address");
+  assert.equal(r.body?.source, "manual", "a direct create has source=manual");
+  assert.equal(r.body?.display_name, "Coverage Contact");
+  assert.ok(
+    r.headers.location?.includes(`/v1/contacts/${encodeURIComponent(address)}`),
+    `Location header names the new contact: ${r.headers.location}`,
+  );
+
+  // The address is canonicalized before storage, so a second create of the
+  // same address is a conflict, not a second contact.
+  const dup = await client.post<ErrorEnvelope>("/v1/contacts", { body: { address } });
+  assert.equal(dup.status, 409, `duplicate create expected 409, got ${dup.status}: ${dup.raw.slice(0, 200)}`);
+  assert.equal(dup.body?.error?.code, "conflict", "duplicate create carries error.code=conflict");
+});
+
+test("getContact/updateContact: ETag + If-Match optimistic concurrency (200 → stale 412)", async () => {
+  const address = `${uniqueSlug("ctetag")}@example.com`;
+  await createContact(address, "Original Name");
+
+  const got = await client.get<ContactView>(`/v1/contacts/${encodeURIComponent(address)}`, { expect: 200 });
+  const etag = got.headers.etag;
+  assert.ok(etag && ETAG_RE.test(etag), `getContact returns a quoted 32-hex ETag, got ${JSON.stringify(etag)}`);
+  assert.equal(got.body?.display_name, "Original Name");
+
+  // A conditional write with the CURRENT validator applies and moves the ETag.
+  const upd = await client.patch<ContactView>(`/v1/contacts/${encodeURIComponent(address)}`, {
+    headers: { "If-Match": etag! },
+    body: { display_name: "Renamed Contact" },
+  });
+  assert.equal(upd.status, 200, `PATCH with current ETag expected 200, got ${upd.status}: ${upd.raw.slice(0, 200)}`);
+  assert.equal(upd.body?.display_name, "Renamed Contact", "the conditional write applied");
+  const etag2 = upd.headers.etag;
+  assert.ok(etag2 && ETAG_RE.test(etag2), `PATCH returns a fresh ETag, got ${JSON.stringify(etag2)}`);
+  assert.notEqual(etag2, etag, "an accepted write moves the validator");
+
+  // The same (now stale) validator must NOT silently overwrite.
+  const stale = await client.patch<ErrorEnvelope>(`/v1/contacts/${encodeURIComponent(address)}`, {
+    headers: { "If-Match": etag! },
+    body: { display_name: "Stale Writer" },
+  });
+  assert.equal(stale.status, 412, `PATCH with stale ETag expected 412, got ${stale.status}: ${stale.raw.slice(0, 200)}`);
+  assert.equal(stale.body?.error?.code, "precondition_failed", "stale write carries error.code=precondition_failed");
+
+  const after = await client.get<ContactView>(`/v1/contacts/${encodeURIComponent(address)}`, { expect: 200 });
+  assert.equal(after.body?.display_name, "Renamed Contact", "the stale write did not apply");
+});
+
+test("listContacts: cursor pagination without overlap; source filter; invalid source → 400 invalid_filter", async () => {
+  // Three manual contacts for the pagination walk, one import-created contact
+  // the source=manual filter must EXCLUDE.
+  const paged = [`${uniqueSlug("ctpg1")}@example.com`, `${uniqueSlug("ctpg2")}@example.com`, `${uniqueSlug("ctpg3")}@example.com`];
+  for (const a of paged) await createContact(a);
+  const imported = `${uniqueSlug("ctpgi")}@example.com`;
+  const imp = await client.post<ContactImportResult>("/v1/contacts/import", {
+    body: { contacts: [{ address: imported }] },
+    expect: 200,
+  });
+  trackedBatches.add(imp.body!.batch_id);
+  trackedContacts.add(imported);
+
+  // Walk with limit=2 until all three are seen (cap pages so a broken cursor
+  // can't loop forever). Pages may also contain survivors of earlier runs —
+  // the assertion is on OUR three: each seen exactly once, never twice.
+  const seen = new Map<string, number>();
+  let cursor: string | null = null;
+  let pages = 0;
+  do {
+    const page: RawResponse<PageContactView> = await client.get<PageContactView>("/v1/contacts", {
+      query: { limit: 2, ...(cursor ? { cursor } : {}) },
+      expect: 200,
+    });
+    pages++;
+    assert.ok(page.body!.items.length <= 2, "limit=2 clamps the page size");
+    for (const item of page.body!.items) {
+      assert.ok(!seen.has(item.address), `pagination overlap: ${item.address} appeared on two pages`);
+      seen.set(item.address, 1);
+    }
+    cursor = page.body!.next_cursor;
+  } while (cursor && pages < 8 && !paged.every((a) => seen.has(a)));
+  for (const a of paged) assert.ok(seen.has(a), `paginated listing reached ${a}`);
+
+  // source=manual returns the manual contact and not the import-created one.
+  const manualOnly = await client.get<PageContactView>("/v1/contacts", {
+    query: { source: "manual", limit: 100 },
+    expect: 200,
+  });
+  assert.ok(manualOnly.body!.items.some((c) => c.address === paged[0]), "source=manual returns the manual contact");
+  assert.ok(!manualOnly.body!.items.some((c) => c.address === imported), "source=manual excludes the import-created contact");
+  for (const c of manualOnly.body!.items) assert.equal(c.source, "manual", "source filter is honored on every row");
+
+  // A value outside the known provenance vocabulary is rejected, not ignored.
+  const bogus = await client.get<ErrorEnvelope>("/v1/contacts", { query: { source: "bogus" } });
+  assert.equal(bogus.status, 400, `invalid source expected 400, got ${bogus.status}: ${bogus.raw.slice(0, 200)}`);
+  assert.equal(bogus.body?.error?.code, "invalid_filter", "invalid source carries error.code=invalid_filter");
+});
+
+test("importContacts: per-row outcomes incl. duplicate_in_batch; import_batch_id list filter", async () => {
+  const a1 = `${uniqueSlug("ctim1")}@example.com`;
+  const a2 = `${uniqueSlug("ctim2")}@example.com`;
+  const a3 = `${uniqueSlug("ctim3")}@example.com`;
+  const r = await client.post<ContactImportResult>("/v1/contacts/import", {
+    body: {
+      contacts: [
+        { address: a1, display_name: "Import One" },
+        { address: a2 },
+        { address: a3 },
+        { address: a1 }, // duplicated in-batch: exercises the per-row skip path
+      ],
+    },
+  });
+  assert.equal(r.status, 200, `importContacts expected 200, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  const result = r.body!;
+  assert.ok(typeof result.batch_id === "string" && result.batch_id.length > 0, "import returns a batch_id");
+  trackedBatches.add(result.batch_id);
+  for (const a of [a1, a2, a3]) trackedContacts.add(a);
+
+  assert.equal(result.created, 3, "three fresh rows created");
+  assert.equal(result.skipped, 1, "the in-batch duplicate is skipped");
+  assert.equal(result.failed, 0, "no row failed");
+  assert.equal(result.results.length, 4, "one result entry per submitted row, in request order");
+  assert.deepEqual(
+    result.results.map((x) => x.status),
+    ["created", "created", "created", "skipped"],
+    "per-row statuses",
+  );
+  assert.equal(result.results[3].code, "duplicate_in_batch", "the skipped row names why");
+
+  // The batch filter lists exactly this batch's contacts.
+  const batchList = await client.get<PageContactView>("/v1/contacts", {
+    query: { import_batch_id: result.batch_id, limit: 100 },
+    expect: 200,
+  });
+  assert.deepEqual(
+    batchList.body!.items.map((c) => c.address).sort(),
+    [a1, a2, a3].sort(),
+    "import_batch_id filter returns exactly the batch's contacts",
+  );
+  for (const c of batchList.body!.items) {
+    assert.equal(c.source, "import", "batch contacts have source=import");
+    assert.equal(c.import_batch_id, result.batch_id, "the row carries its batch id");
+  }
+});
+
+test("deleteImportBatch: reversal counts; a batch contact then 404s", async () => {
+  const b1 = `${uniqueSlug("ctdel1")}@example.com`;
+  const b2 = `${uniqueSlug("ctdel2")}@example.com`;
+  const imp = await client.post<ContactImportResult>("/v1/contacts/import", {
+    body: { contacts: [{ address: b1 }, { address: b2 }] },
+    expect: 200,
+  });
+  const batchId = imp.body!.batch_id;
+  trackedBatches.add(batchId);
+  trackedContacts.add(b1);
+  trackedContacts.add(b2);
+
+  const del = await client.delete<DeleteImportBatchResult>(
+    `/v1/contacts/imports/${encodeURIComponent(batchId)}?confirm=DELETE`,
+  );
+  assert.equal(del.status, 200, `deleteImportBatch expected 200, got ${del.status}: ${del.raw.slice(0, 200)}`);
+  assert.equal(del.body?.deleted, true);
+  assert.equal(del.body?.batch_id, batchId);
+  // Neither contact has correspondence history, so both are removed.
+  assert.equal(del.body?.contacts_deleted, 2, "both untouched batch contacts removed");
+  assert.equal(del.body?.contacts_retained, 0, "nothing retained (no correspondence history)");
+  assert.equal(del.body?.engagements_deleted, 0, "the import enrolled no engagements");
+  trackedBatches.delete(batchId);
+  trackedContacts.delete(b1);
+  trackedContacts.delete(b2);
+
+  const gone = await client.get<ErrorEnvelope>(`/v1/contacts/${encodeURIComponent(b1)}`);
+  assert.equal(gone.status, 404, `batch contact after reversal expected 404, got ${gone.status}: ${gone.raw.slice(0, 200)}`);
+  assert.equal(gone.body?.error?.code, "contact_not_found");
+});
+
+test("engagements: enrol (201+ETag) → If-Match update (200) → filters → per-agent isolation → delete", async () => {
+  const agentA = await freshAgent("enga");
+  const agentB = await freshAgent("engb");
+  const address = `${uniqueSlug("cteng")}@example.com`;
+  const future = new Date(Date.now() + 3_600_000).toISOString();
+  const base = `/v1/agents/${encodeURIComponent(agentA)}/contacts`;
+
+  // First enrolment → 201 + ETag + Location; the contact is auto-created.
+  const enrol = await client.put<ContactEngagementView>(`${base}/${encodeURIComponent(address)}`, {
+    body: { stage: "prospect", next_action_at: future },
+  });
+  assert.equal(enrol.status, 201, `first upsertEngagement expected 201, got ${enrol.status}: ${enrol.raw.slice(0, 200)}`);
+  trackEngagement(agentA, address);
+  const etag = enrol.headers.etag;
+  assert.ok(etag && ETAG_RE.test(etag), `201 upsert returns an ETag, got ${JSON.stringify(etag)}`);
+  assert.ok(enrol.headers.location?.includes(`/v1/agents/`), `201 upsert returns a Location: ${enrol.headers.location}`);
+  assert.equal(enrol.body?.stage, "prospect");
+  assert.equal(enrol.body?.agent_email, agentA);
+  assert.equal(enrol.body?.replied, false, "a fresh engagement has not been replied to");
+
+  // Conditional update with the current validator → 200 (update, not create).
+  const upd = await client.put<ContactEngagementView>(`${base}/${encodeURIComponent(address)}`, {
+    headers: { "If-Match": etag! },
+    body: { stage: "nurture" },
+  });
+  assert.equal(upd.status, 200, `If-Match upsert expected 200, got ${upd.status}: ${upd.raw.slice(0, 200)}`);
+  assert.equal(upd.body?.stage, "nurture", "the conditional update applied");
+  assert.ok(upd.headers.etag && ETAG_RE.test(upd.headers.etag) && upd.headers.etag !== etag, "the update moves the ETag");
+  // An omitted field is left unchanged. Compare parsed instants, not strings:
+  // the server may normalize RFC 3339 precision differently from toISOString.
+  assert.ok(
+    upd.body?.next_action_at && Math.abs(Date.parse(upd.body.next_action_at) - Date.parse(future)) < 1000,
+    `next_action_at preserved (sent ${future}, got ${upd.body?.next_action_at})`,
+  );
+
+  // getEngagement: 200 + ETag + the embedded contact.
+  const got = await client.get<ContactEngagementView>(`${base}/${encodeURIComponent(address)}`, { expect: 200 });
+  assert.ok(got.headers.etag && ETAG_RE.test(got.headers.etag), "getEngagement returns an ETag");
+  assert.equal(got.body?.contact?.address, address, "the engagement embeds the contact");
+
+  // listEngagements filters: stage match / non-match, replied=false / true.
+  const byStage = await client.get<PageContactEngagementView>(base, { query: { stage: "nurture" }, expect: 200 });
+  assert.ok(byStage.body!.items.some((e) => e.address === address), "stage=nurture lists the engagement");
+  const wrongStage = await client.get<PageContactEngagementView>(base, { query: { stage: "prospect" }, expect: 200 });
+  assert.ok(!wrongStage.body!.items.some((e) => e.address === address), "stage=prospect no longer matches after the update");
+  const unreplied = await client.get<PageContactEngagementView>(base, { query: { replied: "false" }, expect: 200 });
+  assert.ok(unreplied.body!.items.some((e) => e.address === address), "replied=false lists the fresh engagement");
+  const replied = await client.get<PageContactEngagementView>(base, { query: { replied: "true" }, expect: 200 });
+  assert.ok(!replied.body!.items.some((e) => e.address === address), "replied=true excludes it");
+
+  // Per-agent scoping: the SAME contact address under a second agent is an
+  // independent engagement — B's stage must not leak into A's view.
+  const enrolB = await client.put<ContactEngagementView>(
+    `/v1/agents/${encodeURIComponent(agentB)}/contacts/${encodeURIComponent(address)}`,
+    { body: { stage: "qualify" } },
+  );
+  assert.equal(enrolB.status, 201, `agent B enrolment expected 201, got ${enrolB.status}: ${enrolB.raw.slice(0, 200)}`);
+  trackEngagement(agentB, address);
+  const listA = await client.get<PageContactEngagementView>(base, { expect: 200 });
+  assert.equal(
+    listA.body!.items.find((e) => e.address === address)?.stage,
+    "nurture",
+    "agent A's engagement is untouched by agent B's enrolment",
+  );
+  const listB = await client.get<PageContactEngagementView>(`/v1/agents/${encodeURIComponent(agentB)}/contacts`, { expect: 200 });
+  assert.equal(listB.body!.items.find((e) => e.address === address)?.stage, "qualify", "agent B sees its own stage");
+
+  // deleteEngagement: the engagement goes, the account-level CONTACT survives.
+  const del = await client.delete<{ deleted: boolean; address: string }>(
+    `${base}/${encodeURIComponent(address)}?confirm=DELETE`,
+  );
+  assert.equal(del.status, 200, `deleteEngagement expected 200, got ${del.status}: ${del.raw.slice(0, 200)}`);
+  assert.equal(del.body?.deleted, true);
+  assert.equal(del.body?.address, address);
+  untrackEngagement(agentA, address);
+
+  const gone = await client.get<ErrorEnvelope>(`${base}/${encodeURIComponent(address)}`);
+  assert.equal(gone.status, 404, `deleted engagement expected 404, got ${gone.status}: ${gone.raw.slice(0, 200)}`);
+  assert.equal(gone.body?.error?.code, "engagement_not_found");
+  const contact = await client.get<ContactView>(`/v1/contacts/${encodeURIComponent(address)}`, { expect: 200 });
+  assert.equal(contact.body?.address, address, "the account-level contact survives un-enrolment");
+  const stillB = await client.get<ContactEngagementView>(
+    `/v1/agents/${encodeURIComponent(agentB)}/contacts/${encodeURIComponent(address)}`,
+    { expect: 200 },
+  );
+  assert.equal(stillB.body?.stage, "qualify", "agent B's engagement survives A's un-enrolment");
+});
+
+test("deleteContact: 200 deletion object; the contact then 404s", async () => {
+  const address = `${uniqueSlug("ctrm")}@example.com`;
+  await createContact(address);
+  const del = await client.delete<{ deleted: boolean; address: string }>(
+    `/v1/contacts/${encodeURIComponent(address)}?confirm=DELETE`,
+  );
+  assert.equal(del.status, 200, `deleteContact expected 200, got ${del.status}: ${del.raw.slice(0, 200)}`);
+  assert.equal(del.body?.deleted, true);
+  assert.equal(del.body?.address, address);
+  trackedContacts.delete(address);
+
+  const gone = await client.get<ErrorEnvelope>(`/v1/contacts/${encodeURIComponent(address)}`);
+  assert.equal(gone.status, 404, `deleted contact expected 404, got ${gone.status}: ${gone.raw.slice(0, 200)}`);
+  assert.equal(gone.body?.error?.code, "contact_not_found");
+});
+
+test("scoping: an agent-scoped API key is 403 forbidden on the account contacts surface", async () => {
+  // Minting an agent-scoped key is the established pattern (19-account):
+  // POST /v1/account/api-keys with scope=agent + agent_email.
+  const agent = await freshAgent("ctkey");
+  const mint = await client.post<{ id: string; key: string; scope: string }>("/v1/account/api-keys", {
+    body: { name: uniqueSlug("ctkey"), scope: "agent", agent_email: agent },
+  });
+  assert.equal(mint.status, 201, `createApiKey(scope=agent) expected 201, got ${mint.status}: ${mint.raw.slice(0, 200)}`);
+  const keyId = mint.body!.id;
+  try {
+    const list = await client.get<ErrorEnvelope>("/v1/contacts", { apiKey: mint.body!.key });
+    assert.equal(list.status, 403, `agent-scoped listContacts expected 403, got ${list.status}: ${list.raw.slice(0, 200)}`);
+    assert.equal(list.body?.error?.code, "forbidden", "the scope ceiling carries error.code=forbidden");
+    const create = await client.post<ErrorEnvelope>("/v1/contacts", {
+      apiKey: mint.body!.key,
+      body: { address: `${uniqueSlug("ctsc")}@example.com` },
+    });
+    assert.equal(create.status, 403, `agent-scoped createContact expected 403, got ${create.status}: ${create.raw.slice(0, 200)}`);
+  } finally {
+    await client.delete(`/v1/account/api-keys/${encodeURIComponent(keyId)}?confirm=DELETE`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Section 2 — MCP contact tools. Fresh addresses (mcp- prefix), disjoint from
+// section 1, sequenced so the deletes run last. Each call asserts on the
+// parsed tool-result content; isError !== true is what the coverage gate
+// counts, and a bare no-error call would prove nothing about the payload.
+// ---------------------------------------------------------------------------
+
+before(async () => {
+  info(SUITE, "transport", `MCP over HTTP → ${client.env.mcpUrl}`);
+  // Feeds the mcp-coverage denominator (tools/list) even if a later test
+  // short-circuits.
+  const list = await mcp.call<{ tools: Array<{ name: string }> }>("tools/list");
+  info(SUITE, "tools-list", `server advertises ${list.tools.length} tools`);
+});
+
+function extractText(r: { content?: Array<{ type: string; text?: string }> }): string {
+  return r.content?.find((c) => c.type === "text")?.text ?? "";
+}
+
+function parseJson<T>(r: { content?: Array<{ type: string; text?: string }> }): T {
+  return JSON.parse(extractText(r)) as T;
+}
+
+let mcpAgentPromise: Promise<string> | undefined;
+function mcpAgent(): Promise<string> {
+  mcpAgentPromise ??= freshAgent("mcpct");
+  return mcpAgentPromise;
+}
+
+test("mcp-contacts: create/get/update/list/delete_contact lifecycle", async () => {
+  const address = `${uniqueSlug("mcpct1")}@example.com`;
+
+  const created = await callTool(mcp, "create_contact", { address, display_name: "MCP Contact" });
+  assert.equal(created.isError, undefined, `create_contact isError: ${extractText(created).slice(0, 200)}`);
+  const createdView = parseJson<ContactView>(created);
+  assert.equal(createdView.address, address, "create_contact echoes the canonical address");
+  trackedContacts.add(address);
+
+  const got = await callTool(mcp, "get_contact", { address });
+  assert.equal(got.isError, undefined, `get_contact isError: ${extractText(got).slice(0, 200)}`);
+  const gotView = parseJson<ContactView & { etag?: string }>(got);
+  assert.equal(gotView.address, address);
+  assert.equal(gotView.display_name, "MCP Contact");
+  assert.ok(gotView.etag && ETAG_RE.test(gotView.etag), `get_contact surfaces the ETag, got ${JSON.stringify(gotView.etag)}`);
+
+  const renamed = await callTool(mcp, "update_contact", { address, display_name: "MCP Renamed", if_match: gotView.etag });
+  assert.equal(renamed.isError, undefined, `update_contact isError: ${extractText(renamed).slice(0, 200)}`);
+  assert.equal(parseJson<ContactView>(renamed).display_name, "MCP Renamed", "update_contact applies the new name");
+
+  const listed = await callTool(mcp, "list_contacts", { source: "manual", limit: 100 });
+  assert.equal(listed.isError, undefined, `list_contacts isError: ${extractText(listed).slice(0, 200)}`);
+  const page = parseJson<{ contacts?: ContactView[] }>(listed);
+  assert.ok(page.contacts?.some((c) => c.address === address), "list_contacts includes the created contact");
+
+  const deleted = await callTool(mcp, "delete_contact", { address });
+  assert.equal(deleted.isError, undefined, `delete_contact isError: ${extractText(deleted).slice(0, 200)}`);
+  assert.deepEqual(parseJson<{ deleted?: boolean; address?: string }>(deleted), { deleted: true, address }, "delete_contact result shape");
+  trackedContacts.delete(address);
+
+  const gone = await client.get(`/v1/contacts/${encodeURIComponent(address)}`);
+  assert.equal(gone.status, 404, "the contact is gone via REST after the MCP delete");
+});
+
+test("mcp-contacts: import_contacts then delete_contact_import reverses it", async () => {
+  const a1 = `${uniqueSlug("mcpim1")}@example.com`;
+  const a2 = `${uniqueSlug("mcpim2")}@example.com`;
+
+  const imported = await callTool(mcp, "import_contacts", {
+    contacts: [{ address: a1, display_name: "MCP Import One" }, { address: a2 }],
+  });
+  assert.equal(imported.isError, undefined, `import_contacts isError: ${extractText(imported).slice(0, 200)}`);
+  const result = parseJson<ContactImportResult>(imported);
+  assert.ok(result.batch_id, "import_contacts returns a batch_id");
+  assert.equal(result.created, 2, "both rows created");
+  trackedBatches.add(result.batch_id);
+  trackedContacts.add(a1);
+  trackedContacts.add(a2);
+
+  const reversed = await callTool(mcp, "delete_contact_import", { batch_id: result.batch_id });
+  assert.equal(reversed.isError, undefined, `delete_contact_import isError: ${extractText(reversed).slice(0, 200)}`);
+  const receipt = parseJson<DeleteImportBatchResult>(reversed);
+  assert.equal(receipt.deleted, true);
+  assert.equal(receipt.contacts_deleted, 2, "both untouched batch contacts removed");
+  trackedBatches.delete(result.batch_id);
+  trackedContacts.delete(a1);
+  trackedContacts.delete(a2);
+});
+
+test("mcp-contacts: set/get/list/delete_outreach_contact lifecycle", async () => {
+  const agent = await mcpAgent();
+  const address = `${uniqueSlug("mcpout")}@example.com`;
+  const future = new Date(Date.now() + 3_600_000).toISOString();
+
+  const enrolled = await callTool(mcp, "set_outreach_contact", {
+    email: agent,
+    address,
+    stage: "prospect",
+    next_action_at: future,
+  });
+  assert.equal(enrolled.isError, undefined, `set_outreach_contact isError: ${extractText(enrolled).slice(0, 200)}`);
+  const view = parseJson<ContactEngagementView>(enrolled);
+  assert.equal(view.agent_email, agent);
+  assert.equal(view.address, address);
+  assert.equal(view.stage, "prospect");
+  trackEngagement(agent, address);
+
+  const got = await callTool(mcp, "get_outreach_contact", { email: agent, address });
+  assert.equal(got.isError, undefined, `get_outreach_contact isError: ${extractText(got).slice(0, 200)}`);
+  const gotView = parseJson<ContactEngagementView & { etag?: string }>(got);
+  assert.equal(gotView.stage, "prospect");
+  assert.ok(gotView.etag && ETAG_RE.test(gotView.etag), `get_outreach_contact surfaces the ETag, got ${JSON.stringify(gotView.etag)}`);
+  assert.equal(gotView.contact?.address, address, "the outreach record embeds the contact");
+
+  const listed = await callTool(mcp, "list_outreach_contacts", { email: agent, stage: "prospect" });
+  assert.equal(listed.isError, undefined, `list_outreach_contacts isError: ${extractText(listed).slice(0, 200)}`);
+  const page = parseJson<{ contacts?: ContactEngagementView[] }>(listed);
+  assert.ok(page.contacts?.some((e) => e.address === address), "list_outreach_contacts includes the enrolment");
+
+  const removed = await callTool(mcp, "delete_outreach_contact", { email: agent, address });
+  assert.equal(removed.isError, undefined, `delete_outreach_contact isError: ${extractText(removed).slice(0, 200)}`);
+  assert.deepEqual(parseJson<{ deleted?: boolean; address?: string }>(removed), { deleted: true, address }, "delete_outreach_contact result shape");
+  untrackEngagement(agent, address);
+
+  const gone = await client.get(`/v1/agents/${encodeURIComponent(agent)}/contacts/${encodeURIComponent(address)}`);
+  assert.equal(gone.status, 404, "the engagement is gone via REST after the MCP delete");
+});
+
+// ---------------------------------------------------------------------------
+// Section 3 — contact.due emission (dual-assertion, mirroring
+// 21-webhook-events). Capability probe identical to that suite's: skip only on
+// a genuine events_log_disabled, never on a connectivity failure.
+// ---------------------------------------------------------------------------
+
+let skip: string | false = false;
+try {
+  const eventsProbe = await client.get("/v1/events", { query: { limit: 1 } });
+  if (isEventsLogDisabled(eventsProbe.status, eventsProbe.body)) {
+    skip = "event-log capability disabled on this target (events_log_disabled)";
+  }
+} catch {
+  // Probe couldn't reach the target — do NOT skip; let the test surface the
+  // real connectivity error rather than masking an outage as a clean skip.
+}
+
+// pollEvent mirrors 21-webhook-events' helper, with two parameterizable
+// knobs the 5-minute contactdue sweep cadence needs: a long overall budget
+// and a slower backoff cap (polling every 3s for 8 minutes would just be
+// rate-limit noise).
+async function pollEvent(
+  params: { type: string; agentId: string; since: string },
+  match: (e: EventView) => boolean,
+  timeoutMs = 15000,
+  maxDelayMs = 3000,
+): Promise<EventView | null> {
+  const deadline = Date.now() + timeoutMs;
+  let delay = 500;
+  while (Date.now() < deadline) {
+    const r = await client.get<PageEventView>("/v1/events", {
+      query: { type: params.type, agent_email: params.agentId, since: params.since, limit: 50 },
+    });
+    if (r.status === 200 && r.body?.items) {
+      const found = r.body.items.find(match);
+      if (found) return found;
+    }
+    await sleep(delay);
+    delay = Math.min(Math.floor(delay * 1.5), maxDelayMs);
+  }
+  return null;
+}
+
+// pollEventFanout: EVENT-scoped proof THIS event fanned out to >=1 subscriber.
+async function pollEventFanout(
+  eventId: string,
+  timeoutMs = 15000,
+): Promise<NonNullable<EventView["delivery_status"]> | null> {
+  const deadline = Date.now() + timeoutMs;
+  let delay = 500;
+  while (Date.now() < deadline) {
+    const r = await client.get<EventView>(`/v1/events/${eventId}`);
+    const ds = r.body?.delivery_status;
+    if (r.status === 200 && ds && (ds.matched_webhooks ?? 0) >= 1) return ds;
+    await sleep(delay);
+    delay = Math.min(Math.floor(delay * 1.5), 3000);
+  }
+  return null;
+}
+
+// pollDelivery: WEBHOOK-scoped proof OUR webhook's HTTP delivery leg ran
+// (attempts>=1 — the example.com sink 405s the POST, which still proves the
+// leg fired; delivery SUCCESS would test the sink, not e2a).
+async function pollDelivery(webhookId: string, eventType: string, timeoutMs = 15000): Promise<WebhookDeliveryView | null> {
+  const deadline = Date.now() + timeoutMs;
+  let delay = 500;
+  while (Date.now() < deadline) {
+    const r = await client.get<PageWebhookDeliveryView>(`/v1/webhooks/${webhookId}/deliveries`);
+    if (r.status === 200 && r.body?.items) {
+      const found = r.body.items.find((d) => d.type === eventType && d.attempts >= 1);
+      if (found) return found;
+    }
+    await sleep(delay);
+    delay = Math.min(Math.floor(delay * 1.5), 3000);
+  }
+  return null;
+}
+
+test("emit: contact.due — a past-due engagement emits the event and attempts a delivery", { skip }, async () => {
+  const agent = await freshAgent("cdue");
+  const address = `${uniqueSlug("cdue")}@example.com`;
+  // Dummy HTTPS target: passes the create-time HTTPS/SSRF guard, then 405s the
+  // POST at delivery time — proving the delivery ATTEMPT without a real sink.
+  // filters.agent_emails scopes the subscription to exactly our fresh agent.
+  const hookRes = await client.post<CreateWebhookResponse>("/v1/webhooks", {
+    body: {
+      url: "https://example.com/e2e-contacts-outreach",
+      events: ["contact.due"],
+      description: `e2e ${uniqueSlug("whcd")}`,
+      filters: { agent_emails: [agent] },
+    },
+  });
+  assert.equal(hookRes.status, 201, `create webhook expected 201, got ${hookRes.status}: ${hookRes.raw.slice(0, 200)}`);
+  const hook = hookRes.body!;
+  trackedHooks.add(hook.id);
+  const since = sinceNow();
+  try {
+    // Arm the wake-up: next_action_at in the PAST, so the very next sweep
+    // (5-minute River periodic, RunOnStart) claims it.
+    const enrol = await client.put<ContactEngagementView>(
+      `/v1/agents/${encodeURIComponent(agent)}/contacts/${encodeURIComponent(address)}`,
+      { body: { stage: "follow-up", next_action_at: new Date(Date.now() - 10_000).toISOString() } },
+    );
+    assert.equal(enrol.status, 201, `upsertEngagement expected 201, got ${enrol.status}: ${enrol.raw.slice(0, 200)}`);
+    trackEngagement(agent, address);
+
+    // The sweep claims next_action_at <= now in batches of 200 and emits one
+    // contact.due per engagement; budget ~8 minutes to straddle two intervals
+    // (plus fan-out) without being so tight that a just-missed sweep flakes.
+    const ev = await pollEvent(
+      { type: "contact.due", agentId: agent, since },
+      (e) => e.data.address === address,
+      8 * 60 * 1000,
+      20000,
+    );
+    assert.ok(ev, `contact.due event for ${address} must appear in listEvents within ~8 minutes (two sweep intervals)`);
+    assert.ok(ev!.id.startsWith("evt_"), `event id has evt_ prefix: ${ev!.id}`);
+    assert.equal(ev!.type, "contact.due");
+    assert.equal(ev!.agent_email, agent, "event.agent_email is the enrolled agent");
+    assert.equal(ev!.data.agent_email, agent, "payload carries the agent");
+    assert.equal(ev!.data.stage, "follow-up", "payload carries the engagement stage");
+
+    // Event-scoped: THIS event fanned out to >=1 subscriber.
+    const fanout = await pollEventFanout(ev!.id, 30000);
+    assert.ok(fanout, `event ${ev!.id} must fan out (matched_webhooks>=1) within 30s`);
+    // Webhook-scoped: OUR fresh webhook's delivery leg actually RAN.
+    const del = await pollDelivery(hook.id, "contact.due", 30000);
+    assert.ok(del, `a delivery ATTEMPT for contact.due must appear on webhook ${hook.id}`);
+    assert.ok(del!.attempts >= 1, `delivery attempted (attempts=${del!.attempts})`);
+    info(SUITE, "contact.due", `emitted evt=${ev!.id} fanned to ${fanout!.matched_webhooks} webhook(s); our webhook whd=${del!.id} attempts=${del!.attempts} last_status=${del!.last_status_code}`);
+    verifiedEventTypes.add("contact.due");
+  } finally {
+    trackedHooks.delete(hook.id);
+    await client.delete(`/v1/webhooks/${encodeURIComponent(hook.id)}?confirm=DELETE`);
+    untrackEngagement(agent, address);
+    await client.delete(`/v1/agents/${encodeURIComponent(agent)}/contacts/${encodeURIComponent(address)}?confirm=DELETE`);
+    trackedContacts.delete(address);
+    await client.delete(`/v1/contacts/${encodeURIComponent(address)}?confirm=DELETE`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Teardown: best-effort deletion of every survivor, each delete wrapped so one
+// failure can't abort the rest (404/403 = already gone = success). Runs even
+// when tests abort mid-section. Then the shared agent cleanup, the suite
+// report, and the event-coverage shard (only verified types — recorded after
+// BOTH halves of the dual assertion passed).
+// ---------------------------------------------------------------------------
+after(async () => {
+  await mcp.stop();
+  const failures: string[] = [];
+  for (const key of [...trackedEngagements]) {
+    const [agent, address] = key.split("\n");
+    try {
+      const r = await client.delete(
+        `/v1/agents/${encodeURIComponent(agent)}/contacts/${encodeURIComponent(address)}?confirm=DELETE`,
+      );
+      if (![200, 404, 403].includes(r.status)) failures.push(`engagement ${agent}/${address}: HTTP ${r.status}`);
+    } catch (e) {
+      failures.push(`engagement ${agent}/${address}: ${(e as Error).message}`);
+    }
+  }
+  for (const batch of [...trackedBatches]) {
+    try {
+      const r = await client.delete(`/v1/contacts/imports/${encodeURIComponent(batch)}?confirm=DELETE`);
+      if (![200, 404, 403].includes(r.status)) failures.push(`import batch ${batch}: HTTP ${r.status}`);
+    } catch (e) {
+      failures.push(`import batch ${batch}: ${(e as Error).message}`);
+    }
+  }
+  for (const address of [...trackedContacts]) {
+    try {
+      const r = await client.delete(`/v1/contacts/${encodeURIComponent(address)}?confirm=DELETE`);
+      if (![200, 404, 403].includes(r.status)) failures.push(`contact ${address}: HTTP ${r.status}`);
+    } catch (e) {
+      failures.push(`contact ${address}: ${(e as Error).message}`);
+    }
+  }
+  for (const id of [...trackedHooks]) {
+    try {
+      const r = await client.delete(`/v1/webhooks/${encodeURIComponent(id)}?confirm=DELETE`);
+      if (![200, 404, 403].includes(r.status)) failures.push(`webhook ${id}: HTTP ${r.status}`);
+    } catch (e) {
+      failures.push(`webhook ${id}: ${(e as Error).message}`);
+    }
+  }
+  if (failures.length) warn(SUITE, "cleanup", `${failures.length} survivor delete(s) failed`, failures);
+  const r = await cleanup(client);
+  if (r.failed.length) warn(SUITE, "cleanup", `shared agent cleanup failed ${r.failed.length}`, r.failed);
+  await writeReport(`./reports/${SUITE}.json`);
+  if (verifiedEventTypes.size > 0) {
+    mkdirSync(EVENT_COVERAGE_DIR, { recursive: true });
+    writeFileSync(`${EVENT_COVERAGE_DIR}${process.pid}.json`, JSON.stringify([...verifiedEventTypes]));
+  }
+});

--- a/tests/e2e-prod/test_gates.py
+++ b/tests/e2e-prod/test_gates.py
@@ -1,0 +1,201 @@
+"""Unit tests for the three coverage gates, run as SUBPROCESSES against
+synthetic shard directories in a temp dir.
+
+Nothing is imported from the gates themselves: each test drives the real CLI
+contract (`python3 <gate>.py --reports … --openapi … --target-dir …`) so the
+tests keep passing only while the gates keep behaving the way the suites and
+CI rely on — fail closed on a coverage gap (exit 1), pass on full coverage
+(exit 0). Hermetic and offline: the only repo file read is api/openapi.yaml
+(the drift-gated SSOT the gates themselves consume).
+
+Run: python3 -m unittest test_gates -v   (from tests/e2e-prod/)
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+HERE = Path(__file__).resolve().parent
+OPENAPI = (HERE / ".." / ".." / "api" / "openapi.yaml").resolve()
+
+# The 11 contacts/outreach operationIds suite 30 was added to cover.
+CONTACTS_OPS = {
+    "createContact",
+    "listContacts",
+    "getContact",
+    "updateContact",
+    "deleteContact",
+    "importContacts",
+    "deleteImportBatch",
+    "listEngagements",
+    "getEngagement",
+    "upsertEngagement",
+    "deleteEngagement",
+}
+
+# Mirrors of the gates' own allowlist tiers for a NON-production target (the
+# synthetic target shard below is staging). The gates fail loudly if these
+# drift out of sync with the real constants — which is the point: the tests
+# pin the documented tiers, they don't weaken them.
+COVERAGE_GATE_ALWAYS_ALLOWLIST = {"deleteAccount"}
+COVERAGE_GATE_STAGING_ONLY_ALLOWLIST = {"deleteSuppression"}
+
+EVENT_GATE_ALWAYS_ALLOWLIST = {"domain.sending_failed"}
+EVENT_GATE_STAGING_ONLY_ALLOWLIST = {
+    "email.delivered",
+    "email.bounced",
+    "email.complained",
+    "domain.suppression_added",
+    "agent.suppression_added",
+    "domain.sending_verified",
+}
+
+# mcp_coverage_gate.py refuses to run when its allowlist names a tool the
+# shard does not advertise, so every synthetic advertisement must include them.
+MCP_GATE_ALLOWLISTED_TOOLS = {"send_email", "approve_pending_message", "reject_pending_message"}
+
+# Synthetic target shard: staging, so the staging-only allowlist tiers apply.
+STAGING_TARGET = {"apiUrl": "https://api-staging.e2a.dev", "isProd": False}
+
+
+def load_ops() -> list[tuple[str, str, str]]:
+    """(METHOD, path template, operationId) for every operation in the spec."""
+    with open(OPENAPI) as f:
+        spec = yaml.safe_load(f)
+    ops = []
+    for path, item in (spec.get("paths") or {}).items():
+        for method, op in (item or {}).items():
+            if isinstance(op, dict) and "operationId" in op:
+                ops.append((method.upper(), path, op["operationId"]))
+    return ops
+
+
+def concrete_path(template: str) -> str:
+    """Substitute every {param} segment with a concrete value — match_op only
+    needs a non-empty segment in the right position."""
+    return "/".join("x" if seg.startswith("{") and seg.endswith("}") else seg for seg in template.split("/"))
+
+
+def load_event_types() -> set[str]:
+    with open(OPENAPI) as f:
+        spec = yaml.safe_load(f)
+    return set(spec["components"]["schemas"]["CreateWebhookRequest"]["properties"]["events"]["items"]["enum"])
+
+
+def run_gate(script: str, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(HERE / script), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def write_shard(directory: Path, name: str, payload: object) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    with open(directory / name, "w") as f:
+        json.dump(payload, f)
+
+
+class CoverageGateTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        root = Path(self._tmp.name)
+        self.reports = root / "coverage"
+        self.target = root / "target"
+        self.reports.mkdir()
+        write_shard(self.target, "1.json", STAGING_TARGET)
+        allowlisted = COVERAGE_GATE_ALWAYS_ALLOWLIST | COVERAGE_GATE_STAGING_ONLY_ALLOWLIST
+        # The full "METHOD /concrete/path" set a perfect run would record,
+        # minus the documented allowlist tiers, paired with the operationId
+        # each pair covers (so tests can subtract by operationId).
+        self.full = sorted(
+            (f"{method} {concrete_path(path)}", opid)
+            for method, path, opid in load_ops()
+            if opid not in allowlisted
+        )
+        self.full_pairs = [pair for pair, _ in self.full]
+        self.args = (
+            "--openapi", str(OPENAPI),
+            "--reports", str(self.reports),
+            "--target-dir", str(self.target),
+        )
+
+    def test_missing_contacts_ops_fail_closed(self) -> None:
+        covered = [pair for pair, opid in self.full if opid not in CONTACTS_OPS]
+        write_shard(self.reports, "1.json", covered)
+        proc = run_gate("coverage_gate.py", *self.args)
+        self.assertEqual(proc.returncode, 1, proc.stdout + proc.stderr)
+        for opid in CONTACTS_OPS:
+            self.assertIn(opid, proc.stdout, f"gate output must name uncovered {opid}")
+
+    def test_full_coverage_passes(self) -> None:
+        write_shard(self.reports, "1.json", self.full_pairs)
+        proc = run_gate("coverage_gate.py", *self.args)
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+
+
+class EventCoverageGateTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        root = Path(self._tmp.name)
+        self.reports = root / "event-coverage"
+        self.target = root / "target"
+        self.reports.mkdir()
+        write_shard(self.target, "1.json", STAGING_TARGET)
+        allowlisted = EVENT_GATE_ALWAYS_ALLOWLIST | EVENT_GATE_STAGING_ONLY_ALLOWLIST
+        self.required = load_event_types() - allowlisted
+        self.assertIn("contact.due", self.required, "contact.due must be a REQUIRED type on a staging target")
+        self.args = (
+            "--openapi", str(OPENAPI),
+            "--reports", str(self.reports),
+            "--target-dir", str(self.target),
+        )
+
+    def test_missing_contact_due_fails_closed(self) -> None:
+        write_shard(self.reports, "1.json", sorted(self.required - {"contact.due"}))
+        proc = run_gate("event_coverage_gate.py", *self.args)
+        self.assertEqual(proc.returncode, 1, proc.stdout + proc.stderr)
+        self.assertIn("contact.due", proc.stdout)
+
+    def test_all_required_types_verified_passes(self) -> None:
+        write_shard(self.reports, "1.json", sorted(self.required))
+        proc = run_gate("event_coverage_gate.py", *self.args)
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+
+
+class McpCoverageGateTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        root = Path(self._tmp.name)
+        self.reports = root / "mcp-coverage"
+        self.reports.mkdir()
+        self.advertised = sorted(MCP_GATE_ALLOWLISTED_TOOLS | {"whoami", "create_contact"})
+        self.args = ("--reports", str(self.reports))
+
+    def test_uncovered_tool_fails_closed(self) -> None:
+        write_shard(self.reports, "1.json", {"advertised": self.advertised, "covered": ["whoami"]})
+        proc = run_gate("mcp_coverage_gate.py", *self.args)
+        self.assertEqual(proc.returncode, 1, proc.stdout + proc.stderr)
+        self.assertIn("create_contact", proc.stdout + proc.stderr)
+
+    def test_all_advertised_covered_passes(self) -> None:
+        write_shard(
+            self.reports,
+            "1.json",
+            {"advertised": self.advertised, "covered": ["whoami", "create_contact"]},
+        )
+        proc = run_gate("mcp_coverage_gate.py", *self.args)
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Makes the release candidate fully cover the contacts/outreach surface on the hosted staging conformance gates. The surface shipped in #754 (11 REST ops), the 11 MCP tools, and `contact.due` (#764) had zero live coverage, so every fail-closed gate was red. This PR adds the coverage without touching any gate script, allowlist, or denominator.

- **REST** — new `tests/e2e-prod/suites/30-contacts-outreach.test.ts` exercises 2xx paths of all 11 contacts operationIds with real behavior: cursor pagination (limit=2 walk, no-overlap), `source`/`import_batch_id` filters (+400 `invalid_filter`), ETag/`If-Match` round-trips with stale-write 412, import with per-row outcomes (`duplicate_in_batch`) and batch reversal counts, per-agent engagement isolation (same address, two agents), agent-scoped key → 403 on the account contacts surface, delete-preserves-contact.
- **MCP** — same suite calls all 11 contact tools successfully through `HttpMcpClient`, asserting on parsed tool-result content (fresh addresses, disjoint from the REST section). No allowlist entries added.
- **Event** — same suite produces a real `contact.due` (fresh agent + webhook filtered to it, `next_action_at` in the past, ~8-minute poll straddling the 5-minute sweep) and records the shard only after the standard dual assertion: event-scoped `matched_webhooks >= 1` **and** webhook-scoped delivery `attempts >= 1`. The suite documents that `contact.due` is a wake-up signal; it does not claim an agent runtime launches.
- **TypeScript SDK** — new `sdks/typescript/test/e2e-contacts.test.ts` covers all 13 introspected `contacts.*` ids; new `test/v1/introspect.test.ts` (offline, runs in `npm test`) pins the walker denominator.
- **Python SDK** — new contacts sections in `sdks/python/tests/test_e2e_resources.py` cover all 13 `contacts.*` methods; new offline `test_resource_coverage_discovery.py` pins the discovery denominator; stale method-count docstring fixed.
- **CLI** — `contacts` added to the pinned `--help` catalog (the pin predated the command, so the denominator test itself was red); new live e2e drives the full tree (create/get/list/update/delete, CSV import with `--dry-run`, imports delete, outreach set/get/list/delete); new offline `parseHelpCommands` unit test, now reachable from the default unit run.
- **Gate unit tests** — new `tests/e2e-prod/test_gates.py` (offline, subprocess against the real gate CLIs with synthetic shards) proves missing-contacts fails red and complete shards pass green for all three e2e-prod gates; wired into the `harness-tests` CI job.

Environment discipline: unique `uniqueSlug()`/`example.com` addresses per run, deterministic best-effort cleanup safe on partial failure, no founder agents or personal inboxes, no prod DB access, no e2a-ops changes (analysis found no ops defect — the gates were correctly red).

## Verification (local, no staging credentials)

- `tests/e2e-prod`: `npm run test:unit` (18/18), `npm run typecheck`, `python3 -m unittest test_gates -v` (6/6)
- Each gate run against synthetic shards: red naming the missing contacts surface, green when complete (coverage/event/MCP gates, TS `gate.mjs`, Python `resource_coverage_gate.py`, CLI `cli-coverage-gate.ts`)
- `npm test --workspace @e2a/sdk` (225 tests incl. 4 new), `npm test --workspace @e2a/cli` (259 incl. 3 new), `sdks/python` pytest (501 passed, 34 skipped) + mypy clean
- CLI `--help` denominator parsed offline from the built binary: matches the updated pin exactly
- Independent + adversarial review passes: no blockers; three should-fix findings (cleanup ordering in the contact.due `finally`, CI wiring of `test_gates.py`, CLI parser-test reachability) fixed in 1ccb8f08; remaining nits documented and deferred (pre-existing conventions)

## Live validations still required (not claimed here)

These need the staging conformance credentials and run in the e2a-ops release pipeline (`conformance-gate` + `client-surface-gates` jobs, `oss_test_ref` override):

1. `npm test` in `tests/e2e-prod` against `api-staging.e2a.dev` (incl. suite 30 and the ~8-minute `contact.due` poll) + `report:gate`, `coverage:gate`, `coverage:gate:mcp`, `coverage:gate:events`
2. `npm run coverage:live` in `sdks/typescript`
3. `pytest tests/test_e2e.py tests/test_e2e_resources.py` + `tests/resource_coverage_gate.py` in `sdks/python`
4. `npm run test:e2e:coverage` in `cli/`

🤖 Generated with [Kimi Code](https://www.kimi.com/code)