### PR TITLE
fix(contacts): return post-update row from conditional engagement update; accept RFC-3986 Location in suite 30

### DIFF
--- a/internal/identity/engagements.go
+++ b/internal/identity/engagements.go
@@ -259,6 +259,17 @@ func (s *Store) UpsertEngagement(ctx context.Context, userID, agentID, address s
 // existing engagement when updated_at still equals expectedUpdatedAt. The
 // version check is in the UPDATE predicate, closing the race between an HTTP
 // If-Match comparison and the persistence write.
+//
+// The UPDATE and the read-back are two statements in one transaction, NOT a
+// data-modifying CTE with an outer SELECT over the table. In Postgres the
+// outer query of such a CTE runs on the statement snapshot, which predates the
+// CTE's own writes — so a `WITH updated AS (UPDATE …) SELECT … FROM
+// contact_engagements` returns the PRE-update row, and the derived ETag can
+// never match the row again (found live by the staging conformance suite). A
+// second statement in the same transaction sees the first statement's writes,
+// and the version predicate already lives in the UPDATE, so the follow-up
+// read by primary key is race-free. This also mirrors UpsertEngagement, which
+// re-reads via GetEngagement after its write.
 func (s *Store) UpdateEngagementIfUnchanged(ctx context.Context, userID, agentID, address string, stage *string, nextActionAt **time.Time, metadata map[string]any, expectedUpdatedAt time.Time) (ContactEngagement, error) {
 	agentID = NormalizeEmail(agentID)
 	address = NormalizeMailboxAddress(address)
@@ -277,24 +288,26 @@ func (s *Store) UpdateEngagementIfUnchanged(ctx context.Context, userID, agentID
 		nextVal = *nextActionAt
 	}
 
-	row := s.pool.QueryRow(ctx,
-		`WITH updated AS (
-			UPDATE contact_engagements
-			   SET stage          = COALESCE($4, stage),
-			       next_action_at = CASE WHEN $5 THEN $6 ELSE next_action_at END,
-			       metadata       = COALESCE($7::jsonb, metadata),
-			       updated_at     = now()
-			 WHERE user_id = $1 AND agent_id = $2 AND address = $3
-			   AND updated_at = $8
-			 RETURNING id
-		)
-		SELECT `+engagementColumns+engagementFrom+`
-		 WHERE ce.id = (SELECT id FROM updated)`,
-		userID, agentID, address, stage, nextSet, nextVal, encoded, expectedUpdatedAt)
-	e, err := scanEngagement(row)
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return ContactEngagement{}, err
+	}
+	defer tx.Rollback(ctx)
+
+	var id string
+	err = tx.QueryRow(ctx,
+		`UPDATE contact_engagements
+		    SET stage          = COALESCE($4, stage),
+		        next_action_at = CASE WHEN $5 THEN $6 ELSE next_action_at END,
+		        metadata       = COALESCE($7::jsonb, metadata),
+		        updated_at     = now()
+		  WHERE user_id = $1 AND agent_id = $2 AND address = $3
+		    AND updated_at = $8
+		  RETURNING id`,
+		userID, agentID, address, stage, nextSet, nextVal, encoded, expectedUpdatedAt).Scan(&id)
 	if errors.Is(err, pgx.ErrNoRows) {
 		var exists bool
-		if qerr := s.pool.QueryRow(ctx,
+		if qerr := tx.QueryRow(ctx,
 			`SELECT EXISTS (
 				SELECT 1 FROM contact_engagements
 				 WHERE user_id = $1 AND agent_id = $2 AND address = $3
@@ -306,7 +319,20 @@ func (s *Store) UpdateEngagementIfUnchanged(ctx context.Context, userID, agentID
 		}
 		return ContactEngagement{}, ErrEngagementNotFound
 	}
-	return e, err
+	if err != nil {
+		return ContactEngagement{}, err
+	}
+
+	e, err := scanEngagement(tx.QueryRow(ctx,
+		`SELECT `+engagementColumns+engagementFrom+`
+		  WHERE ce.id = $1`, id))
+	if err != nil {
+		return ContactEngagement{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return ContactEngagement{}, err
+	}
+	return e, nil
 }
 
 // GetEngagement loads one engagement scoped to (account, agent, address).

--- a/internal/identity/engagements_test.go
+++ b/internal/identity/engagements_test.go
@@ -178,6 +178,65 @@ func TestUpdateEngagementIfUnchangedIsAtomic(t *testing.T) {
 	}
 }
 
+// TestUpdateEngagementIfUnchangedReturnsPostUpdateRow pins the other half of
+// the If-Match contract: an accepted conditional update must return the row AS
+// UPDATED, with an advanced updated_at, so the response ETag matches the stored
+// state and a guarded read-modify-write chain can continue.
+//
+// Regression: the original implementation ran the read-back as the outer
+// SELECT of a data-modifying CTE. In Postgres that outer query runs on the
+// statement snapshot, which predates the CTE's UPDATE — the call committed the
+// new stage but returned the old one with the old updated_at, so the derived
+// ETag was permanently stale (caught live by the staging conformance suite,
+// suite 30, on the prospect→nurture transition).
+func TestUpdateEngagementIfUnchangedReturnsPostUpdateRow(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	user := newEngagementOwner(t, store, "engfresh")
+
+	original := enroll(t, store, user.ID, "raise@e.com", "partner@fresh.vc", "prospect")
+
+	next := time.Now().Add(48 * time.Hour).UTC().Truncate(time.Second)
+	nextP := &next
+	stage := "nurture"
+	got, err := store.UpdateEngagementIfUnchanged(ctx, user.ID, "raise@e.com",
+		"partner@fresh.vc", &stage, &nextP, nil, original.UpdatedAt)
+	if err != nil {
+		t.Fatalf("conditional update: %v", err)
+	}
+	if got.Stage != "nurture" {
+		t.Errorf("stage = %q, want post-update %q — the conditional update returned the pre-update row", got.Stage, "nurture")
+	}
+	if got.NextActionAt == nil || !got.NextActionAt.Equal(next) {
+		t.Errorf("next_action_at = %v, want post-update %v", got.NextActionAt, next)
+	}
+	if !got.UpdatedAt.After(original.UpdatedAt) {
+		t.Errorf("updated_at = %v, want later than expected %v — a stale updated_at means the derived ETag never moves", got.UpdatedAt, original.UpdatedAt)
+	}
+
+	// The returned row must agree with a subsequent read, exactly where the
+	// ETag is concerned: same stage, same updated_at.
+	reread, err := store.GetEngagement(ctx, user.ID, "raise@e.com", "partner@fresh.vc")
+	if err != nil {
+		t.Fatalf("get after update: %v", err)
+	}
+	if reread.Stage != got.Stage {
+		t.Errorf("stored stage = %q, returned %q", reread.Stage, got.Stage)
+	}
+	if !reread.UpdatedAt.Equal(got.UpdatedAt) {
+		t.Errorf("stored updated_at = %v, returned %v — the response validator would not match the row", reread.UpdatedAt, got.UpdatedAt)
+	}
+
+	// And the returned updated_at is the real new validator: conditioning the
+	// next update on it must succeed.
+	stage2 := "engaged"
+	if _, err := store.UpdateEngagementIfUnchanged(ctx, user.ID, "raise@e.com",
+		"partner@fresh.vc", &stage2, nil, nil, got.UpdatedAt); err != nil {
+		t.Errorf("chained conditional update with returned updated_at: %v", err)
+	}
+}
+
 // TestUpsertEngagementCannotBypassContactCap pins that enrollment and manual
 // contact creation share one account limit. An engagement may create a missing
 // contact for convenience, but it is not a back door around the safety cap.

--- a/tests/e2e-prod/suites/30-contacts-outreach.test.ts
+++ b/tests/e2e-prod/suites/30-contacts-outreach.test.ts
@@ -214,8 +214,14 @@ test("createContact: 201 + Location; a duplicate create → 409 conflict", async
   assert.equal(r.body?.address, address, "ContactView echoes the canonical address");
   assert.equal(r.body?.source, "manual", "a direct create has source=manual");
   assert.equal(r.body?.display_name, "Coverage Contact");
+  // RFC 3986 allows '@' unescaped in a path segment (pchar includes '@'), so
+  // the server may legally emit either "/v1/contacts/a@b.com" or the
+  // percent-encoded form. Compare the DECODED trailing segment instead of
+  // demanding one spelling (prod emits the raw '@' via Go's url.PathEscape).
+  const location = r.headers.location ?? "";
+  const locationAddress = decodeURIComponent(location.slice(location.lastIndexOf("/") + 1));
   assert.ok(
-    r.headers.location?.includes(`/v1/contacts/${encodeURIComponent(address)}`),
+    location.includes("/v1/contacts/") && locationAddress === address,
     `Location header names the new contact: ${r.headers.location}`,
   );
 


### PR DESCRIPTION
## Summary

Fixes the two deterministic failures found by the **first live staging run of the conformance suite** (e2a-ops `release-pipeline` run 30612956986). **Must merge before the v1.5.0 tag** — the conformance gate fails deterministically on both without it.

### Issue B — server bug: conditional engagement update returns the pre-update row

`identity.Store.UpdateEngagementIfUnchanged` read the row back as the outer SELECT of a data-modifying CTE:

```sql
WITH updated AS (UPDATE contact_engagements SET ... WHERE ... AND updated_at = $8 RETURNING id)
SELECT <joined columns> FROM contact_engagements ce ... WHERE ce.id = (SELECT id FROM updated)
```

In Postgres the outer query of a data-modifying CTE runs on the **statement snapshot**, which predates the CTE's own writes — so the outer SELECT scans the *pre-update* version of the row. The UPDATE commits correctly; only the returned row is stale (old `stage`, old `next_action_at`, old `updated_at`). Since the response ETag derives from `updated_at`, the returned validator **can never match the stored row again**, breaking every If-Match read-modify-write chain.

**Live evidence:** `tests/e2e-prod/suites/30-contacts-outreach.test.ts:414` — the If-Match update returned 200 with stage `"prospect"` (expected `"nurture"`) and a stale ETag.

**Fix:** split into two statements in one transaction — the UPDATE (version predicate unchanged, so the If-Match race stays closed exactly as before) `RETURNING id`, then a read of the full joined row by primary key, which sees the prior statement's writes. This mirrors `UpsertEngagement`'s write-then-`GetEngagement` shape, so both paths now have identical read-back semantics. The `ErrEngagementPreconditionFailed` / `ErrEngagementNotFound` disambiguation is byte-for-byte unchanged.

**Audit of other data-modifying CTEs under `internal/`** (grep `WITH updated|touched|upd|candidates|children|requested`):
- `identity/store.go` `GetPrincipalByAPIKey` (`WITH touched`) — outer SELECT reads `FROM touched` (the RETURNING output) joined to unmodified `users`. Safe.
- `identity/store.go` `GetMessageWithContent` (`WITH upd`) — outer SELECT reads `FROM upd` joined to unmodified `webhook_deliveries`. Safe.
- `webhook/store.go` + `webhookpub/worker.go` lease queries (`WITH candidates`) — read-only SELECT … FOR UPDATE CTE feeding the main UPDATE, whose RETURNING carries post-update values. Safe.
- `identity/thread_identity.go` (`WITH requested`), `identity/store.go` `detachThreadChildrenBatchTx` (`WITH children`) — read-only CTEs. Safe.

`UpdateEngagementIfUnchanged` was the **only** instance of the stale pattern (outer SELECT over the modified table itself).

**Regression test:** `TestUpdateEngagementIfUnchangedReturnsPostUpdateRow` (DB-backed, `internal/identity`) asserts the accepted conditional update returns the post-update stage/next_action_at, that `updated_at` advanced past `expectedUpdatedAt` (the ETag moves), that the returned row equals a subsequent `GetEngagement`, and that chaining a second conditional update on the returned validator succeeds. Verified it **fails against the old implementation** with exactly the live symptoms (stage stays `"prospect"`, stale validator, chained update → precondition failed) and passes with the fix. Handler-level pinning in `internal/httpapi/engagements_test.go` is moot: the handler deps mock `UpdateEngagementIfUnchanged` outright and the ETag is computed from whatever the store returns, so the store test is the right (and only meaningful) level.

### Issue C — test over-strictness: Location-header encoding in suite 30

`30-contacts-outreach.test.ts:217-220` required the createContact `Location` to contain `encodeURIComponent(address)` (`%40`), but the server emits a raw `@` via Go's `url.PathEscape` — valid RFC 3986 (pchar allows `@` in a path segment). Live failure: `Location: /v1/contacts/ctdup-cd2014-6e046f@example.com`.

Fixed the **test only** (no server change): decode the trailing path segment and compare addresses, accepting either spelling. Audited every other `encodeURIComponent` use in the suite — all others build request URLs (encoding a request path is always legal) except the engagement-Location assertion at line 409, which only checks the `/v1/agents/` prefix and is encoding-agnostic.

## Client surface checklist

No API surface change — server-internal persistence fix + test relaxation. No spec, SDK, CLI, MCP, or web changes; `api/openapi.yaml` untouched.

## Operational risk

Low. One extra statement inside a short transaction on the conditional-update path only (If-Match requests). No schema change, no migration.

## Test evidence

- `go test -tags integration ./internal/identity/ ./internal/httpapi/` — **ok** (118s / 5s)
- New regression test fails on old code, passes on fix (see above)
- `tests/e2e-prod`: `tsc --noEmit` clean, `npm run test:unit` 18/18 pass, `npm run test:unit:gates` 6/6 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)