### PR TITLE
docs: catch up CHANGELOGs for contacts, scheduled send, and threadId

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -40,6 +40,23 @@ configuration failure. `0`/`1`/`4` keep their existing meanings for healthy,
 transient-connectivity, and authentication outcomes. Every network operation
 is bounded by a 5-second timeout.
 
+**Added:** `e2a contacts` — manage account-level contact identity and
+per-agent outreach state, with suppression visibility (`list`/`get`/
+`create`/`update`/`delete`/`import`/`imports delete`, plus `outreach
+list`/`get`/`set`/`delete`). Contact identity operations require account
+scope; `outreach` also supports an agent-scoped credential for its bound
+inbox. `create`/`import` accept `--idempotency-key`; `update`/`outreach set`
+accept `--if-match <etag>` to reject a stale edit.
+
+**Added:** `--send-at` on `send`/`reply` — schedule a future send (RFC 3339
+with an explicit UTC offset, at most 90 days ahead). Beta and may change
+before it is declared stable. A future schedule exits `0` with
+`status=scheduled` and is durably queued, so do not retry.
+
+**Added:** beta `threadId` on message list/get/listen JSON — a server-owned,
+read-only mailbox-local identity, distinct from the caller-owned
+`conversation_id` filter. Human-readable formats are unchanged.
+
 ## 2.0.0
 
 A major bump: the published 1.6.0 and this tree had diverged

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -29,6 +29,25 @@ parameters are keyword-only with defaults that preserve 5.3.0 behavior.
   address (``none`` | ``pending`` | ``verified`` | ``failed``, with detail in
   ``sending_error``). Both are open string sets — tolerate unknown values.
 
+- **`client.contacts`** — manage the people an account corresponds with:
+  `list`/`get`/`get_with_etag`/`create`/`update`/`delete` (account-scoped,
+  optimistic concurrency via `if_match`), plus `import_`/`delete_import` for
+  structured-row bulk imports. `client.contacts.outreach(email, ...)` and its
+  `get_outreach`/`get_outreach_with_etag`/`set_outreach`/`delete_outreach`
+  counterparts track one agent's per-contact engagement (stage, next action,
+  reply/suppression state) and may be driven by an agent-scoped credential.
+  Available on both `AsyncE2AClient` and the synchronous `E2AClient`.
+- **``send_at`` on ``messages.send`` / ``.reply`` / ``.forward``** — schedule a
+  future send with a timezone-aware ``datetime``, no more than 90 days ahead.
+  Beta and may change before it is declared stable. The durable ``scheduled``
+  result is success, not a reason to retry; even with ``wait="sent"`` it
+  returns immediately rather than holding the HTTP request until the future
+  time.
+- **``message.thread_id``** — an optional beta, server-owned, read-only
+  identity for the mailbox-local reply graph, exposed on message list/detail
+  models. Legacy messages can omit it. There is no ``thread_id`` request
+  field, list filter, thread endpoint, or complete-thread retrieval method.
+
 ### Fixed
 - **``unsubscribe=`` no longer mutates the caller's request model.** When the
   body was already a ``SendEmailRequest`` / ``ReplyRequest`` / ``ForwardRequest``

--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -29,6 +29,23 @@ Additive only. Every 5.3.0 call site keeps compiling and behaving identically.
   `pending` | `verified` | `failed`, with detail in `sendingError`). Both are
   open string sets — tolerate unknown values.
 
+- **`client.contacts`** — manage the people an account corresponds with:
+  `list`/`get`/`getWithETag`/`create`/`update`/`delete` (account-scoped,
+  optimistic concurrency via `ifMatch`), plus `import`/`deleteImport` for
+  structured-row bulk imports. `client.contacts.outreach(email, params)` and
+  its `getOutreach`/`getOutreachWithETag`/`setOutreach`/`deleteOutreach`
+  counterparts track one agent's per-contact engagement (stage, next action,
+  reply/suppression state) and may be driven by an agent-scoped credential.
+- **`sendAt` on `messages.send` / `.reply` / `.forward`** — schedule a future
+  send by passing a `Date`, no more than 90 days ahead. Beta and may change
+  before it is declared stable. The durable `scheduled` result is success, not
+  a reason to retry; even with `wait: "sent"` it returns immediately rather
+  than holding the HTTP request until the future time.
+- **`message.threadId`** — an optional beta, server-owned, read-only identity
+  for the mailbox-local reply graph, exposed on message list/detail models.
+  Legacy messages can omit it. There is no `threadId` request field, list
+  filter, thread endpoint, or complete-thread retrieval method.
+
 ### Fixed
 - **HTTP 410 now maps to `E2ANotFoundError`** in the status fallback, matching
   the family the `gone` error code already took in the code table. Previously a


### PR DESCRIPTION
## Summary

Routine documentation audit found that three already-shipped, already-README-documented features were never recorded in any CHANGELOG:

- The `contacts` resource (CLI `e2a contacts`, TS `client.contacts`, Python `client.contacts`)
- Scheduled sending (`--send-at` / `sendAt` / `send_at`)
- The beta `threadId` / `thread_id` message field

I grepped all three CHANGELOGs and confirmed zero occurrences of "contacts", "send-at"/"sendAt"/"send_at", or "threadId"/"thread_id" anywhere, while `cli/README.md`, `sdks/typescript/README.md`, and `sdks/python/README.md` all document these as current, available functionality. None of the three package versions were bumped for this work (`cli/package.json` is still `2.1.0`, `sdks/typescript/package.json` and `sdks/python/pyproject.toml` are still `5.4.0`, matching the top CHANGELOG heading in each file), so this PR appends `Added` entries to each package's existing top section rather than inventing a new version number.

Docs-only; no code, behavior, or version changes.

## Test plan

- [x] Verified via `grep` that the three CHANGELOGs had no mentions of contacts/send-at/threadId before this change
- [x] Cross-checked the new entries' method names/flags against `cli/src/commands/contacts.ts`, `sdks/typescript/src/v1/client.ts`, and `sdks/python/src/e2a/v1/client.py`

---
_Generated by [Claude Code](https://claude.ai/code/session_019sfe1MZDdE3McFV6zsj2FV)_