### PR TITLE
test: pin the generated-header and CTE-snapshot bug classes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,6 +314,29 @@ manually on every API change even though the template won't remind you.
   feature, extend all three interpreters in parity, add runner-level regressions
   in every language, and prefer dynamic placeholders over fixtures that age or
   collide under concurrent runs.
+- **New SDK surface needs live coverage in per-PR CI, not only staging.** The
+  post-merge staging conformance gate must never be the FIRST live exercise
+  of a method — that is how `If-Match: undefined` shipped (#774). The
+  ts-contract job enforces a denominator: every ergonomic client method must
+  be exercised by `sdks/typescript/test/v1/contract-client.test.ts` or carry
+  an explicit allowlist entry in `contract-coverage.test.ts` (a ratchet —
+  shrink it; grow it only with a reason the contract server can't run the
+  path).
+- **Generated clients are pipeline artifacts — never hand-edit them.** Any
+  behavior fix belongs in the generation pipeline (`make generate-sdk`, e.g.
+  the TS post-processing step `scripts/guard-optional-header-params.py`), so
+  regeneration cannot undo it. Static audits pin the load-bearing emission
+  shapes per PR — optional header params must stay guarded in both generated
+  clients (TS: `test/v1/optional-header-params.test.ts`; Python:
+  `tests/test_generated_header_guards.py`) — because the freshness gate alone
+  re-blesses whatever a new generator version emits.
+- **Data-modifying CTEs must not re-select from the table they modified.** In
+  Postgres the outer query runs on the statement snapshot, which predates the
+  CTE's own writes — `WITH x AS (UPDATE t … RETURNING …) SELECT … FROM t`
+  returns the pre-update row (this broke `UpdateEngagementIfUnchanged`'s ETag
+  chain, #775). Read FROM the CTE's RETURNING output, or split write and read
+  into two statements in one transaction. Guarded repo-wide by
+  `internal/sqlguard` (waiver: `// cte-snapshot-safe: <reason>`).
 - **Schema-change rule**: when changing a table shape, add/update DB-backed
   tests in every package that writes direct SQL against that table — the
   idempotent migration runner will not catch drifted runtime SQL.

--- a/internal/sqlguard/cte_snapshot_discrimination_test.go
+++ b/internal/sqlguard/cte_snapshot_discrimination_test.go
@@ -1,0 +1,215 @@
+package sqlguard
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+// TestAnalyzeSQLDiscrimination pins the matcher's own behaviour: the shapes
+// it must catch (the reason it exists) and the shapes it must not flag (the
+// reason it can hold a zero-waiver tree). The clean cases are distilled from
+// the five real in-tree CTE sites audited in PR #775.
+func TestAnalyzeSQLDiscrimination(t *testing.T) {
+	hazardous := map[string]string{
+		"outer SELECT re-reads the UPDATEd table (the UpdateEngagementIfUnchanged bug)": `
+			WITH updated AS (
+				UPDATE contact_engagements
+				   SET stage = COALESCE($4, stage), updated_at = now()
+				 WHERE user_id = $1 AND agent_id = $2 AND address = $3
+				 RETURNING id
+			)
+			SELECT ce.id, ce.stage FROM contact_engagements ce
+			 WHERE ce.id = (SELECT id FROM updated)`,
+		"outer SELECT JOINs the INSERTed table": `
+			WITH ins AS (
+				INSERT INTO messages (id, subject) VALUES ($1, $2) RETURNING id
+			)
+			SELECT m.id, m.subject FROM ins JOIN messages m ON m.id = ins.id`,
+		"outer SELECT re-reads a DELETEd table": `
+			WITH gone AS (
+				DELETE FROM api_keys WHERE expires_at < now() RETURNING user_id
+			)
+			SELECT count(*) FROM api_keys WHERE user_id IN (SELECT user_id FROM gone)`,
+		"second CTE of a list modifies, outer re-reads it": `
+			WITH scope AS (
+				SELECT id FROM users WHERE account_class = 'internal'
+			), upd AS (
+				UPDATE agent_identities SET deleted_at = now()
+				 WHERE user_id IN (SELECT id FROM scope) RETURNING id
+			)
+			SELECT a.id FROM agent_identities a WHERE a.deleted_at IS NOT NULL`,
+		"schema-qualified reference to the modified table": `
+			WITH updated AS (
+				UPDATE messages SET inbox_status = 'read' WHERE id = $1 RETURNING id
+			)
+			SELECT m.id FROM public.messages m WHERE m.id = (SELECT id FROM updated)`,
+	}
+	for label, sql := range hazardous {
+		findings, hasWith, hasModifying := analyzeSQL(sql)
+		if len(findings) == 0 {
+			t.Errorf("matcher missed a hazardous shape (%s); hasWith=%v hasModifying=%v", label, hasWith, hasModifying)
+		}
+	}
+
+	clean := map[string]string{
+		"outer SELECT reads the CTE's RETURNING output (GetPrincipalByAPIKey shape)": `
+			WITH touched AS (
+				UPDATE api_keys SET last_used_at = now()
+				WHERE key_hash = $1 RETURNING user_id, scope, agent_id
+			)
+			SELECT u.id, u.email, t.scope FROM touched t JOIN users u ON u.id = t.user_id`,
+		"outer SELECT LEFT JOINs a DIFFERENT table (GetMessageWithContent shape)": `
+			WITH upd AS (
+				UPDATE messages SET inbox_status = 'read' WHERE id = $1 RETURNING id, subject
+			)
+			SELECT upd.id, upd.subject, COALESCE(wd.status, '')
+			FROM upd LEFT JOIN webhook_deliveries wd ON wd.message_id = upd.id`,
+		"read-only CTE feeding an outer UPDATE (webhook lease shape)": `
+			WITH candidates AS (
+				SELECT id FROM webhook_events
+				WHERE status = 'pending' ORDER BY created_at LIMIT $1
+				FOR UPDATE SKIP LOCKED
+			)
+			UPDATE webhook_events e SET next_poll_at = now()
+			FROM candidates c WHERE e.id = c.id
+			RETURNING e.id, e.envelope`,
+		"read-only locking CTE feeding an outer UPDATE (detachThreadChildrenBatchTx shape)": `
+			WITH children AS (
+				SELECT id FROM messages WHERE thread_parent_id = ANY($1)
+				ORDER BY id LIMIT $2 FOR UPDATE SKIP LOCKED
+			)
+			UPDATE messages AS m SET thread_parent_id = NULL
+			FROM children WHERE m.id = children.id`,
+		"read-only CTE with an outer SELECT over the same table (threadAnchorBatchQuery shape)": `
+			WITH requested AS (
+				SELECT * FROM unnest($2::integer[], $3::text[]) AS input(ordinal, original)
+			)
+			SELECT requested.ordinal, m.id FROM requested
+			CROSS JOIN LATERAL (
+				SELECT id FROM messages WHERE rfc_message_id_key = requested.original LIMIT $5
+			) m`,
+		"modifying CTE, outer SELECT reads only other tables": `
+			WITH upd AS (
+				UPDATE messages SET flagged = true WHERE id = $1 RETURNING agent_id
+			)
+			SELECT a.email FROM upd JOIN agent_identities a ON a.id = upd.agent_id`,
+		"WITH TIME ZONE is not a CTE": `
+			SELECT id, created_at::timestamp WITH TIME ZONE FROM messages WHERE id = $1`,
+		"modified table name inside a masked string literal is not a reference": `
+			WITH upd AS (
+				UPDATE messages SET status = 'read' WHERE id = $1 RETURNING id
+			)
+			SELECT x.note FROM upd JOIN audit_log x ON x.ref = upd.id AND x.kind = 'from messages'`,
+	}
+	for label, sql := range clean {
+		findings, _, _ := analyzeSQL(sql)
+		if len(findings) != 0 {
+			t.Errorf("matcher false-positived on a clean shape (%s): %v", label, findings)
+		}
+	}
+
+	// A prefix-collision guard: modifying table "messages" must not be
+	// "found" in a reference to "messages_archive".
+	findings, _, _ := analyzeSQL(`
+		WITH upd AS (
+			UPDATE messages SET status = 'read' WHERE id = $1 RETURNING id
+		)
+		SELECT a.id FROM upd JOIN messages_archive a ON a.src = upd.id`)
+	if len(findings) != 0 {
+		t.Errorf("matcher confused messages_archive with messages: %v", findings)
+	}
+}
+
+// TestScanParsedFileEndToEnd drives the same per-file pipeline the tree-wide
+// guard uses over synthetic Go source, pinning the parts a raw analyzeSQL
+// call can't reach: const-concatenation resolution (the ORIGINAL bug's outer
+// FROM clause lived in the package const engagementFrom — a literal-only scan
+// misses it), waiver comments, and stale-waiver detection.
+func TestScanParsedFileEndToEnd(t *testing.T) {
+	parse := func(t *testing.T, src string) (*token.FileSet, *ast.File, map[string]string) {
+		t.Helper()
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, "synthetic.go", src, parser.ParseComments)
+		if err != nil {
+			t.Fatalf("parse synthetic source: %v", err)
+		}
+		return fset, file, collectStringConsts(map[string]*ast.File{"synthetic.go": file})
+	}
+
+	t.Run("const concatenation reproducing the original bug is flagged", func(t *testing.T) {
+		fset, file, consts := parse(t, `package identity
+
+const engagementColumns = "ce.id, ce.stage, ce.updated_at"
+const engagementFrom = " FROM contact_engagements ce JOIN contacts c ON c.id = ce.contact_id"
+
+func q() string {
+	return "WITH updated AS (" +
+		"UPDATE contact_engagements SET stage = $4, updated_at = now() " +
+		"WHERE user_id = $1 RETURNING id" +
+		") SELECT " + engagementColumns + engagementFrom +
+		" WHERE ce.id = (SELECT id FROM updated)"
+}
+`)
+		scan := scanParsedFile(fset, "synthetic.go", file, consts)
+		if len(scan.violations) != 1 || !strings.Contains(scan.violations[0], "contact_engagements") {
+			t.Fatalf("expected exactly one contact_engagements violation, got %v", scan.violations)
+		}
+	})
+
+	t.Run("waiver comment suppresses the finding and registers as used", func(t *testing.T) {
+		fset, file, consts := parse(t, `package identity
+
+func q() string {
+	// cte-snapshot-safe: this read WANTS the pre-update row (audit trail diff).
+	return "WITH upd AS (UPDATE messages SET status = 'read' WHERE id = $1 RETURNING id) " +
+		"SELECT m.status FROM messages m WHERE m.id = (SELECT id FROM upd)"
+}
+`)
+		scan := scanParsedFile(fset, "synthetic.go", file, consts)
+		if len(scan.violations) != 0 {
+			t.Fatalf("waived query still flagged: %v", scan.violations)
+		}
+		if len(scan.staleWaivers) != 0 {
+			t.Fatalf("used waiver reported stale: %v", scan.staleWaivers)
+		}
+	})
+
+	t.Run("waiver that suppresses nothing is reported stale", func(t *testing.T) {
+		fset, file, consts := parse(t, `package identity
+
+func q() string {
+	// cte-snapshot-safe: left behind after the query was fixed.
+	return "WITH upd AS (UPDATE messages SET status = 'read' WHERE id = $1 RETURNING id) " +
+		"SELECT upd.id FROM upd"
+}
+`)
+		scan := scanParsedFile(fset, "synthetic.go", file, consts)
+		if len(scan.violations) != 0 {
+			t.Fatalf("clean query flagged: %v", scan.violations)
+		}
+		if len(scan.staleWaivers) != 1 {
+			t.Fatalf("expected one stale waiver, got %v", scan.staleWaivers)
+		}
+	})
+
+	t.Run("unresolvable dynamic fragments stay inert", func(t *testing.T) {
+		fset, file, consts := parse(t, `package identity
+
+func q(lockClause string) string {
+	return "WITH children AS (SELECT id FROM messages WHERE thread_parent_id = ANY($1) " +
+		lockClause +
+		") UPDATE messages AS m SET thread_parent_id = NULL FROM children WHERE m.id = children.id"
+}
+`)
+		scan := scanParsedFile(fset, "synthetic.go", file, consts)
+		if len(scan.violations) != 0 {
+			t.Fatalf("dynamic-fragment query flagged: %v", scan.violations)
+		}
+		if scan.withStatements != 1 {
+			t.Fatalf("expected the WITH statement to be recognised despite the placeholder, got %d", scan.withStatements)
+		}
+	})
+}

--- a/internal/sqlguard/cte_snapshot_guard_test.go
+++ b/internal/sqlguard/cte_snapshot_guard_test.go
@@ -1,0 +1,580 @@
+// Package sqlguard holds repo-wide static guards over the SQL embedded in Go
+// source. Test-only: there is no runtime code here, only tripwires in the
+// spirit of internal/logredact's logguard.
+package sqlguard
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestNoSelectFromCTEModifiedTable is a tripwire for one Postgres hazard: a
+// data-modifying CTE (WITH x AS (UPDATE/INSERT/DELETE … RETURNING …)) whose
+// outer statement SELECTs from the table the CTE modified, instead of from
+// the CTE's RETURNING output.
+//
+// In Postgres, ALL parts of one statement run on the same snapshot, taken
+// before the statement's own writes: the outer query of a data-modifying CTE
+// therefore sees the table as it was BEFORE the CTE's UPDATE/INSERT/DELETE.
+// `WITH updated AS (UPDATE t … RETURNING id) SELECT … FROM t WHERE t.id =
+// (SELECT id FROM updated)` silently returns the PRE-update row. That is not
+// theoretical: UpdateEngagementIfUnchanged (internal/identity/engagements.go)
+// shipped exactly that shape — the conditional engagement update committed
+// the new state but returned the old row, so the derived ETag never matched
+// again and every guarded read-modify-write chain died with 412. It was
+// caught only by the first live staging conformance run (e2a-ops
+// release-pipeline run 30612956986); no offline gate looked at the shape.
+// The fix (PR #775) splits the statement: UPDATE … RETURNING id, then a
+// second read by primary key in the same transaction, which does see the
+// first statement's writes. Reading FROM the CTE's own RETURNING output
+// (`SELECT … FROM updated …`) is equally safe and stays a single statement —
+// GetPrincipalByAPIKey and GetMessageWithContent (internal/identity) are the
+// in-tree reference examples.
+//
+// What the guard does: for every tracked non-test .go file it resolves each
+// string expression (including `+` concatenation chains, substituting
+// same-package const strings — the original bug's outer FROM clause lived in
+// the package const `engagementFrom`, so a literal-only scan would have
+// missed it), finds WITH clauses, classifies each CTE body as data-modifying
+// or read-only, and fails if a statement with a data-modifying CTE has an
+// outer SELECT that references a modified table via FROM/JOIN.
+//
+// What it deliberately does NOT flag, so it stays conservative:
+//   - Read-only CTEs (the webhook/webhookpub lease queries, thread_identity's
+//     threadAnchorBatchQuery, detachThreadChildrenBatchTx): no CTE write, no
+//     snapshot hazard of this class.
+//   - Outer statements that are themselves UPDATE/INSERT/DELETE (the lease
+//     queries' outer UPDATE … FROM candidates): a different statement shape
+//     with its own rules; this guard pins the SELECT-read-back class only.
+//   - SQL assembled through variables/function calls it cannot resolve —
+//     unresolvable fragments become inert placeholders. A hazard smuggled
+//     through dynamic SQL passes this guard; that stays a review concern.
+//
+// If this test failed on your change: either read back FROM the CTE's
+// RETURNING output, or split the write and the read into two statements in
+// one transaction (see UpdateEngagementIfUnchanged). If the outer SELECT's
+// read of the modified table is GENUINELY intentional — you want the
+// pre-write snapshot — add a `// cte-snapshot-safe: <reason>` comment on the
+// line(s) directly above the query string and the guard will skip it (and
+// will flag the waiver as stale if the query stops matching).
+func TestNoSelectFromCTEModifiedTable(t *testing.T) {
+	root := moduleRoot(t)
+
+	byDir := map[string][]string{}
+	for _, rel := range guardedGoFiles(t, root) {
+		byDir[filepath.Dir(rel)] = append(byDir[filepath.Dir(rel)], rel)
+	}
+
+	filesChecked := 0
+	withStatements := 0
+	modifyingCTEStatements := 0
+	var violations []string
+	var staleWaivers []string
+
+	for _, files := range byDir {
+		fset := token.NewFileSet()
+		parsed := make(map[string]*ast.File, len(files))
+		for _, rel := range files {
+			f, err := parser.ParseFile(fset, filepath.Join(root, filepath.FromSlash(rel)), nil, parser.ParseComments)
+			if err != nil {
+				t.Fatalf("parse %s: %v", rel, err)
+			}
+			parsed[rel] = f
+			filesChecked++
+		}
+		consts := collectStringConsts(parsed)
+
+		for _, rel := range files {
+			scan := scanParsedFile(fset, rel, parsed[rel], consts)
+			withStatements += scan.withStatements
+			modifyingCTEStatements += scan.modifyingCTEStatements
+			violations = append(violations, scan.violations...)
+			staleWaivers = append(staleWaivers, scan.staleWaivers...)
+		}
+	}
+
+	for _, v := range violations {
+		t.Errorf("%s\n"+
+			"In Postgres the outer query of a data-modifying CTE runs on the statement\n"+
+			"snapshot, which predates the CTE's own writes — the SELECT returns the\n"+
+			"PRE-write row (this killed UpdateEngagementIfUnchanged's ETag chain; found\n"+
+			"live by the staging conformance gate, fixed in PR #775). Read FROM the CTE's\n"+
+			"RETURNING output instead (see GetPrincipalByAPIKey / GetMessageWithContent in\n"+
+			"internal/identity), or split write and read into two statements in one\n"+
+			"transaction (see UpdateEngagementIfUnchanged), or — only if the pre-write\n"+
+			"snapshot is genuinely intended — waive with `// cte-snapshot-safe: <reason>`\n"+
+			"directly above the query string.", v)
+	}
+	for _, w := range staleWaivers {
+		t.Errorf("%s: `cte-snapshot-safe` waiver matches no flagged query — remove the stale waiver", w)
+	}
+
+	// Non-vacuity: the guard must actually be seeing the tree's SQL. Today's
+	// tree carries several WITH statements (webhook/webhookpub leases,
+	// thread_identity) and at least two data-modifying CTEs that read from
+	// their RETURNING output (GetPrincipalByAPIKey, GetMessageWithContent).
+	// If parsing or resolution drifts so these are no longer recognised, fail
+	// loudly rather than pass over an empty denominator.
+	if filesChecked == 0 {
+		t.Fatal("scanned no Go source files — file discovery is broken")
+	}
+	if withStatements < 4 {
+		t.Fatalf("recognised only %d WITH statement(s) across the tree (expected >= 4) — the SQL extraction has drifted", withStatements)
+	}
+	if modifyingCTEStatements < 2 {
+		t.Fatalf("recognised only %d statement(s) with a data-modifying CTE (expected >= 2) — the CTE classifier has drifted", modifyingCTEStatements)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Per-file scan (shared by the tree-wide guard and the self-tests)
+// ---------------------------------------------------------------------------
+
+type fileScan struct {
+	violations             []string
+	staleWaivers           []string
+	withStatements         int
+	modifyingCTEStatements int
+}
+
+func scanParsedFile(fset *token.FileSet, rel string, file *ast.File, consts map[string]string) fileScan {
+	var scan fileScan
+	waivers := waiverLines(fset, file)
+	usedWaivers := map[int]bool{}
+
+	forEachStringExpr(file, func(expr ast.Expr) {
+		sql, ok := resolveString(expr, consts)
+		if !ok {
+			return
+		}
+		findings, hasWith, hasModifying := analyzeSQL(sql)
+		if hasWith {
+			scan.withStatements++
+		}
+		if hasModifying {
+			scan.modifyingCTEStatements++
+		}
+		if len(findings) == 0 {
+			return
+		}
+		start := fset.Position(expr.Pos()).Line
+		end := fset.Position(expr.End()).Line
+		if line, ok := waiverInRange(waivers, start-2, end); ok {
+			usedWaivers[line] = true
+			return
+		}
+		for _, f := range findings {
+			scan.violations = append(scan.violations, fmt.Sprintf(
+				"%s:%d: CTE %q modifies table %q but the outer SELECT reads FROM/JOIN %q",
+				rel, start, f.cte, f.table, f.table))
+		}
+	})
+
+	for _, line := range waivers {
+		if !usedWaivers[line] {
+			scan.staleWaivers = append(scan.staleWaivers, fmt.Sprintf("%s:%d", rel, line))
+		}
+	}
+	return scan
+}
+
+// ---------------------------------------------------------------------------
+// SQL analysis
+// ---------------------------------------------------------------------------
+
+type finding struct {
+	cte   string // CTE name
+	table string // table the CTE modifies and the outer SELECT reads
+}
+
+var (
+	withStart    = regexp.MustCompile(`(?is)\bWITH\s+(RECURSIVE\s+)?`)
+	cteHeader    = regexp.MustCompile(`(?is)^\s*([A-Za-z_][A-Za-z0-9_]*)\s*(?:\([^)]*\)\s*)?AS\s+(?:NOT\s+MATERIALIZED\s+|MATERIALIZED\s+)?\(`)
+	updateTarget = regexp.MustCompile(`(?is)^\s*UPDATE\s+(?:ONLY\s+)?(?:[A-Za-z_][A-Za-z0-9_]*\.)?([A-Za-z_][A-Za-z0-9_]*)`)
+	insertTarget = regexp.MustCompile(`(?is)^\s*INSERT\s+INTO\s+(?:[A-Za-z_][A-Za-z0-9_]*\.)?([A-Za-z_][A-Za-z0-9_]*)`)
+	deleteTarget = regexp.MustCompile(`(?is)^\s*DELETE\s+FROM\s+(?:ONLY\s+)?(?:[A-Za-z_][A-Za-z0-9_]*\.)?([A-Za-z_][A-Za-z0-9_]*)`)
+	outerSelect  = regexp.MustCompile(`(?is)^\s*\(*\s*SELECT\b`)
+)
+
+// analyzeSQL scans one resolved SQL string. Returns the violations, whether a
+// WITH clause (CTE list) was recognised, and whether any recognised CTE was
+// data-modifying (both counters feed the guard's non-vacuity checks).
+//
+// Every `WITH` occurrence is tried until one parses as a CTE list, so
+// non-CTE uses of the keyword (`timestamp WITH time zone`, `WITH
+// ORDINALITY`) can neither shadow a real CTE nor trip the parser.
+func analyzeSQL(sql string) (findings []finding, hasWith, hasModifying bool) {
+	masked := maskLiteralsAndComments(sql)
+
+	for _, loc := range withStart.FindAllStringIndex(masked, -1) {
+		findings, ok, modifying := analyzeCTEListAt(masked, loc[1])
+		if ok {
+			return findings, true, modifying
+		}
+	}
+	return nil, false, false
+}
+
+// analyzeCTEListAt parses a CTE list starting just past a WITH keyword at
+// offset rest. ok is false when the text there is not a CTE list.
+func analyzeCTEListAt(masked string, rest int) (findings []finding, ok, hasModifying bool) {
+	type cte struct {
+		name  string
+		table string // non-empty when data-modifying
+	}
+	var ctes []cte
+
+	for {
+		m := cteHeader.FindStringSubmatchIndex(masked[rest:])
+		if m == nil {
+			return nil, false, false
+		}
+		name := masked[rest+m[2] : rest+m[3]]
+		bodyStart := rest + m[1] // just past the opening paren
+		bodyEnd := matchParen(masked, bodyStart)
+		if bodyEnd < 0 {
+			return nil, false, false
+		}
+		body := masked[bodyStart:bodyEnd]
+
+		entry := cte{name: name}
+		for _, target := range []*regexp.Regexp{updateTarget, insertTarget, deleteTarget} {
+			if tm := target.FindStringSubmatch(body); tm != nil {
+				entry.table = strings.ToLower(tm[1])
+				break
+			}
+		}
+		ctes = append(ctes, entry)
+
+		rest = bodyEnd + 1
+		// Skip whitespace; a comma continues the CTE list.
+		for rest < len(masked) && (masked[rest] == ' ' || masked[rest] == '\t' || masked[rest] == '\n' || masked[rest] == '\r') {
+			rest++
+		}
+		if rest < len(masked) && masked[rest] == ',' {
+			rest++
+			continue
+		}
+		break
+	}
+
+	for _, c := range ctes {
+		if c.table != "" {
+			hasModifying = true
+		}
+	}
+	outer := masked[rest:]
+	if !hasModifying || !outerSelect.MatchString(outer) {
+		return nil, true, hasModifying
+	}
+
+	for _, c := range ctes {
+		if c.table == "" {
+			continue
+		}
+		// The outer SELECT referencing the modified table via FROM or JOIN —
+		// anywhere, including subqueries — reads the pre-write snapshot.
+		ref := regexp.MustCompile(`(?is)\b(?:FROM|JOIN)\s+(?:ONLY\s+)?(?:[A-Za-z_][A-Za-z0-9_]*\.)?` + regexp.QuoteMeta(c.table) + `\b`)
+		if ref.MatchString(outer) {
+			findings = append(findings, finding{cte: c.name, table: c.table})
+		}
+	}
+	return findings, true, hasModifying
+}
+
+// maskLiteralsAndComments blanks single-quoted SQL literals and `--` line
+// comments so their content can't confuse paren matching or keyword scans.
+// Replacement preserves length and line structure.
+func maskLiteralsAndComments(sql string) string {
+	b := []byte(sql)
+	for i := 0; i < len(b); i++ {
+		switch {
+		case b[i] == '\'':
+			for j := i + 1; j < len(b); j++ {
+				if b[j] == '\'' {
+					// Escaped '' quote: mask and continue the literal.
+					if j+1 < len(b) && b[j+1] == '\'' {
+						b[j], b[j+1] = ' ', ' '
+						j++
+						continue
+					}
+					for k := i + 1; k < j; k++ {
+						if b[k] != '\n' {
+							b[k] = ' '
+						}
+					}
+					i = j
+					break
+				}
+				if j == len(b)-1 {
+					i = j // unterminated: mask to end
+					for k := i; k < len(b); k++ {
+						if b[k] != '\n' {
+							b[k] = ' '
+						}
+					}
+				}
+			}
+		case b[i] == '-' && i+1 < len(b) && b[i+1] == '-':
+			for j := i; j < len(b) && b[j] != '\n'; j++ {
+				b[j] = ' '
+			}
+		}
+	}
+	return string(b)
+}
+
+// matchParen returns the index of the ')' closing the paren just before
+// start (i.e. the body opened at start), or -1.
+func matchParen(s string, start int) int {
+	depth := 1
+	for i := start; i < len(s); i++ {
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// ---------------------------------------------------------------------------
+// Go-source string resolution
+// ---------------------------------------------------------------------------
+
+const exprPlaceholder = " __goexpr__ "
+
+// collectStringConsts maps every package-level string constant declared in
+// the directory's files to its (recursively resolved) value. This is what
+// lets the guard see through `"SELECT " + engagementColumns + engagementFrom`
+// — the shape the original bug used.
+func collectStringConsts(files map[string]*ast.File) map[string]string {
+	// Two passes so a const referencing a const declared later still resolves.
+	raw := map[string]ast.Expr{}
+	for _, f := range files {
+		for _, decl := range f.Decls {
+			gd, ok := decl.(*ast.GenDecl)
+			if !ok || gd.Tok != token.CONST {
+				continue
+			}
+			for _, spec := range gd.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for i, name := range vs.Names {
+					if i < len(vs.Values) {
+						raw[name.Name] = vs.Values[i]
+					}
+				}
+			}
+		}
+	}
+	resolved := map[string]string{}
+	var resolve func(name string, seen map[string]bool) (string, bool)
+	resolve = func(name string, seen map[string]bool) (string, bool) {
+		if v, ok := resolved[name]; ok {
+			return v, true
+		}
+		if seen[name] {
+			return "", false
+		}
+		seen[name] = true
+		expr, ok := raw[name]
+		if !ok {
+			return "", false
+		}
+		v, ok := resolveExpr(expr, func(ident string) (string, bool) { return resolve(ident, seen) })
+		if !ok {
+			return "", false
+		}
+		resolved[name] = v
+		return v, true
+	}
+	for name := range raw {
+		resolve(name, map[string]bool{})
+	}
+	return resolved
+}
+
+// resolveExpr renders a string expression: literals verbatim, identifiers via
+// lookup, anything else as an inert placeholder. The bool is false only when
+// the expression contains no string literal at all.
+func resolveExpr(expr ast.Expr, lookup func(string) (string, bool)) (string, bool) {
+	switch e := expr.(type) {
+	case *ast.BasicLit:
+		if e.Kind != token.STRING {
+			return exprPlaceholder, false
+		}
+		v, err := strconv.Unquote(e.Value)
+		if err != nil {
+			return exprPlaceholder, false
+		}
+		return v, true
+	case *ast.BinaryExpr:
+		if e.Op != token.ADD {
+			return exprPlaceholder, false
+		}
+		l, lok := resolveExpr(e.X, lookup)
+		r, rok := resolveExpr(e.Y, lookup)
+		return l + r, lok || rok
+	case *ast.ParenExpr:
+		return resolveExpr(e.X, lookup)
+	case *ast.Ident:
+		if v, ok := lookup(e.Name); ok {
+			return v, true
+		}
+		return exprPlaceholder, false
+	default:
+		return exprPlaceholder, false
+	}
+}
+
+func resolveString(expr ast.Expr, consts map[string]string) (string, bool) {
+	return resolveExpr(expr, func(name string) (string, bool) {
+		v, ok := consts[name]
+		return v, ok
+	})
+}
+
+// forEachStringExpr visits every MAXIMAL string-ish expression in the file:
+// a string literal or a `+` chain containing one, not nested inside a larger
+// chain (so one concatenated query is analyzed exactly once, whole).
+func forEachStringExpr(file *ast.File, visit func(ast.Expr)) {
+	ast.Inspect(file, func(n ast.Node) bool {
+		expr, ok := n.(ast.Expr)
+		if !ok || !isStringish(expr) {
+			return true
+		}
+		visit(expr)
+		return false // don't descend into the chain's parts
+	})
+}
+
+func isStringish(expr ast.Expr) bool {
+	switch e := expr.(type) {
+	case *ast.BasicLit:
+		return e.Kind == token.STRING
+	case *ast.BinaryExpr:
+		return e.Op == token.ADD && (isStringish(e.X) || isStringish(e.Y))
+	case *ast.ParenExpr:
+		return isStringish(e.X)
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Waivers
+// ---------------------------------------------------------------------------
+
+const waiverMarker = "cte-snapshot-safe:"
+
+// waiverLines returns the line numbers of every waiver comment in the file.
+func waiverLines(fset *token.FileSet, file *ast.File) []int {
+	var lines []int
+	for _, group := range file.Comments {
+		for _, c := range group.List {
+			if strings.Contains(c.Text, waiverMarker) {
+				lines = append(lines, fset.Position(c.Pos()).Line)
+			}
+		}
+	}
+	return lines
+}
+
+// waiverInRange reports whether a waiver comment sits within [lo, hi]
+// (typically the query string's span plus the two lines above it).
+func waiverInRange(waivers []int, lo, hi int) (int, bool) {
+	for _, line := range waivers {
+		if line >= lo && line <= hi {
+			return line, true
+		}
+	}
+	return 0, false
+}
+
+// ---------------------------------------------------------------------------
+// File discovery (same approach as internal/logredact's logguard: tracked
+// plus untracked-but-not-ignored files, so nested worktrees under gitignored
+// paths are never attributed to this tree)
+// ---------------------------------------------------------------------------
+
+func guardedGoFiles(t *testing.T, root string) []string {
+	t.Helper()
+
+	if out, err := exec.Command("git", "-C", root, "ls-files", "-z",
+		"--cached", "--others", "--exclude-standard", "*.go").Output(); err == nil {
+		var files []string
+		seen := map[string]bool{}
+		for _, rel := range strings.Split(string(out), "\x00") {
+			if rel == "" || strings.HasSuffix(rel, "_test.go") || seen[rel] {
+				continue
+			}
+			seen[rel] = true
+			files = append(files, rel)
+		}
+		return files
+	}
+
+	var files []string
+	if err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", "node_modules", "vendor", "web", "sdks", "docs":
+				return filepath.SkipDir
+			}
+			if path != root {
+				if _, statErr := os.Stat(filepath.Join(path, ".git")); statErr == nil {
+					return filepath.SkipDir
+				}
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		files = append(files, filepath.ToSlash(rel))
+		return nil
+	}); err != nil {
+		t.Fatalf("walk module source: %v", err)
+	}
+	return files
+}
+
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found above the test directory")
+		}
+		dir = parent
+	}
+}

--- a/sdks/python/tests/test_generated_header_guards.py
+++ b/sdks/python/tests/test_generated_header_guards.py
@@ -1,0 +1,162 @@
+"""Static audit: generated api modules must None-guard header params.
+
+The Python analogue of the TS SDK's static audit in
+sdks/typescript/test/v1/optional-header-params.test.ts, pinning the same bug
+class from the other side. Background: OpenAPI Generator's `typescript`
+generator emitted setHeaderParam(...) unconditionally for optional header
+params, so an omitted etag reached the wire as the literal string
+"If-Match: undefined" and every unkeyed contacts.update / contacts.setOutreach
+failed with 412 precondition_failed — found only by the first live staging
+conformance run (e2a-ops release-pipeline run 30612956986), because no offline
+gate looked at the emission. The TS pipeline now post-processes the generated
+code (scripts/guard-optional-header-params.py) and audits it in unit CI.
+
+The Python generator currently does the right thing on its own: every
+param-sourced header assignment it emits is guarded —
+
+    if if_match is not None:
+        _header_params['If-Match'] = if_match
+
+— but until this file, NOTHING pinned that. A generator upgrade or template
+change that dropped the guard would regenerate green (the freshness gate only
+checks the committed code matches the generator output — it re-blesses
+whatever the generator does) and ship `If-Match: None` on the wire, failing
+only at the staging gate again. This audit makes that a per-PR unit-CI
+failure instead.
+
+Rule enforced: in every generated api module, a header assignment whose
+right-hand side is a plain method parameter
+
+    _header_params['X'] = some_param
+
+must be immediately preceded by its own None guard (`if some_param is not
+None:`). Generator-internal assignments (Accept / Content-Type negotiation)
+assign from underscore-prefixed locals or method calls and are out of scope.
+
+The audit is deliberately stricter than "optional params only": the Python
+generator guards EVERY param-sourced header (including ones a spec marks
+required), so requiring the guard universally can't false-fail today's tree
+and needs no optionality inference from the public-method signatures. If a
+future header param legitimately must be emitted unguarded, add it to
+UNGUARDED_HEADER_ALLOWLIST with the reason (the TS pipeline has exactly one
+such exception, Idempotency-Key, whose retry layer needs the stub; the Python
+retry layer does not use that mechanism, so the list starts empty).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+GENERATED_API_DIR = (
+    Path(__file__).resolve().parent.parent / "src" / "e2a" / "v1" / "generated" / "api"
+)
+
+# Header names (lowercased) allowed to be assigned from a param WITHOUT a
+# None guard, mapped to the reason. Every entry is a decision — an unguarded
+# optional header goes on the wire rendered from None when omitted.
+UNGUARDED_HEADER_ALLOWLIST: dict[str, str] = {}
+
+# A param-sourced header assignment: RHS is a single plain identifier that
+# does not start with an underscore (generator-internal locals like
+# _content_type / _default_content_type are underscore-prefixed, and
+# negotiation assignments like select_header_accept(...) are calls, so
+# neither shape matches).
+HEADER_ASSIGNMENT = re.compile(
+    r"^(?P<indent>[ \t]*)_header_params\[(?P<quote>['\"])(?P<header>[^'\"]+)(?P=quote)\]"
+    r"\s*=\s*(?P<param>[A-Za-z][A-Za-z0-9_]*)\s*(?:#.*)?$"
+)
+
+
+def none_guard(param: str) -> re.Pattern[str]:
+    return re.compile(rf"^[ \t]*if\s+{re.escape(param)}\s+is\s+not\s+None\s*:\s*$")
+
+
+def audit_lines(lines: list[str]) -> tuple[list[tuple[int, str, str]], int]:
+    """Return ([(line_no, header, param) offenders], guarded_site_count)."""
+    offenders: list[tuple[int, str, str]] = []
+    guarded = 0
+    for i, line in enumerate(lines):
+        m = HEADER_ASSIGNMENT.match(line)
+        if m is None:
+            continue
+        if m.group("header").lower() in UNGUARDED_HEADER_ALLOWLIST:
+            continue
+        if i > 0 and none_guard(m.group("param")).match(lines[i - 1]):
+            guarded += 1
+            continue
+        offenders.append((i + 1, m.group("header"), m.group("param")))
+    return offenders, guarded
+
+
+def test_generated_api_files_none_guard_every_param_sourced_header() -> None:
+    api_files = sorted(GENERATED_API_DIR.glob("*_api.py"))
+    assert api_files, f"no generated api modules found under {GENERATED_API_DIR}"
+
+    offenders: list[str] = []
+    guarded_total = 0
+    for path in api_files:
+        file_offenders, guarded = audit_lines(
+            path.read_text(encoding="utf-8").splitlines()
+        )
+        guarded_total += guarded
+        offenders.extend(
+            f"{path.name}:{line_no} assigns header {header!r} from param "
+            f"{param!r} without an `if {param} is not None:` guard"
+            for line_no, header, param in file_offenders
+        )
+
+    assert not offenders, (
+        "generated Python api modules set param-sourced headers unconditionally "
+        "(an omitted optional param would reach the wire rendered from None, the "
+        "same bug class as the TS SDK's literal 'If-Match: undefined' — see this "
+        "file's docstring). Fix the generation pipeline (never hand-edit "
+        "generated code) or, if the emission is deliberate, add the header to "
+        "UNGUARDED_HEADER_ALLOWLIST with the reason:\n  " + "\n  ".join(offenders)
+    )
+
+    # Non-vacuity: today's tree carries guarded param-sourced header sites
+    # (contacts If-Match, messages Idempotency-Key). If a generator upgrade
+    # changes the emission shape so the audit no longer recognises ANY site,
+    # this must fail loudly rather than pass with an empty denominator.
+    assert guarded_total >= 2, (
+        f"audit recognised only {guarded_total} guarded header site(s) — the "
+        "generator's emission shape has drifted from what HEADER_ASSIGNMENT "
+        "matches; update the audit so it still sees the real header sites"
+    )
+
+
+def test_audit_discrimination() -> None:
+    """Pin the matcher's own behaviour on the shapes it must catch and skip."""
+    unguarded = [
+        "        _header_params['If-Match'] = if_match",
+        '        _header_params["X-Custom"] = custom',
+    ]
+    for line in unguarded:
+        offenders, _ = audit_lines(["        # process the header parameters", line])
+        assert offenders, f"audit missed an unguarded header assignment: {line!r}"
+
+    guarded = [
+        "        if if_match is not None:",
+        "            _header_params['If-Match'] = if_match",
+    ]
+    offenders, guarded_count = audit_lines(guarded)
+    assert not offenders and guarded_count == 1
+
+    # Guard for a DIFFERENT param must not satisfy the assignment's guard.
+    mismatched = [
+        "        if other_param is not None:",
+        "            _header_params['If-Match'] = if_match",
+    ]
+    offenders, _ = audit_lines(mismatched)
+    assert offenders, "audit accepted a None guard for the wrong param"
+
+    out_of_scope = [
+        # Generator-internal negotiation: call RHS and underscore locals.
+        "            _header_params['Accept'] = self.api_client.select_header_accept(",
+        "            _header_params['Content-Type'] = _content_type",
+        "                _header_params['Content-Type'] = _default_content_type",
+    ]
+    for line in out_of_scope:
+        offenders, _ = audit_lines([line])
+        assert not offenders, f"audit false-positived on generator plumbing: {line!r}"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -25,7 +25,7 @@
     "test:unit": "vitest run test/v1 --exclude '**/contract*.test.ts'",
     "test:coverage": "npm run typecheck && npm run test:unit -- --coverage && npm run test:types",
     "test:types": "tsc -p tsconfig.type-tests.json",
-    "test:contract": "vitest run test/v1/contract.test.ts test/v1/contract-client.test.ts",
+    "test:contract": "vitest run test/v1/contract.test.ts test/v1/contract-client.test.ts test/v1/contract-coverage.test.ts",
     "pretest:live": "rm -rf test/coverage/reports",
     "test:live": "vitest run --no-file-parallelism test/e2e.test.ts test/e2e-*.test.ts",
     "coverage:gate": "node test/coverage/gate.mjs",

--- a/sdks/typescript/test/v1/contract-coverage.test.ts
+++ b/sdks/typescript/test/v1/contract-coverage.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Per-PR live-contract coverage ratchet.
+ *
+ * The staging conformance suite is the only place most SDK methods meet a
+ * real server — and that gate runs post-merge, per release. That is how the
+ * `If-Match: undefined` bug (fixed in #774) shipped: the method existed, unit
+ * CI was green, and the first LIVE exercise of the path was staging run
+ * 30612956986. This gate gives the per-PR ts-contract job a coverage
+ * DENOMINATOR: every method on the ergonomic client must either be exercised
+ * by contract-client.test.ts (against cmd/e2a-contract-server) or carry an
+ * explicit entry in NOT_CONTRACT_TESTED below. A NEW SDK method therefore
+ * cannot land silently untested-against-a-live-server — adding it forces
+ * either a contract test or a visible, reviewable allowlist entry.
+ *
+ * Mechanics (deliberately cheap):
+ *  - Denominator: runtime introspection of the built client
+ *    (test/coverage/introspect.ts — the same walker the staging-side
+ *    coverage gate uses), so hand-listing can't drift.
+ *  - Numerator: static call sites in contract-client.test.ts —
+ *    `client.<path>.<method>(...)` chains, comments stripped. Static scan of
+ *    the suite's source, not runtime recording, so it needs no server and no
+ *    ordering guarantees; the flip side is that only DIRECT chains off
+ *    `client` are seen. Write contract tests that way (the whole file already
+ *    does), or the method counts as uncovered.
+ *  - The allowlist is pruned both ways: an entry whose method disappears, or
+ *    whose method gains a contract test, fails the gate until removed.
+ *
+ * This is a RATCHET, not a proof: a seeded entry means "known hole, decided
+ * at gate introduction" (full inventory below), and coverage claims nothing
+ * about assertion quality. Shrink the list by moving methods into
+ * contract-client.test.ts; never grow it without a reason that names why the
+ * contract server cannot exercise the method.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+import { E2AClient } from "../../src/v1/client.js";
+import { walkErgonomicSurface } from "../coverage/introspect.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Methods with no live per-PR contract test, each with the reason. Two
+ * legitimate kinds of entry:
+ *  - "contract server can't": the path needs infrastructure the shared test
+ *    server does not run (real SMTP egress/ingress, SES feedback, external
+ *    webhook targets, WebSocket lifecycles under vitest).
+ *  - "seeded": covered today only by the post-merge staging conformance
+ *    suite; carried over as-is when this gate was introduced. Removing seeds
+ *    by writing contract tests is welcome — the gate fails if an entry goes
+ *    stale, so the list can only shrink truthfully.
+ */
+const SEEDED =
+  "seeded at gate introduction — exercised only by the post-merge staging " +
+  "conformance suite (tests/e2e-prod + the SDK live-coverage gate); add a " +
+  "contract-client test to shrink this list";
+
+const NOT_CONTRACT_TESTED: Record<string, string> = {
+  // -- paths the contract server genuinely cannot exercise ------------------
+  "account.delete":
+    "irreversibly cascades the ONE shared contract-server account every suite " +
+    "in this vitest run depends on; mirrors the live gate's identical entry",
+  "account.suppressions.delete":
+    "an account-level suppression is only created by real SES bounce/complaint " +
+    "feedback, which the contract server does not run — nothing can exist to delete",
+  "domains.verify":
+    "verification checks real DNS records; a contract-server domain can never " +
+    "have them, so only the error path would be reachable",
+  "inbound.fromEvent":
+    "local webhook-payload adapter — no HTTP round trip, so there is no live " +
+    "contract to test; covered by offline inbound.test.ts fixtures",
+
+  // -- seeded inventory (known holes, decided when the gate landed) ---------
+  "account.apiKeys.list": SEEDED,
+  "account.export": SEEDED,
+  "account.get": SEEDED,
+  "account.suppressions.list": SEEDED,
+  "agents.createSuppression": SEEDED,
+  "agents.deleteSuppression": SEEDED,
+  "agents.getProtection": SEEDED,
+  "agents.list": SEEDED,
+  "agents.listSuppressions": SEEDED,
+  "agents.replaceProtection": SEEDED,
+  "agents.restore": SEEDED,
+  "agents.test": SEEDED,
+  "agents.update": SEEDED,
+  "contacts.deleteImport": SEEDED,
+  "contacts.deleteOutreach": SEEDED,
+  "contacts.get": SEEDED,
+  "contacts.getOutreach": SEEDED,
+  "contacts.getOutreachWithETag": SEEDED,
+  "contacts.import": SEEDED,
+  "contacts.list": SEEDED,
+  "contacts.outreach": SEEDED,
+  "conversations.get": SEEDED,
+  "conversations.list": SEEDED,
+  "domains.create": SEEDED,
+  "domains.delete": SEEDED,
+  "domains.get": SEEDED,
+  "domains.list": SEEDED,
+  "events.get": SEEDED,
+  "events.list": SEEDED,
+  "events.redeliver": SEEDED,
+  "info": SEEDED,
+  "listen": SEEDED,
+  "messages.delete": SEEDED,
+  "messages.forward": SEEDED,
+  "messages.get": SEEDED,
+  "messages.getAttachment": SEEDED,
+  "messages.getLifecycle": SEEDED,
+  "messages.list": SEEDED,
+  "messages.reply": SEEDED,
+  "messages.restore": SEEDED,
+  "messages.updateLabels": SEEDED,
+  "reviews.approve": SEEDED,
+  "reviews.get": SEEDED,
+  "reviews.list": SEEDED,
+  "reviews.reject": SEEDED,
+  "templates.create": SEEDED,
+  "templates.delete": SEEDED,
+  "templates.get": SEEDED,
+  "templates.getStarter": SEEDED,
+  "templates.list": SEEDED,
+  "templates.listStarters": SEEDED,
+  "templates.update": SEEDED,
+  "templates.validate": SEEDED,
+  "webhooks.create": SEEDED,
+  "webhooks.delete": SEEDED,
+  "webhooks.deliveries": SEEDED,
+  "webhooks.fetchMessage": SEEDED,
+  "webhooks.get": SEEDED,
+  "webhooks.list": SEEDED,
+  "webhooks.rotateSecret": SEEDED,
+  "webhooks.test": SEEDED,
+  "webhooks.update": SEEDED,
+};
+
+function coveredMethodIds(source: string): Set<string> {
+  const stripped = source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^\s*\/\/.*$/gm, "");
+  const covered = new Set<string>();
+  for (const match of stripped.matchAll(/\bclient((?:\.\w+)+)\(/g)) {
+    covered.add(match[1].slice(1));
+  }
+  return covered;
+}
+
+describe("live-contract coverage ratchet", () => {
+  // Pure reflection over the built client — no network, runs even when the
+  // contract-server env vars are absent (the check is static either way).
+  const surface = walkErgonomicSurface(
+    new E2AClient({ apiKey: "unused", baseUrl: "http://contract.invalid" }),
+  );
+  const covered = coveredMethodIds(
+    readFileSync(join(HERE, "contract-client.test.ts"), "utf8"),
+  );
+
+  it("every ergonomic method has a contract-client test or an explicit allowlist entry", () => {
+    const missing = surface.filter(
+      (id) => !covered.has(id) && !(id in NOT_CONTRACT_TESTED),
+    );
+    expect(
+      missing,
+      "these client methods have no live per-PR contract coverage — add a test " +
+        "to contract-client.test.ts (a direct `client.x.y(...)` call with result " +
+        "assertions) or an explicit NOT_CONTRACT_TESTED entry with the reason",
+    ).toEqual([]);
+  });
+
+  it("the allowlist stays the exact inventory of uncovered methods", () => {
+    const phantom = Object.keys(NOT_CONTRACT_TESTED).filter(
+      (id) => !surface.includes(id),
+    );
+    expect(
+      phantom,
+      "allowlist entries for methods the client no longer exposes — remove them",
+    ).toEqual([]);
+
+    const stale = Object.keys(NOT_CONTRACT_TESTED).filter((id) =>
+      covered.has(id),
+    );
+    expect(
+      stale,
+      "allowlisted methods now covered by contract-client.test.ts — remove the entries",
+    ).toEqual([]);
+  });
+
+  it("the scan itself is non-vacuous", () => {
+    // If the walker or the call-site regex drifts, fail loudly instead of
+    // passing over an empty denominator/numerator.
+    expect(surface.length).toBeGreaterThan(30);
+    expect(covered.has("agents.create")).toBe(true);
+    expect(covered.has("contacts.setOutreach")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why

The first live staging run of the v1.5.0 conformance suite (e2a-ops release-pipeline run 30612956986) caught two bug classes that offline CI structurally missed:

1. **Generated optional headers hitting the wire unguarded** — the TS generator emitted `setHeaderParam` unconditionally for optional params, so an omitted etag arrived as the literal `If-Match: undefined` and every unkeyed `contacts.update` / `contacts.setOutreach` failed 412. Fixed in #774 (generation-pipeline guard + TS static audit + offline RequestContext tests + live contract tests).
2. **Data-modifying CTE reading the statement snapshot** — `UpdateEngagementIfUnchanged` read the row back via the outer SELECT of a `WITH updated AS (UPDATE …)` statement; in Postgres that outer query predates the CTE's own write, so an accepted conditional update returned the pre-update row and a dead ETag. Fixed in #775.

Those PRs fixed the *instances*. This PR pins the *classes*.

## What each net catches

### A. Python SDK static header-guard audit (`sdks/python/tests/test_generated_header_guards.py`)
The Python generator already emits `if if_match is not None:` guards — but nothing pinned that. The generated-code freshness gate re-blesses whatever a new generator version emits, so a generator upgrade that dropped the guard would regenerate green and ship `If-Match: None`, failing only at the staging gate again. The audit (runs in the per-PR `python-sdk` job) fails if any generated api module assigns a param-sourced header without its own None guard, requires an explicit allowlist entry for any deliberate exception (empty today — unlike TS, Python's retry layer needs no Idempotency-Key stub), and carries non-vacuity + self-discrimination checks so emission-shape drift fails loudly instead of shrinking the denominator silently.

### B. CTE-snapshot guard (`internal/sqlguard`, runs in every plain `go test ./...`)
Repo-wide tripwire modeled on `internal/logredact`'s logguard. For every tracked non-test Go file it resolves each string expression **including `+` concatenation through package consts** — load-bearing: the original bug's outer `FROM contact_engagements` lived in the const `engagementFrom`, so a literal-only scan misses the actual incident. It then parses WITH clauses (paren-balanced, literal/comment-masked, tolerant of non-CTE `WITH TIME ZONE`/`WITH ORDINALITY`), classifies each CTE body, and fails when a data-modifying CTE's outer SELECT reads FROM/JOIN a modified table instead of the CTE's RETURNING output — with an error message explaining the snapshot hazard and pointing at `UpdateEngagementIfUnchanged`'s fix as the reference.

Kept conservative per #775's audit: read-only CTEs (webhook/webhookpub leases, `threadAnchorBatchQuery`, `detachThreadChildrenBatchTx`) and modifying CTEs read back through their RETURNING output (`GetPrincipalByAPIKey`, `GetMessageWithContent`) do not trigger. **The current tree passes with zero waivers.** Legitimate pre-write reads can waive with `// cte-snapshot-safe: <reason>` (stale waivers are themselves flagged).

### C. Live-contract coverage ratchet (`sdks/typescript/test/v1/contract-coverage.test.ts`)
Assessment answer: the per-PR ts-contract job had **no coverage denominator** — `contract.test.ts` interprets scenarios.yaml over raw HTTP, `contract-client.test.ts` exercised ~7 ergonomic methods, and nothing failed when a new SDK method shipped with no live per-PR test (exactly how the If-Match bug reached staging first). The cheap gate was feasible, so it's included: denominator = runtime introspection of the built client (`test/coverage/introspect.ts`, the same walker the staging-side live gate uses); numerator = direct `client.x.y(...)` call sites in `contract-client.test.ts`; every method must be exercised or carry an explicit `NOT_CONTRACT_TESTED` entry. The 66-entry seed is the honest inventory of today's gap (4 with specific can't-run reasons, 62 marked seeded), pruned in both directions — phantom and newly-covered entries fail the gate — so the list can only shrink truthfully. Wired into `npm run test:contract` (per-PR).

Residual gaps flagged as follow-ups (deliberately not built here):
- The numerator is a static call-site scan, not runtime recording — indirect calls aren't seen, and a skipped test still counts its sites. Upgrading to recorder-based coverage (recorder.ts machinery already exists) is straightforward if the seed list ever shrinks enough to make it worth it.
- The **python-contract** job has no equivalent: `tests/test_contract.py` is the scenario interpreter only; there is no Python analogue of `contract-client.test.ts`, so the Python ergonomic client has zero per-PR live coverage. Same ratchet pattern would apply if/when a Python contract-client suite exists.

### D. Conventions (AGENTS.md → Testing strategy)
Three new bullets: new SDK surface needs live coverage in per-PR CI, not only staging; generated clients are pipeline artifacts — never hand-edit, and the load-bearing emission shapes are pinned by static audits; data-modifying CTEs must not re-select from the modified table.

## Evidence the tree passes

- Python: `pytest tests/` under 3.12 with the coverage gate — **508 passed, 37 skipped** (includes the new audit); `mypy` clean; mutation check: stripping one real `if if_match is not None:` guard from `contacts_api.py` fails the audit.
- Go: `go build ./...`; `go test ./internal/sqlguard/` — all guards + discrimination suites pass, **zero waivers needed**; mutation check: restoring the pre-#775 `engagements.go` flags exactly `internal/identity/engagements.go: CTE "updated" modifies table "contact_engagements" but the outer SELECT reads FROM/JOIN "contact_engagements"`.
- TS: `npm run typecheck` clean; `test:unit` **233 passed**; full `npm run test:contract` against a locally built `cmd/e2a-contract-server` (CI-equivalent, Postgres-backed) — **3 files / 22 passed, 14 skipped** (seed-gated scenarios, same as CI), including the ratchet's 3 tests green on the seeded allowlist.
- `scripts/check-repository-text-integrity.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)