### PR TITLE
fix(contacts): safe import reversal, strict import validation, RFC 3339 timestamp parity

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -6923,7 +6923,7 @@ paths:
       x-stability-level: beta
   /v1/contacts/imports/{batch_id}:
     delete:
-      description: "Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, and contacts_deleted + contacts_retained reconciles against what the batch created. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable."
+      description: "Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable."
       operationId: deleteImportBatch
       parameters:
         - in: path

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1130,13 +1130,13 @@ components:
           format: int64
           type: integer
         contacts_retained:
-          description: How many contacts from this batch were deliberately kept because they have correspondence history.
+          description: "How many contacts from this batch were deliberately kept: edited since the import, enrolled in outreach that survives, or carrying correspondence history."
           format: int64
           type: integer
         deleted:
           type: boolean
         engagements_deleted:
-          description: How many per-agent outreach enrolments created by this import were removed.
+          description: How many per-agent outreach enrolments created by this import were removed. Enrolments edited or used since the import survive and are not counted here.
           format: int64
           type: integer
       required:
@@ -2284,9 +2284,7 @@ components:
             $ref: "#/components/schemas/ContactImportRow"
           maxItems: 1000
           minItems: 1
-          type:
-            - array
-            - "null"
+          type: array
         on_conflict:
           default: merge
           description: What to do when the address already exists. merge (default) refreshes display_name and metadata and leaves provenance and any state hanging off the contact untouched — so re-uploading a corrected spreadsheet is safe. skip leaves the existing contact completely alone.
@@ -6925,7 +6923,7 @@ paths:
       x-stability-level: beta
   /v1/contacts/imports/{batch_id}:
     delete:
-      description: "Reverses the durable import batch. Requires ?confirm=DELETE. It removes untouched contacts created by the batch and per-agent enrolments the batch created, including enrolments on pre-existing contacts. Contacts with correspondence history are retained; pre-existing outreach and suppressions are never affected. The response reports each category. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable."
+      description: "Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, and contacts_deleted + contacts_retained reconciles against what the batch created. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable."
       operationId: deleteImportBatch
       parameters:
         - in: path

--- a/cli/src/__tests__/contacts.test.ts
+++ b/cli/src/__tests__/contacts.test.ts
@@ -259,4 +259,63 @@ describe("contacts commands", () => {
     await expect(outreachList({ nextActionBefore: "not-a-date" })).rejects.toThrow("process.exit");
     await expect(contactsList({ limit: "0" })).rejects.toThrow("process.exit");
   });
+
+  it("accepts explicit RFC 3339 offsets on every contact time argument", async () => {
+    mockList.mockReturnValue({ toArray: vi.fn(async () => []) });
+    mockOutreach.mockReturnValue({ toArray: vi.fn(async () => []) });
+    mockSetOutreach.mockResolvedValue({ address: "partner@fund.vc" });
+    const { contactsList, outreachList, outreachSet } = await import("../commands/contacts.js");
+
+    // Z, a negative offset, and a positive half-hour offset all name the same
+    // kind of unambiguous instant and must reach the SDK as that exact Date.
+    await contactsList({
+      createdAfter: "2026-07-01T09:00:00-07:00",
+      createdBefore: "2026-08-01T12:00:00+05:30",
+    });
+    expect(mockList).toHaveBeenCalledWith({
+      source: undefined,
+      importBatchId: undefined,
+      createdAfter: new Date("2026-07-01T09:00:00-07:00"),
+      createdBefore: new Date("2026-08-01T12:00:00+05:30"),
+    });
+
+    await outreachList({
+      nextActionBefore: "2026-08-01T09:00:00-07:00",
+      lastOutboundBefore: "2026-07-01T12:00:00+05:30",
+    });
+    expect(mockOutreach).toHaveBeenCalledWith("bot@agents.e2a.dev", {
+      stage: undefined,
+      replied: undefined,
+      suppressed: undefined,
+      nextActionBefore: new Date("2026-08-01T09:00:00-07:00"),
+      lastOutboundBefore: new Date("2026-07-01T12:00:00+05:30"),
+    });
+
+    await outreachSet("partner@fund.vc", { nextAction: "2026-08-01T09:00:00+05:30" });
+    expect(mockSetOutreach).toHaveBeenCalledWith(
+      "bot@agents.e2a.dev",
+      "partner@fund.vc",
+      { stage: undefined, metadata: undefined, nextActionAt: new Date("2026-08-01T09:00:00+05:30") },
+    );
+  });
+
+  it("rejects date-only and offsetless contact timestamps", async () => {
+    const { contactsList, outreachList, outreachSet } = await import("../commands/contacts.js");
+    // Without an explicit offset the instant is ambiguous: the JS Date
+    // constructor reads a bare date-time in LOCAL time and a date-only value
+    // as UTC midnight, so the filter would shift with the runner's timezone.
+    for (const stamp of ["2026-08-01", "2026-08-01T09:00:00"]) {
+      await expect(contactsList({ createdAfter: stamp })).rejects.toThrow("process.exit");
+      await expect(contactsList({ createdBefore: stamp })).rejects.toThrow("process.exit");
+      await expect(outreachList({ nextActionBefore: stamp })).rejects.toThrow("process.exit");
+      await expect(outreachList({ lastOutboundBefore: stamp })).rejects.toThrow("process.exit");
+      await expect(outreachSet("partner@fund.vc", { nextAction: stamp })).rejects.toThrow("process.exit");
+    }
+    expect(process.stderr.write).toHaveBeenCalledWith(
+      expect.stringContaining("RFC 3339"),
+    );
+    expect(mockList).not.toHaveBeenCalled();
+    expect(mockOutreach).not.toHaveBeenCalled();
+    expect(mockSetOutreach).not.toHaveBeenCalled();
+  });
 });

