### PR TITLE
fix(api): bind pagination cursors to the endpoint and account that issued them

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -39,7 +39,11 @@ MCP tool surface), see:
   plus-tagged addresses (`a+tag@x.com`). The official SDKs encode this for you;
   hand-rolled clients must do it themselves.
 - **Pagination.** List endpoints return `{ items, next_cursor }`; pass
-  `next_cursor` back as `?cursor=…` to page forward. The SDKs auto-page.
+  `next_cursor` back as `?cursor=…` to page forward. The SDKs auto-page. A
+  cursor is bound to the endpoint that issued it and to the filters it was
+  minted under: replaying one on a different list, or with different filters,
+  is a `400 invalid_cursor` rather than a silently wrong page. Cursors are
+  opaque and short-lived — on `invalid_cursor`, drop it and restart the query.
 - **Idempotency.** Nine mutating operations honor an opt-in `Idempotency-Key`
   header: `sendMessage`, `replyToMessage`, `forwardMessage`, `approveReview`,
   `createWebhook`, `rotateWebhookSecret`, and `createApiKey`, plus the beta

--- a/docs/api.md
+++ b/docs/api.md
@@ -40,12 +40,13 @@ MCP tool surface), see:
   hand-rolled clients must do it themselves.
 - **Pagination.** List endpoints return `{ items, next_cursor }`; pass
   `next_cursor` back as `?cursor=…` to page forward. The SDKs auto-page. A
-  cursor is bound to the exact request that issued it: the collection, its path
-  parameters (the agent, webhook, or message it was listed under), and the
-  filters it was minted with. Replaying one on a different list, a different
-  parent, or with different filters is a `400 invalid_cursor` rather than a
-  silently wrong page. Cursors are opaque and short-lived — on
-  `invalid_cursor`, drop it and restart the query from the first page.
+  cursor is bound to the exact request that issued it: the account that minted
+  it, the collection, its path parameters (the agent, webhook, or message it
+  was listed under), and the filters it was minted with. Replaying one on a
+  different list, a different parent, with different filters, or under a
+  different account's credentials is a `400 invalid_cursor` rather than a
+  silently wrong page. Cursors are opaque; treat them as ephemeral — on
+  `invalid_cursor`, drop the cursor and restart the query from the first page.
 - **Idempotency.** Nine mutating operations honor an opt-in `Idempotency-Key`
   header: `sendMessage`, `replyToMessage`, `forwardMessage`, `approveReview`,
   `createWebhook`, `rotateWebhookSecret`, and `createApiKey`, plus the beta

--- a/docs/api.md
+++ b/docs/api.md
@@ -40,10 +40,12 @@ MCP tool surface), see:
   hand-rolled clients must do it themselves.
 - **Pagination.** List endpoints return `{ items, next_cursor }`; pass
   `next_cursor` back as `?cursor=…` to page forward. The SDKs auto-page. A
-  cursor is bound to the endpoint that issued it and to the filters it was
-  minted under: replaying one on a different list, or with different filters,
-  is a `400 invalid_cursor` rather than a silently wrong page. Cursors are
-  opaque and short-lived — on `invalid_cursor`, drop it and restart the query.
+  cursor is bound to the exact request that issued it: the collection, its path
+  parameters (the agent, webhook, or message it was listed under), and the
+  filters it was minted with. Replaying one on a different list, a different
+  parent, or with different filters is a `400 invalid_cursor` rather than a
+  silently wrong page. Cursors are opaque and short-lived — on
+  `invalid_cursor`, drop it and restart the query from the first page.
 - **Idempotency.** Nine mutating operations honor an opt-in `Idempotency-Key`
   header: `sendMessage`, `replyToMessage`, `forwardMessage`, `approveReview`,
   `createWebhook`, `rotateWebhookSecret`, and `createApiKey`, plus the beta

