### PR TITLE
fix(ts-sdk): omit If-Match header when no etag is supplied

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,8 @@ generate-check: spec-check generate-sdk-check
 generate-sdk-check: generate-sdk
 	@echo "==> Testing generated import normalization"
 	python3 -m unittest scripts/test_strip_unused_generated_imports.py
+	@echo "==> Testing optional-header-param guard normalization"
+	python3 -m unittest scripts/test_guard_optional_header_params.py
 	@echo "==> Checking generated code is up to date"
 	git diff --exit-code sdks/typescript/src/v1/generated/ sdks/python/src/e2a/v1/generated/
 

--- a/scripts/guard-optional-header-params.py
+++ b/scripts/guard-optional-header-params.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Guard optional header params in the generated TypeScript request factories.
+
+OpenAPI Generator's `typescript` generator (v7.16.0) emits
+
+    requestContext.setHeaderParam("X", ObjectSerializer.serialize(param, ...));
+
+unconditionally for every header parameter, including OPTIONAL ones.
+`ObjectSerializer.serialize(undefined, ...)` returns undefined, the
+RequestContext stores it, and the fetch layer's `Headers.set` coerces it to the
+literal string "undefined" on the wire. A server then receives e.g.
+`If-Match: undefined` and correctly treats the request as conditional, so an
+unkeyed `contacts.update` / `contacts.setOutreach` always fails with 412
+precondition_failed. The Python generator already guards these sites
+(`if if_match is not None: ...`); this step normalizes the TypeScript output to
+match:
+
+    if (param !== undefined) {
+        requestContext.setHeaderParam("X", ObjectSerializer.serialize(param, ...));
+    }
+
+Exception: "Idempotency-Key" is deliberately left UNGUARDED. The retry layer
+(sdks/typescript/src/v1/retry.ts) relies on the presence of the generated
+present-but-undefined stub to (a) recognise server-deduped POSTs as retry-safe
+and (b) mint a key once before the first attempt. Guarding it would silently
+disable retry + key minting on send/reply/forward/approve/create-webhook/
+create-api-key. The stub never reaches the wire through the supported client:
+ensureIdempotencyKey overwrites it with a minted key first.
+
+Usage: guard-optional-header-params.py FILE_OR_DIR [FILE_OR_DIR ...]
+Directories are expanded to their immediate *.ts files. Idempotent: already
+guarded emissions are left alone.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+import sys
+
+
+UNGUARDED_HEADERS = {"idempotency-key"}
+
+SIGNATURE = re.compile(
+    r"^\s*public async \w+\((?P<params>[^)]*)\): Promise<RequestContext> \{\s*$"
+)
+OPTIONAL_PARAM = re.compile(r"(?P<name>[A-Za-z_$][A-Za-z0-9_$]*)\?:")
+HEADER_PARAM = re.compile(
+    r"^(?P<indent>[ \t]*)requestContext\.setHeaderParam\("
+    r"\"(?P<header>[^\"]+)\", ObjectSerializer\.serialize\("
+    r"(?P<param>[A-Za-z_$][A-Za-z0-9_$]*), .*\);[ \t]*(?P<newline>\r?\n)?$"
+)
+
+
+def guard_file(path: Path) -> bool:
+    source = path.read_text(encoding="utf-8")
+    lines = source.splitlines(keepends=True)
+    output: list[str] = []
+    changed = False
+    optional_params: set[str] = set()
+
+    for line in lines:
+        signature = SIGNATURE.match(line)
+        if signature is not None:
+            optional_params = {
+                match.group("name")
+                for match in OPTIONAL_PARAM.finditer(signature.group("params"))
+            }
+            output.append(line)
+            continue
+
+        header = HEADER_PARAM.match(line)
+        if (
+            header is None
+            or header.group("header").lower() in UNGUARDED_HEADERS
+            or header.group("param") not in optional_params
+        ):
+            output.append(line)
+            continue
+
+        guard = f"if ({header.group('param')} !== undefined) {{"
+        if output and output[-1].strip() == guard:
+            output.append(line)  # already guarded (idempotent re-run)
+            continue
+
+        indent = header.group("indent")
+        newline = header.group("newline") or "\n"
+        output.append(f"{indent}{guard}{newline}")
+        output.append(f"{indent}    {line.lstrip()}")
+        output.append(f"{indent}}}{newline}")
+        changed = True
+
+    if changed:
+        path.write_text("".join(output), encoding="utf-8")
+    return changed
+
+
+def expand(argument: str) -> list[Path]:
+    path = Path(argument)
+    if path.is_dir():
+        return sorted(path.glob("*.ts"))
+    return [path]
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print(
+            "usage: guard-optional-header-params.py FILE_OR_DIR [FILE_OR_DIR ...]",
+            file=sys.stderr,
+        )
+        return 2
+
+    changed = sum(guard_file(path) for argument in argv for path in expand(argument))
+    print(f"guard-optional-header-params: guarded {changed} file(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/test_guard_optional_header_params.py
+++ b/scripts/test_guard_optional_header_params.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("guard-optional-header-params.py")
+
+
+def load_guard():
+    spec = importlib.util.spec_from_file_location("guard_optional_header_params", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load {SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+METHOD = (
+    "    public async updateContact(address: string, "
+    "updateContactRequest: UpdateContactRequest, ifMatch?: string, "
+    "_options?: Configuration): Promise<RequestContext> {\n"
+)
+
+
+def api_source(header_lines: str) -> str:
+    return (
+        "export class ContactsApiRequestFactory extends BaseAPIRequestFactory {\n\n"
+        + METHOD
+        + "        // Header Params\n"
+        + header_lines
+        + "\n        return requestContext;\n"
+        + "    }\n\n"
+        + "}\n"
+    )
+
+
+class GuardOptionalHeaderParamsTest(unittest.TestCase):
+    def test_guards_optional_header_param(self) -> None:
+        guard = load_guard()
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "ContactsApi.ts"
+            path.write_text(
+                api_source(
+                    '        requestContext.setHeaderParam("If-Match", '
+                    'ObjectSerializer.serialize(ifMatch, "string", ""));\n'
+                ),
+                encoding="utf-8",
+            )
+
+            self.assertTrue(guard.guard_file(path))
+            self.assertEqual(
+                api_source(
+                    "        if (ifMatch !== undefined) {\n"
+                    '            requestContext.setHeaderParam("If-Match", '
+                    'ObjectSerializer.serialize(ifMatch, "string", ""));\n'
+                    "        }\n"
+                ),
+                path.read_text(encoding="utf-8"),
+            )
+
+    def test_leaves_idempotency_key_stub_unguarded(self) -> None:
+        # retry.ts depends on the present-but-undefined Idempotency-Key stub to
+        # recognise server-deduped POSTs and mint a key — never guard it.
+        guard = load_guard()
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "MessagesApi.ts"
+            source = api_source(
+                '        requestContext.setHeaderParam("Idempotency-Key", '
+                'ObjectSerializer.serialize(ifMatch, "string", ""));\n'
+            )
+            path.write_text(source, encoding="utf-8")
+
+            self.assertFalse(guard.guard_file(path))
+            self.assertEqual(source, path.read_text(encoding="utf-8"))
+
+    def test_leaves_required_header_param_unguarded(self) -> None:
+        guard = load_guard()
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "RequiredApi.ts"
+            source = (
+                "export class RequiredApiRequestFactory {\n"
+                "    public async op(tenant: string, _options?: Configuration): "
+                "Promise<RequestContext> {\n"
+                '        requestContext.setHeaderParam("X-Tenant", '
+                'ObjectSerializer.serialize(tenant, "string", ""));\n'
+                "        return requestContext;\n"
+                "    }\n"
+                "}\n"
+            )
+            path.write_text(source, encoding="utf-8")
+
+            self.assertFalse(guard.guard_file(path))
+            self.assertEqual(source, path.read_text(encoding="utf-8"))
+
+    def test_rerun_is_idempotent(self) -> None:
+        guard = load_guard()
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "ContactsApi.ts"
+            path.write_text(
+                api_source(
+                    '        requestContext.setHeaderParam("If-Match", '
+                    'ObjectSerializer.serialize(ifMatch, "string", ""));\n'
+                ),
+                encoding="utf-8",
+            )
+
+            self.assertTrue(guard.guard_file(path))
+            first_pass = path.read_text(encoding="utf-8")
+            self.assertFalse(guard.guard_file(path))
+            self.assertEqual(first_pass, path.read_text(encoding="utf-8"))
+
+    def test_optional_params_are_scoped_per_method(self) -> None:
+        # `ifMatch` optional in one method must not guard a same-named REQUIRED
+        # param in the next method.
+        guard = load_guard()
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "MixedApi.ts"
+            unguarded = (
+                "    public async second(ifMatch: string, _options?: Configuration): "
+                "Promise<RequestContext> {\n"
+                '        requestContext.setHeaderParam("If-Match", '
+                'ObjectSerializer.serialize(ifMatch, "string", ""));\n'
+                "    }\n"
+            )
+            path.write_text(
+                api_source(
+                    '        requestContext.setHeaderParam("If-Match", '
+                    'ObjectSerializer.serialize(ifMatch, "string", ""));\n'
+                )
+                + unguarded,
+                encoding="utf-8",
+            )
+
+            self.assertTrue(guard.guard_file(path))
+            content = path.read_text(encoding="utf-8")
+            self.assertIn(
+                "        if (ifMatch !== undefined) {\n"
+                '            requestContext.setHeaderParam("If-Match", ',
+                content,
+            )
+            self.assertIn(unguarded, content)
+
+    def test_directory_argument_expands_to_ts_files(self) -> None:
+        guard = load_guard()
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "ContactsApi.ts"
+            path.write_text(
+                api_source(
+                    '        requestContext.setHeaderParam("If-Match", '
+                    'ObjectSerializer.serialize(ifMatch, "string", ""));\n'
+                ),
+                encoding="utf-8",
+            )
+
+            self.assertEqual(0, guard.main([directory]))
+            self.assertIn("if (ifMatch !== undefined) {", path.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdks/typescript/scripts/generate-oag.sh
+++ b/sdks/typescript/scripts/generate-oag.sh
@@ -43,6 +43,12 @@ docker run --rm --user "$(id -u):$(id -g)" -e HOME=/tmp -v "$ROOT:/work" "$IMG" 
 find "$OUT" -name '*.ts' -print0 | xargs -0 perl -i -ne \
   'print unless /^\s*import\s+["'"'"']whatwg-fetch["'"'"'];\s*$/'
 
+# The generator emits setHeaderParam(...) unconditionally for OPTIONAL header
+# params (e.g. If-Match); an omitted param then reaches the wire as the literal
+# string "undefined". Wrap those emissions in `if (param !== undefined)` guards
+# (Idempotency-Key stays unguarded — retry.ts depends on the stub; see script).
+python3 "$ROOT/scripts/guard-optional-header-params.py" "$OUT/apis"
+
 # OpenAPI Generator imports every schema into its API wrapper variants and
 # imports HttpFile into standalone models even when those symbols are unused.
 # Normalize selected generator-known unused imports so static analysis and the

--- a/sdks/typescript/src/v1/generated/apis/ContactsApi.ts
+++ b/sdks/typescript/src/v1/generated/apis/ContactsApi.ts
@@ -566,7 +566,9 @@ export class ContactsApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Header Params
-        requestContext.setHeaderParam("If-Match", ObjectSerializer.serialize(ifMatch, "string", ""));
+        if (ifMatch !== undefined) {
+            requestContext.setHeaderParam("If-Match", ObjectSerializer.serialize(ifMatch, "string", ""));
+        }
 
 
         // Body Params
@@ -635,7 +637,9 @@ export class ContactsApiRequestFactory extends BaseAPIRequestFactory {
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
 
         // Header Params
-        requestContext.setHeaderParam("If-Match", ObjectSerializer.serialize(ifMatch, "string", ""));
+        if (ifMatch !== undefined) {
+            requestContext.setHeaderParam("If-Match", ObjectSerializer.serialize(ifMatch, "string", ""));
+        }
 
 
         // Body Params

--- a/sdks/typescript/test/v1/contract-client.test.ts
+++ b/sdks/typescript/test/v1/contract-client.test.ts
@@ -80,4 +80,45 @@ describe.skipIf(!baseUrl || !apiKey)("E2AClient contract (high-level)", () => {
       await client.account.apiKeys.delete(first.id);
     }
   });
+
+  it("contacts.update / contacts.setOutreach without an etag are unconditional", async () => {
+    // Regression (staging release-pipeline run 30612956986): the generated
+    // layer used to emit `If-Match: undefined` when no etag was supplied,
+    // turning both calls into conditional requests that always failed 412 —
+    // on update the stored validator never matches "undefined", and a
+    // conditional request never creates a first enrolment. Only a live server
+    // can prove the header truly stays off the wire end to end.
+    const email = `${slug("sdkc-ifm")}@agents.e2a.dev`;
+    const address = `${slug("sdkc-ifm-c")}@fund.vc`;
+    await client.agents.create({ email });
+    try {
+      await client.contacts.create({ address });
+      try {
+        const updated = await client.contacts.update(address, { displayName: "Unconditional" });
+        expect(updated.displayName).toBe("Unconditional");
+
+        const enrolment = await client.contacts.setOutreach(email, address, { stage: "touch1" });
+        expect(enrolment.stage).toBe("touch1");
+
+        // A caller-supplied etag still arrives verbatim: the current validator
+        // is accepted, and replaying it after the write proves the header was
+        // really sent (412 on the now-stale value).
+        const { etag } = await client.contacts.getWithETag(address);
+        expect(etag).toBeTruthy();
+        const guarded = await client.contacts.update(
+          address,
+          { displayName: "Guarded" },
+          { ifMatch: etag },
+        );
+        expect(guarded.displayName).toBe("Guarded");
+        await expect(
+          client.contacts.update(address, { displayName: "Stale" }, { ifMatch: etag }),
+        ).rejects.toMatchObject({ status: 412 });
+      } finally {
+        await client.contacts.delete(address);
+      }
+    } finally {
+      await client.agents.delete(email, { permanent: true });
+    }
+  });
 });

--- a/sdks/typescript/test/v1/optional-header-params.test.ts
+++ b/sdks/typescript/test/v1/optional-header-params.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Offline regression tests for optional header parameters in the generated
+ * request factories.
+ *
+ * The `typescript` OpenAPI generator emits setHeaderParam(...) unconditionally
+ * for every header param. For an omitted OPTIONAL param that stored `undefined`
+ * on the RequestContext, and the fetch layer's Headers.set coerced it to the
+ * literal string "undefined" on the wire — so `contacts.update` /
+ * `contacts.setOutreach` without an etag always hit a real server as a
+ * conditional request (`If-Match: undefined`) and failed with 412
+ * precondition_failed (first observed live: e2a-ops release-pipeline run
+ * 30612956986, test/e2e-contacts.test.ts). The generation pipeline now wraps
+ * optional header emissions in `if (param !== undefined)` guards
+ * (scripts/guard-optional-header-params.py); these tests pin that behavior
+ * WITHOUT a live server, so a regression fails ordinary unit CI instead of
+ * only the staging gate.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+import { ContactsApiRequestFactory } from "../../src/v1/generated/apis/ContactsApi.js";
+import { createConfiguration } from "../../src/v1/generated/configuration.js";
+import { ServerConfiguration } from "../../src/v1/generated/servers.js";
+
+const config = createConfiguration({
+  baseServer: new ServerConfiguration("http://contract.invalid", {}),
+});
+const factory = new ContactsApiRequestFactory(config);
+
+function headerNames(headers: Record<string, string>): string[] {
+  return Object.keys(headers).map((name) => name.toLowerCase());
+}
+
+describe("optional If-Match header (generated request factories)", () => {
+  it("updateContact without an etag sends NO If-Match header", async () => {
+    const ctx = await factory.updateContact("partner@fund.vc", { displayName: "P" });
+    expect(headerNames(ctx.getHeaders())).not.toContain("if-match");
+  });
+
+  it("updateContact with an etag sends exactly that etag", async () => {
+    const ctx = await factory.updateContact("partner@fund.vc", { displayName: "P" }, 'W/"c42"');
+    expect(ctx.getHeaders()["If-Match"]).toBe('W/"c42"');
+  });
+
+  it("upsertEngagement without an etag sends NO If-Match header (first enrolment must not be conditional)", async () => {
+    const ctx = await factory.upsertEngagement(
+      "raise@agents.e2a.dev",
+      "partner@fund.vc",
+      { stage: "contacted" },
+    );
+    expect(headerNames(ctx.getHeaders())).not.toContain("if-match");
+  });
+
+  it("upsertEngagement with an etag sends exactly that etag", async () => {
+    const ctx = await factory.upsertEngagement(
+      "raise@agents.e2a.dev",
+      "partner@fund.vc",
+      { stage: "contacted" },
+      'W/"e7"',
+    );
+    expect(ctx.getHeaders()["If-Match"]).toBe('W/"e7"');
+  });
+});
+
+describe("generated APIs never emit an optional header param unconditionally", () => {
+  // Static audit across ALL committed generated request factories: every
+  // serialized header emission must either target a required param, be wrapped
+  // in an `if (param !== undefined)` guard, or be the deliberate
+  // Idempotency-Key stub (retry.ts depends on that stub for POST retry-safety
+  // gating and key minting — see scripts/guard-optional-header-params.py).
+  const apisDir = join(
+    dirname(fileURLToPath(import.meta.url)),
+    "../../src/v1/generated/apis",
+  );
+
+  it("holds for every committed generated API file", () => {
+    const offenders: string[] = [];
+    for (const file of readdirSync(apisDir).filter((f) => f.endsWith("Api.ts"))) {
+      const lines = readFileSync(join(apisDir, file), "utf8").split("\n");
+      let optionalParams = new Set<string>();
+      for (let i = 0; i < lines.length; i++) {
+        const sig = lines[i].match(/public async \w+\(([^)]*)\): Promise<RequestContext>/);
+        if (sig) {
+          optionalParams = new Set(
+            [...sig[1].matchAll(/(\w+)\?:/g)].map((m) => m[1]),
+          );
+          continue;
+        }
+        const header = lines[i].match(
+          /^\s*requestContext\.setHeaderParam\("([^"]+)", ObjectSerializer\.serialize\((\w+),/,
+        );
+        if (!header) continue;
+        const [, name, param] = header;
+        if (name.toLowerCase() === "idempotency-key") continue;
+        if (!optionalParams.has(param)) continue;
+        if (lines[i - 1]?.trim() === `if (${param} !== undefined) {`) continue;
+        offenders.push(`${file}:${i + 1} sets optional header "${name}" unconditionally`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

The generated TypeScript client set the optional `If-Match` header **unconditionally** in `ContactsApi` (`updateContact`, `upsertEngagement`). `ObjectSerializer.serialize(undefined, ...)` returns `undefined`, the `RequestContext` stores it, and the fetch layer's `Headers.set` coerces it to the literal string `"undefined"` on the wire. The server then treats the request as conditional (`internal/httpapi/engagements.go`, `in.IfMatch != ""`) and correctly returns **412 precondition_failed**: on update of an existing contact the stored ETag never matches `"undefined"`, and on first enrolment a conditional request never creates.

**Net effect:** `client.contacts.update(address, patch)` and `client.contacts.setOutreach(email, address, body)` without an etag always failed against a real server — the etag-less path is the *default* path.

**Staging evidence:** first live run of the TS SDK contacts suite through the release pipeline — e2a-ops `release-pipeline.yml` run `30612956986`, `sdks/typescript/test/e2e-contacts.test.ts:179`, 412 `precondition_failed` against `api-staging.e2a.dev`.

**Blast radius:** TS SDK + CLI (`e2a contacts` update/outreach without `--if-match` uses the SDK and inherits the bug) — contacts/outreach beta surface only. The Python SDK is unaffected (its generated code already guards `if if_match is not None`). Offline CI passed because the live suite self-skips outside the staging gate and the raw-HTTP scenario interpreter (`tests/contract/contract.test.ts`) deliberately never exercises the generated client — that hole is closed below.

## Fix (generation pipeline, not hand-edited output)

New post-processing step `scripts/guard-optional-header-params.py`, wired into `sdks/typescript/scripts/generate-oag.sh`, wraps every **optional** header-param emission in the generated request factories in an `if (param !== undefined)` guard — mirroring the Python generator's behavior. `make generate-sdk-ts` reproduces the committed output byte-for-byte, so the "Generated code freshness" gate stays green (`make generate-sdk-check` run locally: clean).

**Deliberate exception — `Idempotency-Key` stays unguarded.** `sdks/typescript/src/v1/retry.ts` depends on the generated present-but-undefined stub to (a) classify server-deduped POSTs as retry-safe (`isRetrySafe` → `hasIdempotencyHeader`) and (b) mint a key once before the first attempt (`ensureIdempotencyKey`). Guarding it would have silently disabled retry + key minting on send/reply/forward/approve/create-webhook/create-api-key. The stub never reaches the wire through the supported client because `ensureIdempotencyKey` overwrites it. This is documented in the script, pinned by its unittest, and excluded from the static audit test.

**Audit:** the only serialized header params in all generated APIs are `If-Match` (2 sites, both fixed) and `Idempotency-Key` (9 sites, all POSTs covered by the retry-stub contract). A static audit test now fails offline CI if any future optional header is ever emitted unconditionally.

## Client surface checklist

- [x] TypeScript SDK — generated base regenerated via `make generate-sdk` (pipeline change, not a hand edit); hand-written `E2AClient` unchanged (already passed `undefined` correctly)
- [x] Tests — offline regression + static audit + live contract-client coverage (see test plan)

> All other rows skipped: no API change — server, OpenAPI spec, Python SDK, CLI code, and MCP are untouched. The CLI inherits the fix through the workspace SDK.

## Operational risk

None beyond the SDK wire change: requests that previously carried `If-Match: undefined` / stray optional-header `"undefined"` values now omit the header, which is the documented unconditional-write behavior. **Release coupling: this must merge before the TS SDK 5.5.0 / CLI 2.2.0 publish and before the v1.5.0 tag** — the contacts surface in the TS SDK/CLI is broken without it and the staging conformance gate will keep failing at e2e-contacts.

## Test plan

- [x] `python3 -m unittest scripts/test_guard_optional_header_params.py` — 6 tests (guarding, Idempotency-Key exemption, required-param exemption, per-method scoping, idempotent re-run, dir expansion)
- [x] `make generate-sdk-check` — regenerates TS + Python via OAG v7.16.0 (Docker) and diffs clean against the committed trees
- [x] `npm test --workspace @e2a/sdk` — 233 unit tests incl. new `test/v1/optional-header-params.test.ts` (RequestContext for `updateContact`/`upsertEngagement` has **no** If-Match when omitted, exact etag when provided, plus the static audit across all generated APIs). Verified the new tests fail (3/5) with the fix reverted.
- [x] `npm run test:contract --workspace @e2a/sdk` against a local `cmd/e2a-contract-server` — new contract-client test green: unconditional update + first enrolment succeed without an etag; supplied etag round-trips verbatim (current → 200, stale → 412). This runs in the per-PR `ts-contract` job, closing the "only the staging gate can catch it" hole.
- [x] `npm test --workspace @e2a/cli`, `npm test --workspace @e2a/mcp-server`, `node scripts/check-sdk-version-sync.mjs`, `scripts/check-repository-text-integrity.sh` — all green
- [ ] After merge: staging release pipeline re-run — e2e-contacts suite green at the staging gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
