### PR TITLE
docs(design-system): fix stale Collapsible provenance in design-sync notes

### DIFF
--- a/design-system/.design-sync/NOTES.md
+++ b/design-system/.design-sync/NOTES.md
@@ -81,10 +81,17 @@ Durable, human-readable notes for future syncs. Committed.
   `Dot`, `Eyebrow`, `ThemeToggle`, `InkConsole`); brand SVGs in `web/public`
   (`Logo` — one themeable component replacing the 4 static svgs); and other
   app components ported CSS-driven (`Field` ← `Field.tsx`, `Avatar` ←
-  `CounterpartyAvatar`, `Collapsible` ← `messages/Collapsible.tsx`); plus
-  net-new `Card`. Still NOT synced: `PageShell`/`Topbar` (responsive Tailwind
-  layout — want Tailwind in the package first) and `Sidebar` (Next.js routing +
-  auth context).
+  `CounterpartyAvatar`); plus net-new `Card`. Still NOT synced: `PageShell`/
+  `Topbar` (responsive Tailwind layout — want Tailwind in the package first)
+  and `Sidebar` (Next.js routing + auth context).
+  **`Collapsible` is now orphaned:** it was ported from
+  `web/src/app/components/messages/Collapsible.tsx`, but that source file was
+  deleted in commit `b25046c` ("refactor(hitl): consolidate dashboard review
+  flow") when the authenticated review flow was consolidated onto `/reviews`
+  and the old disclosure-row UI it backed was removed. The design-system copy
+  (`design-system/src/Collapsible/`) still ships and is not upstream-tracked
+  by anything in `web/src` — treat it as a package-owned component going
+  forward, or drop it from the synced set if nothing consumes it.
 - **`Logo` and `Avatar` are token-faithful, not file-faithful.** `Logo` is one
   React component drawn from Loft tokens (the `web/public/*.svg` files are flat
   recolorings of the same marks); `Avatar` needs the `--av-1..8` palette, which


### PR DESCRIPTION
## Summary

Routine documentation audit found that `design-system/.design-sync/NOTES.md`'s component-provenance list still attributed `Collapsible` to `web/src/app/components/messages/Collapsible.tsx`. That file was deleted in `b25046c` ("refactor(hitl): consolidate dashboard review flow (#762)") when the disclosure-row UI it backed was retired in favor of `/reviews`. Confirmed there is no other file named `Collapsible` anywhere under `web/src`, and the design-system's own `Collapsible` (still exported from `design-system/src/index.ts`) is not imported by anything in `web/src` anymore.

Updated the note so a future design-sync run doesn't chase a path that no longer exists, and flagged the component as currently package-owned/unconsumed rather than upstream-tracked.

Docs-only; no component or build changes.

## Test plan

- [x] `grep -rn "Collapsible" web/src/` — confirmed no source file or import remains
- [x] Confirmed the deletion commit (`b25046c`) and its stated purpose via `git log`/`git show`

---
_Generated by [Claude Code](https://claude.ai/code/session_019sfe1MZDdE3McFV6zsj2FV)_