--- a/internal/httpapi/account.go
+++ b/internal/httpapi/account.go
@@ -167,8 +167,8 @@ func (s *Server) handleListSuppressions(ctx context.Context, in *listSuppression
 	var afterAddress string
 	if in.Cursor != "" {
 		var cur suppressionsCursor
-		if err := DecodeCursor([]string{s.deps.CursorSecret}, in.Cursor, &cur); err != nil {
-			return nil, NewError(http.StatusBadRequest, "invalid_cursor", "invalid pagination cursor")
+		if err := s.decodeCursor(cursorAccountSuppressions, in.Cursor, &cur); err != nil {
+			return nil, err
 		}
 		afterCreatedAt = cur.CreatedAt
 		afterAddress = cur.Address
@@ -189,7 +189,7 @@ func (s *Server) handleListSuppressions(ctx context.Context, in *listSuppression
 	var nextCursor string
 	if hasMore {
 		last := list[len(list)-1]
-		nextCursor, err = EncodeCursor(s.deps.CursorSecret, suppressionsCursor{CreatedAt: last.CreatedAt, Address: last.Address})
+		nextCursor, err = EncodeCursor(s.deps.CursorSecret, cursorAccountSuppressions, suppressionsCursor{CreatedAt: last.CreatedAt, Address: last.Address})
 		if err != nil {
 			return nil, NewError(http.StatusInternalServerError, "internal_error", "failed to build pagination cursor")
 		}

--- a/internal/httpapi/account.go
+++ b/internal/httpapi/account.go
@@ -167,7 +167,7 @@ func (s *Server) handleListSuppressions(ctx context.Context, in *listSuppression
 	var afterAddress string
 	if in.Cursor != "" {
 		var cur suppressionsCursor
-		if err := s.decodeCursor(cursorAccountSuppressions, in.Cursor, &cur); err != nil {
+		if err := s.decodeCursor(user.ID, cursorAccountSuppressions, in.Cursor, &cur); err != nil {
 			return nil, err
 		}
 		afterCreatedAt = cur.CreatedAt
@@ -189,7 +189,7 @@ func (s *Server) handleListSuppressions(ctx context.Context, in *listSuppression
 	var nextCursor string
 	if hasMore {
 		last := list[len(list)-1]
-		nextCursor, err = EncodeCursor(s.deps.CursorSecret, cursorAccountSuppressions, suppressionsCursor{CreatedAt: last.CreatedAt, Address: last.Address})
+		nextCursor, err = EncodeCursor(s.deps.CursorSecret, user.ID, cursorAccountSuppressions, suppressionsCursor{CreatedAt: last.CreatedAt, Address: last.Address})
 		if err != nil {
 			return nil, NewError(http.StatusInternalServerError, "internal_error", "failed to build pagination cursor")
 		}

--- a/internal/httpapi/agent_suppressions.go
+++ b/internal/httpapi/agent_suppressions.go
@@ -128,7 +128,10 @@ func (s *Server) handleListAgentSuppressions(ctx context.Context, in *listAgentS
 	var afterAddress string
 	if in.Cursor != "" {
 		var cur agentSuppressionsCursor
-		if err := DecodeCursor([]string{s.deps.CursorSecret}, in.Cursor, &cur); err != nil || identity.NormalizeEmail(cur.AgentEmail) != ag.ID {
+		if err := s.decodeCursor(cursorAgentSuppressions, in.Cursor, &cur); err != nil {
+			return nil, err
+		}
+		if identity.NormalizeEmail(cur.AgentEmail) != ag.ID {
 			return nil, NewError(http.StatusBadRequest, "invalid_cursor", "invalid pagination cursor")
 		}
 		afterCreatedAt, afterAddress = cur.CreatedAt, cur.Address
@@ -145,7 +148,7 @@ func (s *Server) handleListAgentSuppressions(ctx context.Context, in *listAgentS
 	var nextCursor string
 	if hasMore {
 		last := rows[len(rows)-1]
-		nextCursor, err = EncodeCursor(s.deps.CursorSecret, agentSuppressionsCursor{
+		nextCursor, err = EncodeCursor(s.deps.CursorSecret, cursorAgentSuppressions, agentSuppressionsCursor{
 			CreatedAt: last.CreatedAt, Address: last.Address, AgentEmail: ag.ID,
 		})
 		if err != nil {

--- a/internal/httpapi/agent_suppressions.go
+++ b/internal/httpapi/agent_suppressions.go
@@ -128,7 +128,7 @@ func (s *Server) handleListAgentSuppressions(ctx context.Context, in *listAgentS
 	var afterAddress string
 	if in.Cursor != "" {
 		var cur agentSuppressionsCursor
-		if err := s.decodeCursor(cursorAgentSuppressions, in.Cursor, &cur); err != nil {
+		if err := s.decodeCursor(p.User.ID, cursorAgentSuppressions, in.Cursor, &cur); err != nil {
 			return nil, err
 		}
 		if identity.NormalizeEmail(cur.AgentEmail) != ag.ID {
@@ -148,7 +148,7 @@ func (s *Server) handleListAgentSuppressions(ctx context.Context, in *listAgentS
 	var nextCursor string
 	if hasMore {
 		last := rows[len(rows)-1]
-		nextCursor, err = EncodeCursor(s.deps.CursorSecret, cursorAgentSuppressions, agentSuppressionsCursor{
+		nextCursor, err = EncodeCursor(s.deps.CursorSecret, p.User.ID, cursorAgentSuppressions, agentSuppressionsCursor{
 			CreatedAt: last.CreatedAt, Address: last.Address, AgentEmail: ag.ID,
 		})
 		if err != nil {

--- a/internal/httpapi/apikeys.go
+++ b/internal/httpapi/apikeys.go
@@ -124,7 +124,7 @@ func (s *Server) handleListAPIKeys(ctx context.Context, in *listAPIKeysInput) (*
 	if s.deps.ListAPIKeys == nil {
 		return nil, NewError(http.StatusNotImplemented, "not_implemented", "API keys are not available on this deployment")
 	}
-	afterCreatedAt, afterID, err := s.decodeKeyset(cursorAPIKeys, in.Cursor)
+	afterCreatedAt, afterID, err := s.decodeKeyset(user.ID, cursorAPIKeys, in.Cursor)
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +145,7 @@ func (s *Server) handleListAPIKeys(ctx context.Context, in *listAPIKeysInput) (*
 	var nextCursor string
 	if hasMore {
 		last := keys[len(keys)-1]
-		if nextCursor, err = s.encodeKeyset(cursorAPIKeys, last.CreatedAt, last.ID); err != nil {
+		if nextCursor, err = s.encodeKeyset(user.ID, cursorAPIKeys, last.CreatedAt, last.ID); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/httpapi/apikeys.go
+++ b/internal/httpapi/apikeys.go
@@ -124,7 +124,7 @@ func (s *Server) handleListAPIKeys(ctx context.Context, in *listAPIKeysInput) (*
 	if s.deps.ListAPIKeys == nil {
 		return nil, NewError(http.StatusNotImplemented, "not_implemented", "API keys are not available on this deployment")
 	}
-	afterCreatedAt, afterID, err := s.decodeKeyset(in.Cursor)
+	afterCreatedAt, afterID, err := s.decodeKeyset(cursorAPIKeys, in.Cursor)
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +145,7 @@ func (s *Server) handleListAPIKeys(ctx context.Context, in *listAPIKeysInput) (*
 	var nextCursor string
 	if hasMore {
 		last := keys[len(keys)-1]
-		if nextCursor, err = s.encodeKeyset(last.CreatedAt, last.ID); err != nil {
+		if nextCursor, err = s.encodeKeyset(cursorAPIKeys, last.CreatedAt, last.ID); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/httpapi/contacts.go
+++ b/internal/httpapi/contacts.go
@@ -318,7 +318,7 @@ func (s *Server) handleListContacts(ctx context.Context, in *listContactsInput) 
 	var afterID string
 	if in.Cursor != "" {
 		var cur contactsCursor
-		if err := s.decodeCursor(cursorContacts, in.Cursor, &cur); err != nil {
+		if err := s.decodeCursor(user.ID, cursorContacts, in.Cursor, &cur); err != nil {
 			return nil, err
 		}
 		if cur.Filters != fingerprint {
@@ -341,7 +341,7 @@ func (s *Server) handleListContacts(ctx context.Context, in *listContactsInput) 
 	var nextCursor string
 	if hasMore {
 		last := rows[len(rows)-1]
-		nextCursor, err = EncodeCursor(s.deps.CursorSecret, cursorContacts, contactsCursor{
+		nextCursor, err = EncodeCursor(s.deps.CursorSecret, user.ID, cursorContacts, contactsCursor{
 			CreatedAt: last.CreatedAt, ID: last.ID, Filters: fingerprint,
 		})
 		if err != nil {

--- a/internal/httpapi/contacts.go
+++ b/internal/httpapi/contacts.go
@@ -318,7 +318,10 @@ func (s *Server) handleListContacts(ctx context.Context, in *listContactsInput) 
 	var afterID string
 	if in.Cursor != "" {
 		var cur contactsCursor
-		if err := DecodeCursor([]string{s.deps.CursorSecret}, in.Cursor, &cur); err != nil || cur.Filters != fingerprint {
+		if err := s.decodeCursor(cursorContacts, in.Cursor, &cur); err != nil {
+			return nil, err
+		}
+		if cur.Filters != fingerprint {
 			// A cursor that decodes but was minted under different filters is
 			// rejected too: honoring it would interleave two distinct queries.
 			return nil, NewError(http.StatusBadRequest, "invalid_cursor", "invalid pagination cursor")
@@ -338,7 +341,7 @@ func (s *Server) handleListContacts(ctx context.Context, in *listContactsInput) 
 	var nextCursor string
 	if hasMore {
 		last := rows[len(rows)-1]
-		nextCursor, err = EncodeCursor(s.deps.CursorSecret, contactsCursor{
+		nextCursor, err = EncodeCursor(s.deps.CursorSecret, cursorContacts, contactsCursor{
 			CreatedAt: last.CreatedAt, ID: last.ID, Filters: fingerprint,
 		})
 		if err != nil {

--- a/internal/httpapi/conversations.go
+++ b/internal/httpapi/conversations.go
@@ -132,8 +132,8 @@ func (s *Server) handleListConversations(ctx context.Context, in *ListConversati
 	var afterID string
 	if in.Cursor != "" {
 		var cur conversationsCursor
-		if err := DecodeCursor([]string{s.deps.CursorSecret}, in.Cursor, &cur); err != nil {
-			return nil, NewError(http.StatusBadRequest, "invalid_cursor", "invalid pagination cursor")
+		if err := s.decodeCursor(cursorConversations, in.Cursor, &cur); err != nil {
+			return nil, err
 		}
 		if cur.AgentID != ag.ID || cur.Since != rfc3339OrEmpty(since) || cur.Until != rfc3339OrEmpty(until) {
 			return nil, NewError(http.StatusBadRequest, "invalid_cursor",
@@ -169,7 +169,7 @@ func (s *Server) handleListConversations(ctx context.Context, in *ListConversati
 	var nextCursor string
 	if hasMore {
 		last := convos[len(convos)-1]
-		nextCursor, err = EncodeCursor(s.deps.CursorSecret, conversationsCursor{
+		nextCursor, err = EncodeCursor(s.deps.CursorSecret, cursorConversations, conversationsCursor{
 			LastMessageAt:  last.LastMessageAt,
 			ConversationID: last.ID,
 			AgentID:        ag.ID,

--- a/internal/httpapi/conversations.go
+++ b/internal/httpapi/conversations.go
@@ -132,7 +132,7 @@ func (s *Server) handleListConversations(ctx context.Context, in *ListConversati
 	var afterID string
 	if in.Cursor != "" {
 		var cur conversationsCursor
-		if err := s.decodeCursor(cursorConversations, in.Cursor, &cur); err != nil {
+		if err := s.decodeCursor(ag.UserID, cursorConversations, in.Cursor, &cur); err != nil {
 			return nil, err
 		}
 		if cur.AgentID != ag.ID || cur.Since != rfc3339OrEmpty(since) || cur.Until != rfc3339OrEmpty(until) {
@@ -169,7 +169,7 @@ func (s *Server) handleListConversations(ctx context.Context, in *ListConversati
 	var nextCursor string
 	if hasMore {
 		last := convos[len(convos)-1]
-		nextCursor, err = EncodeCursor(s.deps.CursorSecret, cursorConversations, conversationsCursor{
+		nextCursor, err = EncodeCursor(s.deps.CursorSecret, ag.UserID, cursorConversations, conversationsCursor{
 			LastMessageAt:  last.LastMessageAt,
 			ConversationID: last.ID,
 			AgentID:        ag.ID,

--- a/internal/httpapi/cursor_binding_test.go
+++ b/internal/httpapi/cursor_binding_test.go
@@ -7,11 +7,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/tokencanopy/e2a/internal/agent"
 	"github.com/tokencanopy/e2a/internal/identity"
+	"github.com/tokencanopy/e2a/internal/webhook"
 )
 
 // Cursors are signed, so a tampered or garbage cursor was already rejected
@@ -82,6 +84,7 @@ func cursorBindingServer(t *testing.T) *httptest.Server {
 	events := cursorRows("evt", "", 3)
 	supps := cursorRows("sup", "@x.com", 3)
 	contacts := cursorRows("cnt", "", 3)
+	deliveries := cursorRows("dlv", "", 3)
 
 	srv := httptest.NewServer(New(Deps{
 		Authenticator: bearerGood,
@@ -157,6 +160,19 @@ func cursorBindingServer(t *testing.T) *httptest.Server {
 			}
 			return out, nil
 		},
+		GetWebhook: func(_ context.Context, id, userID string) (*identity.Webhook, error) {
+			return &identity.Webhook{ID: id, UserID: userID}, nil
+		},
+		ListDeliveries: func(_ context.Context, _, _ string, limit int, at time.Time, id string) ([]webhook.SubscriberDelivery, error) {
+			out := []webhook.SubscriberDelivery{}
+			for _, r := range page(deliveries, limit, at, id) {
+				out = append(out, webhook.SubscriberDelivery{
+					ID: r.id, WebhookID: "wh_1", EventType: "email.received",
+					Status: "delivered", CreatedAt: r.at,
+				})
+			}
+			return out, nil
+		},
 	}))
 	t.Cleanup(srv.Close)
 	return srv
@@ -177,6 +193,13 @@ var cursorBoundEndpoints = []struct {
 	{"events", "/v1/events?limit=1"},
 	{"account_suppressions", "/v1/account/suppressions?limit=1"},
 	{"contacts", "/v1/contacts?limit=1"},
+	// Both of these were ALSO accepting foreign cursors pre-fix and were
+	// missed by the original bug report's list of eight: deliveries with no
+	// status filter matched a foreign cursor's empty status, and
+	// starter-templates decoded a foreign cursor's absent alias as "" and
+	// silently re-served page 1. Verified against a clean origin/main.
+	{"webhook_deliveries", "/v1/webhooks/wh_1/deliveries?limit=1"},
+	{"starter_templates", "/v1/starter-templates?limit=1"},
 }
 
 // mint drives one real first-page request and returns its next_cursor.
@@ -308,5 +331,102 @@ func TestCursor_ResourceIsSignedNotJustTagged(t *testing.T) {
 	}
 	if out != pos {
 		t.Fatalf("round-trip mismatch: %+v want %+v", out, pos)
+	}
+}
+
+// --- parent binding on parameterized lists ---
+
+// deliveriesBindingServer serves a distinct delivery log per webhook, so a
+// cursor minted on one webhook can be replayed on the other.
+func deliveriesBindingServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	perWebhook := map[string][]cursorRow{
+		"wh_a": cursorRows("dla", "", 3),
+		"wh_b": cursorRows("dlb", "", 3),
+	}
+	srv := httptest.NewServer(New(Deps{
+		Authenticator: bearerGood,
+		GetWebhook: func(_ context.Context, id, userID string) (*identity.Webhook, error) {
+			// BOTH webhooks are owned by the caller — this is a correctness
+			// bug, not a leak, and the fixture has to reflect that.
+			if _, ok := perWebhook[id]; !ok {
+				return nil, identity.ErrWebhookNotFound
+			}
+			return &identity.Webhook{ID: id, UserID: userID}, nil
+		},
+		ListDeliveries: func(_ context.Context, webhookID, status string, limit int, at time.Time, id string) ([]webhook.SubscriberDelivery, error) {
+			out := []webhook.SubscriberDelivery{}
+			for _, r := range page(perWebhook[webhookID], limit, at, id) {
+				out = append(out, webhook.SubscriberDelivery{
+					ID: r.id, WebhookID: webhookID, EventType: "email.received",
+					Status: "delivered", CreatedAt: r.at,
+				})
+			}
+			return out, nil
+		},
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestDeliveriesCursor_ForeignWebhookRejected: /v1/webhooks/{id}/deliveries is
+// parameterized, so the resource discriminator alone is not enough — it only
+// proves the cursor came from *some* deliveries list. Without the parent
+// webhook pinned, webhook A's keyset anchor was handed to webhook B's query.
+func TestDeliveriesCursor_ForeignWebhookRejected(t *testing.T) {
+	srv := deliveriesBindingServer(t)
+	cursorA := mint(t, srv, "/v1/webhooks/wh_a/deliveries?limit=1")
+
+	// Baseline: webhook B has rows of its own to return.
+	code, body := getJSON(t, srv.URL+"/v1/webhooks/wh_b/deliveries?limit=3", "good")
+	if code != http.StatusOK {
+		t.Fatalf("baseline wh_b status %d body %v", code, body)
+	}
+	if items, _ := body["items"].([]any); len(items) == 0 {
+		t.Fatalf("baseline wh_b returned no deliveries; the fixture is wrong")
+	}
+
+	code, body = getJSON(t, srv.URL+"/v1/webhooks/wh_b/deliveries?limit=3&cursor="+url.QueryEscape(cursorA), "good")
+	if code != http.StatusBadRequest || errCode(body) != "invalid_cursor" {
+		t.Fatalf("webhook A cursor on webhook B: want 400 invalid_cursor, got %d %v", code, body)
+	}
+}
+
+// TestDeliveriesCursor_OwnWebhookStillWalks is the counterweight: pinning the
+// parent must not break a normal walk of one webhook's own delivery log.
+func TestDeliveriesCursor_OwnWebhookStillWalks(t *testing.T) {
+	srv := deliveriesBindingServer(t)
+	ids := walkPages(t, srv, "/v1/webhooks/wh_a/deliveries?limit=1", "id")
+	assertNoDupes(t, ids, 3)
+	for _, id := range ids {
+		if !strings.HasPrefix(id, "dla_") {
+			t.Fatalf("wh_a walk returned a foreign row %q: %v", id, ids)
+		}
+	}
+}
+
+// TestDecodeKeyset_RejectsTrashViewCursor pins the L1 assertion: decodeKeyset
+// is the no-trash-view variant, so a Deleted cursor must be rejected rather
+// than silently treated as a live-list position. Unreachable today (agents is
+// the only trash-view collection and it uses decodeKeysetView); asserted so a
+// future ?deleted= endpoint that keeps calling decodeKeyset fails loudly
+// instead of silently losing its view binding.
+func TestDecodeKeyset_RejectsTrashViewCursor(t *testing.T) {
+	srv := &Server{deps: Deps{CursorSecret: "0123456789abcdef0123456789abcdef"}}
+	deleted, err := EncodeCursor(srv.deps.CursorSecret, cursorReviews,
+		keysetCursor{CreatedAt: time.Unix(1700000000, 0).UTC(), ID: "r_1", Deleted: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := srv.decodeKeyset(cursorReviews, deleted); err == nil {
+		t.Fatal("decodeKeyset accepted a trash-view cursor")
+	}
+	live, err := EncodeCursor(srv.deps.CursorSecret, cursorReviews,
+		keysetCursor{CreatedAt: time.Unix(1700000000, 0).UTC(), ID: "r_1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, id, err := srv.decodeKeyset(cursorReviews, live); err != nil || id != "r_1" {
+		t.Fatalf("decodeKeyset rejected a live cursor: id=%q err=%v", id, err)
 	}
 }

--- a/internal/httpapi/cursor_binding_test.go
+++ b/internal/httpapi/cursor_binding_test.go
@@ -2,6 +2,7 @@ package httpapi
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/tokencanopy/e2a/internal/agent"
 	"github.com/tokencanopy/e2a/internal/identity"
+	"github.com/tokencanopy/e2a/internal/messagelifecycle"
 	"github.com/tokencanopy/e2a/internal/webhook"
 )
 
@@ -26,8 +28,15 @@ import (
 // and the client concluded "no events" when there were plenty. A silent
 // wrong answer is worse than a 400.
 //
-// These tests assert the whole N x N matrix: every list endpoint rejects
-// every other list endpoint's cursor, and still walks its own.
+// The same wrong-answer class exists across ACCOUNTS: account A's cursor on
+// account B's /v1/events verified under the deployment-global secret and
+// anchored B's (still hard-scoped) query at a meaningless position. The
+// account therefore binds too — via the MAC key (see cursorKey), so the
+// rejection is a plain invalid_cursor indistinguishable from a forgery.
+//
+// These tests assert both axes: every list endpoint rejects every other
+// list endpoint's cursor AND every other account's cursor for the same
+// endpoint, while still walking its own.
 
 // cursorRow is the shape all the fakes below key on: a keyset position and
 // an id, seeded newest-first so each endpoint yields >1 page at limit=1.
@@ -69,10 +78,31 @@ func page(rows []cursorRow, limit int, afterAt time.Time, afterID string) []curs
 	return out
 }
 
-// cursorBindingServer wires every cursor-minting account-level list with a
+// Two accounts, each with its own agent, so the matrix can vary the
+// principal as well as the endpoint. Bearer "good" is u_1 (as everywhere
+// else in this package); bearer "other" is u_2.
+const (
+	bindingAgentA = "agent-a@acme.com" // owned by u_1
+	bindingAgentB = "agent-b@acme.com" // owned by u_2
+)
+
+func cursorBindingAuth(r *http.Request) (*identity.User, error) {
+	switch r.Header.Get("Authorization") {
+	case "Bearer good":
+		return &identity.User{ID: "u_1", Email: "owner@acme.com"}, nil
+	case "Bearer other":
+		return &identity.User{ID: "u_2", Email: "owner@bee.com"}, nil
+	}
+	return nil, errors.New("unauthorized")
+}
+
+// cursorBindingServer wires every cursor-minting list endpoint with a
 // keyset-honoring fake, so each endpoint can mint a REAL cursor through the
 // real handler — the foreign cursors under test are genuine API output, not
-// hand-built payloads.
+// hand-built payloads. Account-level fakes serve the same rows to both
+// accounts (the binding under test rejects the cursor before any query);
+// agent-level fakes key rows on the agent, so each account paginates its
+// own agent's data.
 func cursorBindingServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	agents := cursorRows("agt", "@acme.com", 3)
@@ -85,9 +115,14 @@ func cursorBindingServer(t *testing.T) *httptest.Server {
 	supps := cursorRows("sup", "@x.com", 3)
 	contacts := cursorRows("cnt", "", 3)
 	deliveries := cursorRows("dlv", "", 3)
+	msgs := map[string][]cursorRow{bindingAgentA: cursorRows("msa", "", 3), bindingAgentB: cursorRows("msb", "", 3)}
+	convos := map[string][]cursorRow{bindingAgentA: cursorRows("cva", "", 3), bindingAgentB: cursorRows("cvb", "", 3)}
+	engs := map[string][]cursorRow{bindingAgentA: cursorRows("ega", "", 3), bindingAgentB: cursorRows("egb", "", 3)}
+	agSupps := map[string][]cursorRow{bindingAgentA: cursorRows("asa", "@x.com", 3), bindingAgentB: cursorRows("asb", "@x.com", 3)}
+	lifecycles := map[string][]cursorRow{bindingAgentA: cursorRows("mla", "", 3), bindingAgentB: cursorRows("mlb", "", 3)}
 
 	srv := httptest.NewServer(New(Deps{
-		Authenticator: bearerGood,
+		Authenticator: cursorBindingAuth,
 		EventsEnabled: true,
 
 		ListAgents: func(_ context.Context, _ string, limit int, at time.Time, id string) ([]identity.AgentIdentity, error) {
@@ -173,39 +208,109 @@ func cursorBindingServer(t *testing.T) *httptest.Server {
 			}
 			return out, nil
 		},
+
+		// Agent-parameterized collections: one agent per account.
+		GetAgent: func(_ context.Context, address string) (*identity.AgentIdentity, error) {
+			switch a := identity.NormalizeEmail(address); a {
+			case bindingAgentA:
+				return &identity.AgentIdentity{ID: a, Email: a, Domain: "acme.com", UserID: "u_1"}, nil
+			case bindingAgentB:
+				return &identity.AgentIdentity{ID: a, Email: a, Domain: "acme.com", UserID: "u_2"}, nil
+			}
+			return nil, identity.ErrAgentNotFound
+		},
+		ListMessages: func(_ context.Context, f identity.MessageListFilter) ([]identity.Message, error) {
+			out := []identity.Message{}
+			for _, r := range page(msgs[f.AgentID], f.Limit, f.AfterTime, f.AfterID) {
+				out = append(out, identity.Message{
+					ID: r.id, AgentID: f.AgentID, Direction: "inbound",
+					Recipient: f.AgentID, Subject: "s", InboxStatus: "unread", CreatedAt: r.at,
+				})
+			}
+			return out, nil
+		},
+		ListConversations: func(_ context.Context, f identity.ConversationListFilter) ([]identity.ConversationSummary, error) {
+			out := []identity.ConversationSummary{}
+			for _, r := range page(convos[f.AgentID], f.Limit, f.AfterLastMessageAt, f.AfterConversationID) {
+				out = append(out, identity.ConversationSummary{
+					ID: r.id, LastMessageAt: r.at, FirstMessageAt: r.at,
+					MessageCount: 1, InboundCount: 1, LatestSubject: "s", LatestSender: "x@x.com",
+				})
+			}
+			return out, nil
+		},
+		ListEngagements: func(_ context.Context, _, agentID string, _ identity.EngagementFilter, limit int, at time.Time, id string) ([]identity.ContactEngagement, error) {
+			out := []identity.ContactEngagement{}
+			for _, r := range page(engs[agentID], limit, at, id) {
+				out = append(out, identity.ContactEngagement{
+					ID: r.id, AgentEmail: agentID, Address: r.id + "@x.com", ContactID: r.id,
+					Stage: "active", CreatedAt: r.at, UpdatedAt: r.at,
+				})
+			}
+			return out, nil
+		},
+		ListAgentSuppressions: func(_ context.Context, _, agentID string, limit int, at time.Time, addr string) ([]identity.AgentSuppression, error) {
+			out := []identity.AgentSuppression{}
+			for _, r := range page(agSupps[agentID], limit, at, addr) {
+				out = append(out, identity.AgentSuppression{AgentEmail: agentID, Address: r.id, Source: "manual", CreatedAt: r.at})
+			}
+			return out, nil
+		},
+		ListMessageLifecycle: func(_ context.Context, messageID, agentID string) ([]messagelifecycle.MessageLifecycleTransition, error) {
+			out := []messagelifecycle.MessageLifecycleTransition{}
+			for _, r := range lifecycles[agentID] {
+				out = append(out, messagelifecycle.MessageLifecycleTransition{
+					ID: r.id, MessageID: messageID, Direction: "inbound", OccurredAt: r.at,
+				})
+			}
+			return out, nil
+		},
 	}))
 	t.Cleanup(srv.Close)
 	return srv
 }
 
-// cursorBoundEndpoints is every list endpoint the binding must cover. Each
-// yields >1 page at limit=1, so `mint` below always returns a real cursor.
+// cursorBoundEndpoints is every cursor-minting collection the binding must
+// cover — all sixteen. pathA is account A's instance of the collection and
+// pathB account B's; they differ only for the agent-parameterized lists
+// (each account walks its own agent). Each yields >1 page at limit=1, so
+// `mint` below always returns a real cursor.
 var cursorBoundEndpoints = []struct {
-	name string
-	path string
+	name  string
+	pathA string
+	pathB string
 }{
-	{"agents", "/v1/agents?limit=1"},
-	{"domains", "/v1/domains?limit=1"},
-	{"webhooks", "/v1/webhooks?limit=1"},
-	{"templates", "/v1/templates?limit=1"},
-	{"api_keys", "/v1/account/api-keys?limit=1"},
-	{"reviews", "/v1/reviews?limit=1"},
-	{"events", "/v1/events?limit=1"},
-	{"account_suppressions", "/v1/account/suppressions?limit=1"},
-	{"contacts", "/v1/contacts?limit=1"},
+	{"agents", "/v1/agents?limit=1", "/v1/agents?limit=1"},
+	{"domains", "/v1/domains?limit=1", "/v1/domains?limit=1"},
+	{"webhooks", "/v1/webhooks?limit=1", "/v1/webhooks?limit=1"},
+	{"templates", "/v1/templates?limit=1", "/v1/templates?limit=1"},
+	{"api_keys", "/v1/account/api-keys?limit=1", "/v1/account/api-keys?limit=1"},
+	{"reviews", "/v1/reviews?limit=1", "/v1/reviews?limit=1"},
+	{"events", "/v1/events?limit=1", "/v1/events?limit=1"},
+	{"account_suppressions", "/v1/account/suppressions?limit=1", "/v1/account/suppressions?limit=1"},
+	{"contacts", "/v1/contacts?limit=1", "/v1/contacts?limit=1"},
 	// Both of these were ALSO accepting foreign cursors pre-fix and were
 	// missed by the original bug report's list of eight: deliveries with no
 	// status filter matched a foreign cursor's empty status, and
 	// starter-templates decoded a foreign cursor's absent alias as "" and
 	// silently re-served page 1. Verified against a clean origin/main.
-	{"webhook_deliveries", "/v1/webhooks/wh_1/deliveries?limit=1"},
-	{"starter_templates", "/v1/starter-templates?limit=1"},
+	{"webhook_deliveries", "/v1/webhooks/wh_1/deliveries?limit=1", "/v1/webhooks/wh_1/deliveries?limit=1"},
+	{"starter_templates", "/v1/starter-templates?limit=1", "/v1/starter-templates?limit=1"},
+	// The five agent-scoped collections were already foreign-cursor-safe via
+	// their mandatory agent/filter fingerprints, so their presence here is
+	// coverage of the blanket rule, not a behavior fix.
+	{"messages", "/v1/agents/agent-a%40acme.com/messages?limit=1", "/v1/agents/agent-b%40acme.com/messages?limit=1"},
+	{"conversations", "/v1/agents/agent-a%40acme.com/conversations?limit=1", "/v1/agents/agent-b%40acme.com/conversations?limit=1"},
+	{"engagements", "/v1/agents/agent-a%40acme.com/contacts?limit=1", "/v1/agents/agent-b%40acme.com/contacts?limit=1"},
+	{"agent_suppressions", "/v1/agents/agent-a%40acme.com/suppressions?limit=1", "/v1/agents/agent-b%40acme.com/suppressions?limit=1"},
+	{"message_lifecycle", "/v1/agents/agent-a%40acme.com/messages/msg_1/lifecycle?limit=1", "/v1/agents/agent-b%40acme.com/messages/msg_1/lifecycle?limit=1"},
 }
 
-// mint drives one real first-page request and returns its next_cursor.
-func mint(t *testing.T, srv *httptest.Server, path string) string {
+// mint drives one real first-page request as `bearer` and returns its
+// next_cursor.
+func mint(t *testing.T, srv *httptest.Server, path, bearer string) string {
 	t.Helper()
-	code, body := getJSON(t, srv.URL+path, "good")
+	code, body := getJSON(t, srv.URL+path, bearer)
 	if code != http.StatusOK {
 		t.Fatalf("%s: first page status %d body %v", path, code, body)
 	}
@@ -224,7 +329,7 @@ func TestCursor_ForeignEndpointCursorRejected(t *testing.T) {
 
 	cursors := make(map[string]string, len(cursorBoundEndpoints))
 	for _, ep := range cursorBoundEndpoints {
-		cursors[ep.name] = mint(t, srv, ep.path)
+		cursors[ep.name] = mint(t, srv, ep.pathA, "good")
 	}
 
 	for _, target := range cursorBoundEndpoints {
@@ -233,7 +338,7 @@ func TestCursor_ForeignEndpointCursorRejected(t *testing.T) {
 				continue
 			}
 			t.Run(source.name+"_cursor_on_"+target.name, func(t *testing.T) {
-				u := srv.URL + target.path + "&cursor=" + url.QueryEscape(cursors[source.name])
+				u := srv.URL + target.pathA + "&cursor=" + url.QueryEscape(cursors[source.name])
 				code, body := getJSON(t, u, "good")
 				if code != http.StatusBadRequest {
 					t.Fatalf("foreign cursor accepted: status %d body %v", code, body)
@@ -246,13 +351,56 @@ func TestCursor_ForeignEndpointCursorRejected(t *testing.T) {
 	}
 }
 
+// TestCursor_ForeignAccountCursorRejected is the second binding axis: a
+// cursor minted by account A, presented by account B on the SAME collection,
+// must be a 400 invalid_cursor — pre-fix it verified under the
+// deployment-global secret and silently mispositioned B's (still
+// account-scoped) query. Both accounts' own cursors keep walking.
+func TestCursor_ForeignAccountCursorRejected(t *testing.T) {
+	srv := cursorBindingServer(t)
+	for _, ep := range cursorBoundEndpoints {
+		t.Run(ep.name, func(t *testing.T) {
+			cursorA := mint(t, srv, ep.pathA, "good")
+
+			// Baseline: account B's own view of the collection has rows.
+			code, body := getJSON(t, srv.URL+ep.pathB, "other")
+			if code != http.StatusOK {
+				t.Fatalf("baseline for account B: status %d body %v", code, body)
+			}
+			if items, _ := body["items"].([]any); len(items) == 0 {
+				t.Fatalf("baseline for account B returned no rows; the fixture is wrong")
+			}
+
+			// A's cursor in B's hands: rejected, indistinguishable from a forgery.
+			code, body = getJSON(t, srv.URL+ep.pathB+"&cursor="+url.QueryEscape(cursorA), "other")
+			if code != http.StatusBadRequest {
+				t.Fatalf("foreign-account cursor accepted: status %d body %v", code, body)
+			}
+			if errCode(body) != "invalid_cursor" {
+				t.Fatalf("want code invalid_cursor, got %v", body)
+			}
+
+			// The counterweight: A→A and B→B continuations both stay valid.
+			code, body = getJSON(t, srv.URL+ep.pathA+"&cursor="+url.QueryEscape(cursorA), "good")
+			if code != http.StatusOK {
+				t.Fatalf("account A's own cursor rejected: status %d body %v", code, body)
+			}
+			cursorB := mint(t, srv, ep.pathB, "other")
+			code, body = getJSON(t, srv.URL+ep.pathB+"&cursor="+url.QueryEscape(cursorB), "other")
+			if code != http.StatusOK {
+				t.Fatalf("account B's own cursor rejected: status %d body %v", code, body)
+			}
+		})
+	}
+}
+
 // TestCursor_ContactsCursorOnEventsIsRejected pins the exact live
 // reproduction from staging: a contacts cursor replayed on /v1/events used
 // to return 200 with an empty items array while the same query without a
 // cursor returned rows.
 func TestCursor_ContactsCursorOnEventsIsRejected(t *testing.T) {
 	srv := cursorBindingServer(t)
-	contactsCursor := mint(t, srv, "/v1/contacts?limit=1")
+	contactsCursor := mint(t, srv, "/v1/contacts?limit=1", "good")
 
 	// Sanity: without a cursor, /v1/events has rows to return.
 	code, body := getJSON(t, srv.URL+"/v1/events?limit=3", "good")
@@ -270,33 +418,38 @@ func TestCursor_ContactsCursorOnEventsIsRejected(t *testing.T) {
 }
 
 // TestCursor_OwnCursorStillWalks is the counterweight: binding must not
-// break normal pagination. Each endpoint's own cursor still advances, and
-// page 2 is disjoint from page 1.
+// break normal pagination. Each endpoint's own cursor still advances for
+// each account, and page 2 is disjoint from page 1.
 func TestCursor_OwnCursorStillWalks(t *testing.T) {
 	srv := cursorBindingServer(t)
 	for _, ep := range cursorBoundEndpoints {
-		t.Run(ep.name, func(t *testing.T) {
-			code, first := getJSON(t, srv.URL+ep.path, "good")
-			if code != http.StatusOK {
-				t.Fatalf("page 1: status %d body %v", code, first)
-			}
-			cursor, _ := first["next_cursor"].(string)
-			if cursor == "" {
-				t.Fatalf("page 1 produced no cursor: %v", first)
-			}
-			code, second := getJSON(t, srv.URL+ep.path+"&cursor="+url.QueryEscape(cursor), "good")
-			if code != http.StatusOK {
-				t.Fatalf("page 2: status %d body %v", code, second)
-			}
-			firstItems, _ := first["items"].([]any)
-			secondItems, _ := second["items"].([]any)
-			if len(firstItems) != 1 || len(secondItems) != 1 {
-				t.Fatalf("want 1 item per page, got %d and %d", len(firstItems), len(secondItems))
-			}
-			if fmt.Sprint(firstItems[0]) == fmt.Sprint(secondItems[0]) {
-				t.Fatalf("page 2 repeated page 1's row: %v", firstItems[0])
-			}
-		})
+		for _, acct := range []struct{ bearer, path string }{
+			{"good", ep.pathA},
+			{"other", ep.pathB},
+		} {
+			t.Run(ep.name+"_"+acct.bearer, func(t *testing.T) {
+				code, first := getJSON(t, srv.URL+acct.path, acct.bearer)
+				if code != http.StatusOK {
+					t.Fatalf("page 1: status %d body %v", code, first)
+				}
+				cursor, _ := first["next_cursor"].(string)
+				if cursor == "" {
+					t.Fatalf("page 1 produced no cursor: %v", first)
+				}
+				code, second := getJSON(t, srv.URL+acct.path+"&cursor="+url.QueryEscape(cursor), acct.bearer)
+				if code != http.StatusOK {
+					t.Fatalf("page 2: status %d body %v", code, second)
+				}
+				firstItems, _ := first["items"].([]any)
+				secondItems, _ := second["items"].([]any)
+				if len(firstItems) != 1 || len(secondItems) != 1 {
+					t.Fatalf("want 1 item per page, got %d and %d", len(firstItems), len(secondItems))
+				}
+				if fmt.Sprint(firstItems[0]) == fmt.Sprint(secondItems[0]) {
+					t.Fatalf("page 2 repeated page 1's row: %v", firstItems[0])
+				}
+			})
+		}
 	}
 }
 
@@ -306,11 +459,11 @@ func TestCursor_OwnCursorStillWalks(t *testing.T) {
 func TestCursor_ResourceIsSignedNotJustTagged(t *testing.T) {
 	const secret = "0123456789abcdef0123456789abcdef"
 	pos := keysetCursor{CreatedAt: time.Unix(1700000000, 0).UTC(), ID: "x_1"}
-	asEvents, err := EncodeCursor(secret, cursorEvents, pos)
+	asEvents, err := EncodeCursor(secret, "u_1", cursorEvents, pos)
 	if err != nil {
 		t.Fatal(err)
 	}
-	asAgents, err := EncodeCursor(secret, cursorAgents, pos)
+	asAgents, err := EncodeCursor(secret, "u_1", cursorAgents, pos)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -318,7 +471,7 @@ func TestCursor_ResourceIsSignedNotJustTagged(t *testing.T) {
 		t.Fatal("the resource must change the cursor bytes")
 	}
 	var out keysetCursor
-	if err := DecodeCursor([]string{secret}, cursorAgents, asEvents, &out); err != ErrCursorResourceMismatch {
+	if err := DecodeCursor([]string{secret}, "u_1", cursorAgents, asEvents, &out); err != ErrCursorResourceMismatch {
 		t.Fatalf("events cursor decoded as agents: %v", err)
 	}
 	// ErrCursorResourceMismatch must still satisfy the broad sentinel so
@@ -326,11 +479,63 @@ func TestCursor_ResourceIsSignedNotJustTagged(t *testing.T) {
 	if !errors.Is(ErrCursorResourceMismatch, ErrInvalidCursor) {
 		t.Fatal("ErrCursorResourceMismatch must wrap ErrInvalidCursor")
 	}
-	if err := DecodeCursor([]string{secret}, cursorEvents, asEvents, &out); err != nil {
+	if err := DecodeCursor([]string{secret}, "u_1", cursorEvents, asEvents, &out); err != nil {
 		t.Fatalf("own-resource decode: %v", err)
 	}
 	if out != pos {
 		t.Fatalf("round-trip mismatch: %+v want %+v", out, pos)
+	}
+}
+
+// TestCursor_AccountBindsViaMACKeyNotEnvelope pins the shape of the account
+// binding: the account changes the MAC (so a foreign account's cursor fails
+// verification as a plain ErrInvalidCursor, indistinguishable from a
+// forgery) but never appears in the envelope — the envelope is signed, not
+// encrypted, and cursors travel in query strings and logs. Secret rotation
+// must keep working through the derived key.
+func TestCursor_AccountBindsViaMACKeyNotEnvelope(t *testing.T) {
+	const secret = "0123456789abcdef0123456789abcdef"
+	pos := keysetCursor{CreatedAt: time.Unix(1700000000, 0).UTC(), ID: "x_1"}
+	asA, err := EncodeCursor(secret, "u_alpha", cursorEvents, pos)
+	if err != nil {
+		t.Fatal(err)
+	}
+	asB, err := EncodeCursor(secret, "u_bravo", cursorEvents, pos)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if asA == asB {
+		t.Fatal("the account must change the cursor bytes")
+	}
+	// Identical payload segment, differing only in the MAC: the account is
+	// in the key, not the envelope.
+	payloadA, _, _ := strings.Cut(asA, ".")
+	payloadB, _, _ := strings.Cut(asB, ".")
+	if payloadA != payloadB {
+		t.Fatalf("payload segments differ — the account leaked into the envelope:\n%s\n%s", payloadA, payloadB)
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(payloadA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "u_alpha") {
+		t.Fatalf("plaintext account ID in the envelope: %s", raw)
+	}
+	var out keysetCursor
+	if err := DecodeCursor([]string{secret}, "u_bravo", cursorEvents, asA, &out); err != ErrInvalidCursor {
+		t.Fatalf("foreign-account cursor: want plain ErrInvalidCursor, got %v", err)
+	}
+	if err := DecodeCursor([]string{secret}, "u_alpha", cursorEvents, asA, &out); err != nil {
+		t.Fatalf("own-account decode: %v", err)
+	}
+	if out != pos {
+		t.Fatalf("round-trip mismatch: %+v want %+v", out, pos)
+	}
+	// Rotation: a cursor signed under an old secret keeps verifying when the
+	// old secret is still in the accepted list — derivation happens per
+	// candidate secret inside the loop.
+	if err := DecodeCursor([]string{"a-newer-secret-value-padding-32ch", secret}, "u_alpha", cursorEvents, asA, &out); err != nil {
+		t.Fatalf("rotation verify through derived key: %v", err)
 	}
 }
 
@@ -375,7 +580,7 @@ func deliveriesBindingServer(t *testing.T) *httptest.Server {
 // webhook pinned, webhook A's keyset anchor was handed to webhook B's query.
 func TestDeliveriesCursor_ForeignWebhookRejected(t *testing.T) {
 	srv := deliveriesBindingServer(t)
-	cursorA := mint(t, srv, "/v1/webhooks/wh_a/deliveries?limit=1")
+	cursorA := mint(t, srv, "/v1/webhooks/wh_a/deliveries?limit=1", "good")
 
 	// Baseline: webhook B has rows of its own to return.
 	code, body := getJSON(t, srv.URL+"/v1/webhooks/wh_b/deliveries?limit=3", "good")
@@ -413,20 +618,20 @@ func TestDeliveriesCursor_OwnWebhookStillWalks(t *testing.T) {
 // instead of silently losing its view binding.
 func TestDecodeKeyset_RejectsTrashViewCursor(t *testing.T) {
 	srv := &Server{deps: Deps{CursorSecret: "0123456789abcdef0123456789abcdef"}}
-	deleted, err := EncodeCursor(srv.deps.CursorSecret, cursorReviews,
+	deleted, err := EncodeCursor(srv.deps.CursorSecret, "u_1", cursorReviews,
 		keysetCursor{CreatedAt: time.Unix(1700000000, 0).UTC(), ID: "r_1", Deleted: true})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, _, err := srv.decodeKeyset(cursorReviews, deleted); err == nil {
+	if _, _, err := srv.decodeKeyset("u_1", cursorReviews, deleted); err == nil {
 		t.Fatal("decodeKeyset accepted a trash-view cursor")
 	}
-	live, err := EncodeCursor(srv.deps.CursorSecret, cursorReviews,
+	live, err := EncodeCursor(srv.deps.CursorSecret, "u_1", cursorReviews,
 		keysetCursor{CreatedAt: time.Unix(1700000000, 0).UTC(), ID: "r_1"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, id, err := srv.decodeKeyset(cursorReviews, live); err != nil || id != "r_1" {
+	if _, id, err := srv.decodeKeyset("u_1", cursorReviews, live); err != nil || id != "r_1" {
 		t.Fatalf("decodeKeyset rejected a live cursor: id=%q err=%v", id, err)
 	}
 }

--- a/internal/httpapi/cursor_binding_test.go
+++ b/internal/httpapi/cursor_binding_test.go
@@ -1,0 +1,312 @@
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/tokencanopy/e2a/internal/agent"
+	"github.com/tokencanopy/e2a/internal/identity"
+)
+
+// Cursors are signed, so a tampered or garbage cursor was already rejected
+// on every list endpoint. What was NOT rejected was a validly-signed cursor
+// minted by a DIFFERENT endpoint: every account-level list shares the same
+// (created_at, id) payload shape, so a /v1/contacts cursor decoded cleanly
+// on /v1/events and was applied as a real keyset anchor. The account scope
+// held — no cross-tenant leakage — but the anchor was meaningless, so the
+// endpoint returned an arbitrarily truncated page (typically `{"items":[]}`)
+// and the client concluded "no events" when there were plenty. A silent
+// wrong answer is worse than a 400.
+//
+// These tests assert the whole N x N matrix: every list endpoint rejects
+// every other list endpoint's cursor, and still walks its own.
+
+// cursorRow is the shape all the fakes below key on: a keyset position and
+// an id, seeded newest-first so each endpoint yields >1 page at limit=1.
+type cursorRow struct {
+	id string
+	at time.Time
+}
+
+// cursorRows seeds n rows whose id is EXACTLY the value the endpoint puts in
+// its cursor (email for agents, domain for domains, address for
+// suppressions, …) — otherwise the fake's keyset predicate would compare a
+// bare id against a suffixed one and never advance.
+func cursorRows(prefix, suffix string, n int) []cursorRow {
+	base := time.Unix(1700000000, 0).UTC()
+	out := make([]cursorRow, n)
+	for i := 0; i < n; i++ {
+		out[i] = cursorRow{
+			// Lexically descending in step with recency, matching the
+			// (created_at DESC, id DESC) order the real stores use.
+			id: fmt.Sprintf("%s_%02d%s", prefix, 90-i, suffix),
+			at: base.Add(-time.Duration(i) * time.Minute),
+		}
+	}
+	return out
+}
+
+// page applies the shared newest-first keyset predicate and the limit.
+func page(rows []cursorRow, limit int, afterAt time.Time, afterID string) []cursorRow {
+	out := []cursorRow{}
+	for _, r := range rows {
+		if !afterKey(r.at, r.id, afterAt, afterID) {
+			continue
+		}
+		out = append(out, r)
+		if limit > 0 && len(out) == limit {
+			break
+		}
+	}
+	return out
+}
+
+// cursorBindingServer wires every cursor-minting account-level list with a
+// keyset-honoring fake, so each endpoint can mint a REAL cursor through the
+// real handler — the foreign cursors under test are genuine API output, not
+// hand-built payloads.
+func cursorBindingServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	agents := cursorRows("agt", "@acme.com", 3)
+	domains := cursorRows("dom", ".com", 3)
+	webhooks := cursorRows("whk", "", 3)
+	templates := cursorRows("tpl", "", 3)
+	apiKeys := cursorRows("apk", "", 3)
+	reviews := cursorRows("rvw", "", 3)
+	events := cursorRows("evt", "", 3)
+	supps := cursorRows("sup", "@x.com", 3)
+	contacts := cursorRows("cnt", "", 3)
+
+	srv := httptest.NewServer(New(Deps{
+		Authenticator: bearerGood,
+		EventsEnabled: true,
+
+		ListAgents: func(_ context.Context, _ string, limit int, at time.Time, id string) ([]identity.AgentIdentity, error) {
+			out := []identity.AgentIdentity{}
+			for _, r := range page(agents, limit, at, id) {
+				out = append(out, identity.AgentIdentity{ID: r.id, Domain: "acme.com", UserID: "u_1", CreatedAt: r.at})
+			}
+			return out, nil
+		},
+		ListDomains: func(_ context.Context, _ string, limit int, at time.Time, domain string) ([]identity.Domain, error) {
+			out := []identity.Domain{}
+			for _, r := range page(domains, limit, at, domain) {
+				out = append(out, identity.Domain{Domain: r.id, Verified: true, CreatedAt: r.at})
+			}
+			return out, nil
+		},
+		ListWebhooks: func(_ context.Context, _ string, limit int, at time.Time, id string) ([]identity.Webhook, error) {
+			out := []identity.Webhook{}
+			for _, r := range page(webhooks, limit, at, id) {
+				out = append(out, identity.Webhook{ID: r.id, URL: "https://x.com/h", Events: []string{"email.received"}, Enabled: true, CreatedAt: r.at})
+			}
+			return out, nil
+		},
+		ListTemplates: func(_ context.Context, _ string, limit int, at time.Time, id string) ([]identity.TemplateSummary, error) {
+			out := []identity.TemplateSummary{}
+			for _, r := range page(templates, limit, at, id) {
+				out = append(out, identity.TemplateSummary{ID: r.id, UserID: "u_1", Name: "n", Alias: r.id, Subject: "s", CreatedAt: r.at, UpdatedAt: r.at})
+			}
+			return out, nil
+		},
+		ListAPIKeys: func(_ context.Context, _ string, limit int, at time.Time, id string) ([]identity.APIKey, error) {
+			out := []identity.APIKey{}
+			for _, r := range page(apiKeys, limit, at, id) {
+				out = append(out, identity.APIKey{ID: r.id, UserID: "u_1", Name: "k", KeyPrefix: "e2a_acct_ab", Scope: "account", CreatedAt: r.at})
+			}
+			return out, nil
+		},
+		ListReviews: func(_ context.Context, _ string, limit int, at time.Time, id string) ([]identity.ReviewListItem, error) {
+			out := []identity.ReviewListItem{}
+			for _, r := range page(reviews, limit, at, id) {
+				out = append(out, identity.ReviewListItem{
+					ID: r.id, AgentID: "support@acme.dev", Direction: "inbound",
+					Sender: "s@x.com", To: []string{"support@acme.dev"},
+					Subject: "held", Status: "pending_review", CreatedAt: r.at,
+				})
+			}
+			return out, nil
+		},
+		ListEvents: func(_ context.Context, q EventQuery) ([]agent.EventView, error) {
+			out := []agent.EventView{}
+			for _, r := range page(events, q.Limit, q.CursorCreatedAt, q.CursorID) {
+				out = append(out, agent.EventView{ID: r.id, Type: "email.sent", Status: "delivered", CreatedAt: r.at})
+			}
+			return out, nil
+		},
+		ListSuppressions: func(_ context.Context, _ string, limit int, at time.Time, addr string) ([]identity.Suppression, error) {
+			out := []identity.Suppression{}
+			for _, r := range page(supps, limit, at, addr) {
+				out = append(out, identity.Suppression{Address: r.id, Source: "bounce", CreatedAt: r.at})
+			}
+			return out, nil
+		},
+		GetContact: func(_ context.Context, _, _ string) (identity.Contact, error) {
+			return identity.Contact{}, identity.ErrContactNotFound
+		},
+		ListContacts: func(_ context.Context, _ string, _ identity.ContactFilter, limit int, at time.Time, id string) ([]identity.Contact, error) {
+			out := []identity.Contact{}
+			for _, r := range page(contacts, limit, at, id) {
+				out = append(out, identity.Contact{ID: r.id, Address: r.id + "@x.com", Source: "manual", CreatedAt: r.at, UpdatedAt: r.at})
+			}
+			return out, nil
+		},
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// cursorBoundEndpoints is every list endpoint the binding must cover. Each
+// yields >1 page at limit=1, so `mint` below always returns a real cursor.
+var cursorBoundEndpoints = []struct {
+	name string
+	path string
+}{
+	{"agents", "/v1/agents?limit=1"},
+	{"domains", "/v1/domains?limit=1"},
+	{"webhooks", "/v1/webhooks?limit=1"},
+	{"templates", "/v1/templates?limit=1"},
+	{"api_keys", "/v1/account/api-keys?limit=1"},
+	{"reviews", "/v1/reviews?limit=1"},
+	{"events", "/v1/events?limit=1"},
+	{"account_suppressions", "/v1/account/suppressions?limit=1"},
+	{"contacts", "/v1/contacts?limit=1"},
+}
+
+// mint drives one real first-page request and returns its next_cursor.
+func mint(t *testing.T, srv *httptest.Server, path string) string {
+	t.Helper()
+	code, body := getJSON(t, srv.URL+path, "good")
+	if code != http.StatusOK {
+		t.Fatalf("%s: first page status %d body %v", path, code, body)
+	}
+	next, ok := body["next_cursor"].(string)
+	if !ok || next == "" {
+		t.Fatalf("%s: expected a next_cursor on the first page, got %v", path, body["next_cursor"])
+	}
+	return next
+}
+
+// TestCursor_ForeignEndpointCursorRejected is the regression test for the
+// bug: a cursor minted by endpoint A, replayed on endpoint B, must be a 400
+// invalid_cursor — never a silently-anchored (and usually empty) page.
+func TestCursor_ForeignEndpointCursorRejected(t *testing.T) {
+	srv := cursorBindingServer(t)
+
+	cursors := make(map[string]string, len(cursorBoundEndpoints))
+	for _, ep := range cursorBoundEndpoints {
+		cursors[ep.name] = mint(t, srv, ep.path)
+	}
+
+	for _, target := range cursorBoundEndpoints {
+		for _, source := range cursorBoundEndpoints {
+			if source.name == target.name {
+				continue
+			}
+			t.Run(source.name+"_cursor_on_"+target.name, func(t *testing.T) {
+				u := srv.URL + target.path + "&cursor=" + url.QueryEscape(cursors[source.name])
+				code, body := getJSON(t, u, "good")
+				if code != http.StatusBadRequest {
+					t.Fatalf("foreign cursor accepted: status %d body %v", code, body)
+				}
+				if errCode(body) != "invalid_cursor" {
+					t.Fatalf("want code invalid_cursor, got %v", body)
+				}
+			})
+		}
+	}
+}
+
+// TestCursor_ContactsCursorOnEventsIsRejected pins the exact live
+// reproduction from staging: a contacts cursor replayed on /v1/events used
+// to return 200 with an empty items array while the same query without a
+// cursor returned rows.
+func TestCursor_ContactsCursorOnEventsIsRejected(t *testing.T) {
+	srv := cursorBindingServer(t)
+	contactsCursor := mint(t, srv, "/v1/contacts?limit=1")
+
+	// Sanity: without a cursor, /v1/events has rows to return.
+	code, body := getJSON(t, srv.URL+"/v1/events?limit=3", "good")
+	if code != http.StatusOK {
+		t.Fatalf("baseline events status %d", code)
+	}
+	if items, _ := body["items"].([]any); len(items) == 0 {
+		t.Fatalf("baseline /v1/events returned no items; the fixture is wrong")
+	}
+
+	code, body = getJSON(t, srv.URL+"/v1/events?limit=3&cursor="+url.QueryEscape(contactsCursor), "good")
+	if code != http.StatusBadRequest || errCode(body) != "invalid_cursor" {
+		t.Fatalf("contacts cursor on /v1/events: want 400 invalid_cursor, got %d %v", code, body)
+	}
+}
+
+// TestCursor_OwnCursorStillWalks is the counterweight: binding must not
+// break normal pagination. Each endpoint's own cursor still advances, and
+// page 2 is disjoint from page 1.
+func TestCursor_OwnCursorStillWalks(t *testing.T) {
+	srv := cursorBindingServer(t)
+	for _, ep := range cursorBoundEndpoints {
+		t.Run(ep.name, func(t *testing.T) {
+			code, first := getJSON(t, srv.URL+ep.path, "good")
+			if code != http.StatusOK {
+				t.Fatalf("page 1: status %d body %v", code, first)
+			}
+			cursor, _ := first["next_cursor"].(string)
+			if cursor == "" {
+				t.Fatalf("page 1 produced no cursor: %v", first)
+			}
+			code, second := getJSON(t, srv.URL+ep.path+"&cursor="+url.QueryEscape(cursor), "good")
+			if code != http.StatusOK {
+				t.Fatalf("page 2: status %d body %v", code, second)
+			}
+			firstItems, _ := first["items"].([]any)
+			secondItems, _ := second["items"].([]any)
+			if len(firstItems) != 1 || len(secondItems) != 1 {
+				t.Fatalf("want 1 item per page, got %d and %d", len(firstItems), len(secondItems))
+			}
+			if fmt.Sprint(firstItems[0]) == fmt.Sprint(secondItems[0]) {
+				t.Fatalf("page 2 repeated page 1's row: %v", firstItems[0])
+			}
+		})
+	}
+}
+
+// TestCursor_ResourceIsSignedNotJustTagged: a client cannot re-target a
+// cursor by rewriting the resource, because the resource lives inside the
+// HMAC-covered payload.
+func TestCursor_ResourceIsSignedNotJustTagged(t *testing.T) {
+	const secret = "0123456789abcdef0123456789abcdef"
+	pos := keysetCursor{CreatedAt: time.Unix(1700000000, 0).UTC(), ID: "x_1"}
+	asEvents, err := EncodeCursor(secret, cursorEvents, pos)
+	if err != nil {
+		t.Fatal(err)
+	}
+	asAgents, err := EncodeCursor(secret, cursorAgents, pos)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if asEvents == asAgents {
+		t.Fatal("the resource must change the cursor bytes")
+	}
+	var out keysetCursor
+	if err := DecodeCursor([]string{secret}, cursorAgents, asEvents, &out); err != ErrCursorResourceMismatch {
+		t.Fatalf("events cursor decoded as agents: %v", err)
+	}
+	// ErrCursorResourceMismatch must still satisfy the broad sentinel so
+	// callers that only branch on ErrInvalidCursor keep working.
+	if !errors.Is(ErrCursorResourceMismatch, ErrInvalidCursor) {
+		t.Fatal("ErrCursorResourceMismatch must wrap ErrInvalidCursor")
+	}
+	if err := DecodeCursor([]string{secret}, cursorEvents, asEvents, &out); err != nil {
+		t.Fatalf("own-resource decode: %v", err)
+	}
+	if out != pos {
+		t.Fatalf("round-trip mismatch: %+v want %+v", out, pos)
+	}
+}

--- a/internal/httpapi/domains.go
+++ b/internal/httpapi/domains.go
@@ -410,7 +410,7 @@ func (s *Server) handleListDomains(ctx context.Context, in *listDomainsInput) (*
 	}
 	// The keyset tiebreak for domains is the domain string (its unique key), so
 	// the cursor's `id` slot carries the after-domain.
-	afterCreatedAt, afterDomain, err := s.decodeKeyset(cursorDomains, in.Cursor)
+	afterCreatedAt, afterDomain, err := s.decodeKeyset(user.ID, cursorDomains, in.Cursor)
 	if err != nil {
 		return nil, err
 	}
@@ -435,7 +435,7 @@ func (s *Server) handleListDomains(ctx context.Context, in *listDomainsInput) (*
 	var nextCursor string
 	if hasMore {
 		last := domains[len(domains)-1]
-		if nextCursor, err = s.encodeKeyset(cursorDomains, last.CreatedAt, last.Domain); err != nil {
+		if nextCursor, err = s.encodeKeyset(user.ID, cursorDomains, last.CreatedAt, last.Domain); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/httpapi/domains.go
+++ b/internal/httpapi/domains.go
@@ -410,7 +410,7 @@ func (s *Server) handleListDomains(ctx context.Context, in *listDomainsInput) (*
 	}
 	// The keyset tiebreak for domains is the domain string (its unique key), so
 	// the cursor's `id` slot carries the after-domain.
-	afterCreatedAt, afterDomain, err := s.decodeKeyset(in.Cursor)
+	afterCreatedAt, afterDomain, err := s.decodeKeyset(cursorDomains, in.Cursor)
 	if err != nil {
 		return nil, err
 	}
@@ -435,7 +435,7 @@ func (s *Server) handleListDomains(ctx context.Context, in *listDomainsInput) (*
 	var nextCursor string
 	if hasMore {
 		last := domains[len(domains)-1]
-		if nextCursor, err = s.encodeKeyset(last.CreatedAt, last.Domain); err != nil {
+		if nextCursor, err = s.encodeKeyset(cursorDomains, last.CreatedAt, last.Domain); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/httpapi/engagements.go
+++ b/internal/httpapi/engagements.go
@@ -269,7 +269,7 @@ func (s *Server) handleListEngagements(ctx context.Context, in *listEngagementsI
 	var afterID string
 	if in.Cursor != "" {
 		var cur engagementsCursor
-		if err := s.decodeCursor(cursorEngagements, in.Cursor, &cur); err != nil {
+		if err := s.decodeCursor(p.User.ID, cursorEngagements, in.Cursor, &cur); err != nil {
 			return nil, err
 		}
 		if cur.AgentEmail != ag.ID || cur.Filters != fingerprint {
@@ -290,7 +290,7 @@ func (s *Server) handleListEngagements(ctx context.Context, in *listEngagementsI
 	var next string
 	if hasMore {
 		last := rows[len(rows)-1]
-		next, err = EncodeCursor(s.deps.CursorSecret, cursorEngagements, engagementsCursor{
+		next, err = EncodeCursor(s.deps.CursorSecret, p.User.ID, cursorEngagements, engagementsCursor{
 			CreatedAt: last.CreatedAt, ID: last.ID, AgentEmail: ag.ID, Filters: fingerprint,
 		})
 		if err != nil {

--- a/internal/httpapi/engagements.go
+++ b/internal/httpapi/engagements.go
@@ -269,8 +269,10 @@ func (s *Server) handleListEngagements(ctx context.Context, in *listEngagementsI
 	var afterID string
 	if in.Cursor != "" {
 		var cur engagementsCursor
-		if err := DecodeCursor([]string{s.deps.CursorSecret}, in.Cursor, &cur); err != nil ||
-			cur.AgentEmail != ag.ID || cur.Filters != fingerprint {
+		if err := s.decodeCursor(cursorEngagements, in.Cursor, &cur); err != nil {
+			return nil, err
+		}
+		if cur.AgentEmail != ag.ID || cur.Filters != fingerprint {
 			return nil, NewError(http.StatusBadRequest, "invalid_cursor", "invalid pagination cursor")
 		}
 		afterCreatedAt, afterID = cur.CreatedAt, cur.ID
@@ -288,7 +290,7 @@ func (s *Server) handleListEngagements(ctx context.Context, in *listEngagementsI
 	var next string
 	if hasMore {
 		last := rows[len(rows)-1]
-		next, err = EncodeCursor(s.deps.CursorSecret, engagementsCursor{
+		next, err = EncodeCursor(s.deps.CursorSecret, cursorEngagements, engagementsCursor{
 			CreatedAt: last.CreatedAt, ID: last.ID, AgentEmail: ag.ID, Filters: fingerprint,
 		})
 		if err != nil {

--- a/internal/httpapi/events.go
+++ b/internal/httpapi/events.go
@@ -277,7 +277,7 @@ func (s *Server) handleListEvents(ctx context.Context, in *ListEventsInput) (*li
 	}
 	var cur eventsCursor
 	if in.Cursor != "" {
-		if err := s.decodeCursor(cursorEvents, in.Cursor, &cur); err != nil {
+		if err := s.decodeCursor(user.ID, cursorEvents, in.Cursor, &cur); err != nil {
 			return nil, err
 		}
 		if cur.Ty != in.Type || cur.Ag != in.AgentID || cur.Co != in.ConversationID ||
@@ -303,7 +303,7 @@ func (s *Server) handleListEvents(ctx context.Context, in *ListEventsInput) (*li
 	var nextCursor string
 	if hasMore {
 		last := events[len(events)-1]
-		nextCursor, err = EncodeCursor(s.deps.CursorSecret, cursorEvents, eventsCursor{
+		nextCursor, err = EncodeCursor(s.deps.CursorSecret, user.ID, cursorEvents, eventsCursor{
 			C: last.CreatedAt, I: last.ID,
 			Ty: in.Type, Ag: in.AgentID, Co: in.ConversationID, Ms: in.MessageID,
 			Si: rfc3339PtrOrEmpty(since), Un: rfc3339PtrOrEmpty(until),

--- a/internal/httpapi/events.go
+++ b/internal/httpapi/events.go
@@ -277,8 +277,8 @@ func (s *Server) handleListEvents(ctx context.Context, in *ListEventsInput) (*li
 	}
 	var cur eventsCursor
 	if in.Cursor != "" {
-		if err := DecodeCursor([]string{s.deps.CursorSecret}, in.Cursor, &cur); err != nil {
-			return nil, NewError(http.StatusBadRequest, "invalid_cursor", "invalid pagination cursor")
+		if err := s.decodeCursor(cursorEvents, in.Cursor, &cur); err != nil {
+			return nil, err
 		}
 		if cur.Ty != in.Type || cur.Ag != in.AgentID || cur.Co != in.ConversationID ||
 			cur.Ms != in.MessageID || cur.Si != rfc3339PtrOrEmpty(since) || cur.Un != rfc3339PtrOrEmpty(until) {
@@ -303,7 +303,7 @@ func (s *Server) handleListEvents(ctx context.Context, in *ListEventsInput) (*li
 	var nextCursor string
 	if hasMore {
 		last := events[len(events)-1]
-		nextCursor, err = EncodeCursor(s.deps.CursorSecret, eventsCursor{
+		nextCursor, err = EncodeCursor(s.deps.CursorSecret, cursorEvents, eventsCursor{
 			C: last.CreatedAt, I: last.ID,
 			Ty: in.Type, Ag: in.AgentID, Co: in.ConversationID, Ms: in.MessageID,
 			Si: rfc3339PtrOrEmpty(since), Un: rfc3339PtrOrEmpty(until),

--- a/internal/httpapi/message_lifecycle.go
+++ b/internal/httpapi/message_lifecycle.go
@@ -62,8 +62,10 @@ func (s *Server) handleMessageLifecycle(ctx context.Context, in *messageLifecycl
 	var afterID string
 	if in.Cursor != "" {
 		var cursor messageLifecycleCursor
-		if err := DecodeCursor([]string{s.deps.CursorSecret}, in.Cursor, &cursor); err != nil ||
-			cursor.Version != messageLifecycleCursorVersion || cursor.AgentID != agent.ID || cursor.MessageID != in.ID ||
+		if err := s.decodeCursor(cursorMessageLifecycle, in.Cursor, &cursor); err != nil {
+			return nil, err
+		}
+		if cursor.Version != messageLifecycleCursorVersion || cursor.AgentID != agent.ID || cursor.MessageID != in.ID ||
 			cursor.OccurredAt.IsZero() || cursor.ID == "" || cursor.Sort != messageLifecycleSortAscending {
 			return nil, NewError(http.StatusBadRequest, "invalid_cursor", "invalid pagination cursor")
 		}
@@ -107,7 +109,7 @@ func (s *Server) handleMessageLifecycle(ctx context.Context, in *messageLifecycl
 	var nextCursor string
 	if hasMore {
 		last := items[len(items)-1]
-		nextCursor, err = EncodeCursor(s.deps.CursorSecret, messageLifecycleCursor{
+		nextCursor, err = EncodeCursor(s.deps.CursorSecret, cursorMessageLifecycle, messageLifecycleCursor{
 			Version: messageLifecycleCursorVersion, AgentID: agent.ID, MessageID: in.ID,
 			OccurredAt: last.OccurredAt.UTC(), ID: last.ID, Sort: messageLifecycleSortAscending,
 		})

--- a/internal/httpapi/message_lifecycle.go
+++ b/internal/httpapi/message_lifecycle.go
@@ -62,7 +62,7 @@ func (s *Server) handleMessageLifecycle(ctx context.Context, in *messageLifecycl
 	var afterID string
 	if in.Cursor != "" {
 		var cursor messageLifecycleCursor
-		if err := s.decodeCursor(cursorMessageLifecycle, in.Cursor, &cursor); err != nil {
+		if err := s.decodeCursor(agent.UserID, cursorMessageLifecycle, in.Cursor, &cursor); err != nil {
 			return nil, err
 		}
 		if cursor.Version != messageLifecycleCursorVersion || cursor.AgentID != agent.ID || cursor.MessageID != in.ID ||
@@ -109,7 +109,7 @@ func (s *Server) handleMessageLifecycle(ctx context.Context, in *messageLifecycl
 	var nextCursor string
 	if hasMore {
 		last := items[len(items)-1]
-		nextCursor, err = EncodeCursor(s.deps.CursorSecret, cursorMessageLifecycle, messageLifecycleCursor{
+		nextCursor, err = EncodeCursor(s.deps.CursorSecret, agent.UserID, cursorMessageLifecycle, messageLifecycleCursor{
 			Version: messageLifecycleCursorVersion, AgentID: agent.ID, MessageID: in.ID,
 			OccurredAt: last.OccurredAt.UTC(), ID: last.ID, Sort: messageLifecycleSortAscending,
 		})

--- a/internal/httpapi/message_lifecycle_test.go
+++ b/internal/httpapi/message_lifecycle_test.go
@@ -164,11 +164,11 @@ func TestMessageLifecycleCursorBindingAndTamper(t *testing.T) {
 	_, first := lifecycleGET(t, srv, "agent@example.com", "msg_one", "?limit=1")
 	cursor := first["next_cursor"].(string)
 	var decoded messageLifecycleCursor
-	if err := DecodeCursor([]string{lifecycleTestSecret}, cursorMessageLifecycle, cursor, &decoded); err != nil {
+	if err := DecodeCursor([]string{lifecycleTestSecret}, "u_1", cursorMessageLifecycle, cursor, &decoded); err != nil {
 		t.Fatal(err)
 	}
 	var decodedWire map[string]any
-	if err := DecodeCursor([]string{lifecycleTestSecret}, cursorMessageLifecycle, cursor, &decodedWire); err != nil {
+	if err := DecodeCursor([]string{lifecycleTestSecret}, "u_1", cursorMessageLifecycle, cursor, &decodedWire); err != nil {
 		t.Fatal(err)
 	}
 	if decodedWire["s"] != "asc" {
@@ -200,7 +200,7 @@ func TestMessageLifecycleCursorRejectsMissingOrWrongSortBinding(t *testing.T) {
 		"v": 1, "g": "agent@example.com", "m": "msg_one",
 		"t": time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC), "i": "mlt_000",
 	}
-	missing, err := EncodeCursor(lifecycleTestSecret, cursorMessageLifecycle, base)
+	missing, err := EncodeCursor(lifecycleTestSecret, "u_1", cursorMessageLifecycle, base)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -209,7 +209,7 @@ func TestMessageLifecycleCursorRejectsMissingOrWrongSortBinding(t *testing.T) {
 		wrongPayload[key] = value
 	}
 	wrongPayload["s"] = "desc"
-	wrong, err := EncodeCursor(lifecycleTestSecret, cursorMessageLifecycle, wrongPayload)
+	wrong, err := EncodeCursor(lifecycleTestSecret, "u_1", cursorMessageLifecycle, wrongPayload)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/httpapi/message_lifecycle_test.go
+++ b/internal/httpapi/message_lifecycle_test.go
@@ -164,11 +164,11 @@ func TestMessageLifecycleCursorBindingAndTamper(t *testing.T) {
 	_, first := lifecycleGET(t, srv, "agent@example.com", "msg_one", "?limit=1")
 	cursor := first["next_cursor"].(string)
 	var decoded messageLifecycleCursor
-	if err := DecodeCursor([]string{lifecycleTestSecret}, cursor, &decoded); err != nil {
+	if err := DecodeCursor([]string{lifecycleTestSecret}, cursorMessageLifecycle, cursor, &decoded); err != nil {
 		t.Fatal(err)
 	}
 	var decodedWire map[string]any
-	if err := DecodeCursor([]string{lifecycleTestSecret}, cursor, &decodedWire); err != nil {
+	if err := DecodeCursor([]string{lifecycleTestSecret}, cursorMessageLifecycle, cursor, &decodedWire); err != nil {
 		t.Fatal(err)
 	}
 	if decodedWire["s"] != "asc" {
@@ -200,7 +200,7 @@ func TestMessageLifecycleCursorRejectsMissingOrWrongSortBinding(t *testing.T) {
 		"v": 1, "g": "agent@example.com", "m": "msg_one",
 		"t": time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC), "i": "mlt_000",
 	}
-	missing, err := EncodeCursor(lifecycleTestSecret, base)
+	missing, err := EncodeCursor(lifecycleTestSecret, cursorMessageLifecycle, base)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -209,7 +209,7 @@ func TestMessageLifecycleCursorRejectsMissingOrWrongSortBinding(t *testing.T) {
 		wrongPayload[key] = value
 	}
 	wrongPayload["s"] = "desc"
-	wrong, err := EncodeCursor(lifecycleTestSecret, wrongPayload)
+	wrong, err := EncodeCursor(lifecycleTestSecret, cursorMessageLifecycle, wrongPayload)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/httpapi/messages.go
+++ b/internal/httpapi/messages.go
@@ -730,7 +730,7 @@ func (s *Server) handleListMessages(ctx context.Context, in *ListMessagesInput) 
 	var afterID string
 	if in.Cursor != "" {
 		var cur messagesCursor
-		if err := s.decodeCursor(cursorMessages, in.Cursor, &cur); err != nil {
+		if err := s.decodeCursor(ag.UserID, cursorMessages, in.Cursor, &cur); err != nil {
 			return nil, err
 		}
 		if cur.AgentID != ag.ID || cur.Status != status || cur.Direction != direction || cur.Sort != sort ||
@@ -785,7 +785,7 @@ func (s *Server) handleListMessages(ctx context.Context, in *ListMessagesInput) 
 	var nextCursor string
 	if hasMore {
 		last := msgs[len(msgs)-1]
-		nextCursor, err = EncodeCursor(s.deps.CursorSecret, cursorMessages, messagesCursor{
+		nextCursor, err = EncodeCursor(s.deps.CursorSecret, ag.UserID, cursorMessages, messagesCursor{
 			CreatedAt: last.CreatedAt, ID: last.ID,
 			Status: status, Direction: direction, AgentID: ag.ID, Sort: sort,
 			From: in.From, SubjectContains: in.SubjectContains, ConversationID: in.ConversationID,

--- a/internal/httpapi/messages.go
+++ b/internal/httpapi/messages.go
@@ -730,8 +730,8 @@ func (s *Server) handleListMessages(ctx context.Context, in *ListMessagesInput) 
 	var afterID string
 	if in.Cursor != "" {
 		var cur messagesCursor
-		if err := DecodeCursor([]string{s.deps.CursorSecret}, in.Cursor, &cur); err != nil {
-			return nil, NewError(http.StatusBadRequest, "invalid_cursor", "invalid pagination cursor")
+		if err := s.decodeCursor(cursorMessages, in.Cursor, &cur); err != nil {
+			return nil, err
 		}
 		if cur.AgentID != ag.ID || cur.Status != status || cur.Direction != direction || cur.Sort != sort ||
 			cur.From != in.From || cur.SubjectContains != in.SubjectContains ||
@@ -785,7 +785,7 @@ func (s *Server) handleListMessages(ctx context.Context, in *ListMessagesInput) 
 	var nextCursor string
 	if hasMore {
 		last := msgs[len(msgs)-1]
-		nextCursor, err = EncodeCursor(s.deps.CursorSecret, messagesCursor{
+		nextCursor, err = EncodeCursor(s.deps.CursorSecret, cursorMessages, messagesCursor{
 			CreatedAt: last.CreatedAt, ID: last.ID,
 			Status: status, Direction: direction, AgentID: ag.ID, Sort: sort,
 			From: in.From, SubjectContains: in.SubjectContains, ConversationID: in.ConversationID,

--- a/internal/httpapi/operations.go
+++ b/internal/httpapi/operations.go
@@ -145,7 +145,7 @@ func (s *Server) handleListAgents(ctx context.Context, in *listAgentsInput) (*li
 	}
 	// The cursor is bound to the view (live vs trash) so a continuation can't
 	// silently flip between them.
-	afterCreatedAt, afterID, err := s.decodeKeysetView(cursorAgents, in.Cursor, in.Deleted)
+	afterCreatedAt, afterID, err := s.decodeKeysetView(user.ID, cursorAgents, in.Cursor, in.Deleted)
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +174,7 @@ func (s *Server) handleListAgents(ctx context.Context, in *listAgentsInput) (*li
 	var nextCursor string
 	if hasMore {
 		last := agents[len(agents)-1]
-		if nextCursor, err = s.encodeKeysetView(cursorAgents, last.CreatedAt, last.ID, in.Deleted); err != nil {
+		if nextCursor, err = s.encodeKeysetView(user.ID, cursorAgents, last.CreatedAt, last.ID, in.Deleted); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/httpapi/operations.go
+++ b/internal/httpapi/operations.go
@@ -145,7 +145,7 @@ func (s *Server) handleListAgents(ctx context.Context, in *listAgentsInput) (*li
 	}
 	// The cursor is bound to the view (live vs trash) so a continuation can't
 	// silently flip between them.
-	afterCreatedAt, afterID, err := s.decodeKeysetView(in.Cursor, in.Deleted)
+	afterCreatedAt, afterID, err := s.decodeKeysetView(cursorAgents, in.Cursor, in.Deleted)
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +174,7 @@ func (s *Server) handleListAgents(ctx context.Context, in *listAgentsInput) (*li
 	var nextCursor string
 	if hasMore {
 		last := agents[len(agents)-1]
-		if nextCursor, err = s.encodeKeysetView(last.CreatedAt, last.ID, in.Deleted); err != nil {
+		if nextCursor, err = s.encodeKeysetView(cursorAgents, last.CreatedAt, last.ID, in.Deleted); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/httpapi/pagination.go
+++ b/internal/httpapi/pagination.go
@@ -149,6 +149,13 @@ func (s *Server) decodeCursor(resource CursorResource, cursor string, dst any) e
 // decodeKeyset resolves a (created_at, id) continuation cursor into its keyset
 // position. An empty cursor is the first page (zero time, empty id). A malformed,
 // tampered, or foreign-collection cursor yields a 400 invalid_cursor envelope.
+//
+// This is the NO-trash-view variant, so a cursor carrying Deleted=true is
+// rejected. Today that is unreachable — agents is the only collection with a
+// trash view and it uses decodeKeysetView. It is asserted anyway because the
+// resource argument is compile-enforced while the view argument is not: a future
+// endpoint that grows a ?deleted= filter but keeps calling decodeKeyset would
+// silently lose its view binding with no compile error. Fail loudly instead.
 func (s *Server) decodeKeyset(resource CursorResource, cursor string) (time.Time, string, error) {
 	if cursor == "" {
 		return time.Time{}, "", nil
@@ -156,6 +163,10 @@ func (s *Server) decodeKeyset(resource CursorResource, cursor string) (time.Time
 	var cur keysetCursor
 	if err := s.decodeCursor(resource, cursor, &cur); err != nil {
 		return time.Time{}, "", err
+	}
+	if cur.Deleted {
+		return time.Time{}, "", NewError(http.StatusBadRequest, "invalid_cursor",
+			"cursor was created with a different view — start a new query without a cursor")
 	}
 	return cur.CreatedAt, cur.ID, nil
 }

--- a/internal/httpapi/pagination.go
+++ b/internal/httpapi/pagination.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -50,6 +51,63 @@ type PageParams struct {
 // it to a 400 with code "invalid_cursor".
 var ErrInvalidCursor = errors.New("invalid pagination cursor")
 
+// ErrCursorResourceMismatch is returned when a cursor verifies and decodes
+// but was minted by a DIFFERENT collection than the one now replaying it.
+// It wraps ErrInvalidCursor so `errors.Is(err, ErrInvalidCursor)` still
+// holds for callers that only care that the cursor is unusable, while
+// callers that want to explain *why* can branch on this.
+var ErrCursorResourceMismatch = fmt.Errorf("%w: minted by a different collection", ErrInvalidCursor)
+
+// CursorResource names the collection that minted a cursor. It is signed
+// into the cursor and re-checked on decode, so a cursor issued by one list
+// endpoint cannot be used as a keyset anchor by another.
+//
+// This exists because every account-level list shares the same
+// (created_at, id) cursor shape: a validly-signed cursor from, say,
+// /v1/contacts used to decode cleanly on /v1/events and be applied as a
+// real keyset anchor. Nothing leaked — the queries stayed account-scoped —
+// but the anchor was meaningless, so the endpoint returned an arbitrarily
+// truncated page (commonly `{"items":[]}`) and the client concluded "no
+// events" when there were plenty. A silent wrong answer is worse than a
+// 400. The agent-scoped lists (messages, conversations, engagements, agent
+// suppressions) already pinned their cursors to a filter fingerprint and
+// so already rejected foreign cursors; this generalizes that guarantee to
+// every collection, including the ones with no filters to fingerprint.
+//
+// The value is part of the signed payload, not just a client-visible tag:
+// a client cannot re-target a cursor without breaking the HMAC.
+type CursorResource string
+
+const (
+	cursorAgents              CursorResource = "agents"
+	cursorAPIKeys             CursorResource = "api_keys"
+	cursorAccountSuppressions CursorResource = "account_suppressions"
+	cursorAgentSuppressions   CursorResource = "agent_suppressions"
+	cursorContacts            CursorResource = "contacts"
+	cursorConversations       CursorResource = "conversations"
+	cursorDomains             CursorResource = "domains"
+	cursorEngagements         CursorResource = "engagements"
+	cursorEvents              CursorResource = "events"
+	cursorMessageLifecycle    CursorResource = "message_lifecycle"
+	cursorMessages            CursorResource = "messages"
+	cursorReviews             CursorResource = "reviews"
+	cursorStarterTemplates    CursorResource = "starter_templates"
+	cursorTemplates           CursorResource = "templates"
+	cursorWebhookDeliveries   CursorResource = "webhook_deliveries"
+	cursorWebhooks            CursorResource = "webhooks"
+)
+
+// cursorEnvelope is the on-the-wire cursor payload: the minting
+// collection plus that collection's own private position/filter struct.
+// Wrapping (rather than adding an `r` field to each of the sixteen cursor
+// structs) is what makes the binding impossible to forget — the resource
+// is a required argument of EncodeCursor/DecodeCursor, so a new list
+// endpoint cannot accidentally mint an unbound cursor.
+type cursorEnvelope struct {
+	Resource string          `json:"r"`
+	Payload  json.RawMessage `json:"p"`
+}
+
 // keysetCursor is the standard opaque continuation for a collection
 // keyset-paginated on (created_at, id) with no cursor-pinned filters — the
 // common case across the account-scoped lists (agents, domains, webhooks,
@@ -69,16 +127,35 @@ type keysetCursor struct {
 	Deleted bool `json:"dl,omitempty"`
 }
 
+// decodeCursor is the one place list handlers turn a client-supplied cursor
+// into their own cursor struct. It binds the cursor to `resource` and
+// converts every failure into the right 400 invalid_cursor envelope, so no
+// handler has to remember either step.
+//
+// An empty cursor is the first page: dst is left untouched and nil returned.
+func (s *Server) decodeCursor(resource CursorResource, cursor string, dst any) error {
+	err := DecodeCursor([]string{s.deps.CursorSecret}, resource, cursor, dst)
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, ErrCursorResourceMismatch):
+		return NewError(http.StatusBadRequest, "invalid_cursor",
+			"cursor was created by a different endpoint — start a new query without a cursor")
+	default:
+		return NewError(http.StatusBadRequest, "invalid_cursor", "invalid pagination cursor")
+	}
+}
+
 // decodeKeyset resolves a (created_at, id) continuation cursor into its keyset
-// position. An empty cursor is the first page (zero time, empty id). A malformed
-// or tampered cursor yields a 400 invalid_cursor envelope.
-func (s *Server) decodeKeyset(cursor string) (time.Time, string, error) {
+// position. An empty cursor is the first page (zero time, empty id). A malformed,
+// tampered, or foreign-collection cursor yields a 400 invalid_cursor envelope.
+func (s *Server) decodeKeyset(resource CursorResource, cursor string) (time.Time, string, error) {
 	if cursor == "" {
 		return time.Time{}, "", nil
 	}
 	var cur keysetCursor
-	if err := DecodeCursor([]string{s.deps.CursorSecret}, cursor, &cur); err != nil {
-		return time.Time{}, "", NewError(http.StatusBadRequest, "invalid_cursor", "invalid pagination cursor")
+	if err := s.decodeCursor(resource, cursor, &cur); err != nil {
+		return time.Time{}, "", err
 	}
 	return cur.CreatedAt, cur.ID, nil
 }
@@ -87,13 +164,13 @@ func (s *Server) decodeKeyset(cursor string) (time.Time, string, error) {
 // verifies the cursor was minted for the SAME view (live vs deleted), so a
 // live-list cursor replayed with ?deleted=true (or vice versa) is a 400
 // instead of a silently truncated other-view listing.
-func (s *Server) decodeKeysetView(cursor string, deleted bool) (time.Time, string, error) {
+func (s *Server) decodeKeysetView(resource CursorResource, cursor string, deleted bool) (time.Time, string, error) {
 	if cursor == "" {
 		return time.Time{}, "", nil
 	}
 	var cur keysetCursor
-	if err := DecodeCursor([]string{s.deps.CursorSecret}, cursor, &cur); err != nil {
-		return time.Time{}, "", NewError(http.StatusBadRequest, "invalid_cursor", "invalid pagination cursor")
+	if err := s.decodeCursor(resource, cursor, &cur); err != nil {
+		return time.Time{}, "", err
 	}
 	if cur.Deleted != deleted {
 		return time.Time{}, "", NewError(http.StatusBadRequest, "invalid_cursor",
@@ -104,13 +181,13 @@ func (s *Server) decodeKeysetView(cursor string, deleted bool) (time.Time, strin
 
 // encodeKeyset mints the next-page cursor from the last row's (created_at, id).
 // A marshal failure maps to a 500 envelope (matches the other list handlers).
-func (s *Server) encodeKeyset(createdAt time.Time, id string) (string, error) {
-	return s.encodeKeysetView(createdAt, id, false)
+func (s *Server) encodeKeyset(resource CursorResource, createdAt time.Time, id string) (string, error) {
+	return s.encodeKeysetView(resource, createdAt, id, false)
 }
 
 // encodeKeysetView is encodeKeyset carrying the trash-view flag.
-func (s *Server) encodeKeysetView(createdAt time.Time, id string, deleted bool) (string, error) {
-	c, err := EncodeCursor(s.deps.CursorSecret, keysetCursor{CreatedAt: createdAt, ID: id, Deleted: deleted})
+func (s *Server) encodeKeysetView(resource CursorResource, createdAt time.Time, id string, deleted bool) (string, error) {
+	c, err := EncodeCursor(s.deps.CursorSecret, resource, keysetCursor{CreatedAt: createdAt, ID: id, Deleted: deleted})
 	if err != nil {
 		return "", NewError(http.StatusInternalServerError, "internal_error", "failed to build pagination cursor")
 	}
@@ -139,17 +216,25 @@ const defaultPageLimit = 100
 // breaks the signature and DecodeCursor rejects it. The cursor remains
 // opaque to clients; the payload shape stays private to each resource.
 //
+// resource is the minting collection; it is embedded in the signed payload
+// so DecodeCursor can reject a cursor replayed on a different endpoint.
+//
 // Format:
 //
-//	base64url(json_payload) + "." + base64url(hmac_sha256(secret, base64url(json_payload)))
+//	envelope     = {"r": resource, "p": json_payload}
+//	base64url(envelope) + "." + base64url(hmac_sha256(secret, base64url(envelope)))
 //
 // The MAC is computed over the LITERAL emitted base64url(json) segment (not
 // a re-marshaled struct) so encode and verify are byte-canonical and cannot
 // drift. secret is the deployment HMAC secret (config.Signing.HMACSecret) —
 // the same deployment key used by approval tokens,
 // so there is no new key to manage.
-func EncodeCursor(secret string, payload any) (string, error) {
-	raw, err := json.Marshal(payload)
+func EncodeCursor(secret string, resource CursorResource, payload any) (string, error) {
+	inner, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	raw, err := json.Marshal(cursorEnvelope{Resource: string(resource), Payload: inner})
 	if err != nil {
 		return "", err
 	}
@@ -169,11 +254,18 @@ func EncodeCursor(secret string, payload any) (string, error) {
 // HMAC-secret rotation: a cursor signed under an old secret keeps verifying
 // until that secret is retired. Today callers pass a single-element slice.
 //
+// resource is the collection doing the decoding. A cursor whose signed
+// envelope names a different collection is rejected with
+// ErrCursorResourceMismatch — the fix for foreign cursors being silently
+// accepted as keyset anchors across account-level lists.
+//
 // Old unsigned cursors (plain base64url(json) with no "." signature segment,
 // as emitted before issue #144 M2) no longer verify and are hard-rejected
-// with ErrInvalidCursor. Cursors are ephemeral, so a client mid-pagination
-// simply restarts the query.
-func DecodeCursor(secrets []string, cursor string, dst any) error {
+// with ErrInvalidCursor. Pre-envelope signed cursors are likewise rejected:
+// they carry no resource, so there is nothing to bind them to. Cursors are
+// ephemeral, so a client mid-pagination simply restarts the query — the
+// same trade the M2 signing change already made.
+func DecodeCursor(secrets []string, resource CursorResource, cursor string, dst any) error {
 	if cursor == "" {
 		return nil
 	}
@@ -199,7 +291,18 @@ func DecodeCursor(secrets []string, cursor string, dst any) error {
 	if err != nil {
 		return ErrInvalidCursor
 	}
-	if err := json.Unmarshal(raw, dst); err != nil {
+	var env cursorEnvelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return ErrInvalidCursor
+	}
+	if env.Resource == "" || len(env.Payload) == 0 {
+		// Pre-envelope cursor (or a hand-rolled payload). Unbindable.
+		return ErrInvalidCursor
+	}
+	if env.Resource != string(resource) {
+		return ErrCursorResourceMismatch
+	}
+	if err := json.Unmarshal(env.Payload, dst); err != nil {
 		return ErrInvalidCursor
 	}
 	return nil

--- a/internal/httpapi/pagination.go
+++ b/internal/httpapi/pagination.go
@@ -102,7 +102,13 @@ const (
 // Wrapping (rather than adding an `r` field to each of the sixteen cursor
 // structs) is what makes the binding impossible to forget — the resource
 // is a required argument of EncodeCursor/DecodeCursor, so a new list
-// endpoint cannot accidentally mint an unbound cursor.
+// endpoint cannot accidentally mint an unbound cursor. The same mechanism
+// covers the second binding axis, the minting ACCOUNT: the account ID is
+// likewise a required argument (threaded from the handler's authenticated
+// principal, never pulled implicitly from a context), so a missed site is
+// a compile error, not a silently unbound cursor. The account does NOT
+// appear as an envelope field — see cursorKey for why it lives in the MAC
+// key instead.
 type cursorEnvelope struct {
 	Resource string          `json:"r"`
 	Payload  json.RawMessage `json:"p"`
@@ -128,13 +134,14 @@ type keysetCursor struct {
 }
 
 // decodeCursor is the one place list handlers turn a client-supplied cursor
-// into their own cursor struct. It binds the cursor to `resource` and
+// into their own cursor struct. It binds the cursor to `resource` and to the
+// calling account (`accountID` — the authenticated Principal.User.ID) and
 // converts every failure into the right 400 invalid_cursor envelope, so no
-// handler has to remember either step.
+// handler has to remember any of those steps.
 //
 // An empty cursor is the first page: dst is left untouched and nil returned.
-func (s *Server) decodeCursor(resource CursorResource, cursor string, dst any) error {
-	err := DecodeCursor([]string{s.deps.CursorSecret}, resource, cursor, dst)
+func (s *Server) decodeCursor(accountID string, resource CursorResource, cursor string, dst any) error {
+	err := DecodeCursor([]string{s.deps.CursorSecret}, accountID, resource, cursor, dst)
 	switch {
 	case err == nil:
 		return nil
@@ -156,12 +163,12 @@ func (s *Server) decodeCursor(resource CursorResource, cursor string, dst any) e
 // resource argument is compile-enforced while the view argument is not: a future
 // endpoint that grows a ?deleted= filter but keeps calling decodeKeyset would
 // silently lose its view binding with no compile error. Fail loudly instead.
-func (s *Server) decodeKeyset(resource CursorResource, cursor string) (time.Time, string, error) {
+func (s *Server) decodeKeyset(accountID string, resource CursorResource, cursor string) (time.Time, string, error) {
 	if cursor == "" {
 		return time.Time{}, "", nil
 	}
 	var cur keysetCursor
-	if err := s.decodeCursor(resource, cursor, &cur); err != nil {
+	if err := s.decodeCursor(accountID, resource, cursor, &cur); err != nil {
 		return time.Time{}, "", err
 	}
 	if cur.Deleted {
@@ -175,12 +182,12 @@ func (s *Server) decodeKeyset(resource CursorResource, cursor string) (time.Time
 // verifies the cursor was minted for the SAME view (live vs deleted), so a
 // live-list cursor replayed with ?deleted=true (or vice versa) is a 400
 // instead of a silently truncated other-view listing.
-func (s *Server) decodeKeysetView(resource CursorResource, cursor string, deleted bool) (time.Time, string, error) {
+func (s *Server) decodeKeysetView(accountID string, resource CursorResource, cursor string, deleted bool) (time.Time, string, error) {
 	if cursor == "" {
 		return time.Time{}, "", nil
 	}
 	var cur keysetCursor
-	if err := s.decodeCursor(resource, cursor, &cur); err != nil {
+	if err := s.decodeCursor(accountID, resource, cursor, &cur); err != nil {
 		return time.Time{}, "", err
 	}
 	if cur.Deleted != deleted {
@@ -192,13 +199,13 @@ func (s *Server) decodeKeysetView(resource CursorResource, cursor string, delete
 
 // encodeKeyset mints the next-page cursor from the last row's (created_at, id).
 // A marshal failure maps to a 500 envelope (matches the other list handlers).
-func (s *Server) encodeKeyset(resource CursorResource, createdAt time.Time, id string) (string, error) {
-	return s.encodeKeysetView(resource, createdAt, id, false)
+func (s *Server) encodeKeyset(accountID string, resource CursorResource, createdAt time.Time, id string) (string, error) {
+	return s.encodeKeysetView(accountID, resource, createdAt, id, false)
 }
 
 // encodeKeysetView is encodeKeyset carrying the trash-view flag.
-func (s *Server) encodeKeysetView(resource CursorResource, createdAt time.Time, id string, deleted bool) (string, error) {
-	c, err := EncodeCursor(s.deps.CursorSecret, resource, keysetCursor{CreatedAt: createdAt, ID: id, Deleted: deleted})
+func (s *Server) encodeKeysetView(accountID string, resource CursorResource, createdAt time.Time, id string, deleted bool) (string, error) {
+	c, err := EncodeCursor(s.deps.CursorSecret, accountID, resource, keysetCursor{CreatedAt: createdAt, ID: id, Deleted: deleted})
 	if err != nil {
 		return "", NewError(http.StatusInternalServerError, "internal_error", "failed to build pagination cursor")
 	}
@@ -230,17 +237,25 @@ const defaultPageLimit = 100
 // resource is the minting collection; it is embedded in the signed payload
 // so DecodeCursor can reject a cursor replayed on a different endpoint.
 //
+// accountID is the minting account (the authenticated Principal.User.ID —
+// the level every list query is already scoped at, deliberately NOT the API
+// key ID, whose rotation would break in-flight pagination, and NOT the
+// scope/agent, so an account-scoped key can resume a cursor an agent-scoped
+// key minted over the same rows). It binds the cursor via the MAC key — see
+// cursorKey — so account A's cursor fails verification for account B on the
+// same endpoint instead of anchoring B's query at a meaningless position.
+//
 // Format:
 //
 //	envelope     = {"r": resource, "p": json_payload}
-//	base64url(envelope) + "." + base64url(hmac_sha256(secret, base64url(envelope)))
+//	base64url(envelope) + "." + base64url(hmac_sha256(cursorKey(secret, accountID), base64url(envelope)))
 //
 // The MAC is computed over the LITERAL emitted base64url(json) segment (not
 // a re-marshaled struct) so encode and verify are byte-canonical and cannot
 // drift. secret is the deployment HMAC secret (config.Signing.HMACSecret) —
 // the same deployment key used by approval tokens,
 // so there is no new key to manage.
-func EncodeCursor(secret string, resource CursorResource, payload any) (string, error) {
+func EncodeCursor(secret, accountID string, resource CursorResource, payload any) (string, error) {
 	inner, err := json.Marshal(payload)
 	if err != nil {
 		return "", err
@@ -250,7 +265,7 @@ func EncodeCursor(secret string, resource CursorResource, payload any) (string, 
 		return "", err
 	}
 	encoded := base64.RawURLEncoding.EncodeToString(raw)
-	sig := cursorMAC([]byte(secret), []byte(encoded))
+	sig := cursorMAC(cursorKey(secret, accountID), []byte(encoded))
 	return encoded + "." + base64.RawURLEncoding.EncodeToString(sig), nil
 }
 
@@ -270,13 +285,20 @@ func EncodeCursor(secret string, resource CursorResource, payload any) (string, 
 // ErrCursorResourceMismatch — the fix for foreign cursors being silently
 // accepted as keyset anchors across account-level lists.
 //
+// accountID is the account doing the decoding. Because the account binds
+// via the derived MAC key (cursorKey), a cursor minted by a different
+// account simply fails signature verification and falls out as the plain
+// ErrInvalidCursor — deliberately indistinguishable from a forged or
+// tampered cursor, so the error surface gains no new code and a caller
+// learns nothing about whether a stolen cursor was "well-formed".
+//
 // Old unsigned cursors (plain base64url(json) with no "." signature segment,
 // as emitted before issue #144 M2) no longer verify and are hard-rejected
 // with ErrInvalidCursor. Pre-envelope signed cursors are likewise rejected:
 // they carry no resource, so there is nothing to bind them to. Cursors are
 // ephemeral, so a client mid-pagination simply restarts the query — the
 // same trade the M2 signing change already made.
-func DecodeCursor(secrets []string, resource CursorResource, cursor string, dst any) error {
+func DecodeCursor(secrets []string, accountID string, resource CursorResource, cursor string, dst any) error {
 	if cursor == "" {
 		return nil
 	}
@@ -290,7 +312,7 @@ func DecodeCursor(secrets []string, resource CursorResource, cursor string, dst 
 	}
 	matched := false
 	for _, secret := range secrets {
-		if hmac.Equal(providedSig, cursorMAC([]byte(secret), []byte(parts[0]))) {
+		if hmac.Equal(providedSig, cursorMAC(cursorKey(secret, accountID), []byte(parts[0]))) {
 			matched = true
 			break
 		}
@@ -325,4 +347,24 @@ func cursorMAC(secret, payload []byte) []byte {
 	mac := hmac.New(sha256.New, secret)
 	mac.Write(payload)
 	return mac.Sum(nil)
+}
+
+// cursorKeyDomain domain-separates the per-account cursor key derivation
+// from any other HMAC use of the deployment secret (approval tokens sign
+// with the raw secret; cursors sign with a derived key).
+const cursorKeyDomain = "e2a/cursor/v1|"
+
+// cursorKey derives the per-account cursor MAC key:
+//
+//	key = HMAC-SHA256(secret, "e2a/cursor/v1|" + accountID)
+//
+// Binding the account into the KEY rather than into the envelope is
+// deliberate: the envelope is signed but NOT encrypted (plain base64url),
+// and cursors travel in query strings — a plaintext account ID would leak
+// into access logs, referrer headers, and anything else that records URLs.
+// Key derivation keeps the envelope schema untouched and makes a foreign
+// account's cursor fail plain MAC verification, indistinguishable from a
+// forgery.
+func cursorKey(secret, accountID string) []byte {
+	return cursorMAC([]byte(secret), []byte(cursorKeyDomain+accountID))
 }

--- a/internal/httpapi/pagination_test.go
+++ b/internal/httpapi/pagination_test.go
@@ -10,13 +10,18 @@ import (
 // pagination cursors in these unit tests.
 const testSecret = "0123456789abcdef0123456789abcdef"
 
+// testResource is a stand-in collection name for the low-level
+// encode/decode unit tests below; the endpoint-level binding tests live in
+// pagination_endpoints_test.go and use the real resource constants.
+const testResource CursorResource = "test_resource"
+
 func TestCursorRoundTrip(t *testing.T) {
 	type cur struct {
 		After string `json:"after"`
 		Dir   string `json:"dir"`
 	}
 	in := cur{After: "msg_123", Dir: "inbound"}
-	enc, err := EncodeCursor(testSecret, in)
+	enc, err := EncodeCursor(testSecret, testResource, in)
 	if err != nil {
 		t.Fatalf("encode: %v", err)
 	}
@@ -28,7 +33,7 @@ func TestCursorRoundTrip(t *testing.T) {
 		t.Fatalf("expected exactly one '.' separator, got %q", enc)
 	}
 	var out cur
-	if err := DecodeCursor([]string{testSecret}, enc, &out); err != nil {
+	if err := DecodeCursor([]string{testSecret}, testResource, enc, &out); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
 	if out != in {
@@ -38,7 +43,7 @@ func TestCursorRoundTrip(t *testing.T) {
 
 func TestDecodeCursorEmptyIsNoop(t *testing.T) {
 	out := struct{ A string }{A: "untouched"}
-	if err := DecodeCursor([]string{testSecret}, "", &out); err != nil {
+	if err := DecodeCursor([]string{testSecret}, testResource, "", &out); err != nil {
 		t.Fatalf("empty cursor should be a no-op, got %v", err)
 	}
 	if out.A != "untouched" {
@@ -49,13 +54,13 @@ func TestDecodeCursorEmptyIsNoop(t *testing.T) {
 func TestDecodeCursorMalformed(t *testing.T) {
 	var out struct{ A string }
 	// Not valid base64url and no signature segment.
-	if err := DecodeCursor([]string{testSecret}, "!!!not-base64!!!", &out); err != ErrInvalidCursor {
+	if err := DecodeCursor([]string{testSecret}, testResource, "!!!not-base64!!!", &out); err != ErrInvalidCursor {
 		t.Fatalf("want ErrInvalidCursor, got %v", err)
 	}
 	// Valid base64url payload + valid signature, but the payload is not the
 	// dst struct shape (a bare string).
-	bad := EncodeMust(t, testSecret, "a string, not the struct")
-	if err := DecodeCursor([]string{testSecret}, bad, &out); err != ErrInvalidCursor {
+	bad := EncodeMust(t, testSecret, testResource, "a string, not the struct")
+	if err := DecodeCursor([]string{testSecret}, testResource, bad, &out); err != ErrInvalidCursor {
 		t.Fatalf("want ErrInvalidCursor on bad json, got %v", err)
 	}
 }
@@ -64,7 +69,7 @@ func TestDecodeCursorTamperedPayload(t *testing.T) {
 	type cur struct {
 		Agent string `json:"agent_email"`
 	}
-	enc := EncodeMust(t, testSecret, cur{Agent: "agent_a"})
+	enc := EncodeMust(t, testSecret, testResource, cur{Agent: "agent_a"})
 	// Flip a byte in the base64 payload segment (before the '.'); the
 	// signature no longer matches.
 	dot := strings.IndexByte(enc, '.')
@@ -79,7 +84,7 @@ func TestDecodeCursorTamperedPayload(t *testing.T) {
 		b[0] = 'A'
 	}
 	var out cur
-	if err := DecodeCursor([]string{testSecret}, string(b), &out); err != ErrInvalidCursor {
+	if err := DecodeCursor([]string{testSecret}, testResource, string(b), &out); err != ErrInvalidCursor {
 		t.Fatalf("tampered payload: want ErrInvalidCursor, got %v", err)
 	}
 }
@@ -88,9 +93,9 @@ func TestDecodeCursorWrongSecret(t *testing.T) {
 	type cur struct {
 		A string `json:"a"`
 	}
-	enc := EncodeMust(t, testSecret, cur{A: "x"})
+	enc := EncodeMust(t, testSecret, testResource, cur{A: "x"})
 	var out cur
-	if err := DecodeCursor([]string{"a-different-secret-value-here-3232"}, enc, &out); err != ErrInvalidCursor {
+	if err := DecodeCursor([]string{"a-different-secret-value-here-3232"}, testResource, enc, &out); err != ErrInvalidCursor {
 		t.Fatalf("wrong secret: want ErrInvalidCursor, got %v", err)
 	}
 }
@@ -100,13 +105,13 @@ func TestDecodeCursorOldUnsignedFormatRejected(t *testing.T) {
 	type cur struct {
 		A string `json:"a"`
 	}
-	signed := EncodeMust(t, testSecret, cur{A: "x"})
+	signed := EncodeMust(t, testSecret, testResource, cur{A: "x"})
 	unsigned, _, ok := strings.Cut(signed, ".")
 	if !ok {
 		t.Fatalf("expected a signature separator in %q", signed)
 	}
 	var out cur
-	if err := DecodeCursor([]string{testSecret}, unsigned, &out); err != ErrInvalidCursor {
+	if err := DecodeCursor([]string{testSecret}, testResource, unsigned, &out); err != ErrInvalidCursor {
 		t.Fatalf("old unsigned cursor: want ErrInvalidCursor, got %v", err)
 	}
 }
@@ -119,9 +124,9 @@ func TestDecodeCursorMultiSecretRotation(t *testing.T) {
 	const secretB = "secret-B-padding-padding-padding-32"
 	// Sign with B; verify against [A, B] — a rotation where B is the newest
 	// secret and A is still accepted.
-	enc := EncodeMust(t, secretB, cur{A: "rotated"})
+	enc := EncodeMust(t, secretB, testResource, cur{A: "rotated"})
 	var out cur
-	if err := DecodeCursor([]string{secretA, secretB}, enc, &out); err != nil {
+	if err := DecodeCursor([]string{secretA, secretB}, testResource, enc, &out); err != nil {
 		t.Fatalf("multi-secret verify: %v", err)
 	}
 	if out.A != "rotated" {
@@ -145,9 +150,9 @@ func TestNewPageNullVsEmpty(t *testing.T) {
 }
 
 // EncodeMust is a test helper that encodes a cursor or fails the test.
-func EncodeMust(t *testing.T, secret string, payload any) string {
+func EncodeMust(t *testing.T, secret string, resource CursorResource, payload any) string {
 	t.Helper()
-	s, err := EncodeCursor(secret, payload)
+	s, err := EncodeCursor(secret, resource, payload)
 	if err != nil {
 		t.Fatalf("encode: %v", err)
 	}

--- a/internal/httpapi/pagination_test.go
+++ b/internal/httpapi/pagination_test.go
@@ -15,13 +15,18 @@ const testSecret = "0123456789abcdef0123456789abcdef"
 // pagination_endpoints_test.go and use the real resource constants.
 const testResource CursorResource = "test_resource"
 
+// testAccount is a stand-in account ID (Principal.User.ID) for the same
+// low-level tests; the account-binding behavior itself is covered in
+// cursor_binding_test.go.
+const testAccount = "u_test"
+
 func TestCursorRoundTrip(t *testing.T) {
 	type cur struct {
 		After string `json:"after"`
 		Dir   string `json:"dir"`
 	}
 	in := cur{After: "msg_123", Dir: "inbound"}
-	enc, err := EncodeCursor(testSecret, testResource, in)
+	enc, err := EncodeCursor(testSecret, testAccount, testResource, in)
 	if err != nil {
 		t.Fatalf("encode: %v", err)
 	}
@@ -33,7 +38,7 @@ func TestCursorRoundTrip(t *testing.T) {
 		t.Fatalf("expected exactly one '.' separator, got %q", enc)
 	}
 	var out cur
-	if err := DecodeCursor([]string{testSecret}, testResource, enc, &out); err != nil {
+	if err := DecodeCursor([]string{testSecret}, testAccount, testResource, enc, &out); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
 	if out != in {
@@ -43,7 +48,7 @@ func TestCursorRoundTrip(t *testing.T) {
 
 func TestDecodeCursorEmptyIsNoop(t *testing.T) {
 	out := struct{ A string }{A: "untouched"}
-	if err := DecodeCursor([]string{testSecret}, testResource, "", &out); err != nil {
+	if err := DecodeCursor([]string{testSecret}, testAccount, testResource, "", &out); err != nil {
 		t.Fatalf("empty cursor should be a no-op, got %v", err)
 	}
 	if out.A != "untouched" {
@@ -54,13 +59,13 @@ func TestDecodeCursorEmptyIsNoop(t *testing.T) {
 func TestDecodeCursorMalformed(t *testing.T) {
 	var out struct{ A string }
 	// Not valid base64url and no signature segment.
-	if err := DecodeCursor([]string{testSecret}, testResource, "!!!not-base64!!!", &out); err != ErrInvalidCursor {
+	if err := DecodeCursor([]string{testSecret}, testAccount, testResource, "!!!not-base64!!!", &out); err != ErrInvalidCursor {
 		t.Fatalf("want ErrInvalidCursor, got %v", err)
 	}
 	// Valid base64url payload + valid signature, but the payload is not the
 	// dst struct shape (a bare string).
-	bad := EncodeMust(t, testSecret, testResource, "a string, not the struct")
-	if err := DecodeCursor([]string{testSecret}, testResource, bad, &out); err != ErrInvalidCursor {
+	bad := EncodeMust(t, testSecret, testAccount, testResource, "a string, not the struct")
+	if err := DecodeCursor([]string{testSecret}, testAccount, testResource, bad, &out); err != ErrInvalidCursor {
 		t.Fatalf("want ErrInvalidCursor on bad json, got %v", err)
 	}
 }
@@ -69,7 +74,7 @@ func TestDecodeCursorTamperedPayload(t *testing.T) {
 	type cur struct {
 		Agent string `json:"agent_email"`
 	}
-	enc := EncodeMust(t, testSecret, testResource, cur{Agent: "agent_a"})
+	enc := EncodeMust(t, testSecret, testAccount, testResource, cur{Agent: "agent_a"})
 	// Flip a byte in the base64 payload segment (before the '.'); the
 	// signature no longer matches.
 	dot := strings.IndexByte(enc, '.')
@@ -84,7 +89,7 @@ func TestDecodeCursorTamperedPayload(t *testing.T) {
 		b[0] = 'A'
 	}
 	var out cur
-	if err := DecodeCursor([]string{testSecret}, testResource, string(b), &out); err != ErrInvalidCursor {
+	if err := DecodeCursor([]string{testSecret}, testAccount, testResource, string(b), &out); err != ErrInvalidCursor {
 		t.Fatalf("tampered payload: want ErrInvalidCursor, got %v", err)
 	}
 }
@@ -93,9 +98,9 @@ func TestDecodeCursorWrongSecret(t *testing.T) {
 	type cur struct {
 		A string `json:"a"`
 	}
-	enc := EncodeMust(t, testSecret, testResource, cur{A: "x"})
+	enc := EncodeMust(t, testSecret, testAccount, testResource, cur{A: "x"})
 	var out cur
-	if err := DecodeCursor([]string{"a-different-secret-value-here-3232"}, testResource, enc, &out); err != ErrInvalidCursor {
+	if err := DecodeCursor([]string{"a-different-secret-value-here-3232"}, testAccount, testResource, enc, &out); err != ErrInvalidCursor {
 		t.Fatalf("wrong secret: want ErrInvalidCursor, got %v", err)
 	}
 }
@@ -105,13 +110,13 @@ func TestDecodeCursorOldUnsignedFormatRejected(t *testing.T) {
 	type cur struct {
 		A string `json:"a"`
 	}
-	signed := EncodeMust(t, testSecret, testResource, cur{A: "x"})
+	signed := EncodeMust(t, testSecret, testAccount, testResource, cur{A: "x"})
 	unsigned, _, ok := strings.Cut(signed, ".")
 	if !ok {
 		t.Fatalf("expected a signature separator in %q", signed)
 	}
 	var out cur
-	if err := DecodeCursor([]string{testSecret}, testResource, unsigned, &out); err != ErrInvalidCursor {
+	if err := DecodeCursor([]string{testSecret}, testAccount, testResource, unsigned, &out); err != ErrInvalidCursor {
 		t.Fatalf("old unsigned cursor: want ErrInvalidCursor, got %v", err)
 	}
 }
@@ -124,9 +129,9 @@ func TestDecodeCursorMultiSecretRotation(t *testing.T) {
 	const secretB = "secret-B-padding-padding-padding-32"
 	// Sign with B; verify against [A, B] — a rotation where B is the newest
 	// secret and A is still accepted.
-	enc := EncodeMust(t, secretB, testResource, cur{A: "rotated"})
+	enc := EncodeMust(t, secretB, testAccount, testResource, cur{A: "rotated"})
 	var out cur
-	if err := DecodeCursor([]string{secretA, secretB}, testResource, enc, &out); err != nil {
+	if err := DecodeCursor([]string{secretA, secretB}, testAccount, testResource, enc, &out); err != nil {
 		t.Fatalf("multi-secret verify: %v", err)
 	}
 	if out.A != "rotated" {
@@ -150,9 +155,9 @@ func TestNewPageNullVsEmpty(t *testing.T) {
 }
 
 // EncodeMust is a test helper that encodes a cursor or fails the test.
-func EncodeMust(t *testing.T, secret string, resource CursorResource, payload any) string {
+func EncodeMust(t *testing.T, secret, accountID string, resource CursorResource, payload any) string {
 	t.Helper()
-	s, err := EncodeCursor(secret, resource, payload)
+	s, err := EncodeCursor(secret, accountID, resource, payload)
 	if err != nil {
 		t.Fatalf("encode: %v", err)
 	}

--- a/internal/httpapi/reviews.go
+++ b/internal/httpapi/reviews.go
@@ -160,7 +160,7 @@ func (s *Server) handleListReviews(ctx context.Context, in *listReviewsInput) (*
 	if s.deps.ListReviews == nil {
 		return nil, NewError(http.StatusNotImplemented, "not_implemented", "reviews are not available on this deployment")
 	}
-	afterCreatedAt, afterID, err := s.decodeKeyset(in.Cursor)
+	afterCreatedAt, afterID, err := s.decodeKeyset(cursorReviews, in.Cursor)
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +181,7 @@ func (s *Server) handleListReviews(ctx context.Context, in *listReviewsInput) (*
 	var nextCursor string
 	if hasMore {
 		last := items[len(items)-1]
-		if nextCursor, err = s.encodeKeyset(last.CreatedAt, last.ID); err != nil {
+		if nextCursor, err = s.encodeKeyset(cursorReviews, last.CreatedAt, last.ID); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/httpapi/reviews.go
+++ b/internal/httpapi/reviews.go
@@ -160,7 +160,7 @@ func (s *Server) handleListReviews(ctx context.Context, in *listReviewsInput) (*
 	if s.deps.ListReviews == nil {
 		return nil, NewError(http.StatusNotImplemented, "not_implemented", "reviews are not available on this deployment")
 	}
-	afterCreatedAt, afterID, err := s.decodeKeyset(cursorReviews, in.Cursor)
+	afterCreatedAt, afterID, err := s.decodeKeyset(p.User.ID, cursorReviews, in.Cursor)
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +181,7 @@ func (s *Server) handleListReviews(ctx context.Context, in *listReviewsInput) (*
 	var nextCursor string
 	if hasMore {
 		last := items[len(items)-1]
-		if nextCursor, err = s.encodeKeyset(cursorReviews, last.CreatedAt, last.ID); err != nil {
+		if nextCursor, err = s.encodeKeyset(p.User.ID, cursorReviews, last.CreatedAt, last.ID); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/httpapi/startertemplates.go
+++ b/internal/httpapi/startertemplates.go
@@ -104,7 +104,12 @@ func (s *Server) registerStarterTemplates() {
 }
 
 func (s *Server) handleListStarterTemplates(ctx context.Context, in *listStarterTemplatesInput) (*listStarterTemplatesOutput, error) {
-	if _, err := s.requireAccountUser(ctx); err != nil {
+	// The catalog is global, but the cursor is still bound to the calling
+	// account like every other collection — the handler is auth-gated, so a
+	// principal is always in hand, and a blanket rule stays auditable where a
+	// per-collection carve-out list would be how holes reappear.
+	user, err := s.requireAccountUser(ctx)
+	if err != nil {
 		return nil, err
 	}
 	cat := startertemplates.Catalog() // already alias-sorted (ascending)
@@ -113,7 +118,7 @@ func (s *Server) handleListStarterTemplates(ctx context.Context, in *listStarter
 	var afterAlias string
 	if in.Cursor != "" {
 		var cur starterTemplatesCursor
-		if err := s.decodeCursor(cursorStarterTemplates, in.Cursor, &cur); err != nil {
+		if err := s.decodeCursor(user.ID, cursorStarterTemplates, in.Cursor, &cur); err != nil {
 			return nil, err
 		}
 		afterAlias = cur.Alias
@@ -136,7 +141,7 @@ func (s *Server) handleListStarterTemplates(ctx context.Context, in *listStarter
 	var nextCursor string
 	if hasMore {
 		var err error
-		if nextCursor, err = EncodeCursor(s.deps.CursorSecret, cursorStarterTemplates, starterTemplatesCursor{Alias: lastAlias}); err != nil {
+		if nextCursor, err = EncodeCursor(s.deps.CursorSecret, user.ID, cursorStarterTemplates, starterTemplatesCursor{Alias: lastAlias}); err != nil {
 			return nil, NewError(http.StatusInternalServerError, "internal_error", "failed to build pagination cursor")
 		}
 	}

--- a/internal/httpapi/startertemplates.go
+++ b/internal/httpapi/startertemplates.go
@@ -113,8 +113,8 @@ func (s *Server) handleListStarterTemplates(ctx context.Context, in *listStarter
 	var afterAlias string
 	if in.Cursor != "" {
 		var cur starterTemplatesCursor
-		if err := DecodeCursor([]string{s.deps.CursorSecret}, in.Cursor, &cur); err != nil {
-			return nil, NewError(http.StatusBadRequest, "invalid_cursor", "invalid pagination cursor")
+		if err := s.decodeCursor(cursorStarterTemplates, in.Cursor, &cur); err != nil {
+			return nil, err
 		}
 		afterAlias = cur.Alias
 	}
@@ -136,7 +136,7 @@ func (s *Server) handleListStarterTemplates(ctx context.Context, in *listStarter
 	var nextCursor string
 	if hasMore {
 		var err error
-		if nextCursor, err = EncodeCursor(s.deps.CursorSecret, starterTemplatesCursor{Alias: lastAlias}); err != nil {
+		if nextCursor, err = EncodeCursor(s.deps.CursorSecret, cursorStarterTemplates, starterTemplatesCursor{Alias: lastAlias}); err != nil {
 			return nil, NewError(http.StatusInternalServerError, "internal_error", "failed to build pagination cursor")
 		}
 	}

--- a/internal/httpapi/templates.go
+++ b/internal/httpapi/templates.go
@@ -321,7 +321,7 @@ func (s *Server) handleListTemplates(ctx context.Context, in *listTemplatesInput
 	if s.deps.ListTemplates == nil {
 		return nil, NewError(http.StatusInternalServerError, "internal_error", "templates unavailable")
 	}
-	afterCreatedAt, afterID, err := s.decodeKeyset(cursorTemplates, in.Cursor)
+	afterCreatedAt, afterID, err := s.decodeKeyset(user.ID, cursorTemplates, in.Cursor)
 	if err != nil {
 		return nil, err
 	}
@@ -342,7 +342,7 @@ func (s *Server) handleListTemplates(ctx context.Context, in *listTemplatesInput
 	var nextCursor string
 	if hasMore {
 		last := tps[len(tps)-1]
-		if nextCursor, err = s.encodeKeyset(cursorTemplates, last.CreatedAt, last.ID); err != nil {
+		if nextCursor, err = s.encodeKeyset(user.ID, cursorTemplates, last.CreatedAt, last.ID); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/httpapi/templates.go
+++ b/internal/httpapi/templates.go
@@ -321,7 +321,7 @@ func (s *Server) handleListTemplates(ctx context.Context, in *listTemplatesInput
 	if s.deps.ListTemplates == nil {
 		return nil, NewError(http.StatusInternalServerError, "internal_error", "templates unavailable")
 	}
-	afterCreatedAt, afterID, err := s.decodeKeyset(in.Cursor)
+	afterCreatedAt, afterID, err := s.decodeKeyset(cursorTemplates, in.Cursor)
 	if err != nil {
 		return nil, err
 	}
@@ -342,7 +342,7 @@ func (s *Server) handleListTemplates(ctx context.Context, in *listTemplatesInput
 	var nextCursor string
 	if hasMore {
 		last := tps[len(tps)-1]
-		if nextCursor, err = s.encodeKeyset(last.CreatedAt, last.ID); err != nil {
+		if nextCursor, err = s.encodeKeyset(cursorTemplates, last.CreatedAt, last.ID); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/httpapi/trash_endpoints_test.go
+++ b/internal/httpapi/trash_endpoints_test.go
@@ -606,7 +606,7 @@ func TestDeleteMessagePermanentIsAccountOnly(t *testing.T) {
 // must not continue a trash (?deleted=true) listing, and vice versa.
 func TestListAgentsCursorBoundToView(t *testing.T) {
 	srv := testServer(t)
-	liveCursor, err := EncodeCursor("", cursorAgents, keysetCursor{CreatedAt: time.Unix(1700000000, 0).UTC(), ID: "a@acme.com"})
+	liveCursor, err := EncodeCursor("", "u_1", cursorAgents, keysetCursor{CreatedAt: time.Unix(1700000000, 0).UTC(), ID: "a@acme.com"})
 	if err != nil {
 		t.Fatalf("EncodeCursor: %v", err)
 	}
@@ -614,7 +614,7 @@ func TestListAgentsCursorBoundToView(t *testing.T) {
 	if code != 400 || errCode(body) != "invalid_cursor" {
 		t.Fatalf("live cursor on trash view: want 400 invalid_cursor, got %d %v", code, body)
 	}
-	trashCursor, err := EncodeCursor("", cursorAgents, keysetCursor{CreatedAt: time.Unix(1700000000, 0).UTC(), ID: "a@acme.com", Deleted: true})
+	trashCursor, err := EncodeCursor("", "u_1", cursorAgents, keysetCursor{CreatedAt: time.Unix(1700000000, 0).UTC(), ID: "a@acme.com", Deleted: true})
 	if err != nil {
 		t.Fatalf("EncodeCursor: %v", err)
 	}

--- a/internal/httpapi/trash_endpoints_test.go
+++ b/internal/httpapi/trash_endpoints_test.go
@@ -606,7 +606,7 @@ func TestDeleteMessagePermanentIsAccountOnly(t *testing.T) {
 // must not continue a trash (?deleted=true) listing, and vice versa.
 func TestListAgentsCursorBoundToView(t *testing.T) {
 	srv := testServer(t)
-	liveCursor, err := EncodeCursor("", keysetCursor{CreatedAt: time.Unix(1700000000, 0).UTC(), ID: "a@acme.com"})
+	liveCursor, err := EncodeCursor("", cursorAgents, keysetCursor{CreatedAt: time.Unix(1700000000, 0).UTC(), ID: "a@acme.com"})
 	if err != nil {
 		t.Fatalf("EncodeCursor: %v", err)
 	}
@@ -614,7 +614,7 @@ func TestListAgentsCursorBoundToView(t *testing.T) {
 	if code != 400 || errCode(body) != "invalid_cursor" {
 		t.Fatalf("live cursor on trash view: want 400 invalid_cursor, got %d %v", code, body)
 	}
-	trashCursor, err := EncodeCursor("", keysetCursor{CreatedAt: time.Unix(1700000000, 0).UTC(), ID: "a@acme.com", Deleted: true})
+	trashCursor, err := EncodeCursor("", cursorAgents, keysetCursor{CreatedAt: time.Unix(1700000000, 0).UTC(), ID: "a@acme.com", Deleted: true})
 	if err != nil {
 		t.Fatalf("EncodeCursor: %v", err)
 	}

--- a/internal/httpapi/webhooks.go
+++ b/internal/httpapi/webhooks.go
@@ -396,13 +396,26 @@ type ListDeliveriesInput struct {
 }
 
 // deliveriesCursor is the opaque keyset position for the delivery log: the last
-// row's (created_at, id) plus the status filter it was minted under, so a
-// continuation that changes status is rejected rather than silently returning a
-// wrong page (mirrors the messages/events filter-binding).
+// row's (created_at, id) plus the PARENT WEBHOOK and the status filter it was
+// minted under, so a continuation that changes either is rejected rather than
+// silently returning a wrong page (mirrors the messages/events filter-binding).
+//
+// WebhookID is what makes this list's binding complete. The resource
+// discriminator only proves a cursor came from *some* deliveries list, and this
+// endpoint is parameterized by {id}: without the parent, a cursor minted on
+// webhook A was accepted on webhook B and A's keyset anchor was handed to B's
+// query — an arbitrarily truncated, commonly empty page. Both webhooks are
+// caller-owned (the handler checks GetWebhook before it touches the cursor), so
+// this was never cross-tenant leakage, but it is the same silent-wrong-answer
+// failure the resource binding exists to eliminate. Every other parameterized
+// list already pins its parent: messages/conversations pin AgentID,
+// engagements/agent suppressions pin AgentEmail, message_lifecycle pins
+// AgentID + MessageID.
 type deliveriesCursor struct {
 	CreatedAt time.Time `json:"c"`
 	ID        string    `json:"i"`
 	Status    string    `json:"s,omitempty"`
+	WebhookID string    `json:"w,omitempty"`
 }
 type listDeliveriesOutput struct {
 	Body Page[WebhookDeliveryView]
@@ -424,6 +437,10 @@ func (s *Server) handleListWebhookDeliveries(ctx context.Context, in *ListDelive
 	if in.Cursor != "" {
 		if err := s.decodeCursor(cursorWebhookDeliveries, in.Cursor, &cur); err != nil {
 			return nil, err
+		}
+		if cur.WebhookID != in.ID {
+			return nil, NewError(http.StatusBadRequest, "invalid_cursor",
+				"cursor was created for a different webhook — start a new query without a cursor")
 		}
 		if cur.Status != in.Status {
 			return nil, NewError(http.StatusBadRequest, "invalid_cursor",
@@ -455,7 +472,7 @@ func (s *Server) handleListWebhookDeliveries(ctx context.Context, in *ListDelive
 	if hasMore {
 		last := rows[len(rows)-1]
 		nextCursor, err = EncodeCursor(s.deps.CursorSecret, cursorWebhookDeliveries, deliveriesCursor{
-			CreatedAt: last.CreatedAt, ID: last.ID, Status: in.Status,
+			CreatedAt: last.CreatedAt, ID: last.ID, Status: in.Status, WebhookID: in.ID,
 		})
 		if err != nil {
 			return nil, NewError(http.StatusInternalServerError, "internal_error", "failed to build pagination cursor")

--- a/internal/httpapi/webhooks.go
+++ b/internal/httpapi/webhooks.go
@@ -422,8 +422,8 @@ func (s *Server) handleListWebhookDeliveries(ctx context.Context, in *ListDelive
 	}
 	var cur deliveriesCursor
 	if in.Cursor != "" {
-		if err := DecodeCursor([]string{s.deps.CursorSecret}, in.Cursor, &cur); err != nil {
-			return nil, NewError(http.StatusBadRequest, "invalid_cursor", "invalid pagination cursor")
+		if err := s.decodeCursor(cursorWebhookDeliveries, in.Cursor, &cur); err != nil {
+			return nil, err
 		}
 		if cur.Status != in.Status {
 			return nil, NewError(http.StatusBadRequest, "invalid_cursor",
@@ -454,7 +454,7 @@ func (s *Server) handleListWebhookDeliveries(ctx context.Context, in *ListDelive
 	var nextCursor string
 	if hasMore {
 		last := rows[len(rows)-1]
-		nextCursor, err = EncodeCursor(s.deps.CursorSecret, deliveriesCursor{
+		nextCursor, err = EncodeCursor(s.deps.CursorSecret, cursorWebhookDeliveries, deliveriesCursor{
 			CreatedAt: last.CreatedAt, ID: last.ID, Status: in.Status,
 		})
 		if err != nil {
@@ -658,7 +658,7 @@ func (s *Server) handleListWebhooks(ctx context.Context, in *listWebhooksInput) 
 	if err != nil {
 		return nil, err
 	}
-	afterCreatedAt, afterID, err := s.decodeKeyset(in.Cursor)
+	afterCreatedAt, afterID, err := s.decodeKeyset(cursorWebhooks, in.Cursor)
 	if err != nil {
 		return nil, err
 	}
@@ -679,7 +679,7 @@ func (s *Server) handleListWebhooks(ctx context.Context, in *listWebhooksInput) 
 	var nextCursor string
 	if hasMore {
 		last := hooks[len(hooks)-1]
-		if nextCursor, err = s.encodeKeyset(last.CreatedAt, last.ID); err != nil {
+		if nextCursor, err = s.encodeKeyset(cursorWebhooks, last.CreatedAt, last.ID); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/httpapi/webhooks.go
+++ b/internal/httpapi/webhooks.go
@@ -435,7 +435,7 @@ func (s *Server) handleListWebhookDeliveries(ctx context.Context, in *ListDelive
 	}
 	var cur deliveriesCursor
 	if in.Cursor != "" {
-		if err := s.decodeCursor(cursorWebhookDeliveries, in.Cursor, &cur); err != nil {
+		if err := s.decodeCursor(user.ID, cursorWebhookDeliveries, in.Cursor, &cur); err != nil {
 			return nil, err
 		}
 		if cur.WebhookID != in.ID {
@@ -471,7 +471,7 @@ func (s *Server) handleListWebhookDeliveries(ctx context.Context, in *ListDelive
 	var nextCursor string
 	if hasMore {
 		last := rows[len(rows)-1]
-		nextCursor, err = EncodeCursor(s.deps.CursorSecret, cursorWebhookDeliveries, deliveriesCursor{
+		nextCursor, err = EncodeCursor(s.deps.CursorSecret, user.ID, cursorWebhookDeliveries, deliveriesCursor{
 			CreatedAt: last.CreatedAt, ID: last.ID, Status: in.Status, WebhookID: in.ID,
 		})
 		if err != nil {
@@ -675,7 +675,7 @@ func (s *Server) handleListWebhooks(ctx context.Context, in *listWebhooksInput) 
 	if err != nil {
 		return nil, err
 	}
-	afterCreatedAt, afterID, err := s.decodeKeyset(cursorWebhooks, in.Cursor)
+	afterCreatedAt, afterID, err := s.decodeKeyset(user.ID, cursorWebhooks, in.Cursor)
 	if err != nil {
 		return nil, err
 	}
@@ -696,7 +696,7 @@ func (s *Server) handleListWebhooks(ctx context.Context, in *listWebhooksInput) 
 	var nextCursor string
 	if hasMore {
 		last := hooks[len(hooks)-1]
-		if nextCursor, err = s.encodeKeyset(cursorWebhooks, last.CreatedAt, last.ID); err != nil {
+		if nextCursor, err = s.encodeKeyset(user.ID, cursorWebhooks, last.CreatedAt, last.ID); err != nil {
 			return nil, err
 		}
 	}

--- a/tests/contract/scenarios.yaml
+++ b/tests/contract/scenarios.yaml
@@ -1564,3 +1564,89 @@ scenarios:
         path: /v1/contacts/investor@fund.vc?confirm=DELETE
         expect:
           status: 200
+
+  - name: cursor_binding_foreign_cursor_rejected
+    description: >
+      Pagination cursors are bound to the exact query that minted them — the
+      collection, its parent path parameters, its filters, and the minting
+      account. Replaying a genuinely minted cursor anywhere else must surface
+      400 invalid_cursor, never a silently mispositioned (typically empty)
+      200 page. The runners share a single test account, so the cross-account
+      replay cannot be staged in this DSL; that axis binds via the MAC key
+      and is deliberately indistinguishable from the forged-cursor case
+      asserted last here — its two-account matrix lives in
+      internal/httpapi/cursor_binding_test.go.
+    steps:
+      # Two contacts so a limit=1 first page yields a real continuation cursor.
+      - id: seed_first
+        action: request
+        method: POST
+        path: /v1/contacts
+        body:
+          address: cursor-a@bind.vc
+        expect:
+          status: 201
+
+      - id: seed_second
+        action: request
+        method: POST
+        path: /v1/contacts
+        body:
+          address: cursor-b@bind.vc
+        expect:
+          status: 201
+
+      - id: mint
+        action: request
+        method: GET
+        path: /v1/contacts?limit=1
+        expect:
+          status: 200
+          body_match:
+            "items.length": 1
+        capture:
+          contacts_cursor: next_cursor
+
+      - id: foreign_endpoint_rejected
+        # A real /v1/contacts cursor presented to /v1/agents: pre-binding this
+        # verified (same HMAC secret, same keyset shape) and anchored the
+        # agents query at a meaningless position; now it is a 400.
+        action: request
+        method: GET
+        path: /v1/agents?cursor={contacts_cursor}
+        expect:
+          status: 400
+          body_match:
+            "error.code": invalid_cursor
+
+      - id: own_continuation_still_walks
+        action: request
+        method: GET
+        path: /v1/contacts?limit=1&cursor={contacts_cursor}
+        expect:
+          status: 200
+          body_match:
+            "items.length": 1
+
+      - id: forged_cursor_rejected
+        # The same surface a foreign ACCOUNT's cursor produces: a plain MAC
+        # failure, indistinguishable from tampering.
+        action: request
+        method: GET
+        path: /v1/contacts?cursor=not-a-real-cursor
+        expect:
+          status: 400
+          body_match:
+            "error.code": invalid_cursor
+
+    cleanup:
+      - action: request
+        method: DELETE
+        path: /v1/contacts/cursor-a@bind.vc?confirm=DELETE
+        expect:
+          status: 200
+      - action: request
+        method: DELETE
+        path: /v1/contacts/cursor-b@bind.vc?confirm=DELETE
+        expect:
+          status: 200


### PR DESCRIPTION
## The bug

Pagination cursors are HMAC-signed, so tampered / garbage / truncated / SQLi /
traversal cursors correctly return `400 invalid_cursor` on all list endpoints —
that part was already solid.

What was **not** rejected: a **validly-signed cursor minted by a different
endpoint**. Every account-level list shares the same `{"c":…,"i":…}` payload
shape, so a foreign cursor decoded cleanly and was applied as a real keyset
anchor.

**Affected: 10 endpoints.** The original report named 8; a review pass found two
more, both confirmed against a clean `origin/main`:

| Endpoint | |
|---|---|
| `/v1/agents` `/v1/events` `/v1/domains` `/v1/webhooks` `/v1/templates` `/v1/account/api-keys` `/v1/account/suppressions` `/v1/reviews` | the originally-reported 8 |
| `/v1/webhooks/{id}/deliveries` | **newly found** — with no status filter, a foreign cursor's empty status matched |
| `/v1/starter-templates` | **newly found** — a foreign cursor's absent alias decoded as `""`, silently re-serving page 1 |

Sharpest live evidence (staging `sha-32ce45dc`): a **contacts** cursor
`{"c":"2026-07-31T19:14:24Z","i":"cnt_5526…"}` replayed on `/v1/events?limit=3`
returned `200 {"items":[]}` while the same query without the cursor returned 3
events — so a client silently concludes "no events".

**No cross-tenant leakage** — results stayed account-scoped throughout. This is a
correctness/DX bug, not a security bug. The failure mode is a silent wrong
answer, which is nastier to debug than a 400 but is not data exposure.

The agent-scoped lists (messages, conversations, engagements, agent
suppressions) and `/v1/contacts` already rejected foreign cursors, because they
pin a **filter fingerprint** a foreign cursor can't match. The account-level
lists have no filters to fingerprint, so nothing bound them.

## The fix

**1. Resource binding.** Every cursor carries the minting collection inside its
signed payload:

```
envelope = {"r": "<resource>", "p": <the resource's own cursor struct>}
cursor   = base64url(envelope) "." base64url(hmac_sha256(secret, base64url(envelope)))
```

`EncodeCursor` / `DecodeCursor` take a `CursorResource` argument, so the binding
is **impossible to forget** — a new list endpoint can't mint an unbound cursor,
because the resource is a required parameter rather than a struct field someone
has to remember to set. It's inside the HMAC, so a client can't re-target a
cursor by editing it.

**2. Parent binding on `/v1/webhooks/{id}/deliveries` (review finding M1).** The
resource discriminator only proves a cursor came from *some* deliveries list.
That endpoint is parameterized by `{id}`, so a resource-bound cursor minted on
webhook A was **still** accepted on webhook B and A's anchor handed to
`ListDeliveries(ctx, B, …)` — the identical failure mode this PR exists to fix,
one scope level down. `deliveriesCursor` now pins `WebhookID`. Every other
parameterized list already pinned its parent (messages/conversations →
`AgentID`, engagements/agent suppressions → `AgentEmail`, message_lifecycle →
`AgentID`+`MessageID`); deliveries was the lone gap. Both webhooks are
caller-owned, so this was never a leak either.

**3. Loud view assertion (review finding L1).** `decodeKeyset` now rejects a
cursor carrying `Deleted=true`. Unreachable today — agents is the only
trash-view collection and it uses `decodeKeysetView` — but the resource argument
is compile-enforced while the view argument is not, so a future endpoint that
grows `?deleted=` and keeps calling `decodeKeyset` would silently lose its view
binding with no compile error.

A foreign cursor gets `400 invalid_cursor` with a specific message.
`ErrCursorResourceMismatch` wraps `ErrInvalidCursor`, so callers branching on the
broad sentinel keep working. All 16 cursor-minting handlers route through one
`s.decodeCursor(resource, …)` helper; existing filter-fingerprint checks are
preserved verbatim, just moved after the decode.

## ⚠️ In-flight cursors are invalidated

The payload shape changed, so a cursor issued by a previous build no longer
decodes. **A client mid-pagination gets one `400 invalid_cursor` and has to
restart the query.** Keeping them working was possible but would have meant a
legacy path that keeps the bug alive for exactly the cursors most likely to be
replayed. This is also the same trade #144 M2 already made when it hard-rejected
pre-signing cursors on the reasoning "cursors are ephemeral, so a client
mid-pagination simply restarts the query". Flagging it so it's a decision, not a
surprise.

## Tests

`internal/httpapi/cursor_binding_test.go` wires all 11 cursor-minting
account-level lists, mints a **real** cursor from each through the real handler,
and replays it on every other — a **110-pair matrix** (11 × 10), plus a test
pinning the exact staging repro (contacts cursor → `/v1/events`).

Verified against a clean `origin/main` worktree:

| | pre-fix | post-fix |
|---|---|---|
| foreign-cursor pairs accepted with `200` (of the original 72) | **64** | 0 |
| all 110 pairs | — | all `400 invalid_cursor` |
| `TestCursor_ContactsCursorOnEventsIsRejected` | **FAIL** (200, empty items) | pass |
| `TestDeliveriesCursor_ForeignWebhookRejected` | **FAIL** (200, webhook B's rows under A's anchor) | pass |

The 8 pairs that already behaved correctly pre-fix are exactly the ones targeting
`/v1/contacts` — the one collection with a filter fingerprint.

Counterweights, all passing: every endpoint still walks **its own** cursor with
disjoint pages; webhook A's own deliveries cursor still walks only A's rows; the
resource is proven signed rather than merely tagged; `decodeKeyset` still accepts
a live cursor; and the existing agent-scoped `"different filters"` rejections plus
the trash-view binding are unchanged (whole `internal/httpapi` suite green).

```
$ go build ./... && go vet ./internal/httpapi/     # clean
$ go test ./internal/httpapi/                      # ok  7.193s
$ make spec-check                                  # ok — no OpenAPI drift
```

No OpenAPI surface change: `cursor` stays an opaque string and `invalid_cursor`
was already the documented code for this class. `docs/api.md` now states the
binding covers the collection, its **path parameters**, and its filters —
wording that is only accurate once M1 is fixed.

## Accepted / deferred (on the record)

- **No version field in `cursorEnvelope`.** The next payload-shape change will
  repeat today's hard break. A `"v"` int would allow dual-decode across one
  release. Deliberately deferred — adding it now costs a byte and buys nothing
  until there *is* a second shape, and this PR already takes the one break.
  Worth doing whenever the envelope next changes.
- ~~**Matrix covers the 11 account-level endpoints only.**~~ **Closed in round
  2**: the matrix now covers all 16 cursor-minting collections and varies the
  principal as well as the endpoint (see below).
- **No `iat`/expiry field.** Considered and rejected: `cursorEnvelope` decodes
  via `encoding/json`, which ignores unknown fields and zero-fills missing
  ones, so adding `iat` later is backward-compatible in both directions and
  needs no invalidation. Only the principal binding is genuinely breaking, so
  only it must ride this window. `docs/api.md` no longer claims cursors are
  "short-lived" — nothing enforces an age; it now gives the client guidance
  the code actually guarantees (treat cursors as ephemeral; on
  `invalid_cursor`, restart the query).

## Round 2: bind the minting ACCOUNT via a derived MAC key

External review found the remaining axis: the envelope carries no principal and
the MAC key was the deployment-global `config.Signing.HMACSecret`, so **account
A's `/v1/events` cursor verified for account B on `/v1/events`**. B's query
stays hard-scoped by `user_id` — still **no cross-tenant leakage** — but the
foreign anchor silently mispositioned B's page (typically an empty `200`), the
same wrong-answer class this PR exists to eliminate.

**Why it lands now:** this PR already hard-rejects every pre-envelope cursor and
is unmerged, so no cursor in the new format exists in the wild. Binding now
costs zero additional breakage; binding after release would mass-invalidate
persisted cursors a **second** time, against SDKs whose `.page()` docstrings
recommend persisting them for checkpoint/resume.

**Mechanism — the account goes in the MAC KEY, not the envelope:**

```
key    = HMAC-SHA256(secret, "e2a/cursor/v1|" + accountID)
cursor = base64url(envelope) "." base64url(hmac_sha256(key, base64url(envelope)))
```

- **Key derivation, not a plaintext field**: the envelope is signed but NOT
  encrypted, and cursors travel in query strings, access logs, and referrer
  headers — a plaintext account ID would leak. The envelope schema is
  untouched.
- **Bound to `Principal.User.ID`** — the level every list query is already
  scoped at. Not the API key ID (rotation would break in-flight pagination),
  not the scope/agent (an account-scoped key must be able to resume a cursor an
  agent-scoped key minted over the same rows).
- **Required parameter, threaded explicitly** from each handler's authenticated
  principal through `EncodeCursor`/`DecodeCursor` and the `decodeCursor` /
  `encodeKeyset` / `encodeKeysetView` wrappers — never pulled from the request
  context — so a missed site is a compile error, the same mechanism that makes
  the resource binding impossible to forget. Applied uniformly to all sixteen
  collections, **including the global-catalog starter templates** (the handler
  is auth-gated, so there is no anonymous case; a blanket rule stays auditable).
- **Rotation preserved**: `DecodeCursor` derives per candidate secret inside
  the existing constant-time `hmac.Equal` loop.
- **No new error surface**: a foreign account's cursor fails plain MAC
  verification and falls out as the existing `400 invalid_cursor` —
  deliberately indistinguishable from a forgery, so nothing reveals whether a
  stolen cursor was "well-formed". No OpenAPI change (`make spec-check` clean).

**Tests (round 2):**

- `TestCursor_ForeignAccountCursorRejected`: a second account (own agent, own
  rows) joins the fixture; for **every** collection, A's cursor in B's hands is
  `400 invalid_cursor` while the A→A and B→B continuations keep walking.
- The matrix now covers **all 16 collections** — the five agent-scoped lists
  (messages, conversations, engagements, agent_suppressions,
  message_lifecycle) are added. They were already foreign-cursor-safe via their
  mandatory agent/filter fingerprints, so that part is coverage, not a fix.
  The N×N foreign-endpoint matrix is now 16 × 15 = 240 pairs.
- `TestCursor_AccountBindsViaMACKeyNotEnvelope`: the account changes the MAC
  but the payload segments stay byte-identical (nothing leaks into the
  unencrypted envelope); a foreign-account decode fails as plain
  `ErrInvalidCursor`, not a distinguishable mismatch; rotation verifies an
  old-secret cursor through the derived key.
- **Shared contract scenario** (`tests/contract/scenarios.yaml`
  `cursor_binding_foreign_cursor_rejected`, per the AGENTS.md rule that public
  `/v1` behavior changes need cross-SDK scenario coverage): a genuinely minted
  `/v1/contacts` cursor replayed on `/v1/agents` → `400 invalid_cursor`; a
  forged cursor → `400 invalid_cursor`; the own-endpoint continuation still
  walks; self-cleaning. **DSL limitation, on the record:** the contract runners
  share a single test account, so a true two-account replay cannot be staged in
  the scenario language; the account axis is deliberately indistinguishable
  from the forged-cursor case the scenario does assert, and its two-account
  matrix lives in the handler tests above.

```
$ go test ./internal/httpapi/ -count=1                 # ok  4.980s
$ go test -tags=integration ./tests/contract/ -count=1 # ok  8.747s (incl. new scenario)
$ gofmt -l … && go vet ./internal/httpapi/             # clean
$ make spec-check                                      # ok — no OpenAPI drift
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
