### PR TITLE
fix(limits): guard cache fills against a racing invalidation

### DIFF
--- a/internal/agent/limits_api.go
+++ b/internal/agent/limits_api.go
@@ -106,14 +106,14 @@ func (a *API) handleInvalidateLimits(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "user_id is required", http.StatusBadRequest)
 		return
 	}
-	// Bound what can enter the enforcer's cache map. Invalidate now records a
-	// generation tombstone for whatever key it is handed — it MUST, because a
-	// user with no cached entry is exactly the case the invalidate/fill race
-	// guard exists to cover: the generation has to advance so an in-flight
-	// fill can see it lost. That makes an unvalidated user_id an unbounded
-	// map-growth vector (the map has no TTL sweep), so the bound belongs here,
-	// at the edge, rather than in Invalidate where it would silently
-	// reintroduce the race.
+	// Shape-check the user_id before it reaches the enforcer. This is
+	// defense-in-depth, not the memory bound: the enforcer's process-wide
+	// invalidation epoch means Invalidate only ever DELETES map entries
+	// (see limits.DBEnforcer.Invalidate), so even an unvalidated user_id
+	// could not grow the cache. Rejecting garbage here still keeps the
+	// endpoint's contract tight and makes a misbehaving caller (a sidecar
+	// bug sending the wrong field) fail loudly instead of silently
+	// no-oping.
 	if !isUserID(req.UserID) {
 		http.Error(w, "user_id is malformed", http.StatusBadRequest)
 		return
@@ -132,7 +132,7 @@ const userIDLen = 32
 // userIDLen lowercase hex characters. A shape check, not an existence check —
 // confirming existence would mean a DB round trip on a path whose whole purpose
 // is to avoid one, and a well-formed id for a deleted user is harmless (it
-// tombstones a key nothing will ever read).
+// deletes a cache key nothing will ever read).
 func isUserID(s string) bool {
 	if len(s) != userIDLen {
 		return false

--- a/internal/agent/limits_api.go
+++ b/internal/agent/limits_api.go
@@ -60,6 +60,16 @@ type invalidateLimitsRequest struct {
 // it's an internal seam between the OSS server and its operator's
 // provisioner. Self-hosters who don't run a provisioner simply leave
 // InternalAPISecret empty and the endpoint 503s.
+//
+// Scope caveat: the cache this busts is PER PROCESS. One POST clears it
+// in exactly the server process that handled the request. An operator
+// running several server replicas behind a load balancer must fan the
+// call out to every replica (or accept that non-targeted replicas keep
+// serving the old caps until limits.cache_ttl_seconds expires); a
+// single POST through the load balancer only reaches one of them. The
+// enforcer's generation guard makes each individual invalidation
+// reliable — it cannot make one invalidation reach processes it was
+// never sent to.
 func (a *API) handleInvalidateLimits(w http.ResponseWriter, r *http.Request) {
 	if a.internalAPISecret == "" {
 		http.Error(w, "internal api not configured", http.StatusServiceUnavailable)

--- a/internal/agent/limits_api.go
+++ b/internal/agent/limits_api.go
@@ -106,9 +106,44 @@ func (a *API) handleInvalidateLimits(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "user_id is required", http.StatusBadRequest)
 		return
 	}
+	// Bound what can enter the enforcer's cache map. Invalidate now records a
+	// generation tombstone for whatever key it is handed — it MUST, because a
+	// user with no cached entry is exactly the case the invalidate/fill race
+	// guard exists to cover: the generation has to advance so an in-flight
+	// fill can see it lost. That makes an unvalidated user_id an unbounded
+	// map-growth vector (the map has no TTL sweep), so the bound belongs here,
+	// at the edge, rather than in Invalidate where it would silently
+	// reintroduce the race.
+	if !isUserID(req.UserID) {
+		http.Error(w, "user_id is malformed", http.StatusBadRequest)
+		return
+	}
 
 	a.enforcer.Invalidate(req.UserID)
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// userIDLen is the length of an identity user id: identity.generateID emits
+// 16 random bytes hex-encoded. NOTE it is NOT a UUID — validating as one would
+// reject every real user and take the endpoint down.
+const userIDLen = 32
+
+// isUserID reports whether s has the shape of an identity user id: exactly
+// userIDLen lowercase hex characters. A shape check, not an existence check —
+// confirming existence would mean a DB round trip on a path whose whole purpose
+// is to avoid one, and a well-formed id for a deleted user is harmless (it
+// tombstones a key nothing will ever read).
+func isUserID(s string) bool {
+	if len(s) != userIDLen {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if (c < '0' || c > '9') && (c < 'a' || c > 'f') {
+			return false
+		}
+	}
+	return true
 }
 
 func hmacHexSHA256(key, body []byte) string {

--- a/internal/agent/limits_api_test.go
+++ b/internal/agent/limits_api_test.go
@@ -171,11 +171,11 @@ func TestInvalidateLimits_503WhenSecretUnset(t *testing.T) {
 	}
 }
 
-// TestInvalidateLimits_RejectsMalformedUserID guards the growth vector the
-// generation change introduced. Invalidate now WRITES a tombstone for whatever
-// key it is given (it must — see the comment on limits.DBEnforcer.Invalidate),
-// and the cache map has no TTL sweep, so an unvalidated user_id would let a
-// caller mint permanent entries. The bound lives at the edge.
+// TestInvalidateLimits_RejectsMalformedUserID pins the edge shape check.
+// Since the process-wide invalidation epoch, this is defense-in-depth rather
+// than the memory bound (Invalidate only ever deletes map entries — see
+// limits.DBEnforcer.Invalidate); it keeps the endpoint's contract tight and
+// makes a caller sending the wrong field fail loudly.
 func TestInvalidateLimits_RejectsMalformedUserID(t *testing.T) {
 	const secret = "test-secret-malformed"
 	server, rec := setupAPIWithRecorder(t, secret)
@@ -198,11 +198,12 @@ func TestInvalidateLimits_RejectsMalformedUserID(t *testing.T) {
 }
 
 // TestInvalidateLimits_AcceptsWellFormedUncachedUserID is the counterweight to
-// the test above and pins the trap in the fix: the guard must still fire for a
-// user who has NO cached entry, because that is exactly the racing case
-// (miss -> DB read -> invalidate -> cachePut). A "only tombstone if an entry
-// already exists" bound would pass the malformed test and silently reintroduce
-// the original stale-limits bug.
+// the test above and pins the trap in the fix: the invalidate must still reach
+// the enforcer for a user who has NO cached entry, because that is exactly the
+// racing case (miss -> DB read -> invalidate -> cachePut) — the epoch has to
+// advance so the in-flight fill is dropped. An edge check that rejected
+// unknown-but-well-formed ids would silently reintroduce the original
+// stale-limits bug.
 func TestInvalidateLimits_AcceptsWellFormedUncachedUserID(t *testing.T) {
 	const secret = "test-secret-uncached"
 	server, rec := setupAPIWithRecorder(t, secret)

--- a/internal/agent/limits_api_test.go
+++ b/internal/agent/limits_api_test.go
@@ -55,6 +55,65 @@ func setupAPIWithLimits(t *testing.T, internalSecret string) (*httptest.Server, 
 	return server, store, pool, enf
 }
 
+// validUserID is the shape identity.generateID emits: 16 random bytes hex
+// encoded => 32 lowercase hex chars. NOT a UUID — validating the endpoint's
+// user_id as a UUID would reject every real user.
+const validUserID = "0123456789abcdef0123456789abcdef"
+
+// recordingEnforcer captures Invalidate calls so a test can assert the
+// handler never forwards a malformed user_id (and therefore never mints a
+// permanent cache entry for it).
+type recordingEnforcer struct {
+	limits.Enforcer
+	calls []string
+}
+
+func (r *recordingEnforcer) Invalidate(userID string) { r.calls = append(r.calls, userID) }
+
+// setupAPIWithRecorder is setupAPIWithLimits with the enforcer swapped for a
+// recorder, so tests can observe exactly what reaches Invalidate.
+func setupAPIWithRecorder(t *testing.T, internalSecret string) (*httptest.Server, *recordingEnforcer) {
+	t.Helper()
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	smtpRelay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{})
+	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
+	userAuth := auth.NewUserAuth(&config.OAuthConfig{}, store, false)
+	usageStore := usage.NewStore(pool)
+	rec := &recordingEnforcer{Enforcer: limits.NewEnforcer(
+		limits.NewStore(pool), usageStore,
+		limits.Defaults{PlanCode: "default", MaxAgents: 100, MaxDomains: 10, MaxMessagesMonth: 1_000_000, MaxStorageBytes: 1 << 40},
+		0,
+	)}
+
+	api := agent.NewAPI(store, sender, smtpRelay, userAuth, usage.NewNoopUsageTracker(), "e2a.dev", "test.e2a.dev", "agents.e2a.dev", "", false)
+	api.SetEnforcer(rec)
+	api.SetUsageStore(usageStore)
+	api.SetInternalAPISecret(internalSecret)
+
+	router := mux.NewRouter()
+	api.RegisterRoutes(router)
+	server := httptest.NewServer(router)
+	t.Cleanup(server.Close)
+	return server, rec
+}
+
+// postInvalidate signs and posts an invalidate request.
+func postInvalidate(t *testing.T, server *httptest.Server, secret, userID string) int {
+	t.Helper()
+	body := []byte(`{"user_id":"` + userID + `"}`)
+	h := hmac.New(sha256.New, []byte(secret))
+	h.Write(body)
+	req, _ := http.NewRequest("POST", server.URL+"/api/internal/limits/invalidate", bytes.NewReader(body))
+	req.Header.Set("X-E2A-Internal-Signature", hex.EncodeToString(h.Sum(nil)))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
 func TestInvalidateLimits_RejectsMissingSignature(t *testing.T) {
 	server, _, _, _ := setupAPIWithLimits(t, "test-secret-1")
 
@@ -84,7 +143,7 @@ func TestInvalidateLimits_AcceptsCorrectSignature(t *testing.T) {
 	secret := "test-secret-3"
 	server, _, _, _ := setupAPIWithLimits(t, secret)
 
-	body := []byte(`{"user_id":"u_xyz"}`)
+	body := []byte(`{"user_id":"0123456789abcdef0123456789abcdef"}`)
 	h := hmac.New(sha256.New, []byte(secret))
 	h.Write(body)
 	sig := hex.EncodeToString(h.Sum(nil))
@@ -109,5 +168,49 @@ func TestInvalidateLimits_503WhenSecretUnset(t *testing.T) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusServiceUnavailable {
 		t.Errorf("no-secret config: status = %d, want 503", resp.StatusCode)
+	}
+}
+
+// TestInvalidateLimits_RejectsMalformedUserID guards the growth vector the
+// generation change introduced. Invalidate now WRITES a tombstone for whatever
+// key it is given (it must — see the comment on limits.DBEnforcer.Invalidate),
+// and the cache map has no TTL sweep, so an unvalidated user_id would let a
+// caller mint permanent entries. The bound lives at the edge.
+func TestInvalidateLimits_RejectsMalformedUserID(t *testing.T) {
+	const secret = "test-secret-malformed"
+	server, rec := setupAPIWithRecorder(t, secret)
+
+	for _, bad := range []string{
+		"u_xyz",                             // legacy-looking, wrong shape
+		"0123456789ABCDEF0123456789ABCDEF",  // uppercase hex
+		"0123456789abcdef0123456789abcde",   // 31 chars
+		"0123456789abcdef0123456789abcdef0", // 33 chars
+		"0123456789abcdef0123456789abcdeg",  // non-hex char
+		"../../etc/passwd",                  // traversal-ish junk
+	} {
+		if code := postInvalidate(t, server, secret, bad); code != http.StatusBadRequest {
+			t.Errorf("user_id %q: status = %d, want 400", bad, code)
+		}
+	}
+	if len(rec.calls) != 0 {
+		t.Errorf("malformed user_ids reached Invalidate (would mint cache entries): %v", rec.calls)
+	}
+}
+
+// TestInvalidateLimits_AcceptsWellFormedUncachedUserID is the counterweight to
+// the test above and pins the trap in the fix: the guard must still fire for a
+// user who has NO cached entry, because that is exactly the racing case
+// (miss -> DB read -> invalidate -> cachePut). A "only tombstone if an entry
+// already exists" bound would pass the malformed test and silently reintroduce
+// the original stale-limits bug.
+func TestInvalidateLimits_AcceptsWellFormedUncachedUserID(t *testing.T) {
+	const secret = "test-secret-uncached"
+	server, rec := setupAPIWithRecorder(t, secret)
+
+	if code := postInvalidate(t, server, secret, validUserID); code != http.StatusNoContent {
+		t.Fatalf("well-formed uncached user_id: status = %d, want 204", code)
+	}
+	if len(rec.calls) != 1 || rec.calls[0] != validUserID {
+		t.Fatalf("Invalidate calls = %v, want exactly [%s]", rec.calls, validUserID)
 	}
 }

--- a/internal/limits/enforcer.go
+++ b/internal/limits/enforcer.go
@@ -46,9 +46,32 @@ type DBEnforcer struct {
 	cache map[string]cachedLimits
 }
 
+// cachedLimits is one user's cache slot. It doubles as an invalidation
+// tombstone: Invalidate does not delete the slot, it bumps gen and
+// zeroes expires (a zero expires is always in the past, so cacheGet
+// treats it as a miss). Retaining the slot is what lets a fill that was
+// already in flight discover that it raced an invalidation.
+//
+// gen is the per-user invalidation generation. Get samples it BEFORE
+// the DB read and hands it back to cachePut, which stores the fill only
+// if gen still matches. Without that check this interleaving silently
+// defeats an explicit invalidation:
+//
+//	T1 Get        -> cache miss, reads the OLD account_limits row
+//	T2 sidecar    -> commits NEW limits, POSTs /api/internal/limits/invalidate
+//	T2 Invalidate -> evicts the entry
+//	T1 cachePut   -> stores the PRE-write limits with a FRESH TTL
+//
+// A user who had just upgraded would then keep hitting 402
+// limit_exceeded for up to cacheTTL (60s in prod) even though billing
+// did everything right — defeating the one mechanism billing has to
+// make an upgrade take effect immediately. A counter rather than a
+// timestamp because two events inside one clock tick must still
+// compare as different.
 type cachedLimits struct {
 	limits  Limits
 	expires time.Time
+	gen     uint64
 }
 
 // NewEnforcer constructs the production enforcer. cacheTTL of 0 disables
@@ -77,9 +100,13 @@ func newEnforcerWithReader(reader limitsReader, counter Counter, defaults Defaul
 }
 
 func (e *DBEnforcer) Get(ctx context.Context, userID string) (Limits, error) {
-	if cached, ok := e.cacheGet(userID); ok {
+	cached, gen, ok := e.cacheGet(userID)
+	if ok {
 		return cached, nil
 	}
+	// gen was sampled together with the miss, i.e. strictly BEFORE the
+	// DB read below. cachePut re-checks it so a fill that raced an
+	// Invalidate is dropped instead of re-caching pre-write limits.
 	row, found, err := e.store.Get(ctx, userID)
 	if err != nil {
 		return Limits{}, err
@@ -96,14 +123,24 @@ func (e *DBEnforcer) Get(ctx context.Context, userID string) (Limits, error) {
 			MaxStorageBytes:  e.defaults.MaxStorageBytes,
 		}
 	}
-	e.cachePut(userID, resolved)
+	e.cachePut(userID, resolved, gen)
 	return resolved, nil
 }
 
+// Invalidate evicts the user's cached Limits and bumps their
+// invalidation generation, so any fill already in flight (one that read
+// account_limits before the caller's write committed) is discarded by
+// cachePut rather than stored with a fresh TTL.
 func (e *DBEnforcer) Invalidate(userID string) {
+	if e.cacheTTL <= 0 {
+		return
+	}
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	delete(e.cache, userID)
+	// Leave a tombstone rather than deleting: the bumped generation has
+	// to survive so a racing cachePut can see that it lost. expires is
+	// left zero, which cacheGet reads as already-expired (a miss).
+	e.cache[userID] = cachedLimits{gen: e.cache[userID].gen + 1}
 }
 
 func (e *DBEnforcer) CheckAgentCreate(ctx context.Context, userID string) error {
@@ -201,26 +238,39 @@ func safeInt64ToInt(v int64) int {
 	return int(v)
 }
 
-func (e *DBEnforcer) cacheGet(userID string) (Limits, bool) {
+// cacheGet returns the cached limits when they are present and unexpired.
+// It always returns the user's current invalidation generation alongside
+// the result — sampled under the same lock acquisition as the lookup —
+// so a caller that observes a miss can pass that generation to cachePut
+// and have the store rejected if an Invalidate landed in between.
+func (e *DBEnforcer) cacheGet(userID string) (Limits, uint64, bool) {
 	if e.cacheTTL <= 0 {
-		return Limits{}, false
+		return Limits{}, 0, false
 	}
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	c, ok := e.cache[userID]
 	if !ok || time.Now().After(c.expires) {
-		return Limits{}, false
+		return Limits{}, c.gen, false
 	}
-	return c.limits, true
+	return c.limits, c.gen, true
 }
 
-func (e *DBEnforcer) cachePut(userID string, l Limits) {
+// cachePut stores a fill only if the user's invalidation generation is
+// still the one the caller sampled before its DB read. A stale fill is
+// dropped outright rather than stored with a shorter TTL: the next
+// Get simply re-reads account_limits, which is the correct post-write
+// value and costs one query.
+func (e *DBEnforcer) cachePut(userID string, l Limits, gen uint64) {
 	if e.cacheTTL <= 0 {
 		return
 	}
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	e.cache[userID] = cachedLimits{limits: l, expires: time.Now().Add(e.cacheTTL)}
+	if e.cache[userID].gen != gen {
+		return
+	}
+	e.cache[userID] = cachedLimits{limits: l, expires: time.Now().Add(e.cacheTTL), gen: gen}
 }
 
 // Compile-time check: DBEnforcer satisfies the Enforcer interface and

--- a/internal/limits/enforcer.go
+++ b/internal/limits/enforcer.go
@@ -131,16 +131,39 @@ func (e *DBEnforcer) Get(ctx context.Context, userID string) (Limits, error) {
 // invalidation generation, so any fill already in flight (one that read
 // account_limits before the caller's write committed) is discarded by
 // cachePut rather than stored with a fresh TTL.
+//
+// The generation advances even for a user with NO cached entry. That is
+// deliberate and load-bearing: an uncached user is precisely the racing
+// case (miss → DB read → invalidate → cachePut), so skipping the
+// tombstone when the key is absent would reintroduce the exact bug this
+// guard exists to fix — the fill would come back at gen 0, match, and
+// cache the pre-write limits. The cost is that a caller can mint a map
+// entry for any key, so callers must bound what they pass;
+// handleInvalidateLimits validates the user-id shape for that reason.
 func (e *DBEnforcer) Invalidate(userID string) {
 	if e.cacheTTL <= 0 {
 		return
 	}
 	e.mu.Lock()
 	defer e.mu.Unlock()
+	e.ensureCacheLocked()
 	// Leave a tombstone rather than deleting: the bumped generation has
 	// to survive so a racing cachePut can see that it lost. expires is
 	// left zero, which cacheGet reads as already-expired (a miss).
 	e.cache[userID] = cachedLimits{gen: e.cache[userID].gen + 1}
+}
+
+// ensureCacheLocked lazily allocates the cache map. Both write paths
+// (Invalidate, cachePut) call it because writing to a nil map panics, and
+// Invalidate became a WRITE in the generation change — before it, it only
+// deleted, which is safe on a nil map. The constructors always allocate, so
+// this only covers a zero-value DBEnforcer built inside the package (the
+// fields are unexported, so no external package can construct one that way).
+// Caller must hold e.mu.
+func (e *DBEnforcer) ensureCacheLocked() {
+	if e.cache == nil {
+		e.cache = make(map[string]cachedLimits)
+	}
 }
 
 func (e *DBEnforcer) CheckAgentCreate(ctx context.Context, userID string) error {
@@ -270,6 +293,7 @@ func (e *DBEnforcer) cachePut(userID string, l Limits, gen uint64) {
 	if e.cache[userID].gen != gen {
 		return
 	}
+	e.ensureCacheLocked()
 	e.cache[userID] = cachedLimits{limits: l, expires: time.Now().Add(e.cacheTTL), gen: gen}
 }
 

--- a/internal/limits/enforcer.go
+++ b/internal/limits/enforcer.go
@@ -44,34 +44,38 @@ type DBEnforcer struct {
 
 	mu    sync.Mutex
 	cache map[string]cachedLimits
+
+	// gen is the process-wide invalidation epoch. Get samples it (via
+	// cacheGet, under mu) strictly BEFORE its DB read and hands it back
+	// to cachePut, which stores the fill only if the epoch has not
+	// advanced in between. Without that check this interleaving silently
+	// defeats an explicit invalidation:
+	//
+	//	T1 Get        -> cache miss, reads the OLD account_limits row
+	//	T2 sidecar    -> commits NEW limits, POSTs /api/internal/limits/invalidate
+	//	T2 Invalidate -> evicts the entry
+	//	T1 cachePut   -> stores the PRE-write limits with a FRESH TTL
+	//
+	// A user who had just upgraded would then keep hitting 402
+	// limit_exceeded for up to cacheTTL (60s in prod) even though
+	// billing did everything right — defeating the one mechanism billing
+	// has to make an upgrade take effect immediately. A counter rather
+	// than a timestamp because two events inside one clock tick must
+	// still compare as different.
+	//
+	// The epoch is process-wide, not per-user — see Invalidate for why
+	// (memory bound) and for the tradeoff that buys.
+	gen uint64
 }
 
-// cachedLimits is one user's cache slot. It doubles as an invalidation
-// tombstone: Invalidate does not delete the slot, it bumps gen and
-// zeroes expires (a zero expires is always in the past, so cacheGet
-// treats it as a miss). Retaining the slot is what lets a fill that was
-// already in flight discover that it raced an invalidation.
-//
-// gen is the per-user invalidation generation. Get samples it BEFORE
-// the DB read and hands it back to cachePut, which stores the fill only
-// if gen still matches. Without that check this interleaving silently
-// defeats an explicit invalidation:
-//
-//	T1 Get        -> cache miss, reads the OLD account_limits row
-//	T2 sidecar    -> commits NEW limits, POSTs /api/internal/limits/invalidate
-//	T2 Invalidate -> evicts the entry
-//	T1 cachePut   -> stores the PRE-write limits with a FRESH TTL
-//
-// A user who had just upgraded would then keep hitting 402
-// limit_exceeded for up to cacheTTL (60s in prod) even though billing
-// did everything right — defeating the one mechanism billing has to
-// make an upgrade take effect immediately. A counter rather than a
-// timestamp because two events inside one clock tick must still
-// compare as different.
+// cachedLimits is one user's cache slot: the resolved Limits and their
+// expiry. Invalidation state does not live here — the invalidation
+// epoch is the process-wide DBEnforcer.gen, which is what lets
+// Invalidate delete slots outright instead of retaining per-user
+// tombstones.
 type cachedLimits struct {
 	limits  Limits
 	expires time.Time
-	gen     uint64
 }
 
 // NewEnforcer constructs the production enforcer. cacheTTL of 0 disables
@@ -127,39 +131,46 @@ func (e *DBEnforcer) Get(ctx context.Context, userID string) (Limits, error) {
 	return resolved, nil
 }
 
-// Invalidate evicts the user's cached Limits and bumps their
-// invalidation generation, so any fill already in flight (one that read
-// account_limits before the caller's write committed) is discarded by
-// cachePut rather than stored with a fresh TTL.
+// Invalidate evicts the user's cached Limits and advances the
+// process-wide invalidation epoch, so any fill already in flight (one
+// that read account_limits before the caller's write committed) is
+// discarded by cachePut rather than stored with a fresh TTL.
 //
-// The generation advances even for a user with NO cached entry. That is
-// deliberate and load-bearing: an uncached user is precisely the racing
-// case (miss → DB read → invalidate → cachePut), so skipping the
-// tombstone when the key is absent would reintroduce the exact bug this
-// guard exists to fix — the fill would come back at gen 0, match, and
-// cache the pre-write limits. The cost is that a caller can mint a map
-// entry for any key, so callers must bound what they pass;
-// handleInvalidateLimits validates the user-id shape for that reason.
+// The epoch is process-wide rather than per-user so that Invalidate can
+// DELETE the slot instead of retaining a per-user generation tombstone.
+// A per-user generation must survive the invalidate (an uncached user
+// is precisely the racing case: miss → DB read → invalidate → cachePut),
+// which means every distinct userID ever passed here keeps a map entry
+// for the process lifetime — an unbounded-growth vector, since this is
+// reachable via the HMAC-authenticated /api/internal/limits/invalidate
+// endpoint and the map has no TTL sweep. The global epoch preserves the
+// race guard — it drops a strict superset of the fills a per-user
+// counter would drop — while making deletion the only map effect, so
+// the map is again bounded by users actually cached by real fills.
+//
+// Tradeoff: an Invalidate for user A that lands inside user B's fill
+// window also drops B's fill (a false drop: B's result is still
+// returned to its caller, just not cached, costing one extra DB read on
+// B's next request). Prod invalidates are Stripe-event-driven — a
+// handful per day — against millisecond fill windows, so the collision
+// rate is noise, and correctness is unaffected either way because a
+// dropped fill is simply re-read.
 func (e *DBEnforcer) Invalidate(userID string) {
 	if e.cacheTTL <= 0 {
 		return
 	}
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	e.ensureCacheLocked()
-	// Leave a tombstone rather than deleting: the bumped generation has
-	// to survive so a racing cachePut can see that it lost. expires is
-	// left zero, which cacheGet reads as already-expired (a miss).
-	e.cache[userID] = cachedLimits{gen: e.cache[userID].gen + 1}
+	e.gen++
+	delete(e.cache, userID) // delete is safe even on a nil map
 }
 
-// ensureCacheLocked lazily allocates the cache map. Both write paths
-// (Invalidate, cachePut) call it because writing to a nil map panics, and
-// Invalidate became a WRITE in the generation change — before it, it only
-// deleted, which is safe on a nil map. The constructors always allocate, so
-// this only covers a zero-value DBEnforcer built inside the package (the
-// fields are unexported, so no external package can construct one that way).
-// Caller must hold e.mu.
+// ensureCacheLocked lazily allocates the cache map, because writing to a
+// nil map panics. Only cachePut writes the map now (Invalidate is back
+// to delete, which is nil-safe), and the constructors always allocate,
+// so this only covers a zero-value DBEnforcer built inside the package
+// (the fields are unexported, so no external package can construct one
+// that way). Caller must hold e.mu.
 func (e *DBEnforcer) ensureCacheLocked() {
 	if e.cache == nil {
 		e.cache = make(map[string]cachedLimits)
@@ -262,10 +273,10 @@ func safeInt64ToInt(v int64) int {
 }
 
 // cacheGet returns the cached limits when they are present and unexpired.
-// It always returns the user's current invalidation generation alongside
+// It always returns the current process-wide invalidation epoch alongside
 // the result — sampled under the same lock acquisition as the lookup —
-// so a caller that observes a miss can pass that generation to cachePut
-// and have the store rejected if an Invalidate landed in between.
+// so a caller that observes a miss can pass that epoch to cachePut and
+// have the store rejected if any Invalidate landed in between.
 func (e *DBEnforcer) cacheGet(userID string) (Limits, uint64, bool) {
 	if e.cacheTTL <= 0 {
 		return Limits{}, 0, false
@@ -274,27 +285,29 @@ func (e *DBEnforcer) cacheGet(userID string) (Limits, uint64, bool) {
 	defer e.mu.Unlock()
 	c, ok := e.cache[userID]
 	if !ok || time.Now().After(c.expires) {
-		return Limits{}, c.gen, false
+		return Limits{}, e.gen, false
 	}
-	return c.limits, c.gen, true
+	return c.limits, e.gen, true
 }
 
-// cachePut stores a fill only if the user's invalidation generation is
-// still the one the caller sampled before its DB read. A stale fill is
-// dropped outright rather than stored with a shorter TTL: the next
-// Get simply re-reads account_limits, which is the correct post-write
-// value and costs one query.
+// cachePut stores a fill only if the invalidation epoch is still the one
+// the caller sampled before its DB read. A stale fill is dropped
+// outright rather than stored with a shorter TTL: the next Get simply
+// re-reads account_limits, which is the correct post-write value and
+// costs one query. The epoch being process-wide means an unrelated
+// user's invalidate can also drop this fill — intentionally conservative;
+// see Invalidate for the tradeoff.
 func (e *DBEnforcer) cachePut(userID string, l Limits, gen uint64) {
 	if e.cacheTTL <= 0 {
 		return
 	}
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	if e.cache[userID].gen != gen {
+	if e.gen != gen {
 		return
 	}
 	e.ensureCacheLocked()
-	e.cache[userID] = cachedLimits{limits: l, expires: time.Now().Add(e.cacheTTL), gen: gen}
+	e.cache[userID] = cachedLimits{limits: l, expires: time.Now().Add(e.cacheTTL)}
 }
 
 // Compile-time check: DBEnforcer satisfies the Enforcer interface and

--- a/internal/limits/limits_test.go
+++ b/internal/limits/limits_test.go
@@ -483,3 +483,55 @@ type wrappedErr struct{ inner error }
 
 func (w *wrappedErr) Error() string { return "wrapped: " + w.inner.Error() }
 func (w *wrappedErr) Unwrap() error { return w.inner }
+
+// TestEnforcer_InvalidateAdvancesGenerationForUncachedUser pins the trap in
+// the growth-bounding fix. It is tempting to bound the cache map by only
+// tombstoning when an entry already exists — that would be WRONG. A user with
+// no cached entry is exactly the racing case: the fill is in flight at gen 0,
+// and if Invalidate no-ops the fill comes back, matches gen 0, and caches the
+// pre-write limits with a fresh TTL — the original bug, restored. The
+// generation must advance for unknown users; the growth bound belongs at the
+// HTTP edge (handleInvalidateLimits validates the user-id shape).
+func TestEnforcer_InvalidateAdvancesGenerationForUncachedUser(t *testing.T) {
+	store := &fakeStore{row: raceOldRow, found: true}
+	e := newEnforcerWithReader(store, &fakeCounter{}, defaultsForTest(), time.Minute)
+
+	// No prior Get: "user1" has never been cached, so there is no entry for
+	// Invalidate to find.
+	store.onGet = func(callNo int) {
+		if callNo != 1 {
+			return
+		}
+		store.setRow(raceNewRow)
+		e.Invalidate("user1")
+	}
+
+	if _, err := e.Get(context.Background(), "user1"); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	got, err := e.Get(context.Background(), "user1")
+	if err != nil {
+		t.Fatalf("second Get: %v", err)
+	}
+	if got != raceNewRow {
+		t.Errorf("second Get = %+v, want %+v — the invalidate of an UNCACHED user must still advance the generation", got, raceNewRow)
+	}
+}
+
+// TestEnforcer_ZeroValueInvalidateDoesNotPanic pins the nil-map invariant.
+// Invalidate became a map WRITE in the generation change (it only deleted
+// before, which is safe on a nil map), so a DBEnforcer built as a zero value
+// would panic without either the cacheTTL<=0 early return or lazy init.
+func TestEnforcer_ZeroValueInvalidateDoesNotPanic(t *testing.T) {
+	// cacheTTL <= 0: the early return covers it (this is the shape the
+	// apiserver tests construct).
+	(&DBEnforcer{}).Invalidate("user1")
+
+	// cacheTTL > 0 with a nil map: only lazy init saves this.
+	e := &DBEnforcer{cacheTTL: time.Minute}
+	e.Invalidate("user1")
+	e.cachePut("user2", raceNewRow, 0)
+	if got, _, ok := e.cacheGet("user2"); !ok || got != raceNewRow {
+		t.Fatalf("cachePut on a lazily-initialized map: got %+v ok=%v", got, ok)
+	}
+}

--- a/internal/limits/limits_test.go
+++ b/internal/limits/limits_test.go
@@ -3,6 +3,7 @@ package limits
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -332,27 +333,40 @@ func TestEnforcer_CacheStillWorksAfterInvalidate(t *testing.T) {
 	}
 }
 
-// TestEnforcer_InvalidateIsPerUser: bumping one user's generation must
-// not drop another user's concurrent fill. A single process-wide
-// counter would fail this.
-func TestEnforcer_InvalidateIsPerUser(t *testing.T) {
+// TestEnforcer_InvalidateEvictsOnlyTheNamedUsersCachedEntry: Invalidate
+// deletes only the named user's CACHED entry — an unrelated user's
+// already-cached limits must keep serving from memory.
+//
+// Note what this test deliberately does NOT claim: that an unrelated
+// user's invalidate cannot drop another user's *in-flight fill*. Under
+// the process-wide invalidation epoch it can — intentionally so (the
+// epoch is what bounds the cache map; see Invalidate). A false drop
+// only costs one extra DB read on a path that already missed the cache.
+// What must never happen is a cached entry becoming collateral damage,
+// which is what this test pins.
+func TestEnforcer_InvalidateEvictsOnlyTheNamedUsersCachedEntry(t *testing.T) {
 	store := &fakeStore{row: raceOldRow, found: true}
 	e := newEnforcerWithReader(store, &fakeCounter{}, defaultsForTest(), time.Minute)
 
-	store.onGet = func(callNo int) {
-		if callNo == 1 {
-			e.Invalidate("other-user")
+	// Fill and cache user1, with no invalidation in flight.
+	if _, err := e.Get(context.Background(), "user1"); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	// Invalidate a different user entirely.
+	e.Invalidate("other-user")
+
+	// user1's cached entry must survive and keep serving from memory.
+	for i := 0; i < 3; i++ {
+		got, err := e.Get(context.Background(), "user1")
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if got != raceOldRow {
+			t.Errorf("Get #%d = %+v, want cached %+v", i+2, got, raceOldRow)
 		}
 	}
-
-	if _, err := e.Get(context.Background(), "user1"); err != nil {
-		t.Fatalf("Get: %v", err)
-	}
-	if _, err := e.Get(context.Background(), "user1"); err != nil {
-		t.Fatalf("Get: %v", err)
-	}
 	if n := store.callCount(); n != 1 {
-		t.Errorf("store hit %d times, want 1 (an unrelated user's invalidate must not drop this fill)", n)
+		t.Errorf("store hit %d times, want 1 (an unrelated user's invalidate must not evict this user's cached entry)", n)
 	}
 }
 
@@ -485,13 +499,14 @@ func (w *wrappedErr) Error() string { return "wrapped: " + w.inner.Error() }
 func (w *wrappedErr) Unwrap() error { return w.inner }
 
 // TestEnforcer_InvalidateAdvancesGenerationForUncachedUser pins the trap in
-// the growth-bounding fix. It is tempting to bound the cache map by only
-// tombstoning when an entry already exists — that would be WRONG. A user with
-// no cached entry is exactly the racing case: the fill is in flight at gen 0,
-// and if Invalidate no-ops the fill comes back, matches gen 0, and caches the
-// pre-write limits with a fresh TTL — the original bug, restored. The
-// generation must advance for unknown users; the growth bound belongs at the
-// HTTP edge (handleInvalidateLimits validates the user-id shape).
+// the growth-bounding fix. It is tempting to bound the cache map by no-oping
+// Invalidate when the user has no entry — that would be WRONG. A user with no
+// cached entry is exactly the racing case: the fill is in flight at the
+// sampled epoch, and if Invalidate no-ops the fill comes back, matches, and
+// caches the pre-write limits with a fresh TTL — the original bug, restored.
+// The epoch must advance for unknown users too; the process-wide epoch makes
+// that free (no per-user state to retain), which is precisely why the map
+// stays bounded.
 func TestEnforcer_InvalidateAdvancesGenerationForUncachedUser(t *testing.T) {
 	store := &fakeStore{row: raceOldRow, found: true}
 	e := newEnforcerWithReader(store, &fakeCounter{}, defaultsForTest(), time.Minute)
@@ -519,19 +534,78 @@ func TestEnforcer_InvalidateAdvancesGenerationForUncachedUser(t *testing.T) {
 }
 
 // TestEnforcer_ZeroValueInvalidateDoesNotPanic pins the nil-map invariant.
-// Invalidate became a map WRITE in the generation change (it only deleted
-// before, which is safe on a nil map), so a DBEnforcer built as a zero value
-// would panic without either the cacheTTL<=0 early return or lazy init.
+// Invalidate itself is nil-map-safe again (delete on a nil map is a no-op),
+// but cachePut still writes, so a zero-value DBEnforcer must survive the
+// whole invalidate-then-fill sequence via lazy init.
 func TestEnforcer_ZeroValueInvalidateDoesNotPanic(t *testing.T) {
 	// cacheTTL <= 0: the early return covers it (this is the shape the
 	// apiserver tests construct).
 	(&DBEnforcer{}).Invalidate("user1")
 
-	// cacheTTL > 0 with a nil map: only lazy init saves this.
+	// cacheTTL > 0 with a nil map: Invalidate must not panic, and a fill
+	// afterwards must lazily allocate the map. The epoch is sampled via
+	// the normal path (cacheGet), exactly as Get does.
 	e := &DBEnforcer{cacheTTL: time.Minute}
 	e.Invalidate("user1")
-	e.cachePut("user2", raceNewRow, 0)
+	_, gen, ok := e.cacheGet("user2")
+	if ok {
+		t.Fatalf("cacheGet on empty enforcer reported a hit")
+	}
+	e.cachePut("user2", raceNewRow, gen)
 	if got, _, ok := e.cacheGet("user2"); !ok || got != raceNewRow {
 		t.Fatalf("cachePut on a lazily-initialized map: got %+v ok=%v", got, ok)
+	}
+}
+
+// TestEnforcer_InvalidateNeverCachedUsersRetainsNothing pins the memory bound
+// that motivated the process-wide epoch. The per-user tombstone design
+// retained one map entry per distinct userID ever passed to Invalidate, for
+// the process lifetime — an unbounded-growth vector reachable through the
+// HMAC-authenticated /api/internal/limits/invalidate endpoint. Under the
+// epoch design Invalidate's only map effect is delete, so a flood of
+// invalidates for never-cached users must leave the map empty — and must not
+// have degraded the invalidate/fill race guard.
+func TestEnforcer_InvalidateNeverCachedUsersRetainsNothing(t *testing.T) {
+	store := &fakeStore{row: raceOldRow, found: true}
+	e := newEnforcerWithReader(store, &fakeCounter{}, defaultsForTest(), time.Minute)
+
+	const n = 10_000
+	for i := 0; i < n; i++ {
+		// Syntactically valid user-id shapes (32 lowercase hex chars),
+		// as would pass the handleInvalidateLimits shape check.
+		e.Invalidate(fmt.Sprintf("%032x", i))
+	}
+	e.mu.Lock()
+	retained := len(e.cache)
+	e.mu.Unlock()
+	if retained != 0 {
+		t.Fatalf("cache retained %d entries after %d invalidates of never-cached users, want 0", retained, n)
+	}
+
+	// The race guard must still hold after the flood: an invalidate landing
+	// inside the fill window drops the fill.
+	store.onGet = func(callNo int) {
+		if callNo != 1 {
+			return
+		}
+		store.setRow(raceNewRow)
+		e.Invalidate("user1")
+	}
+	if _, err := e.Get(context.Background(), "user1"); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	got, err := e.Get(context.Background(), "user1")
+	if err != nil {
+		t.Fatalf("second Get: %v", err)
+	}
+	if got != raceNewRow {
+		t.Errorf("second Get = %+v, want %+v (stale fill was cached after invalidate flood)", got, raceNewRow)
+	}
+	// Only the one genuinely-filled user occupies the map.
+	e.mu.Lock()
+	retained = len(e.cache)
+	e.mu.Unlock()
+	if retained != 1 {
+		t.Errorf("cache holds %d entries, want 1 (only users cached by real fills)", retained)
 	}
 }

--- a/internal/limits/limits_test.go
+++ b/internal/limits/limits_test.go
@@ -16,13 +16,41 @@ type fakeStore struct {
 	found bool
 	err   error
 	calls int
+
+	// onGet, when set, runs after the row has been captured but before
+	// Get returns — i.e. exactly in the window between the enforcer's DB
+	// read and its cachePut. It runs WITHOUT f.mu held so it may mutate
+	// the fake, and without the enforcer's mutex held so it may call
+	// Invalidate. This is the seam the invalidate/fill race tests use to
+	// reproduce the interleaving deterministically, with no sleeps.
+	onGet func(callNo int)
 }
 
 func (f *fakeStore) Get(ctx context.Context, userID string) (Limits, bool, error) {
 	f.mu.Lock()
-	defer f.mu.Unlock()
 	f.calls++
-	return f.row, f.found, f.err
+	callNo := f.calls
+	row, found, err := f.row, f.found, f.err
+	hook := f.onGet
+	f.mu.Unlock()
+
+	if hook != nil {
+		hook(callNo)
+	}
+	return row, found, err
+}
+
+func (f *fakeStore) setRow(l Limits) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.row = l
+	f.found = true
+}
+
+func (f *fakeStore) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
 }
 
 // fakeCounter implements Counter. Counts and storage are set directly
@@ -144,6 +172,187 @@ func TestEnforcer_InvalidateClearsCachedRow(t *testing.T) {
 	_, _ = e.Get(context.Background(), "user1")
 	if store.calls != 2 {
 		t.Errorf("store hit %d times after invalidate, want 2", store.calls)
+	}
+}
+
+// oldRow/newRow model a plan upgrade: the sidecar has just replaced the
+// Free row with the Pro row and is about to invalidate the cache.
+var (
+	raceOldRow = Limits{PlanCode: "free", MaxAgents: 3, MaxDomains: 1, MaxMessagesMonth: 100, MaxStorageBytes: 1 << 20}
+	raceNewRow = Limits{PlanCode: "pro", MaxAgents: 50, MaxDomains: 10, MaxMessagesMonth: 50_000, MaxStorageBytes: 1 << 30}
+)
+
+// TestEnforcer_InvalidateDuringFillIsNotCached reproduces the
+// invalidate/fill race deterministically: the invalidation lands in the
+// window between the enforcer's DB read and its cachePut.
+//
+//	Get -> miss -> store.Get reads the OLD row
+//	                 [sidecar commits the NEW row and invalidates]
+//	    -> cachePut
+//
+// Before the generation guard, that cachePut stored the pre-write
+// (Free) limits with a fresh 60s TTL, so the just-upgraded user kept
+// getting 402 limit_exceeded for a full TTL. The fill must be dropped.
+func TestEnforcer_InvalidateDuringFillIsNotCached(t *testing.T) {
+	store := &fakeStore{row: raceOldRow, found: true}
+	e := newEnforcerWithReader(store, &fakeCounter{}, defaultsForTest(), time.Minute)
+
+	store.onGet = func(callNo int) {
+		if callNo != 1 {
+			return
+		}
+		// The sidecar's commit + POST /api/internal/limits/invalidate,
+		// landing after the read above but before the cachePut below.
+		store.setRow(raceNewRow)
+		e.Invalidate("user1")
+	}
+
+	got, err := e.Get(context.Background(), "user1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	// The in-flight request itself legitimately sees the pre-write row;
+	// it read the DB before the write committed. What must not happen is
+	// that value being *cached*.
+	if got != raceOldRow {
+		t.Fatalf("first Get = %+v, want the row it actually read (%+v)", got, raceOldRow)
+	}
+
+	got, err = e.Get(context.Background(), "user1")
+	if err != nil {
+		t.Fatalf("second Get: %v", err)
+	}
+	if got != raceNewRow {
+		t.Errorf("second Get = %+v, want post-invalidate row %+v (stale fill was cached)", got, raceNewRow)
+	}
+	if n := store.callCount(); n != 2 {
+		t.Errorf("store hit %d times, want 2 (the invalidated fill must not have been cached)", n)
+	}
+}
+
+// TestEnforcer_InvalidateDuringFillIsNotCached_Concurrent is the same
+// race with a real second goroutine, so the mutex interleaving is
+// exercised too (this is the one that matters under `go test -race`).
+// The handshake keeps it deterministic: the reader parks inside
+// store.Get until the invalidator has finished.
+func TestEnforcer_InvalidateDuringFillIsNotCached_Concurrent(t *testing.T) {
+	store := &fakeStore{row: raceOldRow, found: true}
+	e := newEnforcerWithReader(store, &fakeCounter{}, defaultsForTest(), time.Minute)
+
+	readInFlight := make(chan struct{})
+	invalidated := make(chan struct{})
+	store.onGet = func(callNo int) {
+		if callNo != 1 {
+			return
+		}
+		close(readInFlight)
+		<-invalidated
+	}
+
+	done := make(chan Limits, 1)
+	go func() {
+		lim, err := e.Get(context.Background(), "user1")
+		if err != nil {
+			t.Errorf("concurrent Get: %v", err)
+		}
+		done <- lim
+	}()
+
+	<-readInFlight
+	store.setRow(raceNewRow)
+	e.Invalidate("user1")
+	close(invalidated)
+	<-done
+
+	got, err := e.Get(context.Background(), "user1")
+	if err != nil {
+		t.Fatalf("Get after race: %v", err)
+	}
+	if got != raceNewRow {
+		t.Errorf("Get after race = %+v, want %+v (stale fill won the race)", got, raceNewRow)
+	}
+}
+
+// TestEnforcer_MissFillIsCached is the counterweight: with no
+// invalidation in the window, a normal miss→fill must still populate
+// the cache and keep subsequent reads off the DB. A guard that dropped
+// every fill would pass the race tests and quietly turn the cache off.
+func TestEnforcer_MissFillIsCached(t *testing.T) {
+	store := &fakeStore{row: raceOldRow, found: true}
+	e := newEnforcerWithReader(store, &fakeCounter{}, defaultsForTest(), time.Minute)
+
+	first, err := e.Get(context.Background(), "user1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if first != raceOldRow {
+		t.Fatalf("Get = %+v, want %+v", first, raceOldRow)
+	}
+	// Change the underlying row without invalidating: the cache is
+	// authoritative until TTL, so the value must not move.
+	store.setRow(raceNewRow)
+	for i := 0; i < 3; i++ {
+		got, err := e.Get(context.Background(), "user1")
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if got != raceOldRow {
+			t.Errorf("Get #%d = %+v, want cached %+v", i+2, got, raceOldRow)
+		}
+	}
+	if n := store.callCount(); n != 1 {
+		t.Errorf("store hit %d times, want 1 (miss→fill must cache)", n)
+	}
+}
+
+// TestEnforcer_CacheStillWorksAfterInvalidate guards the tombstone: an
+// invalidated user must be re-cacheable, not permanently forced to hit
+// the DB on every request.
+func TestEnforcer_CacheStillWorksAfterInvalidate(t *testing.T) {
+	store := &fakeStore{row: raceOldRow, found: true}
+	e := newEnforcerWithReader(store, &fakeCounter{}, defaultsForTest(), time.Minute)
+
+	if _, err := e.Get(context.Background(), "user1"); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	store.setRow(raceNewRow)
+	e.Invalidate("user1")
+
+	for i := 0; i < 3; i++ {
+		got, err := e.Get(context.Background(), "user1")
+		if err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+		if got != raceNewRow {
+			t.Errorf("Get #%d = %+v, want %+v", i+1, got, raceNewRow)
+		}
+	}
+	if n := store.callCount(); n != 2 {
+		t.Errorf("store hit %d times, want 2 (one initial fill + one refill after invalidate)", n)
+	}
+}
+
+// TestEnforcer_InvalidateIsPerUser: bumping one user's generation must
+// not drop another user's concurrent fill. A single process-wide
+// counter would fail this.
+func TestEnforcer_InvalidateIsPerUser(t *testing.T) {
+	store := &fakeStore{row: raceOldRow, found: true}
+	e := newEnforcerWithReader(store, &fakeCounter{}, defaultsForTest(), time.Minute)
+
+	store.onGet = func(callNo int) {
+		if callNo == 1 {
+			e.Invalidate("other-user")
+		}
+	}
+
+	if _, err := e.Get(context.Background(), "user1"); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if _, err := e.Get(context.Background(), "user1"); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if n := store.callCount(); n != 1 {
+		t.Errorf("store hit %d times, want 1 (an unrelated user's invalidate must not drop this fill)", n)
 	}
 }
 


### PR DESCRIPTION
## The bug

`internal/limits/enforcer.go` caches resolved `account_limits` in-process for
`limits.cache_ttl_seconds` (60s in the hosted config). `cachePut` had no
generation guard, so this interleaving silently defeated an explicit
invalidation:

1. A request calls `Get` → cache miss → reads the **OLD** `account_limits` row.
2. The billing sidecar commits **NEW** limits and POSTs
   `/api/internal/limits/invalidate` (HMAC-authed) → the cache entry is deleted.
3. The in-flight `Get` from step 1 then `cachePut`s the **pre-write** limits with
   a **fresh** TTL.

**Customer-visible symptom:** a user who just upgraded their plan keeps hitting
spurious `402 limit_exceeded` for up to a minute. It self-heals on TTL, but it
defeats the one mechanism billing has to make an upgrade take effect
immediately — exactly the moment a paying customer is watching.

## The fix: a process-wide invalidation epoch

*(This section describes the current design. An earlier revision of this branch
used a per-user generation tombstone; review found that design retains one map
entry per distinct userID ever passed to `Invalidate` for the process lifetime —
an unbounded-growth vector (~283 bytes/entry, HMAC-authed endpoint, 2 GB VM with
no container mem_limit). The epoch design below addresses that finding.)*

A single **process-wide invalidation epoch** (`DBEnforcer.gen`, guarded by the
existing mutex):

- `cacheGet` returns the current epoch alongside the (missing) entry, sampled
  under the same lock acquisition as the lookup.
- `Get` carries that epoch across the DB read (no lock is held across it).
- `cachePut` stores the fill only if the epoch has not advanced; a losing fill
  is **dropped outright** (still returned to its caller, just not cached), so
  the next `Get` re-reads the post-write row — one extra query, no staleness.
- `Invalidate` **increments the epoch and deletes the entry**. No tombstone:
  the epoch survives on the enforcer itself, so an in-flight fill can still
  discover it lost even when the user had no cached entry — which is precisely
  the racing case, and there is a dedicated test pinning it.

**Why global is safe:** the epoch drops a strict superset of the fills the
per-user counter dropped, so it cannot reintroduce the stale-fill race. The
cost is an occasional cross-user false drop (one extra DB query) when an
invalidate lands inside another user's fill window; prod invalidates are
Stripe-event-driven — a handful per day — versus millisecond fill windows, so
the collision rate is noise.

**Why this bounds memory:** `delete` is now the only map effect of
`Invalidate`, so the cache is again bounded by users actually cached by real
fills — the pre-branch bound — while keeping the race guard. The earlier
"needs a TTL sweep" caveat is resolved by this design.

A counter rather than a timestamp because two events inside one clock tick
must still compare different.

### `isUserID` stays, as defense-in-depth

`handleInvalidateLimits` still 400s a malformed `user_id`. With the epoch
design this is no longer the memory bound (nothing the caller sends can grow
the map) — it stays because it keeps the endpoint contract tight and makes a
misbehaving caller fail loudly. **Note:** the original review suggested a UUID
parse — that would have taken the endpoint down. Identity user ids are **not**
UUIDs; `identity.generateID` emits 16 random bytes hex encoded (32 lowercase
hex chars), so a UUID parse would reject every real user. The check matches
the real shape.

## Deployment topology: a real gap this PR does NOT close

**Correcting an earlier version of this description, which claimed the hosted
blue/green setup was unaffected. That claim was wrong.** The corrected analysis,
verified against `e2a-ops`:

The sidecar posts to `http://haproxy:8080` and `be_http` does have the inactive
slot `disabled` — but **only in the durable config at rest**
(`haproxy/haproxy.bootstrap.cfg:123-124`). During a deploy,
`scripts/deploy-bluegreen.sh:289` sets the candidate `ready` **while the old
slot is still ready and serving**, and the old slot isn't drained until after a
health-wait loop bounded at 30×2s (typical overlap 2-10s). There is **no
`balance` directive**, so HAProxy defaults to roundrobin across *both* UP
servers in that window. The invalidate is a single POST with no retry and no
fan-out (`billing/internal/accountlimits/writer.go:115-142`; failure is logged
and swallowed).

The damaging interleaving: during the overlap a customer request lands on the
cold candidate and reads pre-write limits; the invalidate POST roundrobins to
the **old** slot; the candidate caches the stale value with a fresh TTL — and
then survives the deploy as the active slot. That's a **~60s (one TTL) spurious-
402 window that the generation guard cannot fix**, because the invalidate never
reached that process.

To be clear about scope: this is **pre-existing, and neither introduced nor
fixed by this PR**. Probability is very low — it needs a plan change to coincide
with a seconds-long cutover window that occurs once per deploy — and it
self-heals on TTL. The genuine fix is fanning the invalidate out to both slots,
or having the sidecar retry across them: ops/billing work, out of scope here.

The generically-correct scope note on the endpoint (`limits_api.go`) stands: one
POST clears the cache of exactly the process that served it, so any
multi-process deployment must fan out or accept the TTL.

Also confirmed there is only **one** cache layer for this data:
`internal/identity` reads `max_contacts` / `max_templates` / `max_webhooks`
straight from `account_limits` on every call, uncached.

## Tests

A `fakeStore.onGet` seam fires between the DB read and the `cachePut`, so the
race is reproduced **deterministically** — no sleeps, no flakes.

| Test | What it pins |
|---|---|
| `TestEnforcer_InvalidateDuringFillIsNotCached` | the core race: a fill that raced an invalidate must not be cached |
| `TestEnforcer_InvalidateDuringFillIsNotCached_Concurrent` (real goroutine + handshake, for `-race`) | same, with real mutex interleaving |
| `TestEnforcer_InvalidateAdvancesGenerationForUncachedUser` | the trap: an invalidate for a user with no entry must still advance the epoch |
| `TestEnforcer_InvalidateNeverCachedUsersRetainsNothing` | **new** — the memory bound: 10k invalidates for never-cached (well-formed) ids leave `len(cache) == 0`, and the race guard still holds afterwards |
| `TestEnforcer_InvalidateEvictsOnlyTheNamedUsersCachedEntry` | rewritten from `InvalidateIsPerUser`: an unrelated user's invalidate must not evict another user's **cached** entry (it may drop an in-flight **fill** — intentionally conservative under the global epoch; costs one DB read) |
| `TestEnforcer_ZeroValueInvalidateDoesNotPanic` | nil-map invariant; epoch now sampled via the normal `cacheGet` path |
| `TestInvalidateLimits_RejectsMalformedUserID` / `AcceptsWellFormedUncachedUserID` | the edge shape check (defense-in-depth) and its counterweight |
| `MissFillIsCached`, `CacheStillWorksAfterInvalidate` | counterweights — a guard that dropped *every* fill, or poisoned a user permanently, would pass the race tests |

```
$ go test -race ./internal/limits -count=1                                        # ok (all pass)
$ go test -race ./internal/agent -run "TestInvalidateLimits|TestIsUserID" -count=1 # ok
$ gofmt -l / go vet                                                                # clean on touched files
```

No API surface change, so no `make spec-check` implications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