--- a/cli/src/__tests__/contacts.test.ts
+++ b/cli/src/__tests__/contacts.test.ts
@@ -304,7 +304,7 @@ describe("contacts commands", () => {
     // Without an explicit offset the instant is ambiguous: the JS Date
     // constructor reads a bare date-time in LOCAL time and a date-only value
     // as UTC midnight, so the filter would shift with the runner's timezone.
-    for (const stamp of ["2026-08-01", "2026-08-01T09:00:00"]) {
+    for (const stamp of ["2026-08-01", "2026-08-01T09:00:00", "2026-02-30T09:00:00Z"]) {
       await expect(contactsList({ createdAfter: stamp })).rejects.toThrow("process.exit");
       await expect(contactsList({ createdBefore: stamp })).rejects.toThrow("process.exit");
       await expect(outreachList({ nextActionBefore: stamp })).rejects.toThrow("process.exit");

--- a/cli/src/__tests__/time.test.ts
+++ b/cli/src/__tests__/time.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// parseRfc3339 is the single gate every CLI time argument passes through
+// (--send-at, contact filters, next actions). These tests pin the two ways a
+// naive new Date(raw) silently lies: reading offsetless values in local time,
+// and ROLLING OVER impossible calendar dates on modern V8 instead of
+// returning NaN.
+
+describe("parseRfc3339", () => {
+  beforeEach(() => {
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("accepts Z and explicit ±HH:MM offsets as the same unambiguous instant", async () => {
+    const { parseRfc3339 } = await import("../time.js");
+    expect(parseRfc3339("2026-08-01T09:00:00Z", "--x").toISOString()).toBe("2026-08-01T09:00:00.000Z");
+    expect(parseRfc3339("2026-08-01T09:00:00-07:00", "--x").toISOString()).toBe("2026-08-01T16:00:00.000Z");
+    expect(parseRfc3339("2026-08-01T09:00:00+05:30", "--x").toISOString()).toBe("2026-08-01T03:30:00.000Z");
+    // Seconds may be omitted per RFC 3339; fractional seconds survive.
+    expect(parseRfc3339("2026-08-01T09:00-07:00", "--x").toISOString()).toBe("2026-08-01T16:00:00.000Z");
+    expect(parseRfc3339("2026-08-01T09:00:00.250Z", "--x").getMilliseconds()).toBe(250);
+  });
+
+  it("rejects date-only and offsetless values", async () => {
+    const { parseRfc3339 } = await import("../time.js");
+    for (const value of ["2026-08-01", "2026-08-01T09:00:00", "2026-08-01 09:00:00Z", "not-a-date"]) {
+      expect(() => parseRfc3339(value, "--x")).toThrow("process.exit");
+    }
+    expect(process.stderr.write).toHaveBeenCalledWith(expect.stringContaining("explicit offset"));
+  });
+
+  it("rejects impossible dates the Date constructor would roll over", async () => {
+    const { parseRfc3339 } = await import("../time.js");
+    // Modern V8 turns these into Mar 2 / May 1 / next-day 00:00 instead of
+    // NaN — the NaN backstop alone never fires.
+    for (const value of [
+      "2026-02-30T09:00:00Z",
+      "2026-04-31T09:00:00Z",
+      "2026-08-01T24:00:00Z",
+      "2026-08-01T09:60:00Z",
+      "2026-13-01T09:00:00Z",
+      "2026-08-01T09:00:00+24:00",
+      "2026-08-01T09:00:00+05:60",
+    ]) {
+      expect(() => parseRfc3339(value, "--x"), value).toThrow("process.exit");
+    }
+  });
+
+  it("keeps leap years and month lengths honest", async () => {
+    const { parseRfc3339 } = await import("../time.js");
+    expect(parseRfc3339("2028-02-29T09:00:00Z", "--x").toISOString()).toBe("2028-02-29T09:00:00.000Z");
+    expect(() => parseRfc3339("2027-02-29T09:00:00Z", "--x")).toThrow("process.exit");
+  });
+});

--- a/cli/src/__tests__/time.test.ts
+++ b/cli/src/__tests__/time.test.ts
@@ -58,4 +58,17 @@ describe("parseRfc3339", () => {
     expect(parseRfc3339("2028-02-29T09:00:00Z", "--x").toISOString()).toBe("2028-02-29T09:00:00.000Z");
     expect(() => parseRfc3339("2027-02-29T09:00:00Z", "--x")).toThrow("process.exit");
   });
+
+  it("matches the MCP/zod rule on its three edge divergences", async () => {
+    const { parseRfc3339 } = await import("../time.js");
+    // Years 0000–0099 are valid RFC 3339 and zod accepts them; Date.UTC would
+    // map them to 19xx, so the round-trip must not use it.
+    expect(parseRfc3339("0026-08-01T09:00:00Z", "--x").getUTCFullYear()).toBe(26);
+    // A fraction requires seconds (RFC 3339 time-second is not optional when
+    // time-secfrac is present).
+    expect(() => parseRfc3339("2026-08-01T09:00.500Z", "--x")).toThrow("process.exit");
+    // Sub-millisecond fractions truncate like server-side parsing; rounding
+    // would roll .9999 into the next second.
+    expect(parseRfc3339("2026-08-01T09:00:00.9999Z", "--x").toISOString()).toBe("2026-08-01T09:00:00.999Z");
+  });
 });

--- a/cli/src/bin/e2a.ts
+++ b/cli/src/bin/e2a.ts
@@ -66,8 +66,8 @@ Usage:
   e2a contacts list [options]        List account contacts
         --source import|manual|inbound   Filter by provenance
         --import-batch <id>          Filter to one upload
-        --created-after <ISO>        Added at or after timestamp
-        --created-before <ISO>       Added before timestamp
+        --created-after <rfc3339>     Added at or after timestamp (explicit offset)
+        --created-before <rfc3339>    Added before timestamp (explicit offset)
         --limit <n> --json           Bound output; JSON emits NDJSON
   e2a contacts get <address>         Show one contact
   e2a contacts create <address>      Create one contact
@@ -88,12 +88,12 @@ Usage:
         --stage <s>                  Exact opaque stage
         --replied true|false         Reply-state filter
         --suppressed true|false      Sendability filter
-        --next-action-before <ISO>   Due before timestamp
-        --last-outbound-before <ISO> Never contacted or stale before timestamp
+        --next-action-before <rfc3339>  Due before timestamp (explicit offset)
+        --last-outbound-before <rfc3339> Never contacted or stale before timestamp (explicit offset)
         --limit <n> --json           Bound output; JSON emits NDJSON
   e2a contacts outreach get <address>
   e2a contacts outreach set <address>
-        --stage <s>|--clear-stage --next-action <ISO|clear> --metadata <json>
+        --stage <s>|--clear-stage --next-action <rfc3339|clear> --metadata <json>
         --if-match <etag>            Reject stale outreach state
   e2a contacts outreach delete <address>
   e2a send [options]                Send an email as the agent

--- a/cli/src/commands/contacts.ts
+++ b/cli/src/commands/contacts.ts
@@ -8,6 +8,7 @@ import type {
 import { ImportContactsRequestOnConflictEnum } from "@e2a/sdk/v1";
 import { createClient, requireAgentEmail } from "../sdk.js";
 import { EXIT, fail } from "../exit.js";
+import { parseRfc3339 } from "../time.js";
 import { sanitizeTsvField } from "./messages.js";
 
 export interface OutputOptions { json?: boolean }
@@ -43,9 +44,10 @@ function boolFilter(raw: string | undefined, flag: string): boolean | undefined 
 
 function dateValue(raw: string | undefined, flag: string): Date | undefined {
   if (raw === undefined) return undefined;
-  const value = new Date(raw);
-  if (Number.isNaN(value.getTime())) fail(EXIT.USAGE, `${flag} must be an ISO timestamp`);
-  return value;
+  // Strict shared parser (time.ts): an explicit UTC offset is required, so a
+  // date-only or offsetless value fails fast instead of being read in local
+  // time and silently shifting the filter.
+  return parseRfc3339(raw, flag);
 }
 
 export async function contactsList(opts: {

--- a/cli/src/commands/send.ts
+++ b/cli/src/commands/send.ts
@@ -3,6 +3,7 @@ import { basename, extname } from "node:path";
 import type { SendResultView, Attachment } from "@e2a/sdk/v1";
 import { createClient, requireAgentEmail } from "../sdk.js";
 import { EXIT, fail } from "../exit.js";
+import { parseRfc3339 } from "../time.js";
 import { htmlToText } from "../html.js";
 
 export interface SendOptions {
@@ -78,23 +79,9 @@ const REPLY_USAGE =
  */
 export function parseSendAt(value: string | undefined, usage: string): Date | undefined {
   if (value === undefined) return undefined;
-  // Require an explicit UTC offset (Z or ±HH:MM), matching the MCP tool's strict
-  // RFC 3339 rule. Without it, `new Date()` reads a bare date-time as LOCAL time
-  // and a date-only value as UTC midnight — silently shifting the intended send
-  // instant across timezones.
-  const rfc3339WithOffset =
-    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?(\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
-  if (!rfc3339WithOffset.test(value)) {
-    return fail(
-      EXIT.USAGE,
-      `--send-at must be an RFC 3339 date-time WITH an explicit offset, e.g. 2026-08-01T09:00:00Z or 2026-08-01T09:00:00-07:00 (got "${value}")\n${usage}`,
-    );
-  }
-  const at = new Date(value);
-  if (Number.isNaN(at.getTime())) {
-    return fail(EXIT.USAGE, `--send-at is not a valid date-time: "${value}" (use RFC 3339, e.g. 2026-08-01T09:00:00Z)\n${usage}`);
-  }
-  return at;
+  // The strict shared parser requires the explicit offset — see time.ts for
+  // why a bare date-time can never be guessed at.
+  return parseRfc3339(value, "--send-at", usage);
 }
 
 function readFileOrUsage(path: string, flag: string): string {

--- a/cli/src/time.ts
+++ b/cli/src/time.ts
@@ -6,7 +6,7 @@ import { EXIT, fail } from "./exit.js";
 // across timezones. Shared by scheduled sending (--send-at) and the contact
 // timestamp filters so every CLI time argument follows the same rule.
 const RFC3339_WITH_OFFSET =
-  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?(\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2})(\.\d+)?)?(Z|[+-]\d{2}:\d{2})$/;
 
 /**
  * Parse a CLI time argument into a Date, rejecting date-only, offsetless, and
@@ -33,14 +33,20 @@ export function parseRfc3339(value: string, flag: string, detail?: string): Date
   const [, yearS, monthS, dayS, hourS, minuteS, secondS, fracS, offsetS] = m;
   const year = Number(yearS), month = Number(monthS), day = Number(dayS);
   const hour = Number(hourS), minute = Number(minuteS), second = secondS === undefined ? 0 : Number(secondS);
-  const fracMs = fracS === undefined ? 0 : Math.round(Number(fracS) * 1000);
+  // Truncate, not round: server-side parsing keeps millisecond precision, so
+  // rounding .9999 up would roll the instant a full second.
+  const fracMs = fracS === undefined ? 0 : Math.trunc(Number(fracS) * 1000);
   if (month < 1 || month > 12 || day < 1 || day > 31 || hour > 23 || minute > 59 || second > 59) {
     return invalid("field out of range");
   }
   // Component round-trip in UTC catches the impossible dates (Feb 30, Apr 31)
   // that the Date constructor would silently roll into the next month.
-  const base = Date.UTC(year, month - 1, day, hour, minute, second);
-  const rt = new Date(base);
+  // setUTCFullYear rather than Date.UTC: Date.UTC maps years 0–99 to 19xx,
+  // which would falsely reject them.
+  const rt = new Date(0);
+  rt.setUTCFullYear(year, month - 1, day);
+  rt.setUTCHours(hour, minute, second, 0);
+  const base = rt.getTime();
   if (
     rt.getUTCFullYear() !== year || rt.getUTCMonth() !== month - 1 || rt.getUTCDate() !== day ||
     rt.getUTCHours() !== hour || rt.getUTCMinutes() !== minute || rt.getUTCSeconds() !== second

--- a/cli/src/time.ts
+++ b/cli/src/time.ts
@@ -1,0 +1,32 @@
+import { EXIT, fail } from "./exit.js";
+
+// RFC 3339 date-time with an explicit UTC offset (Z or ±HH:MM). The offset is
+// mandatory: `new Date()` reads a bare date-time as LOCAL time and a
+// date-only value as UTC midnight, silently shifting the intended instant
+// across timezones. Shared by scheduled sending (--send-at) and the contact
+// timestamp filters so every CLI time argument follows the same rule.
+const RFC3339_WITH_OFFSET =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?(\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
+
+/**
+ * Parse a CLI time argument into a Date, rejecting date-only and offsetless
+ * values with a usage error. `flag` names the offending flag in the message;
+ * `detail` (e.g. a command usage line) is appended when given.
+ */
+export function parseRfc3339(value: string, flag: string, detail?: string): Date {
+  const suffix = detail ? `\n${detail}` : "";
+  if (!RFC3339_WITH_OFFSET.test(value)) {
+    return fail(
+      EXIT.USAGE,
+      `${flag} must be an RFC 3339 date-time WITH an explicit offset, e.g. 2026-08-01T09:00:00Z or 2026-08-01T09:00:00-07:00 (got "${value}")${suffix}`,
+    );
+  }
+  const at = new Date(value);
+  if (Number.isNaN(at.getTime())) {
+    return fail(
+      EXIT.USAGE,
+      `${flag} is not a valid date-time: "${value}" (use RFC 3339, e.g. 2026-08-01T09:00:00Z)${suffix}`,
+    );
+  }
+  return at;
+}

--- a/cli/src/time.ts
+++ b/cli/src/time.ts
@@ -6,27 +6,54 @@ import { EXIT, fail } from "./exit.js";
 // across timezones. Shared by scheduled sending (--send-at) and the contact
 // timestamp filters so every CLI time argument follows the same rule.
 const RFC3339_WITH_OFFSET =
-  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?(\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?(\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
 
 /**
- * Parse a CLI time argument into a Date, rejecting date-only and offsetless
- * values with a usage error. `flag` names the offending flag in the message;
- * `detail` (e.g. a command usage line) is appended when given.
+ * Parse a CLI time argument into a Date, rejecting date-only, offsetless, and
+ * impossible values with a usage error. `flag` names the offending flag in
+ * the message; `detail` (e.g. a command usage line) is appended when given.
+ *
+ * Impossible fields (2026-02-30, 24:00, +99:00) are rejected by round-trip:
+ * the JS Date constructor ROLLS them over on modern V8 instead of returning
+ * NaN, so a NaN check alone is not a validation. Fields are re-read from the
+ * computed instant and must equal the input's.
  */
 export function parseRfc3339(value: string, flag: string, detail?: string): Date {
   const suffix = detail ? `\n${detail}` : "";
-  if (!RFC3339_WITH_OFFSET.test(value)) {
+  const invalid = (why: string): never =>
+    fail(EXIT.USAGE, `${flag} is not a valid date-time: "${value}" (${why}; use RFC 3339, e.g. 2026-08-01T09:00:00Z)${suffix}`);
+
+  const m = RFC3339_WITH_OFFSET.exec(value);
+  if (!m) {
     return fail(
       EXIT.USAGE,
       `${flag} must be an RFC 3339 date-time WITH an explicit offset, e.g. 2026-08-01T09:00:00Z or 2026-08-01T09:00:00-07:00 (got "${value}")${suffix}`,
     );
   }
-  const at = new Date(value);
-  if (Number.isNaN(at.getTime())) {
-    return fail(
-      EXIT.USAGE,
-      `${flag} is not a valid date-time: "${value}" (use RFC 3339, e.g. 2026-08-01T09:00:00Z)${suffix}`,
-    );
+  const [, yearS, monthS, dayS, hourS, minuteS, secondS, fracS, offsetS] = m;
+  const year = Number(yearS), month = Number(monthS), day = Number(dayS);
+  const hour = Number(hourS), minute = Number(minuteS), second = secondS === undefined ? 0 : Number(secondS);
+  const fracMs = fracS === undefined ? 0 : Math.round(Number(fracS) * 1000);
+  if (month < 1 || month > 12 || day < 1 || day > 31 || hour > 23 || minute > 59 || second > 59) {
+    return invalid("field out of range");
   }
-  return at;
+  // Component round-trip in UTC catches the impossible dates (Feb 30, Apr 31)
+  // that the Date constructor would silently roll into the next month.
+  const base = Date.UTC(year, month - 1, day, hour, minute, second);
+  const rt = new Date(base);
+  if (
+    rt.getUTCFullYear() !== year || rt.getUTCMonth() !== month - 1 || rt.getUTCDate() !== day ||
+    rt.getUTCHours() !== hour || rt.getUTCMinutes() !== minute || rt.getUTCSeconds() !== second
+  ) {
+    return invalid("impossible calendar date or time");
+  }
+  let epoch = base + fracMs;
+  if (offsetS !== "Z") {
+    const offsetHour = Number(offsetS.slice(1, 3)), offsetMinute = Number(offsetS.slice(4, 6));
+    if (offsetHour > 23 || offsetMinute > 59) {
+      return invalid("offset out of range");
+    }
+    epoch -= (offsetS[0] === "+" ? 1 : -1) * (offsetHour * 60 + offsetMinute) * 60_000;
+  }
+  return new Date(epoch);
 }

--- a/docs/design/2026-07-24-contacts-and-outreach-state.md
+++ b/docs/design/2026-07-24-contacts-and-outreach-state.md
@@ -369,6 +369,29 @@ Decisions and why:
   genuinely useful columns (fund, check size, warm-intro path) that e2a should
   never model.
 
+**Reversal (DELETE `/v1/contacts/imports/{batch_id}`) is defensive, not
+tag-driven.** `import_batch_id` on both tables is origin provenance: it records
+which batch created the row and never moves (a merge re-import leaves it
+pointing at the original batch). Because the tag alone cannot distinguish
+"still just an import artifact" from "the account has since built on this",
+the reversal removes a tagged row only when it is verifiably untouched:
+
+- `updated_at = created_at` — no PATCH, upsert, activity record, or due
+  notification has ever landed (every mutation path sets `updated_at`), so
+  even stale provenance cannot cause data loss;
+- an engagement must additionally carry no derived wire activity and no
+  message history for that agent/address;
+- a contact must additionally have no message history and **no surviving
+  engagement** — batch-created untouched enrolments are deleted first, so any
+  engagement still present (one created independently of the import, or one
+  edited since) retains the contact. The guard decides; the
+  contacts→engagements `ON DELETE CASCADE` is never relied upon, because
+  reaching it with a live engagement would silently destroy that state.
+
+Anything failing a check is retained and counted, so
+`contacts_deleted + contacts_retained` always reconciles against what the
+batch created.
+
 ### 3.4 Authorization and scope
 
 | Surface | Guard | Rationale |

--- a/docs/design/2026-07-24-contacts-and-outreach-state.md
+++ b/docs/design/2026-07-24-contacts-and-outreach-state.md
@@ -389,8 +389,9 @@ the reversal removes a tagged row only when it is verifiably untouched:
   reaching it with a live engagement would silently destroy that state.
 
 Anything failing a check is retained and counted, so
-`contacts_deleted + contacts_retained` always reconciles against what the
-batch created.
+`contacts_deleted + contacts_retained` accounts for every batch-created
+contact that still exists at reversal time (a contact deleted by other means
+beforehand drops out of the accounting).
 
 ### 3.4 Authorization and scope
 

--- a/internal/httpapi/contacts_import.go
+++ b/internal/httpapi/contacts_import.go
@@ -108,7 +108,7 @@ func (s *Server) registerContactImport() {
 	huma.Register(s.API, huma.Operation{
 		OperationID: "deleteImportBatch", Method: http.MethodDelete, Path: "/v1/contacts/imports/{batch_id}",
 		Summary: "Reverse a contact import (beta)", Tags: []string{"contacts"},
-		Description: "Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, and contacts_deleted + contacts_retained reconciles against what the batch created. Account-scoped credentials only. " + contactImportBetaDescription,
+		Description: "Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. " + contactImportBetaDescription,
 		Security:    []map[string][]string{{"bearer": {}}},
 		Extensions:  beta(),
 	}, s.handleDeleteImportBatch)

--- a/internal/httpapi/contacts_import.go
+++ b/internal/httpapi/contacts_import.go
@@ -37,7 +37,7 @@ type ContactImportRow struct {
 
 // ImportContactsRequest is one upload.
 type ImportContactsRequest struct {
-	Contacts   []ContactImportRow `json:"contacts" required:"true" minItems:"1" maxItems:"1000" doc:"The rows to import. At most 1000 per request; paginate client-side for larger lists."`
+	Contacts   []ContactImportRow `json:"contacts" required:"true" nullable:"false" minItems:"1" maxItems:"1000" doc:"The rows to import. At most 1000 per request; paginate client-side for larger lists."`
 	OnConflict string             `json:"on_conflict,omitempty" enum:"merge,skip" default:"merge" doc:"What to do when the address already exists. merge (default) refreshes display_name and metadata and leaves provenance and any state hanging off the contact untouched — so re-uploading a corrected spreadsheet is safe. skip leaves the existing contact completely alone."`
 	AgentEmail string             `json:"agent_email,omitempty" maxLength:"320" doc:"Optionally enroll every valid resolved contact with this owned, live agent in the same transaction. Existing engagement state is preserved."`
 	Stage      string             `json:"stage,omitempty" maxLength:"128" doc:"Initial opaque stage for engagements created by this import. Requires agent_email and never overwrites an existing engagement's stage."`
@@ -131,6 +131,14 @@ func (s *Server) handleImportContacts(ctx context.Context, in *importContactsInp
 		if err != nil {
 			return nil, NewError(http.StatusBadRequest, "invalid_request", "agent_email must be a valid email address")
 		}
+	}
+	if len(in.Body.Contacts) == 0 {
+		// Defence in depth: the schema already rejects a missing, null, or
+		// empty array with 422 invalid_request, but a successful zero-row
+		// import reads as "it worked" while recording nothing — the worst
+		// possible answer to a bulk upload — so the bound is enforced here
+		// too, mirroring the row cap below.
+		return nil, NewError(http.StatusBadRequest, "invalid_request", "contacts must contain at least one row")
 	}
 	if len(in.Body.Contacts) > maxContactImportRows {
 		// Defence in depth: the schema already caps this, but the bound is what

--- a/internal/httpapi/contacts_import.go
+++ b/internal/httpapi/contacts_import.go
@@ -87,8 +87,8 @@ type DeleteImportBatchResult struct {
 	Deleted            bool   `json:"deleted"`
 	BatchID            string `json:"batch_id"`
 	ContactsDeleted    int    `json:"contacts_deleted" doc:"How many contacts this reversal removed."`
-	ContactsRetained   int    `json:"contacts_retained" doc:"How many contacts from this batch were deliberately kept because they have correspondence history."`
-	EngagementsDeleted int    `json:"engagements_deleted" doc:"How many per-agent outreach enrolments created by this import were removed."`
+	ContactsRetained   int    `json:"contacts_retained" doc:"How many contacts from this batch were deliberately kept: edited since the import, enrolled in outreach that survives, or carrying correspondence history."`
+	EngagementsDeleted int    `json:"engagements_deleted" doc:"How many per-agent outreach enrolments created by this import were removed. Enrolments edited or used since the import survive and are not counted here."`
 }
 
 type deleteImportBatchOutput struct {
@@ -108,7 +108,7 @@ func (s *Server) registerContactImport() {
 	huma.Register(s.API, huma.Operation{
 		OperationID: "deleteImportBatch", Method: http.MethodDelete, Path: "/v1/contacts/imports/{batch_id}",
 		Summary: "Reverse a contact import (beta)", Tags: []string{"contacts"},
-		Description: "Reverses the durable import batch. Requires ?confirm=DELETE. It removes untouched contacts created by the batch and per-agent enrolments the batch created, including enrolments on pre-existing contacts. Contacts with correspondence history are retained; pre-existing outreach and suppressions are never affected. The response reports each category. Account-scoped credentials only. " + contactImportBetaDescription,
+		Description: "Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, and contacts_deleted + contacts_retained reconciles against what the batch created. Account-scoped credentials only. " + contactImportBetaDescription,
 		Security:    []map[string][]string{{"bearer": {}}},
 		Extensions:  beta(),
 	}, s.handleDeleteImportBatch)

--- a/internal/httpapi/contacts_import_test.go
+++ b/internal/httpapi/contacts_import_test.go
@@ -264,12 +264,28 @@ func TestImportRejectsOversizeBatch(t *testing.T) {
 }
 
 // TestImportRejectsEmptyBatch pins that an empty upload is a clear error
-// rather than a successful no-op the user misreads as "it worked".
+// rather than a successful no-op the user misreads as "it worked". Missing,
+// explicit null, and [] are the same failure — the canonical invalid_request
+// envelope — and a one-row upload still succeeds, so the guard rejects only
+// the degenerate shapes.
 func TestImportRejectsEmptyBatch(t *testing.T) {
 	srv := newContactsServer(t, nil)
-	code, body := importBody(t, srv, map[string]any{"contacts": []any{}})
-	if code != http.StatusUnprocessableEntity && code != http.StatusBadRequest {
-		t.Errorf("empty import = %d %v; want 4xx", code, body)
+	cases := map[string]map[string]any{
+		"missing": {},
+		"null":    {"contacts": nil},
+		"empty":   {"contacts": []any{}},
+	}
+	for name, body := range cases {
+		code, resp := importBody(t, srv, body)
+		if (code != http.StatusUnprocessableEntity && code != http.StatusBadRequest) || errCode(resp) != "invalid_request" {
+			t.Errorf("%s contacts import = %d %v; want 4xx invalid_request", name, code, resp)
+		}
+	}
+	code, body := importBody(t, srv, map[string]any{
+		"contacts": []any{map[string]any{"address": "partner@imp.vc"}},
+	})
+	if code != http.StatusOK {
+		t.Errorf("one-row import = %d %v, want 200", code, body)
 	}
 }
 

--- a/internal/identity/contacts.go
+++ b/internal/identity/contacts.go
@@ -574,16 +574,31 @@ func (s *Store) ImportContactsWithOptions(ctx context.Context, userID, batchID s
 //     provenance (a tag re-pointed by any past or future write path) unable to
 //     cause data loss.
 //   - an engagement additionally must carry no derived wire activity
-//     (first/last outbound, last inbound, last conversation, due notice).
-//   - a contact additionally must have no message history and NO surviving
-//     engagement — including one created independently of the import. The
-//     engagements this batch created are deleted first, so any engagement
-//     still present at this point is state the reversal must not destroy.
-//     This guard, not the contacts→engagements ON DELETE CASCADE, decides:
-//     reaching the cascade with a live engagement would silently delete it.
+//     (first/last outbound, last inbound, last conversation, due notice) and
+//     no message history between its agent and the address.
+//   - a contact additionally must have no message history (as sender or as a
+//     To/Cc/Bcc recipient) and NO surviving engagement — including one created
+//     independently of the import. The engagements this batch created are
+//     deleted first, so any engagement still present at this point is state
+//     the reversal must not destroy. This guard, not the
+//     contacts→engagements ON DELETE CASCADE, decides: reaching the cascade
+//     with a live engagement would silently delete it.
 //
-// A row failing any check is retained and counted, so created ==
-// deleted + retained always reconciles against the batch.
+// A row failing any check is retained and counted, so deleted + retained
+// accounts for every batch-created contact that still exists at reversal time
+// (a contact the account deleted by other means beforehand drops out of the
+// accounting entirely).
+//
+// LOCKING. The guards are only as good as the snapshot they read. Before
+// evaluating them, every batch-tagged contact and engagement is locked FOR
+// UPDATE — contacts first, matching the contact→engagement write order of
+// UpsertEngagement and ImportContactsWithOptions so the orders cannot
+// deadlock. Under READ COMMITTED each lock read waits for any in-flight
+// mutation of the row and then sees its newest version, and holds the row
+// against new mutations until this transaction commits. Without this, a PATCH
+// or enrolment racing the reversal could commit after a guard's statement
+// snapshot was taken, and the delete would proceed on a stale "untouched"
+// verdict (EPQ re-checks only the join qual, not the CTE predicates).
 func (s *Store) DeleteImportBatch(ctx context.Context, userID, batchID string) (deleted int, retained int, engagementsDeleted int, err error) {
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
@@ -600,6 +615,34 @@ func (s *Store) DeleteImportBatch(ctx context.Context, userID, batchID string) (
 		return 0, 0, 0, ErrImportBatchNotFound
 	} else if err != nil {
 		return 0, 0, 0, err
+	}
+
+	// Lock the batch-tagged rows, newest versions. The selected ids are not
+	// read — the point is the locks and the post-wait fresh snapshot.
+	for _, lockSQL := range []string{
+		`SELECT id FROM contacts
+		  WHERE user_id = $1 AND import_batch_id = $2
+		  FOR UPDATE`,
+		`SELECT id FROM contact_engagements
+		  WHERE user_id = $1 AND import_batch_id = $2
+		  FOR UPDATE`,
+	} {
+		rows, err := tx.Query(ctx, lockSQL, userID, batchID)
+		if err != nil {
+			return 0, 0, 0, err
+		}
+		for rows.Next() {
+			var id string
+			if err := rows.Scan(&id); err != nil {
+				rows.Close()
+				return 0, 0, 0, err
+			}
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return 0, 0, 0, err
+		}
+		rows.Close()
 	}
 
 	// Engagements first: only enrolments this batch created AND that nobody
@@ -622,7 +665,8 @@ func (s *Store) DeleteImportBatch(ctx context.Context, userID, batchID string) (
 		         WHERE m.agent_id = ce.agent_id
 		           AND (lower(m.sender) = ce.address
 		            OR EXISTS (
-		                 SELECT 1 FROM unnest(m.to_recipients) AS r
+		                 SELECT 1
+		                   FROM unnest(COALESCE(m.to_recipients, '{}') || COALESCE(m.cc, '{}') || COALESCE(m.bcc, '{}')) AS r
 		                  WHERE lower(r) = ce.address))
 		    )`,
 		userID, batchID)
@@ -649,7 +693,8 @@ func (s *Store) DeleteImportBatch(ctx context.Context, userID, batchID string) (
 		                ON a.id = m.agent_id AND a.user_id = c.user_id
 		             WHERE lower(m.sender) = c.address
 		                OR EXISTS (
-		                     SELECT 1 FROM unnest(m.to_recipients) AS r
+		                     SELECT 1
+		                       FROM unnest(COALESCE(m.to_recipients, '{}') || COALESCE(m.cc, '{}') || COALESCE(m.bcc, '{}')) AS r
 		                      WHERE lower(r) = c.address)
 		      )
 		        AND NOT EXISTS (

--- a/internal/identity/contacts.go
+++ b/internal/identity/contacts.go
@@ -560,10 +560,30 @@ func (s *Store) ImportContactsWithOptions(ctx context.Context, userID, batchID s
 // DeleteImportBatch reverses an import, returning how many contacts it removed
 // and how many it deliberately kept.
 //
-// It removes only contacts that batch CREATED (import_batch_id still points at
-// it). A contact whose provenance moved, or that a later merge re-pointed, is
-// retained — reversing an upload must not delete a record the user has since
-// built history on.
+// PROVENANCE SEMANTICS. import_batch_id is origin provenance: it records which
+// batch CREATED the row and never moves afterwards (a later merge re-import
+// leaves it pointing at the original batch — see ImportContactsWithOptions).
+// Because the tag alone cannot distinguish "still just an import artifact"
+// from "the account has since built on this", reversal is defensive and
+// removes a tagged row only when it is verifiably UNTOUCHED:
+//
+//   - updated_at still equals created_at — no PATCH, upsert, activity record,
+//     or due-notification has ever landed on the row. Every mutation path sets
+//     updated_at = now(), and an import writes both defaults in one statement,
+//     so equality is an exact "never mutated" witness. This makes even stale
+//     provenance (a tag re-pointed by any past or future write path) unable to
+//     cause data loss.
+//   - an engagement additionally must carry no derived wire activity
+//     (first/last outbound, last inbound, last conversation, due notice).
+//   - a contact additionally must have no message history and NO surviving
+//     engagement — including one created independently of the import. The
+//     engagements this batch created are deleted first, so any engagement
+//     still present at this point is state the reversal must not destroy.
+//     This guard, not the contacts→engagements ON DELETE CASCADE, decides:
+//     reaching the cascade with a live engagement would silently delete it.
+//
+// A row failing any check is retained and counted, so created ==
+// deleted + retained always reconciles against the batch.
 func (s *Store) DeleteImportBatch(ctx context.Context, userID, batchID string) (deleted int, retained int, engagementsDeleted int, err error) {
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
@@ -582,9 +602,29 @@ func (s *Store) DeleteImportBatch(ctx context.Context, userID, batchID string) (
 		return 0, 0, 0, err
 	}
 
+	// Engagements first: only enrolments this batch created AND that nobody
+	// has touched since. A later stage/next-action edit, any recorded wire
+	// activity, a delivered due notification, or message history involving
+	// this agent and address makes the row live outreach state rather than
+	// an import artifact, and it survives.
 	tag, err := tx.Exec(ctx,
-		`DELETE FROM contact_engagements
-		  WHERE user_id = $1 AND import_batch_id = $2`,
+		`DELETE FROM contact_engagements ce
+		  WHERE ce.user_id = $1 AND ce.import_batch_id = $2
+		    AND ce.updated_at = ce.created_at
+		    AND ce.first_outbound_at IS NULL
+		    AND ce.last_outbound_at IS NULL
+		    AND ce.last_inbound_at IS NULL
+		    AND ce.last_conversation_id = ''
+		    AND ce.notified_next_action_at IS NULL
+		    AND NOT EXISTS (
+		        SELECT 1
+		          FROM messages m
+		         WHERE m.agent_id = ce.agent_id
+		           AND (lower(m.sender) = ce.address
+		            OR EXISTS (
+		                 SELECT 1 FROM unnest(m.to_recipients) AS r
+		                  WHERE lower(r) = ce.address))
+		    )`,
 		userID, batchID)
 	if err != nil {
 		return 0, 0, 0, err
@@ -594,14 +634,15 @@ func (s *Store) DeleteImportBatch(ctx context.Context, userID, batchID string) (
 	var total int
 	err = tx.QueryRow(ctx,
 		`WITH target AS MATERIALIZED (
-		     SELECT c.id, c.user_id, c.address
+		     SELECT c.id, c.user_id, c.address, c.created_at, c.updated_at
 		       FROM contacts c
 		      WHERE c.user_id = $1 AND c.import_batch_id = $2
 		 ),
 		 doomed AS MATERIALIZED (
 		     SELECT c.id
 		       FROM target c
-		      WHERE NOT EXISTS (
+		      WHERE c.updated_at = c.created_at
+		        AND NOT EXISTS (
 		            SELECT 1
 		              FROM messages m
 		              JOIN agent_identities a
@@ -610,6 +651,12 @@ func (s *Store) DeleteImportBatch(ctx context.Context, userID, batchID string) (
 		                OR EXISTS (
 		                     SELECT 1 FROM unnest(m.to_recipients) AS r
 		                      WHERE lower(r) = c.address)
+		      )
+		        AND NOT EXISTS (
+		            SELECT 1
+		              FROM contact_engagements ce
+		             WHERE ce.user_id = c.user_id
+		               AND ce.contact_id = c.id
 		      )
 		 ),
 		 removed AS (

--- a/internal/identity/contacts_reversal_test.go
+++ b/internal/identity/contacts_reversal_test.go
@@ -1,0 +1,270 @@
+package identity_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/tokencanopy/e2a/internal/identity"
+	"github.com/tokencanopy/e2a/internal/testutil"
+)
+
+// The tests in this file pin the reversal safety contract of
+// Store.DeleteImportBatch: undoing an import removes ONLY what is verifiably
+// untouched and attributable solely to that batch. Anything the account has
+// since edited, enrolled elsewhere, or corresponded with survives — an undo
+// addressed only by batch id must never destroy state the caller cannot see.
+
+// newReversalRig builds an account with one live agent, the shape every
+// reversal test needs. The pool is returned as well so a test can stage stale
+// provenance directly; it must come from the SAME TestDB handle, because each
+// TestDB call truncates.
+func newReversalRig(t *testing.T, tag string) (*pgxpool.Pool, *identity.Store, *identity.User, string) {
+	t.Helper()
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	user := newContactOwner(t, store, tag)
+	domain := tag + ".example.com"
+	if _, err := store.ClaimOrCreateDomain(ctx, domain, user.ID); err != nil {
+		t.Fatalf("claim domain: %v", err)
+	}
+	agent := "raise@" + domain
+	if _, err := store.CreateAgent(ctx, agent, domain, "", "", "", user.ID); err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	return pool, store, user, agent
+}
+
+// TestDeleteImportBatchRetainsPatchedContact: a contact edited through PATCH
+// after the import no longer belongs solely to the batch, so reversal must
+// keep it while still removing the untouched row from the same upload.
+func TestDeleteImportBatchRetainsPatchedContact(t *testing.T) {
+	_, store, user, _ := newReversalRig(t, "patched")
+	ctx := context.Background()
+
+	if _, err := store.ImportContacts(ctx, user.ID, "imp_patched", []identity.ContactImportRow{
+		{Address: "edited@patched.vc"}, {Address: "untouched@patched.vc"},
+	}, true); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+
+	name := "A. Partner"
+	if _, err := store.UpdateContact(ctx, user.ID, "edited@patched.vc", &name, nil); err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+
+	deleted, retained, _, err := store.DeleteImportBatch(ctx, user.ID, "imp_patched")
+	if err != nil {
+		t.Fatalf("reverse: %v", err)
+	}
+	if deleted != 1 || retained != 1 {
+		t.Errorf("receipt deleted=%d retained=%d, want 1 and 1 — "+
+			"an edited contact must survive its batch's reversal", deleted, retained)
+	}
+	if _, err := store.GetContactByAddress(ctx, user.ID, "edited@patched.vc"); err != nil {
+		t.Errorf("edited contact deleted by reversal: %v", err)
+	}
+	if _, err := store.GetContactByAddress(ctx, user.ID, "untouched@patched.vc"); !errors.Is(err, identity.ErrContactNotFound) {
+		t.Errorf("untouched contact survived reversal: %v", err)
+	}
+}
+
+// TestDeleteImportBatchRetainsEditedEngagement: an engagement the agent moved
+// forward after the import (stage change, new next action) is live outreach
+// state, not an import artifact. Reversal must leave it — and its contact —
+// alone, while still removing the batch's untouched enrolments.
+func TestDeleteImportBatchRetainsEditedEngagement(t *testing.T) {
+	_, store, user, agent := newReversalRig(t, "engedit")
+	ctx := context.Background()
+
+	if _, err := store.ImportContactsWithOptions(ctx, user.ID, "imp_engedit",
+		[]identity.ContactImportRow{
+			{Address: "advanced@engedit.vc"}, {Address: "idle@engedit.vc"},
+		}, identity.ContactImportOptions{Merge: true, AgentID: agent, Stage: "new"}); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+
+	advanced := "contacted"
+	if _, _, err := store.UpsertEngagement(ctx, user.ID, agent, "advanced@engedit.vc",
+		&advanced, nil, nil); err != nil {
+		t.Fatalf("advance stage: %v", err)
+	}
+
+	deleted, retained, engagementsDeleted, err := store.DeleteImportBatch(ctx, user.ID, "imp_engedit")
+	if err != nil {
+		t.Fatalf("reverse: %v", err)
+	}
+	if engagementsDeleted != 1 {
+		t.Errorf("engagements_deleted=%d, want 1 — an edited enrolment was removed", engagementsDeleted)
+	}
+	if deleted != 1 || retained != 1 {
+		t.Errorf("receipt deleted=%d retained=%d, want 1 and 1", deleted, retained)
+	}
+	engagement, err := store.GetEngagement(ctx, user.ID, agent, "advanced@engedit.vc")
+	if err != nil {
+		t.Fatalf("edited engagement deleted by reversal: %v", err)
+	}
+	if engagement.Stage != advanced {
+		t.Errorf("stage = %q, want %q — reversal clobbered live outreach state", engagement.Stage, advanced)
+	}
+	if _, err := store.GetEngagement(ctx, user.ID, agent, "idle@engedit.vc"); !errors.Is(err, identity.ErrEngagementNotFound) {
+		t.Errorf("untouched enrolment survived reversal: %v", err)
+	}
+}
+
+// TestDeleteImportBatchKeepsIndependentEngagement is the cascade-hazard
+// regression: the import created the contact but NOT this engagement.
+// Reversing the batch must not let the contacts→engagements ON DELETE CASCADE
+// take the independent engagement with it; the contact is retained because it
+// still has a live relationship.
+func TestDeleteImportBatchKeepsIndependentEngagement(t *testing.T) {
+	_, store, user, agent := newReversalRig(t, "indepen")
+	ctx := context.Background()
+
+	if _, err := store.ImportContacts(ctx, user.ID, "imp_independent", []identity.ContactImportRow{
+		{Address: "partner@indepen.vc"},
+	}, true); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	stage := "discovery"
+	if _, created, err := store.UpsertEngagement(ctx, user.ID, agent, "partner@indepen.vc",
+		&stage, nil, nil); err != nil || !created {
+		t.Fatalf("independent enroll created=%v err=%v", created, err)
+	}
+
+	deleted, retained, engagementsDeleted, err := store.DeleteImportBatch(ctx, user.ID, "imp_independent")
+	if err != nil {
+		t.Fatalf("reverse: %v", err)
+	}
+	if deleted != 0 || retained != 1 || engagementsDeleted != 0 {
+		t.Errorf("receipt deleted=%d retained=%d engagements=%d, want 0/1/0 — "+
+			"a contact with a surviving engagement must never be reversed",
+			deleted, retained, engagementsDeleted)
+	}
+	engagement, err := store.GetEngagement(ctx, user.ID, agent, "partner@indepen.vc")
+	if err != nil {
+		t.Fatalf("independent engagement destroyed by reversal (cascade): %v", err)
+	}
+	if engagement.Stage != stage {
+		t.Errorf("stage = %q, want %q", engagement.Stage, stage)
+	}
+	if _, err := store.GetContactByAddress(ctx, user.ID, "partner@indepen.vc"); err != nil {
+		t.Errorf("contact with live outreach deleted by reversal: %v", err)
+	}
+}
+
+// TestDeleteImportBatchRetainsEngagementWithActivity: wire activity recorded
+// against a batch-created engagement means the relationship is real. Reversal
+// must keep the engagement and its contact even though the batch created both.
+func TestDeleteImportBatchRetainsEngagementWithActivity(t *testing.T) {
+	_, store, user, agent := newReversalRig(t, "engwire")
+	ctx := context.Background()
+
+	if _, err := store.ImportContactsWithOptions(ctx, user.ID, "imp_engwire",
+		[]identity.ContactImportRow{{Address: "mailed@engwire.vc"}},
+		identity.ContactImportOptions{Merge: true, AgentID: agent, Stage: "new"}); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if ok, err := store.RecordOutboundActivity(ctx, user.ID, agent, "mailed@engwire.vc",
+		"conv-wire", time.Now()); err != nil || !ok {
+		t.Fatalf("record activity ok=%v err=%v", ok, err)
+	}
+
+	deleted, retained, engagementsDeleted, err := store.DeleteImportBatch(ctx, user.ID, "imp_engwire")
+	if err != nil {
+		t.Fatalf("reverse: %v", err)
+	}
+	if deleted != 0 || retained != 1 || engagementsDeleted != 0 {
+		t.Errorf("receipt deleted=%d retained=%d engagements=%d, want 0/1/0 — "+
+			"an engagement with real outreach was reversed", deleted, retained, engagementsDeleted)
+	}
+	engagement, err := store.GetEngagement(ctx, user.ID, agent, "mailed@engwire.vc")
+	if err != nil {
+		t.Fatalf("engagement with wire activity deleted by reversal: %v", err)
+	}
+	if engagement.FirstOutboundAt == nil {
+		t.Errorf("first_outbound_at lost — reversal destroyed derived activity")
+	}
+}
+
+// TestDeleteImportBatchReceiptCounts pins the exact receipt arithmetic on a
+// mixed batch: one untouched row reversed, one edited row retained, one row
+// retained for correspondence history — so a caller can reconcile
+// created == deleted + retained.
+func TestDeleteImportBatchReceiptCounts(t *testing.T) {
+	_, store, user, agent := newReversalRig(t, "receipt")
+	ctx := context.Background()
+
+	if _, err := store.ImportContactsWithOptions(ctx, user.ID, "imp_receipt",
+		[]identity.ContactImportRow{
+			{Address: "untouched@receipt.vc"},
+			{Address: "edited@receipt.vc"},
+			{Address: "mailed@receipt.vc"},
+		}, identity.ContactImportOptions{Merge: true, AgentID: agent}); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	name := "Renamed"
+	if _, err := store.UpdateContact(ctx, user.ID, "edited@receipt.vc", &name, nil); err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	if _, err := store.CreateOutboundMessage(ctx, agent, []string{"mailed@receipt.vc"}, nil, nil,
+		"Intro", "send", "smtp", "", "conv-receipt", []byte("raw")); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+
+	deleted, retained, engagementsDeleted, err := store.DeleteImportBatch(ctx, user.ID, "imp_receipt")
+	if err != nil {
+		t.Fatalf("reverse: %v", err)
+	}
+	if deleted != 1 || retained != 2 {
+		t.Errorf("contacts deleted=%d retained=%d, want 1 and 2", deleted, retained)
+	}
+	// The untouched row's enrolment and the edited row's enrolment are removed:
+	// both engagements stayed untouched, and the contact PATCH is not an
+	// engagement mutation. The mailed row's engagement survives on its message
+	// history even though the test shortcut never recorded derived activity.
+	if engagementsDeleted != 2 {
+		t.Errorf("engagements_deleted=%d, want 2", engagementsDeleted)
+	}
+}
+
+// TestDeleteImportBatchStaleProvenanceCannotDelete simulates a row whose
+// import_batch_id points at a batch even though the row was mutated after the
+// import — stale provenance from any past or future write path. The reversal's
+// defensive predicates, not the tag alone, must decide what is removable.
+func TestDeleteImportBatchStaleProvenanceCannotDelete(t *testing.T) {
+	pool, store, user, _ := newReversalRig(t, "stale")
+	ctx := context.Background()
+
+	if _, err := store.ImportContacts(ctx, user.ID, "imp_stale", []identity.ContactImportRow{
+		{Address: "partner@stale.vc"},
+	}, true); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	name := "A. Partner"
+	if _, err := store.UpdateContact(ctx, user.ID, "partner@stale.vc", &name, nil); err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+	// Re-point the provenance at the batch directly, as a stale writer would.
+	if _, err := pool.Exec(ctx,
+		`UPDATE contacts SET import_batch_id = 'imp_stale'
+		  WHERE user_id = $1 AND address = 'partner@stale.vc'`, user.ID); err != nil {
+		t.Fatalf("re-tag: %v", err)
+	}
+
+	deleted, retained, _, err := store.DeleteImportBatch(ctx, user.ID, "imp_stale")
+	if err != nil {
+		t.Fatalf("reverse: %v", err)
+	}
+	if deleted != 0 || retained != 1 {
+		t.Errorf("receipt deleted=%d retained=%d, want 0 and 1 — "+
+			"stale provenance caused data loss", deleted, retained)
+	}
+	if _, err := store.GetContactByAddress(ctx, user.ID, "partner@stale.vc"); err != nil {
+		t.Errorf("mutated contact deleted on stale provenance: %v", err)
+	}
+}

--- a/internal/identity/contacts_reversal_test.go
+++ b/internal/identity/contacts_reversal_test.go
@@ -268,3 +268,259 @@ func TestDeleteImportBatchStaleProvenanceCannotDelete(t *testing.T) {
 		t.Errorf("mutated contact deleted on stale provenance: %v", err)
 	}
 }
+
+// TestDeleteImportBatchRetainsCCOnlyHistory: correspondence where the contact
+// appeared only on the Cc/Bcc line is still message history. A reversal that
+// looked only at To would destroy a record the account has genuinely mailed.
+func TestDeleteImportBatchRetainsCCOnlyHistory(t *testing.T) {
+	_, store, user, agent := newReversalRig(t, "cconly")
+	ctx := context.Background()
+
+	if _, err := store.ImportContacts(ctx, user.ID, "imp_cc", []identity.ContactImportRow{
+		{Address: "cced@cconly.vc"},
+	}, true); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if _, err := store.CreateOutboundMessage(ctx, agent, []string{"primary@cconly.vc"},
+		[]string{"cced@cconly.vc"}, nil, "Intro", "send", "smtp", "", "conv-cc", []byte("raw")); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+
+	deleted, retained, _, err := store.DeleteImportBatch(ctx, user.ID, "imp_cc")
+	if err != nil {
+		t.Fatalf("reverse: %v", err)
+	}
+	if deleted != 0 || retained != 1 {
+		t.Errorf("receipt deleted=%d retained=%d, want 0 and 1 — cc-only history was ignored", deleted, retained)
+	}
+	if _, err := store.GetContactByAddress(ctx, user.ID, "cced@cconly.vc"); err != nil {
+		t.Errorf("contact with cc-only correspondence deleted: %v", err)
+	}
+}
+
+// TestDeleteImportBatchRetainsInboundActivity: a reply recorded against a
+// batch-created engagement is live state even when the agent never edited the
+// row. The reversal must keep both the engagement and the contact.
+func TestDeleteImportBatchRetainsInboundActivity(t *testing.T) {
+	_, store, user, agent := newReversalRig(t, "inbact")
+	ctx := context.Background()
+
+	if _, err := store.ImportContactsWithOptions(ctx, user.ID, "imp_inbact",
+		[]identity.ContactImportRow{{Address: "replier@inbact.vc"}},
+		identity.ContactImportOptions{Merge: true, AgentID: agent}); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if ok, err := store.RecordInboundActivity(ctx, user.ID, agent, "replier@inbact.vc",
+		"conv-in", time.Now()); err != nil || !ok {
+		t.Fatalf("record inbound ok=%v err=%v", ok, err)
+	}
+
+	_, retained, engagementsDeleted, err := store.DeleteImportBatch(ctx, user.ID, "imp_inbact")
+	if err != nil {
+		t.Fatalf("reverse: %v", err)
+	}
+	if retained != 1 || engagementsDeleted != 0 {
+		t.Errorf("receipt retained=%d engagements=%d, want 1 and 0", retained, engagementsDeleted)
+	}
+	engagement, err := store.GetEngagement(ctx, user.ID, agent, "replier@inbact.vc")
+	if err != nil {
+		t.Fatalf("engagement with a recorded reply deleted: %v", err)
+	}
+	if engagement.LastInboundAt == nil {
+		t.Errorf("last_inbound_at lost")
+	}
+}
+
+// TestDeleteImportBatchDefensivePredicatesStandAlone isolates the two
+// engagement guards no production path can set without also bumping
+// updated_at: a due-notification marker and a conversation pointer. Staged
+// directly in SQL with updated_at = created_at preserved, each alone must
+// still protect the row — they exist so NO stale state combination can make
+// an in-use engagement look like an import artifact.
+func TestDeleteImportBatchDefensivePredicatesStandAlone(t *testing.T) {
+	pool, store, user, agent := newReversalRig(t, "predicates")
+	ctx := context.Background()
+
+	if _, err := store.ImportContactsWithOptions(ctx, user.ID, "imp_pred",
+		[]identity.ContactImportRow{
+			{Address: "notified@predicates.vc"},
+			{Address: "linked@predicates.vc"},
+			{Address: "untouched@predicates.vc"},
+		}, identity.ContactImportOptions{Merge: true, AgentID: agent}); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	for address, stmt := range map[string]string{
+		"notified@predicates.vc": `UPDATE contact_engagements
+		    SET notified_next_action_at = now()
+		  WHERE user_id = $1 AND address = $2`,
+		"linked@predicates.vc": `UPDATE contact_engagements
+		    SET last_conversation_id = 'conv_staged'
+		  WHERE user_id = $1 AND address = $2`,
+	} {
+		if _, err := pool.Exec(ctx, stmt, user.ID, address); err != nil {
+			t.Fatalf("stage %s: %v", address, err)
+		}
+	}
+
+	_, _, engagementsDeleted, err := store.DeleteImportBatch(ctx, user.ID, "imp_pred")
+	if err != nil {
+		t.Fatalf("reverse: %v", err)
+	}
+	if engagementsDeleted != 1 {
+		t.Errorf("engagements_deleted=%d, want 1 — a due-notified or conversation-linked "+
+			"engagement was treated as untouched", engagementsDeleted)
+	}
+	for _, address := range []string{"notified@predicates.vc", "linked@predicates.vc"} {
+		if _, err := store.GetEngagement(ctx, user.ID, agent, address); err != nil {
+			t.Errorf("%s engagement deleted: %v", address, err)
+		}
+	}
+	if _, err := store.GetEngagement(ctx, user.ID, agent, "untouched@predicates.vc"); !errors.Is(err, identity.ErrEngagementNotFound) {
+		t.Errorf("untouched engagement survived: %v", err)
+	}
+}
+
+// TestDeleteImportBatchWaitsForConcurrentPatch is the regression for the
+// statement-snapshot race: a PATCH holding the contact's row lock commits
+// WHILE the reversal is in flight. The reversal must wait on the lock and
+// then judge the row by its newest version (patched → retained), not by the
+// stale "untouched" snapshot its guard CTE started with.
+func TestDeleteImportBatchWaitsForConcurrentPatch(t *testing.T) {
+	pool, store, user, _ := newReversalRig(t, "racepatch")
+	ctx := context.Background()
+
+	if _, err := store.ImportContacts(ctx, user.ID, "imp_racepatch", []identity.ContactImportRow{
+		{Address: "partner@racepatch.vc"},
+	}, true); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+
+	// Hold the row lock with an uncommitted mutation.
+	patch, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin patch: %v", err)
+	}
+	if _, err := patch.Exec(ctx,
+		`UPDATE contacts SET display_name = 'Raced', updated_at = now()
+		  WHERE user_id = $1 AND address = 'partner@racepatch.vc'`, user.ID); err != nil {
+		t.Fatalf("patch exec: %v", err)
+	}
+
+	type receipt struct {
+		deleted, retained int
+		err               error
+	}
+	done := make(chan receipt, 1)
+	go func() {
+		d, r, _, err := store.DeleteImportBatch(ctx, user.ID, "imp_racepatch")
+		done <- receipt{d, r, err}
+	}()
+
+	// The reversal cannot finish while the patch holds the row lock; wait
+	// until it is visibly blocked so the interleaving is real, not hoped for.
+	waitForBlockedLock(t, pool)
+	if err := patch.Commit(ctx); err != nil {
+		t.Fatalf("patch commit: %v", err)
+	}
+
+	got := <-done
+	if got.err != nil {
+		t.Fatalf("reverse: %v", got.err)
+	}
+	if got.deleted != 0 || got.retained != 1 {
+		t.Errorf("receipt deleted=%d retained=%d, want 0 and 1 — a committed PATCH "+
+			"lost to a stale reversal snapshot", got.deleted, got.retained)
+	}
+	got2, err := store.GetContactByAddress(ctx, user.ID, "partner@racepatch.vc")
+	if err != nil {
+		t.Fatalf("patched contact deleted by racing reversal: %v", err)
+	}
+	if got2.DisplayName != "Raced" {
+		t.Errorf("display_name = %q, want Raced", got2.DisplayName)
+	}
+}
+
+// TestDeleteImportBatchWaitsForConcurrentEngagement is the cascade-race
+// regression: an independent enrolment whose transaction is in flight while
+// the reversal runs must survive. Before the lock-first fix the engagement
+// insert's FK check raced the contact delete and the fresh engagement was
+// cascade-deleted (or the insert failed with an FK violation).
+func TestDeleteImportBatchWaitsForConcurrentEngagement(t *testing.T) {
+	pool, store, user, agent := newReversalRig(t, "raceeng")
+	ctx := context.Background()
+
+	if _, err := store.ImportContacts(ctx, user.ID, "imp_raceeng", []identity.ContactImportRow{
+		{Address: "partner@raceeng.vc"},
+	}, true); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	contact, err := store.GetContactByAddress(ctx, user.ID, "partner@raceeng.vc")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	// An in-flight independent enrolment: lock the contact row (as
+	// UpsertEngagement's conflict-update does) and stage the engagement,
+	// uncommitted.
+	enroll, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin enroll: %v", err)
+	}
+	if _, err := enroll.Exec(ctx,
+		`UPDATE contacts SET updated_at = contacts.updated_at WHERE id = $1`, contact.ID); err != nil {
+		t.Fatalf("enroll contact lock: %v", err)
+	}
+	if _, err := enroll.Exec(ctx,
+		`INSERT INTO contact_engagements
+		     (id, user_id, contact_id, agent_id, address, stage, metadata)
+		  VALUES ($1, $2, $3, $4, $5, 'discovery', '{}'::jsonb)`,
+		identity.NewEngagementID(), user.ID, contact.ID, agent, "partner@raceeng.vc"); err != nil {
+		t.Fatalf("enroll insert: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, _, _, err := store.DeleteImportBatch(ctx, user.ID, "imp_raceeng")
+		done <- err
+	}()
+
+	waitForBlockedLock(t, pool)
+	if err := enroll.Commit(ctx); err != nil {
+		t.Fatalf("enroll commit: %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("reverse: %v", err)
+	}
+
+	engagement, err := store.GetEngagement(ctx, user.ID, agent, "partner@raceeng.vc")
+	if err != nil {
+		t.Fatalf("concurrent independent engagement destroyed: %v", err)
+	}
+	if engagement.Stage != "discovery" {
+		t.Errorf("stage = %q, want discovery", engagement.Stage)
+	}
+	if _, err := store.GetContactByAddress(ctx, user.ID, "partner@raceeng.vc"); err != nil {
+		t.Errorf("contact with a racing enrolment deleted: %v", err)
+	}
+}
+
+// waitForBlockedLock polls until some backend in the test database is waiting
+// on a lock — proof the racing reversal has reached its lock point — so the
+// test's commit lands mid-reversal rather than before it starts.
+func waitForBlockedLock(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	ctx := context.Background()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		var n int
+		if err := pool.QueryRow(ctx,
+			`SELECT count(*) FROM pg_locks WHERE NOT granted`).Scan(&n); err != nil {
+			t.Fatalf("poll locks: %v", err)
+		}
+		if n > 0 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("reversal never blocked on the racing transaction's lock")
+}

--- a/internal/identity/contacts_reversal_test.go
+++ b/internal/identity/contacts_reversal_test.go
@@ -504,9 +504,12 @@ func TestDeleteImportBatchWaitsForConcurrentEngagement(t *testing.T) {
 	}
 }
 
-// waitForBlockedLock polls until some backend in the test database is waiting
-// on a lock — proof the racing reversal has reached its lock point — so the
-// test's commit lands mid-reversal rather than before it starts.
+// waitForBlockedLock polls until some backend in THIS test database is
+// waiting on a lock — proof the racing reversal has reached its lock point —
+// so the test's commit lands mid-reversal rather than before it starts. The
+// database filter matters under `make test -p 4`: per-package derived DBs
+// share one server, and an unrelated blocked lock in another package would
+// satisfy an unscoped wait early, silently un-testing the interleaving.
 func waitForBlockedLock(t *testing.T, pool *pgxpool.Pool) {
 	t.Helper()
 	ctx := context.Background()
@@ -514,7 +517,11 @@ func waitForBlockedLock(t *testing.T, pool *pgxpool.Pool) {
 	for time.Now().Before(deadline) {
 		var n int
 		if err := pool.QueryRow(ctx,
-			`SELECT count(*) FROM pg_locks WHERE NOT granted`).Scan(&n); err != nil {
+			`SELECT count(*)
+			   FROM pg_locks l
+			   JOIN pg_stat_activity a ON a.pid = l.pid
+			  WHERE NOT l.granted
+			    AND a.datname = current_database()`).Scan(&n); err != nil {
 			t.Fatalf("poll locks: %v", err)
 		}
 		if n > 0 {
@@ -523,4 +530,60 @@ func waitForBlockedLock(t *testing.T, pool *pgxpool.Pool) {
 		time.Sleep(20 * time.Millisecond)
 	}
 	t.Fatal("reversal never blocked on the racing transaction's lock")
+}
+
+// TestDeleteImportBatchWaitsForKeyShareEnrolment covers the OTHER enrolment
+// interleaving: the skip-mode import path (ON CONFLICT DO NOTHING + an
+// unlocked read) never takes a contact row lock, so its engagement insert
+// holds only the FK's FOR KEY SHARE on the contact. That still conflicts with
+// the reversal's FOR UPDATE, so the reversal must wait and then retain both
+// rows — same guarantee as the update-lock variant, through a weaker lock.
+func TestDeleteImportBatchWaitsForKeyShareEnrolment(t *testing.T) {
+	pool, store, user, agent := newReversalRig(t, "keyshare")
+	ctx := context.Background()
+
+	if _, err := store.ImportContacts(ctx, user.ID, "imp_keyshare", []identity.ContactImportRow{
+		{Address: "partner@keyshare.vc"},
+	}, true); err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	contact, err := store.GetContactByAddress(ctx, user.ID, "partner@keyshare.vc")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+
+	// Stage the engagement WITHOUT touching the contact row — the FK check's
+	// KEY SHARE is the only lock this transaction holds on it.
+	enroll, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin enroll: %v", err)
+	}
+	if _, err := enroll.Exec(ctx,
+		`INSERT INTO contact_engagements
+		     (id, user_id, contact_id, agent_id, address, stage, metadata)
+		  VALUES ($1, $2, $3, $4, $5, 'discovery', '{}'::jsonb)`,
+		identity.NewEngagementID(), user.ID, contact.ID, agent, "partner@keyshare.vc"); err != nil {
+		t.Fatalf("enroll insert: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, _, _, err := store.DeleteImportBatch(ctx, user.ID, "imp_keyshare")
+		done <- err
+	}()
+
+	waitForBlockedLock(t, pool)
+	if err := enroll.Commit(ctx); err != nil {
+		t.Fatalf("enroll commit: %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("reverse: %v", err)
+	}
+
+	if _, err := store.GetEngagement(ctx, user.ID, agent, "partner@keyshare.vc"); err != nil {
+		t.Fatalf("key-share-only enrolment destroyed by racing reversal: %v", err)
+	}
+	if _, err := store.GetContactByAddress(ctx, user.ID, "partner@keyshare.vc"); err != nil {
+		t.Errorf("contact with a racing key-share enrolment deleted: %v", err)
+	}
 }

--- a/mcp/src/tools/contacts.ts
+++ b/mcp/src/tools/contacts.ts
@@ -11,6 +11,12 @@ const metadata = z.record(
 
 const contactAddress = z.string().email().describe("Contact email address.");
 
+// RFC 3339 date-time with an explicit UTC offset (Z or ±HH:MM both accepted).
+// Bare date-times and date-only values are rejected rather than guessed at:
+// `new Date()` would read them in LOCAL time and silently shift the filter
+// across timezones. Same rule as scheduled sending (messages.ts sendAtField).
+const contactTimestamp = z.string().datetime({ offset: true });
+
 export function registerContactTools(server: McpServer, client: McpClient): void {
   server.registerTool(
     "list_contacts",
@@ -23,8 +29,8 @@ export function registerContactTools(server: McpServer, client: McpClient): void
         ...paginationInput,
         source: z.enum(["import", "manual", "inbound"]).optional(),
         import_batch_id: z.string().optional(),
-        created_after: z.string().datetime().optional(),
-        created_before: z.string().datetime().optional(),
+        created_after: contactTimestamp.optional(),
+        created_before: contactTimestamp.optional(),
       }),
     },
     async (args) => runTool(async () => {
@@ -179,8 +185,8 @@ export function registerContactTools(server: McpServer, client: McpClient): void
         stage: z.string().max(128).optional(),
         replied: z.boolean().optional(),
         suppressed: z.boolean().optional(),
-        next_action_before: z.string().datetime().optional(),
-        last_outbound_before: z.string().datetime().optional(),
+        next_action_before: contactTimestamp.optional(),
+        last_outbound_before: contactTimestamp.optional(),
       }),
     },
     async (args) => runTool(async () => {
@@ -222,7 +228,7 @@ export function registerContactTools(server: McpServer, client: McpClient): void
         email: emailSelector,
         address: contactAddress,
         stage: z.string().max(128).optional(),
-        next_action_at: z.string().datetime().nullable().optional(),
+        next_action_at: contactTimestamp.nullable().optional(),
         metadata,
         if_match: z.string().optional(),
       }).refine(

--- a/mcp/src/tools/contacts.ts
+++ b/mcp/src/tools/contacts.ts
@@ -160,7 +160,7 @@ export function registerContactTools(server: McpServer, client: McpClient): void
       title: "Reverse a contact import (beta)",
       annotations: { destructiveHint: true, idempotentHint: true },
       description:
-        "Remove untouched contacts and per-agent enrolments created by one import batch. Contacts with correspondence history, pre-existing outreach, and suppressions survive and the receipt reports each category. Account scope only.",
+        "Remove only verifiably untouched contacts and per-agent enrolments created by one import batch. Contacts or enrolments edited since the import, contacts with correspondence history or any surviving engagement, pre-existing outreach, and suppressions all survive, and the receipt reports each category. Account scope only.",
       inputSchema: strictInputSchema({ batch_id: z.string().min(1) }),
     },
     async (args) => runTool(() => client.deleteContactImport(args.batch_id)),

--- a/mcp/src/tools/contacts.ts
+++ b/mcp/src/tools/contacts.ts
@@ -15,7 +15,8 @@ const contactAddress = z.string().email().describe("Contact email address.");
 // Bare date-times and date-only values are rejected rather than guessed at:
 // `new Date()` would read them in LOCAL time and silently shift the filter
 // across timezones. Same rule as scheduled sending (messages.ts sendAtField).
-const contactTimestamp = z.string().datetime({ offset: true });
+const contactTimestamp = z.string().datetime({ offset: true })
+  .describe("RFC 3339 date-time with an explicit UTC offset (Z or ±HH:MM), e.g. 2026-08-01T09:00:00Z or 2026-08-01T09:00:00-07:00. Date-only and offsetless values are rejected.");
 
 export function registerContactTools(server: McpServer, client: McpClient): void {
   server.registerTool(

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -604,6 +604,76 @@ describe("e2a MCP server", () => {
     });
   });
 
+  it("contact tools accept any explicit RFC 3339 offset", async () => {
+    // Z, a negative offset, and a positive offset all denote an unambiguous
+    // instant and must validate on every contact timestamp field.
+    for (const stamp of ["2026-07-01T00:00:00Z", "2026-07-01T09:00:00-07:00", "2026-07-01T12:00:00+05:30"]) {
+      const res = await client.callTool({
+        name: "list_contacts",
+        arguments: { created_after: stamp },
+      });
+      expect(res.isError ?? false, `created_after ${stamp}`).toBe(false);
+      expect(stub.listContacts).toHaveBeenCalledWith({ createdAfter: new Date(stamp) });
+    }
+
+    const res = await client.callTool({
+      name: "list_outreach_contacts",
+      arguments: {
+        email: "raise@example.com",
+        next_action_before: "2026-07-28T09:00:00-07:00",
+        last_outbound_before: "2026-07-21T12:00:00+05:30",
+      },
+    });
+    expect(res.isError ?? false).toBe(false);
+    expect(stub.listOutreach).toHaveBeenCalledWith({
+      nextActionBefore: new Date("2026-07-28T09:00:00-07:00"),
+      lastOutboundBefore: new Date("2026-07-21T12:00:00+05:30"),
+    }, "raise@example.com");
+
+    const setRes = await client.callTool({
+      name: "set_outreach_contact",
+      arguments: {
+        email: "raise@example.com",
+        address: "partner@fund.vc",
+        next_action_at: "2026-08-01T09:00:00-07:00",
+      },
+    });
+    expect(setRes.isError ?? false).toBe(false);
+    expect(stub.setOutreach).toHaveBeenCalledWith(
+      "partner@fund.vc",
+      { nextActionAt: new Date("2026-08-01T09:00:00-07:00") },
+      "raise@example.com",
+      undefined,
+    );
+  });
+
+  it("contact tools reject date-only and offsetless timestamps", async () => {
+    // Without an explicit offset the instant is ambiguous: `new Date()` reads a
+    // bare date-time in LOCAL time and a date-only value as UTC midnight.
+    for (const stamp of ["2026-07-01", "2026-07-01T09:00:00"]) {
+      const res = await client.callTool({
+        name: "list_contacts",
+        arguments: { created_before: stamp },
+      });
+      expect(res.isError, `created_before ${stamp}`).toBe(true);
+
+      const outreachRes = await client.callTool({
+        name: "list_outreach_contacts",
+        arguments: { email: "raise@example.com", next_action_before: stamp },
+      });
+      expect(outreachRes.isError, `next_action_before ${stamp}`).toBe(true);
+
+      const setRes = await client.callTool({
+        name: "set_outreach_contact",
+        arguments: { email: "raise@example.com", address: "partner@fund.vc", next_action_at: stamp },
+      });
+      expect(setRes.isError, `next_action_at ${stamp}`).toBe(true);
+    }
+    expect(stub.listContacts).not.toHaveBeenCalled();
+    expect(stub.listOutreach).not.toHaveBeenCalled();
+    expect(stub.setOutreach).not.toHaveBeenCalled();
+  });
+
   it("create_contact forwards a retry key", async () => {
     await client.callTool({
       name: "create_contact",

--- a/sdks/python/src/e2a/v1/generated/api/contacts_api.py
+++ b/sdks/python/src/e2a/v1/generated/api/contacts_api.py
@@ -931,7 +931,7 @@ class ContactsApi:
     ) -> DeleteImportBatchResult:
         """Reverse a contact import (beta)
 
-        Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, and contacts_deleted + contacts_retained reconciles against what the batch created. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
+        Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, ; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
 
         :param batch_id: (required)
         :type batch_id: str
@@ -1002,7 +1002,7 @@ class ContactsApi:
     ) -> ApiResponse[DeleteImportBatchResult]:
         """Reverse a contact import (beta)
 
-        Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, and contacts_deleted + contacts_retained reconciles against what the batch created. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
+        Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, ; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
 
         :param batch_id: (required)
         :type batch_id: str
@@ -1073,7 +1073,7 @@ class ContactsApi:
     ) -> RESTResponseType:
         """Reverse a contact import (beta)
 
-        Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, and contacts_deleted + contacts_retained reconciles against what the batch created. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
+        Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, ; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
 
         :param batch_id: (required)
         :type batch_id: str

--- a/sdks/python/src/e2a/v1/generated/api/contacts_api.py
+++ b/sdks/python/src/e2a/v1/generated/api/contacts_api.py
@@ -931,7 +931,7 @@ class ContactsApi:
     ) -> DeleteImportBatchResult:
         """Reverse a contact import (beta)
 
-        Reverses the durable import batch. Requires ?confirm=DELETE. It removes untouched contacts created by the batch and per-agent enrolments the batch created, including enrolments on pre-existing contacts. Contacts with correspondence history are retained; pre-existing outreach and suppressions are never affected. The response reports each category. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
+        Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, and contacts_deleted + contacts_retained reconciles against what the batch created. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
 
         :param batch_id: (required)
         :type batch_id: str
@@ -1002,7 +1002,7 @@ class ContactsApi:
     ) -> ApiResponse[DeleteImportBatchResult]:
         """Reverse a contact import (beta)
 
-        Reverses the durable import batch. Requires ?confirm=DELETE. It removes untouched contacts created by the batch and per-agent enrolments the batch created, including enrolments on pre-existing contacts. Contacts with correspondence history are retained; pre-existing outreach and suppressions are never affected. The response reports each category. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
+        Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, and contacts_deleted + contacts_retained reconciles against what the batch created. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
 
         :param batch_id: (required)
         :type batch_id: str
@@ -1073,7 +1073,7 @@ class ContactsApi:
     ) -> RESTResponseType:
         """Reverse a contact import (beta)
 
-        Reverses the durable import batch. Requires ?confirm=DELETE. It removes untouched contacts created by the batch and per-agent enrolments the batch created, including enrolments on pre-existing contacts. Contacts with correspondence history are retained; pre-existing outreach and suppressions are never affected. The response reports each category. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
+        Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, and contacts_deleted + contacts_retained reconciles against what the batch created. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
 
         :param batch_id: (required)
         :type batch_id: str

--- a/sdks/python/src/e2a/v1/generated/api/contacts_api.py
+++ b/sdks/python/src/e2a/v1/generated/api/contacts_api.py
@@ -931,7 +931,7 @@ class ContactsApi:
     ) -> DeleteImportBatchResult:
         """Reverse a contact import (beta)
 
-        Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, ; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
+        Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
 
         :param batch_id: (required)
         :type batch_id: str
@@ -1002,7 +1002,7 @@ class ContactsApi:
     ) -> ApiResponse[DeleteImportBatchResult]:
         """Reverse a contact import (beta)
 
-        Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, ; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
+        Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
 
         :param batch_id: (required)
         :type batch_id: str
@@ -1073,7 +1073,7 @@ class ContactsApi:
     ) -> RESTResponseType:
         """Reverse a contact import (beta)
 
-        Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, ; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
+        Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
 
         :param batch_id: (required)
         :type batch_id: str

--- a/sdks/python/src/e2a/v1/generated/models/delete_import_batch_result.py
+++ b/sdks/python/src/e2a/v1/generated/models/delete_import_batch_result.py
@@ -28,9 +28,9 @@ class DeleteImportBatchResult(BaseModel):
     """ # noqa: E501
     batch_id: StrictStr
     contacts_deleted: StrictInt = Field(description="How many contacts this reversal removed.")
-    contacts_retained: StrictInt = Field(description="How many contacts from this batch were deliberately kept because they have correspondence history.")
+    contacts_retained: StrictInt = Field(description="How many contacts from this batch were deliberately kept: edited since the import, enrolled in outreach that survives, or carrying correspondence history.")
     deleted: StrictBool
-    engagements_deleted: StrictInt = Field(description="How many per-agent outreach enrolments created by this import were removed.")
+    engagements_deleted: StrictInt = Field(description="How many per-agent outreach enrolments created by this import were removed. Enrolments edited or used since the import survive and are not counted here.")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["batch_id", "contacts_deleted", "contacts_retained", "deleted", "engagements_deleted"]
 

--- a/sdks/python/src/e2a/v1/generated/models/import_contacts_request.py
+++ b/sdks/python/src/e2a/v1/generated/models/import_contacts_request.py
@@ -29,7 +29,7 @@ class ImportContactsRequest(BaseModel):
     ImportContactsRequest
     """ # noqa: E501
     agent_email: Optional[Annotated[str, Field(strict=True, max_length=320)]] = Field(default=None, description="Optionally enroll every valid resolved contact with this owned, live agent in the same transaction. Existing engagement state is preserved.")
-    contacts: Optional[Annotated[List[ContactImportRow], Field(min_length=1, max_length=1000)]] = Field(description="The rows to import. At most 1000 per request; paginate client-side for larger lists.")
+    contacts: Annotated[List[ContactImportRow], Field(min_length=1, max_length=1000)] = Field(description="The rows to import. At most 1000 per request; paginate client-side for larger lists.")
     on_conflict: Optional[StrictStr] = Field(default='merge', description="What to do when the address already exists. merge (default) refreshes display_name and metadata and leaves provenance and any state hanging off the contact untouched — so re-uploading a corrected spreadsheet is safe. skip leaves the existing contact completely alone.")
     stage: Optional[Annotated[str, Field(strict=True, max_length=128)]] = Field(default=None, description="Initial opaque stage for engagements created by this import. Requires agent_email and never overwrites an existing engagement's stage.")
     additional_properties: Dict[str, Any] = {}
@@ -87,11 +87,6 @@ class ImportContactsRequest(BaseModel):
         if self.additional_properties is not None:
             for _key, _value in self.additional_properties.items():
                 _dict[_key] = _value
-
-        # set to None if contacts (nullable) is None
-        # and model_fields_set contains the field
-        if self.contacts is None and "contacts" in self.model_fields_set:
-            _dict['contacts'] = None
 
         return _dict
 

--- a/sdks/typescript/src/v1/generated/apis/ContactsApi.ts
+++ b/sdks/typescript/src/v1/generated/apis/ContactsApi.ts
@@ -189,7 +189,7 @@ export class ContactsApiRequestFactory extends BaseAPIRequestFactory {
     }
 
     /**
-     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, ; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
+     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
      * Reverse a contact import (beta)
      * @param batchId 
      * @param confirm Must be the literal DELETE — this action is irreversible.

--- a/sdks/typescript/src/v1/generated/apis/ContactsApi.ts
+++ b/sdks/typescript/src/v1/generated/apis/ContactsApi.ts
@@ -189,7 +189,7 @@ export class ContactsApiRequestFactory extends BaseAPIRequestFactory {
     }
 
     /**
-     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, and contacts_deleted + contacts_retained reconciles against what the batch created. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
+     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, ; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
      * Reverse a contact import (beta)
      * @param batchId 
      * @param confirm Must be the literal DELETE — this action is irreversible.

--- a/sdks/typescript/src/v1/generated/apis/ContactsApi.ts
+++ b/sdks/typescript/src/v1/generated/apis/ContactsApi.ts
@@ -189,7 +189,7 @@ export class ContactsApiRequestFactory extends BaseAPIRequestFactory {
     }
 
     /**
-     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes untouched contacts created by the batch and per-agent enrolments the batch created, including enrolments on pre-existing contacts. Contacts with correspondence history are retained; pre-existing outreach and suppressions are never affected. The response reports each category. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
+     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, and contacts_deleted + contacts_retained reconciles against what the batch created. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
      * Reverse a contact import (beta)
      * @param batchId 
      * @param confirm Must be the literal DELETE — this action is irreversible.

--- a/sdks/typescript/src/v1/generated/models/DeleteImportBatchResult.ts
+++ b/sdks/typescript/src/v1/generated/models/DeleteImportBatchResult.ts
@@ -19,12 +19,12 @@ export class DeleteImportBatchResult {
     */
     'contactsDeleted': number;
     /**
-    * How many contacts from this batch were deliberately kept because they have correspondence history.
+    * How many contacts from this batch were deliberately kept: edited since the import, enrolled in outreach that survives, or carrying correspondence history.
     */
     'contactsRetained': number;
     'deleted': boolean;
     /**
-    * How many per-agent outreach enrolments created by this import were removed.
+    * How many per-agent outreach enrolments created by this import were removed. Enrolments edited or used since the import survive and are not counted here.
     */
     'engagementsDeleted': number;
 

--- a/sdks/typescript/src/v1/generated/models/ImportContactsRequest.ts
+++ b/sdks/typescript/src/v1/generated/models/ImportContactsRequest.ts
@@ -21,7 +21,7 @@ export class ImportContactsRequest {
     /**
     * The rows to import. At most 1000 per request; paginate client-side for larger lists.
     */
-    'contacts': Array<ContactImportRow> | null;
+    'contacts': Array<ContactImportRow>;
     /**
     * What to do when the address already exists. merge (default) refreshes display_name and metadata and leaves provenance and any state hanging off the contact untouched — so re-uploading a corrected spreadsheet is safe. skip leaves the existing contact completely alone.
     */

--- a/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
@@ -1182,7 +1182,7 @@ export class ObjectContactsApi {
     }
 
     /**
-     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes untouched contacts created by the batch and per-agent enrolments the batch created, including enrolments on pre-existing contacts. Contacts with correspondence history are retained; pre-existing outreach and suppressions are never affected. The response reports each category. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
+     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, and contacts_deleted + contacts_retained reconciles against what the batch created. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
      * Reverse a contact import (beta)
      * @param param the request object
      */
@@ -1191,7 +1191,7 @@ export class ObjectContactsApi {
     }
 
     /**
-     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes untouched contacts created by the batch and per-agent enrolments the batch created, including enrolments on pre-existing contacts. Contacts with correspondence history are retained; pre-existing outreach and suppressions are never affected. The response reports each category. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
+     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, and contacts_deleted + contacts_retained reconciles against what the batch created. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
      * Reverse a contact import (beta)
      * @param param the request object
      */

--- a/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
@@ -1182,7 +1182,7 @@ export class ObjectContactsApi {
     }
 
     /**
-     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, ; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
+     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
      * Reverse a contact import (beta)
      * @param param the request object
      */
@@ -1191,7 +1191,7 @@ export class ObjectContactsApi {
     }
 
     /**
-     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, ; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
+     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
      * Reverse a contact import (beta)
      * @param param the request object
      */

--- a/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
@@ -1182,7 +1182,7 @@ export class ObjectContactsApi {
     }
 
     /**
-     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, and contacts_deleted + contacts_retained reconciles against what the batch created. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
+     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, ; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
      * Reverse a contact import (beta)
      * @param param the request object
      */
@@ -1191,7 +1191,7 @@ export class ObjectContactsApi {
     }
 
     /**
-     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, and contacts_deleted + contacts_retained reconciles against what the batch created. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
+     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, ; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
      * Reverse a contact import (beta)
      * @param param the request object
      */

--- a/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
@@ -1026,7 +1026,7 @@ export class ObservableContactsApi {
     }
 
     /**
-     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, ; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
+     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
      * Reverse a contact import (beta)
      * @param batchId
      * @param confirm Must be the literal DELETE — this action is irreversible.
@@ -1052,7 +1052,7 @@ export class ObservableContactsApi {
     }
 
     /**
-     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, ; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
+     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
      * Reverse a contact import (beta)
      * @param batchId
      * @param confirm Must be the literal DELETE — this action is irreversible.

--- a/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
@@ -1026,7 +1026,7 @@ export class ObservableContactsApi {
     }
 
     /**
-     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes untouched contacts created by the batch and per-agent enrolments the batch created, including enrolments on pre-existing contacts. Contacts with correspondence history are retained; pre-existing outreach and suppressions are never affected. The response reports each category. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
+     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, and contacts_deleted + contacts_retained reconciles against what the batch created. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
      * Reverse a contact import (beta)
      * @param batchId
      * @param confirm Must be the literal DELETE — this action is irreversible.
@@ -1052,7 +1052,7 @@ export class ObservableContactsApi {
     }
 
     /**
-     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes untouched contacts created by the batch and per-agent enrolments the batch created, including enrolments on pre-existing contacts. Contacts with correspondence history are retained; pre-existing outreach and suppressions are never affected. The response reports each category. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
+     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, and contacts_deleted + contacts_retained reconciles against what the batch created. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
      * Reverse a contact import (beta)
      * @param batchId
      * @param confirm Must be the literal DELETE — this action is irreversible.

--- a/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
@@ -1026,7 +1026,7 @@ export class ObservableContactsApi {
     }
 
     /**
-     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, and contacts_deleted + contacts_retained reconciles against what the batch created. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
+     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, ; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
      * Reverse a contact import (beta)
      * @param batchId
      * @param confirm Must be the literal DELETE — this action is irreversible.
@@ -1052,7 +1052,7 @@ export class ObservableContactsApi {
     }
 
     /**
-     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, and contacts_deleted + contacts_retained reconciles against what the batch created. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
+     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, ; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
      * Reverse a contact import (beta)
      * @param batchId
      * @param confirm Must be the literal DELETE — this action is irreversible.

--- a/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
@@ -748,7 +748,7 @@ export class PromiseContactsApi {
     }
 
     /**
-     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes untouched contacts created by the batch and per-agent enrolments the batch created, including enrolments on pre-existing contacts. Contacts with correspondence history are retained; pre-existing outreach and suppressions are never affected. The response reports each category. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
+     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, and contacts_deleted + contacts_retained reconciles against what the batch created. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
      * Reverse a contact import (beta)
      * @param batchId
      * @param confirm Must be the literal DELETE — this action is irreversible.
@@ -760,7 +760,7 @@ export class PromiseContactsApi {
     }
 
     /**
-     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes untouched contacts created by the batch and per-agent enrolments the batch created, including enrolments on pre-existing contacts. Contacts with correspondence history are retained; pre-existing outreach and suppressions are never affected. The response reports each category. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
+     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, and contacts_deleted + contacts_retained reconciles against what the batch created. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
      * Reverse a contact import (beta)
      * @param batchId
      * @param confirm Must be the literal DELETE — this action is irreversible.

--- a/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
@@ -748,7 +748,7 @@ export class PromiseContactsApi {
     }
 
     /**
-     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, and contacts_deleted + contacts_retained reconciles against what the batch created. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
+     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, ; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
      * Reverse a contact import (beta)
      * @param batchId
      * @param confirm Must be the literal DELETE — this action is irreversible.
@@ -760,7 +760,7 @@ export class PromiseContactsApi {
     }
 
     /**
-     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, and contacts_deleted + contacts_retained reconciles against what the batch created. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
+     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, ; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
      * Reverse a contact import (beta)
      * @param batchId
      * @param confirm Must be the literal DELETE — this action is irreversible.

--- a/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
@@ -748,7 +748,7 @@ export class PromiseContactsApi {
     }
 
     /**
-     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, ; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
+     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
      * Reverse a contact import (beta)
      * @param batchId
      * @param confirm Must be the literal DELETE — this action is irreversible.
@@ -760,7 +760,7 @@ export class PromiseContactsApi {
     }
 
     /**
-     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category, ; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
+     * Reverses the durable import batch. Requires ?confirm=DELETE. It removes only what is verifiably untouched: contacts the batch created that have not been edited, enrolled in surviving outreach, or corresponded with since, and per-agent enrolments the batch created that carry no later edit, message, or recorded activity. Pre-existing outreach and suppressions are never affected, and a contact with any surviving engagement is always retained. The response reports each category; contacts_deleted + contacts_retained accounts for every batch-created contact that still exists. Account-scoped credentials only. Beta: the contact import surface may change before it is declared stable.
      * Reverse a contact import (beta)
      * @param batchId
      * @param confirm Must be the literal DELETE — this action is irreversible.

--- a/tests/contract/scenarios.yaml
+++ b/tests/contract/scenarios.yaml
@@ -1105,6 +1105,23 @@ scenarios:
         expect:
           status: 422
 
+      - id: null_contacts_rejected
+        action: request
+        method: POST
+        path: /v1/contacts/import
+        body:
+          contacts: null
+        expect:
+          status: 422
+
+      - id: missing_contacts_rejected
+        action: request
+        method: POST
+        path: /v1/contacts/import
+        body: {}
+        expect:
+          status: 422
+
     cleanup:
       - action: request
         method: DELETE

--- a/tests/contract/scenarios.yaml
+++ b/tests/contract/scenarios.yaml
@@ -1063,13 +1063,17 @@ scenarios:
               display_name: First
             - address: not-an-email
             - address: FIRST@imp.vc
+            - address: "Second <Second@Imp.VC>"
+              display_name: Second
+        capture:
+          batch_id: batch_id
         expect:
           status: 200
           body_contains:
             - batch_id
             - results
           body_match:
-            created: 1
+            created: 2
             failed: 1
             skipped: 1
             "results[0].status": created
@@ -1077,6 +1081,8 @@ scenarios:
             "results[1].status": failed
             "results[2].status": skipped
             "results[2].code": duplicate_in_batch
+            "results[3].status": created
+            "results[3].address": second@imp.vc
 
       - id: imported_contact_is_readable
         action: request
@@ -1093,8 +1099,9 @@ scenarios:
         path: /v1/contacts?source=import
         expect:
           status: 200
-          body_match:
-            "items[0].address": first@imp.vc
+          body_array_contains:
+            items:
+              address: first@imp.vc
 
       - id: empty_batch_rejected
         action: request
@@ -1122,10 +1129,49 @@ scenarios:
         expect:
           status: 422
 
+      # A contact edited after the import no longer belongs solely to the
+      # batch: reversal must remove the untouched row and keep the edited one,
+      # and the receipt's deleted + retained must account for both.
+      - id: edit_protects_from_reversal
+        action: request
+        method: PATCH
+        path: /v1/contacts/second@imp.vc
+        body:
+          display_name: Second, Edited
+        expect:
+          status: 200
+
+      - id: reverse_batch
+        action: request
+        method: DELETE
+        path: /v1/contacts/imports/{batch_id}?confirm=DELETE
+        expect:
+          status: 200
+          body_match:
+            deleted: true
+            contacts_deleted: 1
+            contacts_retained: 1
+
+      - id: untouched_contact_reversed
+        action: request
+        method: GET
+        path: /v1/contacts/first@imp.vc
+        expect:
+          status: 404
+
+      - id: edited_contact_survives
+        action: request
+        method: GET
+        path: /v1/contacts/second@imp.vc
+        expect:
+          status: 200
+          body_match:
+            display_name: Second, Edited
+
     cleanup:
       - action: request
         method: DELETE
-        path: /v1/contacts/first@imp.vc?confirm=DELETE
+        path: /v1/contacts/second@imp.vc?confirm=DELETE
         expect:
           status: 200
 

--- a/tests/contract/scenarios.yaml
+++ b/tests/contract/scenarios.yaml
@@ -1169,6 +1169,13 @@ scenarios:
             display_name: Second, Edited
 
     cleanup:
+      # Best-effort (no expect): after a passing run the reversal already
+      # removed first@imp.vc (404 here); after a mid-scenario failure this is
+      # what keeps the scenario self-cleaning for the next run.
+      - id: delete_first_contact_if_reversed
+        action: request
+        method: DELETE
+        path: /v1/contacts/first@imp.vc?confirm=DELETE
       - action: request
         method: DELETE
         path: /v1/contacts/second@imp.vc?confirm=DELETE


### PR DESCRIPTION
## Contacts correctness: safe import reversal, import validation, timestamp parity

Three focused fixes across the contacts/outreach surface. All are **beta**-surface changes; the public shapes are unchanged except that `ImportContactsRequest.contacts` is no longer nullable (see Compatibility).

### A. Safe contact-import reversal

`DELETE /v1/contacts/imports/{batch_id}` previously deleted every engagement tagged with the batch and every tagged contact without message history. A contact PATCH did not protect the contact, an engagement edit did not protect the engagement, and contact deletion relied on the `contacts → contact_engagements` `ON DELETE CASCADE`, which silently destroyed engagements created *independently* of the import.

**Provenance semantics (now documented in the code and the design doc §3.3.1):** `import_batch_id` is *origin provenance* — it records which batch created the row and never moves (a merge re-import keeps it pointing at the original batch). Reversal is **defensive, not tag-driven**: a tagged row is removed only when verifiably untouched —

- `updated_at = created_at` (no PATCH/upsert/activity-record/due-notification ever landed);
- engagements: plus no derived wire activity and no message history for that agent/address;
- contacts: plus no message history (sender **or To/Cc/Bcc**) and **no surviving engagement** — evaluated after the batch's own untouched enrolments are deleted, so an independent engagement retains its contact and the cascade is never reached with live state;
- all batch-tagged rows are locked `FOR UPDATE` (contacts first, matching writer lock order) before the guards are evaluated, closing the statement-snapshot race where a concurrent PATCH or enrolment could be deleted on a stale verdict (EPQ re-checks only the join qual).

Receipt semantics: `contacts_deleted + contacts_retained` accounts for every batch-created contact that still exists at reversal time. Tenant scoping by `user_id` is unchanged.

### B. Contact import request validation

`contacts` was `required` + `minItems: 1` but typed `["array", "null"]`, so `contacts: null` validated and produced a **successful zero-row import**. Now:

- the schema is non-nullable (`type: array`), so missing / `null` / `[]` all fail validation with the canonical `invalid_request` envelope (422);
- a runtime `len == 0` guard returns 400 `invalid_request` as defense in depth;
- the 1000-row cap behavior is unchanged;
- `api/openapi.yaml` regenerated; TS + Python generated bases regenerated (`contacts` is now a non-optional array in both).

### C. Contact timestamp parity (MCP + CLI)

- **MCP** (`mcp/src/tools/contacts.ts`): all contact timestamp fields (`created_after/before`, `next_action_before`, `last_outbound_before`, `next_action_at`) now share one `z.string().datetime({ offset: true })` schema, matching `messages.ts`/`apikeys.ts` — `Z`, `-07:00`, and `+05:30` are all accepted; date-only and offsetless values are rejected.
- **CLI**: the permissive `new Date(raw)` parsing in `commands/contacts.ts` is replaced by the strict RFC 3339 parser extracted from `--send-at` into `cli/src/time.ts`. An explicit UTC offset is required everywhere, and impossible dates (`2026-02-30`, `24:00`, `+24:00`) are rejected by component round-trip — modern V8 rolls those over instead of returning `NaN`, so the NaN backstop never fired.

## Compatibility

Tightening `contacts` to non-nullable is a request-side strictness change on a **beta** endpoint. `make openapi-compat-check` reports no breaking changes. A client sending `contacts: null` previously got a useless empty success; it now gets 422 `invalid_request`.

## Testing

New regression coverage (all three SDK contract runners + store/handler/unit):

- reversal: untouched contact reversed; PATCHed contact retained; edited engagement retained; later independent engagement survives (cascade regression); wire activity (outbound **and** recorded inbound) retains engagement + contact; cc-only history protects; `notified_next_action_at` / `last_conversation_id` predicates isolated; exact receipt counts on a mixed batch; stale re-pointed provenance cannot delete; two blocked-lock interleavings (concurrent PATCH, concurrent independent enrolment) pinned; tenant isolation (pre-existing test still green);
- validation: missing / null / `[]` / valid at the handler, plus all three rejected shapes in the shared contract scenario;
- timestamps: positive (`Z`, `-07:00`, `+05:30`, optional seconds, fractional) and negative (date-only, offsetless, impossible dates/offsets, non-leap-year Feb 29) at MCP and CLI levels; `--send-at` behavior unchanged.

Verification run locally (Postgres 5433): `make test-unit`; full `internal/identity` + `internal/httpapi` integration runs; Go contract runner; TS contract (18 passed) and Python contract (19 passed, CI flags) against a live `e2a-contract-server`; TS SDK 221; CLI 262; MCP 289; Python 490 unit + mypy; `make spec-check`; `make openapi-compat-check`; coverage floors pass (78.3% total). Over-the-wire e2e against the real server binary: import → PATCH → reverse receipt 1/1/0, edited contact survives, untouched 404s, second reversal 404s; null/missing/empty → 422 `invalid_request`; CLI exit 2 on ambiguous timestamps, exit 0 on explicit offsets; server log clean.

**One environmental caveat:** OrbStack was removed from this machine mid-session, so `make generate-sdk-check` (Docker-pinned generator) could not be re-run after the final doc-string wording change. The committed generated trees came from the pinned generator earlier in the session; the final wording delta was applied as a verbatim string substitution to the generated docstrings (exactly what the generator copies from the spec), and `TestSpecGoldenNoDrift` passes. CI's generated-code freshness job is the authoritative re-check.

## Reviews

Independent + adversarial review passes were run on the branch. Findings and dispositions:

| Finding | Severity | Disposition |
|---|---|---|
| Statement-snapshot race: concurrent PATCH/enrolment could be deleted on a stale guard verdict (probe-proven by both reviewers) | blocker | **Fixed** — `FOR UPDATE` lock-first ordering; two interleaving regression tests |
| Cc/Bcc-only correspondence not counted as message history | should-fix | **Fixed** — guards include `messages.cc`/`messages.bcc` with NULL-safe concat; regression test |
| Retention predicates `last_inbound_at`, `last_conversation_id`, `notified_next_action_at` untested | should-fix | **Fixed** — predicate-isolation + recorded-inbound tests |
| No shared contract scenario for the changed reversal behavior | should-fix | **Fixed** — `contacts_import` scenario now proves PATCH-protection, reversal, and counts in all three runners |
| CLI accepted impossible dates (V8 roll-over; MCP/zod rejects) — parity gap | should-fix | **Fixed** — component round-trip validation in `parseRfc3339`; tests |
| Receipt "reconciles against what the batch created" over-claims when contacts were manually deleted pre-reversal | nit | **Fixed** — wording corrected in code, spec, SDKs, design doc |
| No `engagements_retained` in the reversal receipt | nit | **Deferred** — additive response field on a beta surface; not required to close the data-loss hole; can ship separately if wanted |
| MCP contact timestamp schema had no offset-requirement description | nit | **Fixed** |
| CLI help still said `<ISO>` for now-strict flags | nit | **Fixed** — `<rfc3339>` |

Adversarial classes explicitly refuted with probes: case/canonicalization mismatch, tenant isolation, timestamp-witness forgery, NULL/trashed message handling, import body-shape games, idempotency replay interference, zod dangerous-accepts, exit-code contract drift.

🤖 Generated with [Kimi Code](https://www.kimi.com/code)
