### PR TITLE
fix(store): return authoritative post-write state from write paths

### DIFF
--- a/internal/agent/selfsend_screening_test.go
+++ b/internal/agent/selfsend_screening_test.go
@@ -27,7 +27,7 @@ func protectedSelfAgent(t *testing.T, store *identity.Store, label string, cfg i
 	t.Helper()
 	ctx := context.Background()
 	user, ag := selfAgent(t, store, label)
-	if err := store.UpdateAgentProtection(ctx, ag.ID, user.ID, cfg); err != nil {
+	if _, err := store.UpdateAgentProtection(ctx, ag.ID, user.ID, cfg); err != nil {
 		t.Fatalf("UpdateAgentProtection: %v", err)
 	}
 	refreshed, err := store.GetAgentByEmail(ctx, ag.EmailAddress())

--- a/internal/agent/test_send_async_test.go
+++ b/internal/agent/test_send_async_test.go
@@ -273,7 +273,7 @@ func TestSendTestCore_ScreeningReviewHolds(t *testing.T) {
 	ctx := context.Background()
 	user, ag := selfAgent(t, store, "testreview")
 
-	if err := store.UpdateAgentProtection(ctx, ag.ID, user.ID, identity.ProtectionConfig{
+	if _, err := store.UpdateAgentProtection(ctx, ag.ID, user.ID, identity.ProtectionConfig{
 		InboundGatePolicy:       "open",
 		InboundGateAction:       "review",
 		InboundScanSensitivity:  identity.SensitivityOff,

--- a/internal/agent/thread_identity_integration_test.go
+++ b/internal/agent/thread_identity_integration_test.go
@@ -215,7 +215,7 @@ func TestHITLReplyHoldCommitsOneIdempotentThreadDecision(t *testing.T) {
 	cfg.OutboundGatePolicy = "allowlist"
 	cfg.OutboundAllowlist = []string{"trusted@example.net"}
 	cfg.OutboundGateAction = "review"
-	if err := store.UpdateAgentProtection(ctx, ag.ID, user.ID, cfg); err != nil {
+	if _, err := store.UpdateAgentProtection(ctx, ag.ID, user.ID, cfg); err != nil {
 		t.Fatalf("enable outbound review: %v", err)
 	}
 	ag, err = store.GetAgentByEmail(ctx, ag.EmailAddress())
@@ -329,7 +329,7 @@ func TestHumanApprovedSelfSendPreservesHeldThreadAcrossLocalTwins(t *testing.T) 
 	cfg.OutboundGatePolicy = "allowlist"
 	cfg.OutboundAllowlist = []string{"trusted@example.net"}
 	cfg.OutboundGateAction = "review"
-	if err := store.UpdateAgentProtection(ctx, ag.ID, user.ID, cfg); err != nil {
+	if _, err := store.UpdateAgentProtection(ctx, ag.ID, user.ID, cfg); err != nil {
 		t.Fatalf("enable outbound review: %v", err)
 	}
 	ag, err := store.GetAgentByEmail(ctx, ag.EmailAddress())

--- a/internal/hitlworker/loopback_screening_test.go
+++ b/internal/hitlworker/loopback_screening_test.go
@@ -25,7 +25,7 @@ func TestWorkerAutoApproveSelfSendScreensInboundLeg(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := store.UpdateAgentProtection(ctx, ag.ID, owner.ID, identity.ProtectionConfig{
+	if _, err := store.UpdateAgentProtection(ctx, ag.ID, owner.ID, identity.ProtectionConfig{
 		InboundGatePolicy: "allowlist", InboundAllowlist: []string{"trusted@friend.example.com"}, InboundGateAction: "review",
 		InboundScanSensitivity: "off",
 		OutboundGatePolicy:     "open", OutboundGateAction: "flag", OutboundScanSensitivity: "off",

--- a/internal/httpapi/agents_write.go
+++ b/internal/httpapi/agents_write.go
@@ -163,13 +163,16 @@ func (s *Server) handleUpdateAgent(ctx context.Context, in *updateAgentInput) (*
 	if s.deps.UpdateAgentName == nil {
 		return nil, NewError(http.StatusInternalServerError, "internal_error", "update unavailable")
 	}
-	if err := s.deps.UpdateAgentName(ctx, ag.ID, ag.UserID, *in.Body.Name); err != nil {
+	// The store returns the authoritative post-update row, read INSIDE the
+	// write's own transaction. Re-reading here after the write committed was a
+	// torn read: a concurrent rename showed this caller the other writer's name
+	// as the result of their own PATCH, and a concurrent trash/delete answered
+	// 500 "failed to reload agent" on a rename that had committed.
+	updated, err := s.deps.UpdateAgentName(ctx, ag.ID, ag.UserID, *in.Body.Name)
+	if err != nil {
 		return nil, NewError(http.StatusBadRequest, "invalid_request", err.Error())
 	}
-
-	// Re-read for the authoritative post-update state (ag.ID is the email).
-	updated, err := s.deps.GetAgent(ctx, ag.ID)
-	if err != nil || updated == nil {
+	if updated == nil {
 		return nil, NewError(http.StatusInternalServerError, "internal_error", "failed to reload agent")
 	}
 	return &agentOutput{Body: agentViewFromIdentity(updated)}, nil
@@ -254,8 +257,13 @@ func (s *Server) handleRestoreAgent(ctx context.Context, in *AddressParam) (*age
 		return nil, err
 	}
 	// The trash-state decision belongs to the store (its UPDATE is the one
-	// atomic check); the handler only maps the sentinel.
-	if err := s.deps.RestoreAgent(ctx, ag.ID, ag.UserID); err != nil {
+	// atomic check); the handler only maps the sentinel. The store also returns
+	// the restored agent, read through the LIVE projection inside the restore's
+	// own transaction — same proof that the agent is visible again as the old
+	// post-commit re-read, minus its race (a concurrent rename or re-trash in
+	// the gap answered with the wrong name, or 500 on a committed restore).
+	restored, err := s.deps.RestoreAgent(ctx, ag.ID, ag.UserID)
+	if err != nil {
 		if errors.Is(err, identity.ErrNotInTrash) {
 			return nil, NewError(http.StatusConflict, "not_in_trash", "agent is not in the trash")
 		}
@@ -264,10 +272,7 @@ func (s *Server) handleRestoreAgent(ctx context.Context, in *AddressParam) (*age
 		}
 		return nil, NewError(http.StatusInternalServerError, "internal_error", "failed to restore agent")
 	}
-	// Re-read via the LIVE getter for the authoritative post-restore state
-	// (ag.ID is the email); it also proves the agent is visible again.
-	restored, err := s.deps.GetAgent(ctx, ag.ID)
-	if err != nil || restored == nil {
+	if restored == nil {
 		return nil, NewError(http.StatusInternalServerError, "internal_error", "failed to reload agent")
 	}
 	return &agentOutput{Body: agentViewFromIdentity(restored)}, nil

--- a/internal/httpapi/httpapi.go
+++ b/internal/httpapi/httpapi.go
@@ -104,13 +104,23 @@ type (
 	AgentDeleter func(ctx context.Context, agentID, userID string) (messagesDeleted int64, err error)
 	// AgentTrashOp moves an agent into or out of trash without deleting messages.
 	AgentTrashOp func(ctx context.Context, agentID, userID string) error
+	// AgentRestoreOp is AgentTrashOp's returning form: restore answers with the
+	// agent as restored. The store reads that row inside the restore's own
+	// transaction, so the response cannot describe a state this restore never
+	// produced — a post-commit re-read raced concurrent renames and re-trashes.
+	AgentRestoreOp func(ctx context.Context, agentID, userID string) (*identity.AgentIdentity, error)
 )
 
 // MessageTrashOp mirrors the store's per-message trash mutations
-// (SoftDeleteMessage / RestoreMessage / PurgeMessage): scoped to
-// (messageID, agentID), returning the sentinel errors ErrMessageHeld /
-// ErrNotInTrash / ErrMessageNotFound for the handler to map.
+// (SoftDeleteMessage / PurgeMessage): scoped to (messageID, agentID),
+// returning the sentinel errors ErrMessageHeld / ErrNotInTrash /
+// ErrMessageNotFound for the handler to map.
 type MessageTrashOp func(ctx context.Context, messageID, agentID string) error
+
+// MessageRestoreOp is MessageTrashOp's returning form, used by RestoreMessage
+// for the same reason AgentRestoreOp exists: the restored view comes from
+// inside the restore transaction rather than a racy re-read afterwards.
+type MessageRestoreOp func(ctx context.Context, messageID, agentID string) (*identity.Message, error)
 
 // Deps are the collaborators the v1 layer needs. Everything is injected so
 // the package has no hidden globals and is straightforward to test.
@@ -142,20 +152,23 @@ type Deps struct {
 	ResolveMX          MXResolver
 	EnforceAgentCreate AgentCreateEnforcer
 	// UpdateAgentName updates an agent's display name (the only mutable field on
-	// the agent PATCH after the screening config moved to /protection).
-	UpdateAgentName func(ctx context.Context, agentID, userID, name string) error
+	// the agent PATCH after the screening config moved to /protection) and
+	// returns the agent as written — read inside the write's transaction, so
+	// the PATCH response describes this write and not a concurrent one.
+	UpdateAgentName func(ctx context.Context, agentID, userID, name string) (*identity.AgentIdentity, error)
 	// UpdateAgentProtection writes the full per-agent protection posture (gate +
-	// scan sensitivity + holds) for the /v1/agents/{email}/protection resource.
-	// Returns a validation error for an invalid posture, which the handler maps
-	// to 400 invalid_request.
-	UpdateAgentProtection func(ctx context.Context, agentID, userID string, cfg identity.ProtectionConfig) error
+	// scan sensitivity + holds) for the /v1/agents/{email}/protection resource
+	// and returns the agent as written, on the same in-transaction contract as
+	// UpdateAgentName. Returns a validation error for an invalid posture, which
+	// the handler maps to 400 invalid_request.
+	UpdateAgentProtection func(ctx context.Context, agentID, userID string, cfg identity.ProtectionConfig) (*identity.AgentIdentity, error)
 	// DeleteAgent is the DEFAULT delete: soft (move to trash, restorable for
 	// identity.TrashRetention, docs/design/trash-soft-delete.md).
 	// PermanentDeleteAgent is the irreversible hard delete behind
 	// ?permanent=true; RestoreAgent brings a trashed agent back.
 	DeleteAgent          AgentTrashOp
 	PermanentDeleteAgent AgentDeleter
-	RestoreAgent         AgentTrashOp
+	RestoreAgent         AgentRestoreOp
 	// GetAgentAnyState loads an agent regardless of trash state (DeletedAt set
 	// when trashed) — the resolution path for restore / permanent delete, which
 	// must find agents the live GetAgent treats as nonexistent.
@@ -167,7 +180,7 @@ type Deps struct {
 	// /v1/agents/{email}/messages/{id}): soft delete, restore, and the
 	// trash-only permanent purge.
 	DeleteMessage  MessageTrashOp
-	RestoreMessage MessageTrashOp
+	RestoreMessage MessageRestoreOp
 	PurgeMessage   MessageTrashOp
 
 	// domains. ListDomains is keyset-paginated on (created_at, domain): the

--- a/internal/httpapi/messages.go
+++ b/internal/httpapi/messages.go
@@ -635,14 +635,18 @@ func (s *Server) handleRestoreMessage(ctx context.Context, in *MessageIDParam) (
 	if err != nil {
 		return nil, err
 	}
-	if s.deps.RestoreMessage == nil || s.deps.GetMessage == nil {
+	if s.deps.RestoreMessage == nil {
 		return nil, NewError(http.StatusInternalServerError, "internal_error", "restore unavailable")
 	}
-	if err := s.deps.RestoreMessage(ctx, in.MessageID, ag.ID); err != nil {
+	// The store builds the restored view INSIDE the restore's own transaction
+	// (same detail projection, read-marking included). Re-reading here after
+	// the restore committed was a torn read: a concurrent re-trash or purge in
+	// the gap answered 500 "failed to reload message" on a committed restore.
+	msg, err := s.deps.RestoreMessage(ctx, in.MessageID, ag.ID)
+	if err != nil {
 		return nil, mapTrashErr(err, "message")
 	}
-	msg, err := s.deps.GetMessage(ctx, in.MessageID, ag.ID)
-	if err != nil || msg == nil {
+	if msg == nil {
 		return nil, NewError(http.StatusInternalServerError, "internal_error", "failed to reload message")
 	}
 	return &messageOutput{Body: messageViewFromIdentity(msg)}, nil

--- a/internal/httpapi/operations_test.go
+++ b/internal/httpapi/operations_test.go
@@ -640,11 +640,11 @@ func testServer(t *testing.T, opts ...func(*Deps)) *httptest.Server {
 			}
 			return nil
 		},
-		UpdateAgentName: func(ctx context.Context, agentID, userID, name string) error {
-			return nil
+		UpdateAgentName: func(ctx context.Context, agentID, userID, name string) (*identity.AgentIdentity, error) {
+			return &identity.AgentIdentity{ID: agentID, RegisteredDomain: "acme.com", Email: agentID, Name: name, UserID: userID}, nil
 		},
-		UpdateAgentProtection: func(ctx context.Context, agentID, userID string, cfg identity.ProtectionConfig) error {
-			return nil
+		UpdateAgentProtection: func(ctx context.Context, agentID, userID string, cfg identity.ProtectionConfig) (*identity.AgentIdentity, error) {
+			return &identity.AgentIdentity{ID: agentID, RegisteredDomain: "acme.com", Email: agentID, UserID: userID}, nil
 		},
 		DeleteAgent: func(ctx context.Context, agentID, userID string) error {
 			if userID != "u_1" {

--- a/internal/httpapi/outbound_scheduled_test.go
+++ b/internal/httpapi/outbound_scheduled_test.go
@@ -243,12 +243,12 @@ func TestTrashRestoreScheduledMessage(t *testing.T) {
 			deleted = true
 			return nil
 		}
-		d.RestoreMessage = func(_ context.Context, messageID, agentID string) error {
+		d.RestoreMessage = func(_ context.Context, messageID, agentID string) (*identity.Message, error) {
 			if !deleted {
-				return identity.ErrNotInTrash
+				return nil, identity.ErrNotInTrash
 			}
 			deleted = false
-			return nil
+			return msg(), nil
 		}
 		d.GetMessage = func(_ context.Context, messageID, agentID string) (*identity.Message, error) {
 			return msg(), nil // direct GET is intentionally any-state

--- a/internal/httpapi/protection.go
+++ b/internal/httpapi/protection.go
@@ -232,11 +232,17 @@ func (s *Server) handlePutProtection(ctx context.Context, in *putProtectionInput
 		cfg.InboundScanSensitivity = identity.SensitivityOff
 		cfg.OutboundScanSensitivity = identity.SensitivityOff
 	}
-	if err := s.deps.UpdateAgentProtection(ctx, ag.ID, ag.UserID, cfg); err != nil {
+	// The store returns the posture it just wrote, read INSIDE the write's own
+	// transaction. Re-reading here after the write committed was a torn read,
+	// and the PUT is a full replace: a concurrent PUT landing in the gap handed
+	// this caller the OTHER writer's posture as the authoritative-looking
+	// result of their own request, and a concurrent trash answered 500 on a
+	// write that had committed.
+	updated, err := s.deps.UpdateAgentProtection(ctx, ag.ID, ag.UserID, cfg)
+	if err != nil {
 		return nil, NewError(http.StatusBadRequest, "invalid_request", err.Error())
 	}
-	updated, err := s.deps.GetAgent(ctx, ag.ID)
-	if err != nil || updated == nil {
+	if updated == nil {
 		return nil, NewError(http.StatusInternalServerError, "internal_error", "failed to reload agent")
 	}
 	return &protectionOutput{Body: protectionViewFromIdentity(updated)}, nil

--- a/internal/httpapi/protection_test.go
+++ b/internal/httpapi/protection_test.go
@@ -10,9 +10,11 @@ import (
 	"github.com/tokencanopy/e2a/internal/identity"
 )
 
-// protectionServer builds a server whose UpdateAgentProtection mutates a captured
-// agent so the handler's re-read reflects the write — the full PUT → store →
-// re-read → view round-trip over the real chi+Huma stack.
+// protectionServer builds a server whose UpdateAgentProtection mutates a
+// captured agent and returns it — the full PUT → store → view round-trip over
+// the real chi+Huma stack. Returning the written row (rather than leaving the
+// handler to re-read) mirrors the store, whose read-back runs inside the
+// write's own transaction.
 func protectionServer(t *testing.T) (*httptest.Server, *identity.AgentIdentity) {
 	t.Helper()
 	ag := sampleAgent()
@@ -36,7 +38,7 @@ func protectionServer(t *testing.T) (*httptest.Server, *identity.AgentIdentity) 
 			}
 			return nil, errors.New("not found")
 		},
-		UpdateAgentProtection: func(ctx context.Context, agentID, userID string, cfg identity.ProtectionConfig) error {
+		UpdateAgentProtection: func(ctx context.Context, agentID, userID string, cfg identity.ProtectionConfig) (*identity.AgentIdentity, error) {
 			ag.InboundPolicy = cfg.InboundGatePolicy
 			ag.InboundAllowlist = cfg.InboundAllowlist
 			ag.InboundPolicyAction = cfg.InboundGateAction
@@ -47,7 +49,8 @@ func protectionServer(t *testing.T) (*httptest.Server, *identity.AgentIdentity) 
 			ag.HITLTTLSeconds = cfg.HITLTTLSeconds
 			ag.HITLExpirationAction = cfg.HITLExpirationAction
 			ag.SuppressNotifications = cfg.SuppressNotifications
-			return nil
+			a := ag
+			return &a, nil
 		},
 		Legacy: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusTeapot) }),
 	}

--- a/internal/httpapi/scope_test.go
+++ b/internal/httpapi/scope_test.go
@@ -62,11 +62,15 @@ func scopeTestServer(t *testing.T) *httptest.Server {
 			}
 			return nil, errors.New("not found")
 		},
-		UpdateAgentName: func(ctx context.Context, agentID, userID, name string) error {
-			return nil
+		UpdateAgentName: func(ctx context.Context, agentID, userID, name string) (*identity.AgentIdentity, error) {
+			a := sampleAgent()
+			a.ID, a.Name = agentID, name
+			return &a, nil
 		},
-		UpdateAgentProtection: func(ctx context.Context, agentID, userID string, cfg identity.ProtectionConfig) error {
-			return nil
+		UpdateAgentProtection: func(ctx context.Context, agentID, userID string, cfg identity.ProtectionConfig) (*identity.AgentIdentity, error) {
+			a := sampleAgent()
+			a.ID = agentID
+			return &a, nil
 		},
 		DeleteAgent: func(ctx context.Context, agentID, userID string) error { return nil },
 		Legacy:      http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusTeapot) }),

--- a/internal/httpapi/trash_endpoints_test.go
+++ b/internal/httpapi/trash_endpoints_test.go
@@ -39,9 +39,16 @@ func withTrashDeps(c *trashCalls) func(*Deps) {
 			c.lastMessageID, c.lastMessageAgent = messageID, agentID
 			return nil
 		}
-		d.RestoreMessage = func(ctx context.Context, messageID, agentID string) error {
+		// Restore answers with the message view itself (the store builds it
+		// inside the restore transaction), so the fake returns the row.
+		d.RestoreMessage = func(ctx context.Context, messageID, agentID string) (*identity.Message, error) {
 			c.restoreMsg++
-			return nil
+			return &identity.Message{
+				ID: messageID, AgentID: agentID, Direction: "inbound",
+				Sender: "alice@gmail.com", Subject: "restored",
+				ThreadID:  assignedThreadID,
+				CreatedAt: time.Unix(1700000000, 0).UTC(),
+			}, nil
 		}
 		d.DeleteAgent = func(ctx context.Context, agentID, userID string) error {
 			c.softAgent++
@@ -53,9 +60,12 @@ func withTrashDeps(c *trashCalls) func(*Deps) {
 			c.lastAgentID = agentID
 			return 4, nil
 		}
-		d.RestoreAgent = func(ctx context.Context, agentID, userID string) error {
+		// Restore answers with the LIVE agent the store read inside the
+		// restore transaction — hence sampleAgent (no deleted_at).
+		d.RestoreAgent = func(ctx context.Context, agentID, userID string) (*identity.AgentIdentity, error) {
 			c.restoreAg++
-			return nil
+			a := sampleAgent()
+			return &a, nil
 		}
 	}
 }
@@ -225,16 +235,7 @@ func TestDeleteMessageSoftSendInProgress(t *testing.T) {
 
 func TestRestoreMessage(t *testing.T) {
 	var c trashCalls
-	srv := testServer(t, withTrashDeps(&c), func(d *Deps) {
-		d.GetMessage = func(ctx context.Context, messageID, agentID string) (*identity.Message, error) {
-			return &identity.Message{
-				ID: messageID, AgentID: agentID, Direction: "inbound",
-				Sender: "alice@gmail.com", Subject: "restored",
-				ThreadID:  assignedThreadID,
-				CreatedAt: time.Unix(1700000000, 0).UTC(),
-			}, nil
-		}
-	})
+	srv := testServer(t, withTrashDeps(&c))
 	code, body := sendJSON(t, "POST", srv.URL+"/v1/agents/support%40acme.com/messages/msg_1/restore", "good", nil)
 	if code != 200 {
 		t.Fatalf("want 200, got %d %v", code, body)
@@ -255,8 +256,8 @@ func TestRestoreMessage(t *testing.T) {
 
 func TestRestoreMessageNotInTrash(t *testing.T) {
 	srv := testServer(t, func(d *Deps) {
-		d.RestoreMessage = func(ctx context.Context, messageID, agentID string) error {
-			return identity.ErrNotInTrash
+		d.RestoreMessage = func(ctx context.Context, messageID, agentID string) (*identity.Message, error) {
+			return nil, identity.ErrNotInTrash
 		}
 	})
 	code, body := sendJSON(t, "POST", srv.URL+"/v1/agents/support%40acme.com/messages/msg_live/restore", "good", nil)
@@ -468,7 +469,8 @@ func TestRestoreAgent(t *testing.T) {
 	if c.restoreAg != 1 {
 		t.Fatalf("restore called %d times", c.restoreAg)
 	}
-	// The response is the LIVE re-read (sampleAgent), so no deleted_at.
+	// The response is the store's LIVE in-transaction read (sampleAgent), so
+	// no deleted_at.
 	if body["email"] != "support@acme.com" {
 		t.Fatalf("unexpected restored agent %v", body)
 	}
@@ -481,8 +483,8 @@ func TestRestoreAgentNotInTrash(t *testing.T) {
 	srv := testServer(t, func(d *Deps) {
 		// The store is the source of truth for the trash-state decision: a
 		// live agent's restore returns ErrNotInTrash.
-		d.RestoreAgent = func(ctx context.Context, agentID, userID string) error {
-			return identity.ErrNotInTrash
+		d.RestoreAgent = func(ctx context.Context, agentID, userID string) (*identity.AgentIdentity, error) {
+			return nil, identity.ErrNotInTrash
 		}
 		d.GetAgentAnyState = func(ctx context.Context, address string) (*identity.AgentIdentity, error) {
 			a := sampleAgent() // live — DeletedAt nil

--- a/internal/identity/engagements.go
+++ b/internal/identity/engagements.go
@@ -232,6 +232,7 @@ func (s *Store) UpsertEngagement(ctx context.Context, userID, agentID, address s
 	}
 
 	var created bool
+	var engagementID string
 	err = tx.QueryRow(ctx,
 		`INSERT INTO contact_engagements
 		     (id, user_id, contact_id, agent_id, address, stage, next_action_at, metadata)
@@ -241,18 +242,34 @@ func (s *Store) UpsertEngagement(ctx context.Context, userID, agentID, address s
 		         next_action_at = CASE WHEN $9 THEN $7 ELSE contact_engagements.next_action_at END,
 		         metadata       = COALESCE($8::jsonb, contact_engagements.metadata),
 		         updated_at     = now()
-		  RETURNING (xmax = 0)`,
+		  RETURNING id, (xmax = 0)`,
 		NewEngagementID(), userID, contactID, agentID, address,
-		stageVal, nextVal, encoded, nextSet).Scan(&created)
+		stageVal, nextVal, encoded, nextSet).Scan(&engagementID, &created)
+	if err != nil {
+		return ContactEngagement{}, false, err
+	}
+
+	// Read the authoritative row INSIDE the write's transaction, by the primary
+	// key the upsert just returned. A read after the commit is a torn read: the
+	// engagement can be deleted (DeleteEngagement, a contact delete, an import
+	// reversal) in the gap, turning a committed write into a bogus
+	// ErrEngagementNotFound — which the HTTP layer reports as 412
+	// precondition_failed on a request that sent no If-Match. Activity hooks
+	// (RecordInbound/OutboundActivity fire on every message touching this
+	// contact) can likewise repaint the row before a 201-created response
+	// describes it. This is a plain SELECT taking no row locks, so it adds no
+	// lock-ordering edge over the contacts→engagements order the batch reversal
+	// relies on. Same shape as UpdateEngagementIfUnchanged.
+	e, err := scanEngagement(tx.QueryRow(ctx,
+		`SELECT `+engagementColumns+engagementFrom+`
+		  WHERE ce.id = $1`, engagementID))
 	if err != nil {
 		return ContactEngagement{}, false, err
 	}
 	if err := tx.Commit(ctx); err != nil {
 		return ContactEngagement{}, false, err
 	}
-
-	e, err := s.GetEngagement(ctx, userID, agentID, address)
-	return e, created, err
+	return e, created, nil
 }
 
 // UpdateEngagementIfUnchanged updates only the agent-owned fields of an
@@ -268,8 +285,7 @@ func (s *Store) UpsertEngagement(ctx context.Context, userID, agentID, address s
 // never match the row again (found live by the staging conformance suite). A
 // second statement in the same transaction sees the first statement's writes,
 // and the version predicate already lives in the UPDATE, so the follow-up
-// read by primary key is race-free. This also mirrors UpsertEngagement, which
-// re-reads via GetEngagement after its write.
+// read by primary key is race-free. UpsertEngagement re-reads the same way.
 func (s *Store) UpdateEngagementIfUnchanged(ctx context.Context, userID, agentID, address string, stage *string, nextActionAt **time.Time, metadata map[string]any, expectedUpdatedAt time.Time) (ContactEngagement, error) {
 	agentID = NormalizeEmail(agentID)
 	address = NormalizeMailboxAddress(address)

--- a/internal/identity/engagements.go
+++ b/internal/identity/engagements.go
@@ -162,6 +162,35 @@ func scanEngagement(row pgx.Row) (ContactEngagement, error) {
 	return e, nil
 }
 
+// monotonicUpdatedAt renders the updated_at bump that EVERY writer of
+// contact_engagements.updated_at uses. qualifier is the table name or alias the
+// statement addresses the row by ("" when the column is unambiguous).
+//
+// `now()` is TRANSACTION START time, not statement time. A transaction that
+// begins earlier but commits later therefore writes an EARLIER updated_at than
+// one that already committed, and the column walks backwards. That is
+// self-consistent for ETag purposes (the validator hashes whatever value it
+// returns) but it corrupts anyone ordering or filtering by updated_at, and the
+// exposure grows with transaction lifetime — UpsertEngagement's transaction now
+// spans its write AND the authoritative read-back.
+//
+// GREATEST(clock_timestamp(), old + 1µs) is evaluated per statement and is
+// strictly greater than the value it replaces, so the column is monotonic per
+// row no matter how the transactions interleave. It also strengthens the
+// If-Match contract: a conditional update's new validator can never collide
+// with the one the caller just used. Mirrors UpdateTemplate, which was the only
+// writer in the codebase already doing this.
+//
+// It has to be applied by every writer or it guarantees nothing: one straggler
+// on now() can still drag the column backwards past a monotonic write.
+func monotonicUpdatedAt(qualifier string) string {
+	col := "updated_at"
+	if qualifier != "" {
+		col = qualifier + ".updated_at"
+	}
+	return "GREATEST(clock_timestamp(), " + col + " + interval '1 microsecond')"
+}
+
 // UpsertEngagement enrolls a contact with an agent, or updates the agent-owned
 // fields of an existing enrollment.
 //
@@ -241,7 +270,7 @@ func (s *Store) UpsertEngagement(ctx context.Context, userID, agentID, address s
 		     SET stage          = COALESCE($6, contact_engagements.stage),
 		         next_action_at = CASE WHEN $9 THEN $7 ELSE contact_engagements.next_action_at END,
 		         metadata       = COALESCE($8::jsonb, contact_engagements.metadata),
-		         updated_at     = now()
+		         updated_at     = `+monotonicUpdatedAt("contact_engagements")+`
 		  RETURNING id, (xmax = 0)`,
 		NewEngagementID(), userID, contactID, agentID, address,
 		stageVal, nextVal, encoded, nextSet).Scan(&engagementID, &created)
@@ -316,7 +345,7 @@ func (s *Store) UpdateEngagementIfUnchanged(ctx context.Context, userID, agentID
 		    SET stage          = COALESCE($4, stage),
 		        next_action_at = CASE WHEN $5 THEN $6 ELSE next_action_at END,
 		        metadata       = COALESCE($7::jsonb, metadata),
-		        updated_at     = now()
+		        updated_at     = `+monotonicUpdatedAt("")+`
 		  WHERE user_id = $1 AND agent_id = $2 AND address = $3
 		    AND updated_at = $8
 		  RETURNING id`,
@@ -461,7 +490,7 @@ func recordOutboundActivity(ctx context.Context, exec contactExecutor, userID, a
 		    SET first_outbound_at    = LEAST(COALESCE(first_outbound_at, $4), $4),
 		        last_outbound_at     = GREATEST(COALESCE(last_outbound_at, $4), $4),
 		        last_conversation_id = COALESCE(NULLIF($5, ''), last_conversation_id),
-		        updated_at           = now()
+		        updated_at           = `+monotonicUpdatedAt("")+`
 		  WHERE user_id = $1 AND agent_id = $2 AND address = $3`,
 		userID, NormalizeEmail(agentID), NormalizeMailboxAddress(address), at.UTC(), conversationID)
 	if err != nil {
@@ -493,7 +522,7 @@ func recordInboundActivity(ctx context.Context, exec contactExecutor, userID, ag
 		`UPDATE contact_engagements
 		    SET last_inbound_at      = GREATEST(COALESCE(last_inbound_at, $4), $4),
 		        last_conversation_id = COALESCE(NULLIF($5, ''), last_conversation_id),
-		        updated_at           = now()
+		        updated_at           = `+monotonicUpdatedAt("")+`
 		  WHERE user_id = $1 AND agent_id = $2 AND address = $3`,
 		userID, NormalizeEmail(agentID), NormalizeMailboxAddress(address), at.UTC(), conversationID)
 	if err != nil {
@@ -556,7 +585,7 @@ func (s *Store) ClaimDueEngagementsTx(ctx context.Context, tx pgx.Tx, now time.T
 	rows, err := tx.Query(ctx,
 		`UPDATE contact_engagements ce
 		    SET notified_next_action_at = ce.next_action_at,
-		        updated_at = now()
+		        updated_at = `+monotonicUpdatedAt("ce")+`
 		  WHERE ce.id IN (
 		        SELECT c.id
 		          FROM contact_engagements c

--- a/internal/identity/engagements_test.go
+++ b/internal/identity/engagements_test.go
@@ -820,7 +820,7 @@ func TestClaimDueEngagementsSkipsTrashedAgents(t *testing.T) {
 
 	// Restoring makes the outreach pull-visible again, but acknowledges past
 	// schedules so a long-trashed inbox does not emit a wake-up thundering herd.
-	if err := store.RestoreAgent(ctx, agent, user.ID); err != nil {
+	if _, err := store.RestoreAgent(ctx, agent, user.ID); err != nil {
 		t.Fatalf("restore: %v", err)
 	}
 	due, err = store.ClaimDueEngagements(ctx, time.Now().UTC(), 50)

--- a/internal/identity/outbound_async_test.go
+++ b/internal/identity/outbound_async_test.go
@@ -492,7 +492,7 @@ func TestMarkOutboundSentTxSkipsTrashRace(t *testing.T) {
 		}
 	})
 
-	if err := store.RestoreMessage(ctx, msg.ID, agentID); err != nil {
+	if _, err := store.RestoreMessage(ctx, msg.ID, agentID); err != nil {
 		t.Fatalf("RestoreMessage: %v", err)
 	}
 	t.Run("trashed agent", func(t *testing.T) {
@@ -569,7 +569,7 @@ func TestMarkOutboundFailedTxSkipsTrashRace(t *testing.T) {
 		}
 	})
 
-	if err := store.RestoreMessage(ctx, msg.ID, agentID); err != nil {
+	if _, err := store.RestoreMessage(ctx, msg.ID, agentID); err != nil {
 		t.Fatalf("RestoreMessage: %v", err)
 	}
 	t.Run("trashed agent", func(t *testing.T) {

--- a/internal/identity/post_write_read_test.go
+++ b/internal/identity/post_write_read_test.go
@@ -1,0 +1,587 @@
+package identity_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/tokencanopy/e2a/internal/identity"
+	"github.com/tokencanopy/e2a/internal/testutil"
+)
+
+// This file holds the regressions for one bug class: a write path that reads
+// its own result back OUTSIDE the write's transaction. PR #775 fixed the
+// severe form (a data-modifying CTE whose outer SELECT ran on the pre-update
+// statement snapshot, so an accepted conditional update returned the OLD row
+// and a permanently dead ETag). These are its weaker cousins — "write, commit,
+// then re-read from the pool" — where the gap between the commit and the
+// re-read is a real window another transaction can commit into. The result is
+// a response that describes somebody else's write, or a spurious 404/412/500
+// on a write that actually succeeded.
+//
+// Every test uses the same deterministic interleaving: a holder transaction
+// takes the row (or advisory) lock the write path needs, the write path is
+// started and confirmed blocked on it, a RACER statement is then started and
+// confirmed blocked BEHIND it (Postgres lock waits are FIFO), and the holder
+// commits. The write path therefore runs first and the racer runs the instant
+// the write path releases the lock — i.e. precisely in the window the buggy
+// shape leaves open. Each racer is one statement carrying no bind parameters,
+// so it goes out over the simple protocol as a single implicit transaction:
+// once woken it completes and commits entirely server-side, while the buggy
+// re-read still owes a client round-trip and loses.
+//
+// Each test also asserts the racer really did land afterwards, so a run where
+// the interleaving failed to happen cannot pass silently.
+
+// lockWaiters counts backends currently blocked on a lock in the test database.
+func lockWaiters(t *testing.T, pool *pgxpool.Pool) int {
+	t.Helper()
+	var n int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT count(*)
+		   FROM pg_locks l
+		   JOIN pg_stat_activity a ON a.pid = l.pid
+		  WHERE NOT l.granted
+		    AND a.datname = current_database()`).Scan(&n); err != nil {
+		t.Fatalf("poll locks: %v", err)
+	}
+	return n
+}
+
+// waitForExtraLockWaiter waits until one MORE backend is blocked than at
+// baseline. Counting relative to a baseline rather than absolutely keeps the
+// interleaving honest if anything else is using the same database.
+func waitForExtraLockWaiter(t *testing.T, pool *pgxpool.Pool, baseline int) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if lockWaiters(t, pool) > baseline {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("the write path never blocked on the holder's lock")
+}
+
+// waitForBlockedRacer waits until the racer carrying this marker is itself
+// blocked on a lock. Identifying the racer by its own query text (rather than
+// by a global waiter count) is what guarantees it is queued BEHIND the write
+// path when the holder lets go — the whole point of the interleaving.
+func waitForBlockedRacer(t *testing.T, pool *pgxpool.Pool, marker string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		var n int
+		if err := pool.QueryRow(context.Background(),
+			`SELECT count(*)
+			   FROM pg_stat_activity a
+			   JOIN pg_locks l ON l.pid = a.pid AND NOT l.granted
+			  WHERE a.datname = current_database()
+			    AND a.query LIKE '%' || $1 || '%'`, marker).Scan(&n); err != nil {
+			t.Fatalf("poll racer lock: %v", err)
+		}
+		if n > 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("the racer never queued behind the write path")
+}
+
+// sqlLit quotes a Go string as a SQL literal. The racers carry no bind
+// parameters on purpose: pgx then sends them over the simple protocol as a
+// single implicit transaction, so once the lock frees they run AND commit
+// entirely server-side, with no client round-trip to lose to the buggy
+// re-read. (Test-controlled values only.)
+func sqlLit(s string) string { return "'" + strings.ReplaceAll(s, "'", "''") + "'" }
+
+// doBlock wraps body in an anonymous code block, for the one racer that has to
+// take a lock before its write. Like a bare statement it goes out with no bind
+// parameters, so it is one simple-protocol statement in one implicit
+// transaction that PostgreSQL runs and commits before answering the client.
+func doBlock(body string) string { return "DO $racer$ BEGIN\n" + body + "\nEND $racer$;" }
+
+// startRacer runs sql on its own pooled connection, tagged with a unique
+// marker comment so waitForBlockedRacer can find that exact backend. Returns
+// the marker and a channel yielding the racer's error.
+func startRacer(t *testing.T, pool *pgxpool.Pool, sql string) (string, <-chan error) {
+	t.Helper()
+	marker := "racer-" + identity.NewMessageID()
+	done := make(chan error, 1)
+	go func() {
+		_, err := pool.Exec(context.Background(), "/* "+marker+" */ "+sql)
+		done <- err
+	}()
+	return marker, done
+}
+
+// TestUpsertEngagementReturnsTheRowItCommitted is the site-1 regression.
+//
+// UpsertEngagement committed its transaction and then called GetEngagement on
+// the POOL. A DeleteEngagement, a contact delete or an import reversal
+// committing in that gap turned a write that had already succeeded into
+// ErrEngagementNotFound — which the HTTP layer reports as 412
+// precondition_failed on a PUT that sent no If-Match at all. Reading the row
+// inside the write's own transaction closes the window: the upsert still holds
+// the engagement row lock, so no deletion can be observed before the read.
+func TestUpsertEngagementReturnsTheRowItCommitted(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	user := newEngagementOwner(t, store, "engtorn")
+	const agent, address = "raise@e.com", "partner@engtorn.vc"
+	enroll(t, store, user.ID, agent, address, "prospect")
+
+	// Hold the contact-capacity advisory lock the upsert takes before any of
+	// its writes — the one deterministic pause point inside that transaction.
+	holder, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin holder: %v", err)
+	}
+	defer holder.Rollback(ctx) //nolint:errcheck
+	if _, err := holder.Exec(ctx,
+		`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`,
+		"contact-cap:"+user.ID); err != nil {
+		t.Fatalf("hold contact-cap lock: %v", err)
+	}
+
+	type upsertResult struct {
+		e   identity.ContactEngagement
+		err error
+	}
+	baseline := lockWaiters(t, pool)
+	upserted := make(chan upsertResult, 1)
+	go func() {
+		stage := "nurture"
+		e, _, err := store.UpsertEngagement(ctx, user.ID, agent, address, &stage, nil, nil)
+		upserted <- upsertResult{e, err}
+	}()
+	waitForExtraLockWaiter(t, pool, baseline)
+
+	// Queue the un-enrolment behind the upsert. It takes the same advisory
+	// lock, so it cannot start until the upsert's transaction commits — which
+	// is exactly the moment the old post-commit re-read was reaching for the
+	// row.
+	marker, racer := startRacer(t, pool, doBlock(
+		`PERFORM pg_advisory_xact_lock(hashtextextended(`+sqlLit("contact-cap:"+user.ID)+`, 0));`+
+			"\n  DELETE FROM contact_engagements WHERE user_id = "+sqlLit(user.ID)+
+			" AND agent_id = "+sqlLit(agent)+" AND address = "+sqlLit(address)+";"))
+	waitForBlockedRacer(t, pool, marker)
+
+	if err := holder.Commit(ctx); err != nil {
+		t.Fatalf("release contact-cap lock: %v", err)
+	}
+	got := <-upserted
+	if err := <-racer; err != nil {
+		t.Fatalf("racing un-enrolment: %v", err)
+	}
+
+	if got.err != nil {
+		t.Fatalf("UpsertEngagement returned %v on a write that committed — a "+
+			"concurrent un-enrolment must not turn a committed enrolment into "+
+			"an error (the handler reports ErrEngagementNotFound here as 412 "+
+			"precondition_failed on a request that sent no If-Match)", got.err)
+	}
+	if got.e.Stage != "nurture" || got.e.Address != address {
+		t.Errorf("returned engagement = %+v, want the row this call wrote (stage nurture, %s)", got.e, address)
+	}
+
+	// Prove the interleaving actually happened: the racer's delete must be the
+	// last write, otherwise this test asserted nothing.
+	if _, err := store.GetEngagement(ctx, user.ID, agent, address); err == nil {
+		t.Fatal("racing un-enrolment never landed — the interleaving did not happen, so this run proves nothing")
+	}
+}
+
+// TestUpdateWebhookReturnsTheRowItWrote is the site-4 regression.
+//
+// UpdateWebhook ran `UPDATE … RETURNING id` in autocommit and then re-read the
+// row with a separate GetWebhookByID. A concurrent PATCH committing between
+// the two handed the caller the OTHER writer's configuration as the result of
+// their own request; a concurrent DELETE turned a committed update into a 404.
+// RETURNING the full row from the UPDATE itself is atomic by construction.
+func TestUpdateWebhookReturnsTheRowItWrote(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	userID := webhookTestUser(t, store, "wh-torn")
+
+	w, err := store.CreateWebhook(ctx, userID, "https://example.com/hook", "original",
+		[]string{"email.received"}, identity.WebhookFilters{})
+	if err != nil {
+		t.Fatalf("CreateWebhook: %v", err)
+	}
+
+	holder, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin holder: %v", err)
+	}
+	defer holder.Rollback(ctx) //nolint:errcheck
+	if _, err := holder.Exec(ctx, `SELECT id FROM webhooks WHERE id = $1 FOR UPDATE`, w.ID); err != nil {
+		t.Fatalf("hold webhook row: %v", err)
+	}
+
+	type updateResult struct {
+		w   *identity.Webhook
+		err error
+	}
+	baseline := lockWaiters(t, pool)
+	updated := make(chan updateResult, 1)
+	go func() {
+		mine := "mine"
+		got, err := store.UpdateWebhook(ctx, w.ID, userID, identity.WebhookUpdate{Description: &mine})
+		updated <- updateResult{got, err}
+	}()
+	waitForExtraLockWaiter(t, pool, baseline)
+
+	marker, racer := startRacer(t, pool,
+		"UPDATE webhooks SET description = 'racer-won' WHERE id = "+sqlLit(w.ID))
+	waitForBlockedRacer(t, pool, marker)
+
+	if err := holder.Commit(ctx); err != nil {
+		t.Fatalf("release webhook row: %v", err)
+	}
+	got := <-updated
+	if err := <-racer; err != nil {
+		t.Fatalf("racing webhook PATCH: %v", err)
+	}
+
+	if got.err != nil {
+		t.Fatalf("UpdateWebhook: %v", got.err)
+	}
+	if got.w.Description != "mine" {
+		t.Errorf("UpdateWebhook returned description %q, want %q — the response described "+
+			"a concurrent writer's update instead of this caller's", got.w.Description, "mine")
+	}
+
+	after, err := store.GetWebhookByID(ctx, w.ID, userID)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if after.Description != "racer-won" {
+		t.Fatal("racing PATCH never landed — the interleaving did not happen, so this run proves nothing")
+	}
+}
+
+// TestUpdateTemplateReturnsTheRowItWrote is the site-5 regression — the same
+// shape as UpdateWebhook, and fixed the same way.
+func TestUpdateTemplateReturnsTheRowItWrote(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	userID := templateTestUser(t, store, "tmpl-torn")
+
+	tpl, err := store.CreateTemplate(ctx, userID, identity.TemplateCreate{
+		Name: "original", Subject: "Hi", Body: "Hello",
+	})
+	if err != nil {
+		t.Fatalf("CreateTemplate: %v", err)
+	}
+
+	holder, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin holder: %v", err)
+	}
+	defer holder.Rollback(ctx) //nolint:errcheck
+	if _, err := holder.Exec(ctx, `SELECT id FROM templates WHERE id = $1 FOR UPDATE`, tpl.ID); err != nil {
+		t.Fatalf("hold template row: %v", err)
+	}
+
+	type updateResult struct {
+		t   *identity.Template
+		err error
+	}
+	baseline := lockWaiters(t, pool)
+	updated := make(chan updateResult, 1)
+	go func() {
+		mine := "mine"
+		got, err := store.UpdateTemplate(ctx, tpl.ID, userID, identity.TemplateUpdate{Name: &mine})
+		updated <- updateResult{got, err}
+	}()
+	waitForExtraLockWaiter(t, pool, baseline)
+
+	marker, racer := startRacer(t, pool,
+		"UPDATE templates SET name = 'racer-won' WHERE id = "+sqlLit(tpl.ID))
+	waitForBlockedRacer(t, pool, marker)
+
+	if err := holder.Commit(ctx); err != nil {
+		t.Fatalf("release template row: %v", err)
+	}
+	got := <-updated
+	if err := <-racer; err != nil {
+		t.Fatalf("racing template PATCH: %v", err)
+	}
+
+	if got.err != nil {
+		t.Fatalf("UpdateTemplate: %v", got.err)
+	}
+	if got.t.Name != "mine" {
+		t.Errorf("UpdateTemplate returned name %q, want %q — the response described "+
+			"a concurrent writer's update instead of this caller's", got.t.Name, "mine")
+	}
+
+	after, err := store.GetTemplateByID(ctx, tpl.ID, userID)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if after.Name != "racer-won" {
+		t.Fatal("racing PATCH never landed — the interleaving did not happen, so this run proves nothing")
+	}
+}
+
+// TestUpdateAgentNameReturnsTheRowItWrote is the site-3 (PATCH) regression.
+// The handler used to re-read with GetAgent after the write committed: a
+// concurrent rename showed the caller the other writer's name as the result of
+// their own PATCH, and a concurrent trash answered 500 "failed to reload
+// agent" on a rename that had committed.
+func TestUpdateAgentNameReturnsTheRowItWrote(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	userID, agentID := trashTestSetup(t, store, "agentname-torn")
+
+	holder := lockAgentRow(t, pool, agentID)
+	type nameResult struct {
+		a   *identity.AgentIdentity
+		err error
+	}
+	baseline := lockWaiters(t, pool)
+	renamed := make(chan nameResult, 1)
+	go func() {
+		a, err := store.UpdateAgentName(ctx, agentID, userID, "mine")
+		renamed <- nameResult{a, err}
+	}()
+	waitForExtraLockWaiter(t, pool, baseline)
+
+	marker, racer := startRacer(t, pool,
+		"UPDATE agent_identities SET name = 'racer-won' WHERE id = "+sqlLit(agentID))
+	waitForBlockedRacer(t, pool, marker)
+
+	if err := holder.Commit(ctx); err != nil {
+		t.Fatalf("release agent row: %v", err)
+	}
+	got := <-renamed
+	if err := <-racer; err != nil {
+		t.Fatalf("racing rename: %v", err)
+	}
+
+	if got.err != nil {
+		t.Fatalf("UpdateAgentName: %v", got.err)
+	}
+	if got.a == nil || got.a.Name != "mine" {
+		t.Errorf("UpdateAgentName returned %+v, want the name this call wrote", got.a)
+	}
+	assertAgentName(t, pool, agentID, "racer-won")
+}
+
+// TestUpdateAgentProtectionReturnsTheRowItWrote is the site-2 regression. The
+// protection PUT is a full replace, which makes the torn read especially bad:
+// the caller was handed a concurrent writer's entire posture as the
+// authoritative-looking result of their own request.
+func TestUpdateAgentProtectionReturnsTheRowItWrote(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	userID, agentID := trashTestSetup(t, store, "protection-torn")
+
+	cfg := identity.ProtectionConfig{
+		InboundGatePolicy: "allowlist", InboundAllowlist: []string{"partner@example.com"},
+		InboundGateAction: "review", InboundScanSensitivity: identity.SensitivityOff,
+		OutboundGatePolicy: "open", OutboundGateAction: "flag",
+		OutboundScanSensitivity: identity.SensitivityOff,
+		HITLTTLSeconds:          3600, HITLExpirationAction: identity.HITLExpirationReject,
+	}
+
+	holder := lockAgentRow(t, pool, agentID)
+	type protResult struct {
+		a   *identity.AgentIdentity
+		err error
+	}
+	baseline := lockWaiters(t, pool)
+	written := make(chan protResult, 1)
+	go func() {
+		a, err := store.UpdateAgentProtection(ctx, agentID, userID, cfg)
+		written <- protResult{a, err}
+	}()
+	waitForExtraLockWaiter(t, pool, baseline)
+
+	// A concurrent full-replace PUT landing right behind this one.
+	marker, racer := startRacer(t, pool,
+		"UPDATE agent_identities SET inbound_policy = 'open', inbound_policy_action = 'block' WHERE id = "+sqlLit(agentID))
+	waitForBlockedRacer(t, pool, marker)
+
+	if err := holder.Commit(ctx); err != nil {
+		t.Fatalf("release agent row: %v", err)
+	}
+	got := <-written
+	if err := <-racer; err != nil {
+		t.Fatalf("racing protection PUT: %v", err)
+	}
+
+	if got.err != nil {
+		t.Fatalf("UpdateAgentProtection: %v", got.err)
+	}
+	if got.a == nil || got.a.InboundPolicy != "allowlist" || got.a.InboundPolicyAction != "review" {
+		t.Errorf("UpdateAgentProtection returned inbound policy %v/%v, want allowlist/review — "+
+			"the response echoed a concurrent writer's posture as this caller's result",
+			got.a.InboundPolicy, got.a.InboundPolicyAction)
+	}
+
+	var policy, action string
+	if err := pool.QueryRow(ctx,
+		`SELECT inbound_policy, inbound_policy_action FROM agent_identities WHERE id = $1`,
+		agentID).Scan(&policy, &action); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if policy != "open" || action != "block" {
+		t.Fatal("racing PUT never landed — the interleaving did not happen, so this run proves nothing")
+	}
+}
+
+// TestRestoreAgentReturnsTheRestoredAgent is the site-3 (restore) regression.
+// A re-trash committing between the restore and the handler's re-read answered
+// 500 "failed to reload agent" on a restore that had committed.
+func TestRestoreAgentReturnsTheRestoredAgent(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	userID, agentID := trashTestSetup(t, store, "agentrestore-torn")
+	if err := store.SoftDeleteAgent(ctx, agentID, userID); err != nil {
+		t.Fatalf("SoftDeleteAgent: %v", err)
+	}
+
+	holder := lockAgentRow(t, pool, agentID)
+	type restoreResult struct {
+		a   *identity.AgentIdentity
+		err error
+	}
+	baseline := lockWaiters(t, pool)
+	restored := make(chan restoreResult, 1)
+	go func() {
+		a, err := store.RestoreAgent(ctx, agentID, userID)
+		restored <- restoreResult{a, err}
+	}()
+	waitForExtraLockWaiter(t, pool, baseline)
+
+	marker, racer := startRacer(t, pool,
+		"UPDATE agent_identities SET deleted_at = now() WHERE id = "+sqlLit(agentID))
+	waitForBlockedRacer(t, pool, marker)
+
+	if err := holder.Commit(ctx); err != nil {
+		t.Fatalf("release agent row: %v", err)
+	}
+	got := <-restored
+	if err := <-racer; err != nil {
+		t.Fatalf("racing re-trash: %v", err)
+	}
+
+	if got.err != nil {
+		t.Fatalf("RestoreAgent returned %v on a restore that committed", got.err)
+	}
+	if got.a == nil || got.a.DeletedAt != nil {
+		t.Errorf("RestoreAgent returned %+v, want the live agent this call restored", got.a)
+	}
+
+	var deletedAt *time.Time
+	if err := pool.QueryRow(ctx,
+		`SELECT deleted_at FROM agent_identities WHERE id = $1`, agentID).Scan(&deletedAt); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if deletedAt == nil {
+		t.Fatal("racing re-trash never landed — the interleaving did not happen, so this run proves nothing")
+	}
+}
+
+// TestRestoreMessageReturnsTheRestoredMessage is the site-6 regression. A
+// re-trash or purge committing between the restore and the handler's
+// GetMessage answered 500 "failed to reload message" on a committed restore.
+func TestRestoreMessageReturnsTheRestoredMessage(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	_, agentID := trashTestSetup(t, store, "msgrestore-torn")
+	msg := trashInbound(t, store, agentID, agentID, "restore me")
+	if err := store.SoftDeleteMessage(ctx, msg.ID, agentID); err != nil {
+		t.Fatalf("SoftDeleteMessage: %v", err)
+	}
+
+	holder, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin holder: %v", err)
+	}
+	defer holder.Rollback(ctx) //nolint:errcheck
+	if _, err := holder.Exec(ctx, `SELECT id FROM messages WHERE id = $1 FOR UPDATE`, msg.ID); err != nil {
+		t.Fatalf("hold message row: %v", err)
+	}
+
+	type restoreResult struct {
+		m   *identity.Message
+		err error
+	}
+	baseline := lockWaiters(t, pool)
+	restored := make(chan restoreResult, 1)
+	go func() {
+		m, err := store.RestoreMessage(ctx, msg.ID, agentID)
+		restored <- restoreResult{m, err}
+	}()
+	waitForExtraLockWaiter(t, pool, baseline)
+
+	marker, racer := startRacer(t, pool,
+		"UPDATE messages SET deleted_at = now() WHERE id = "+sqlLit(msg.ID))
+	waitForBlockedRacer(t, pool, marker)
+
+	if err := holder.Commit(ctx); err != nil {
+		t.Fatalf("release message row: %v", err)
+	}
+	got := <-restored
+	if err := <-racer; err != nil {
+		t.Fatalf("racing re-trash: %v", err)
+	}
+
+	if got.err != nil {
+		t.Fatalf("RestoreMessage returned %v on a restore that committed", got.err)
+	}
+	if got.m == nil || got.m.DeletedAt != nil || got.m.ID != msg.ID {
+		t.Errorf("RestoreMessage returned %+v, want the live message this call restored", got.m)
+	}
+
+	var deletedAt *time.Time
+	if err := pool.QueryRow(ctx,
+		`SELECT deleted_at FROM messages WHERE id = $1`, msg.ID).Scan(&deletedAt); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if deletedAt == nil {
+		t.Fatal("racing re-trash never landed — the interleaving did not happen, so this run proves nothing")
+	}
+}
+
+func lockAgentRow(t *testing.T, pool *pgxpool.Pool, agentID string) pgx.Tx {
+	t.Helper()
+	ctx := context.Background()
+	holder, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin holder: %v", err)
+	}
+	t.Cleanup(func() { _ = holder.Rollback(ctx) })
+	if _, err := holder.Exec(ctx, `SELECT id FROM agent_identities WHERE id = $1 FOR UPDATE`, agentID); err != nil {
+		t.Fatalf("hold agent row: %v", err)
+	}
+	return holder
+}
+
+func assertAgentName(t *testing.T, pool *pgxpool.Pool, agentID, want string) {
+	t.Helper()
+	var name string
+	if err := pool.QueryRow(context.Background(),
+		`SELECT name FROM agent_identities WHERE id = $1`, agentID).Scan(&name); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if name != want {
+		t.Fatalf("racing write never landed (name = %q, want %q) — "+
+			"the interleaving did not happen, so this run proves nothing", name, want)
+	}
+}

--- a/internal/identity/post_write_read_test.go
+++ b/internal/identity/post_write_read_test.go
@@ -37,34 +37,54 @@ import (
 // Each test also asserts the racer really did land afterwards, so a run where
 // the interleaving failed to happen cannot pass silently.
 
-// lockWaiters counts backends currently blocked on a lock in the test database.
-func lockWaiters(t *testing.T, pool *pgxpool.Pool) int {
+// beginHolder opens the holder transaction and returns it with its backend pid,
+// so the waits below can be scoped to "blocked BY THIS transaction" rather than
+// to a global waiter count. The pid is the write path's equivalent of the
+// racer's marker comment: the write path runs store SQL that cannot be tagged,
+// but everything it blocks on here is a lock this transaction holds.
+//
+// Scoping matters in practice — several agent worktrees share one local
+// Postgres. A global count can be satisfied by an unrelated waiter, which lets
+// the racer queue AHEAD of the write path and trips the "interleaving did not
+// happen" assertion as a flake. (It fails safe: never a false pass.)
+func beginHolder(t *testing.T, pool *pgxpool.Pool) (pgx.Tx, int) {
 	t.Helper()
-	var n int
-	if err := pool.QueryRow(context.Background(),
-		`SELECT count(*)
-		   FROM pg_locks l
-		   JOIN pg_stat_activity a ON a.pid = l.pid
-		  WHERE NOT l.granted
-		    AND a.datname = current_database()`).Scan(&n); err != nil {
-		t.Fatalf("poll locks: %v", err)
+	ctx := context.Background()
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin holder: %v", err)
 	}
-	return n
+	t.Cleanup(func() { _ = tx.Rollback(ctx) })
+	var pid int
+	if err := tx.QueryRow(ctx, `SELECT pg_backend_pid()`).Scan(&pid); err != nil {
+		t.Fatalf("holder backend pid: %v", err)
+	}
+	return tx, pid
 }
 
-// waitForExtraLockWaiter waits until one MORE backend is blocked than at
-// baseline. Counting relative to a baseline rather than absolutely keeps the
-// interleaving honest if anything else is using the same database.
-func waitForExtraLockWaiter(t *testing.T, pool *pgxpool.Pool, baseline int) {
+// waitForBlockedBy waits until want backends are blocked specifically by the
+// holder transaction. pg_blocking_pids covers every lock type the harness uses,
+// advisory locks included.
+func waitForBlockedBy(t *testing.T, pool *pgxpool.Pool, holderPID, want int) {
 	t.Helper()
 	deadline := time.Now().Add(10 * time.Second)
+	var n int
 	for time.Now().Before(deadline) {
-		if lockWaiters(t, pool) > baseline {
+		if err := pool.QueryRow(context.Background(),
+			`SELECT count(*)
+			   FROM pg_stat_activity a
+			  WHERE a.datname = current_database()
+			    AND a.pid <> $1
+			    AND $1 = ANY (pg_blocking_pids(a.pid))`, holderPID).Scan(&n); err != nil {
+			t.Fatalf("poll blocked backends: %v", err)
+		}
+		if n >= want {
 			return
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatal("the write path never blocked on the holder's lock")
+	t.Fatalf("%d backend(s) blocked by the holder, want %d — the write path never "+
+		"reached the lock it must contend for", n, want)
 }
 
 // waitForBlockedRacer waits until the racer carrying this marker is itself
@@ -119,6 +139,86 @@ func startRacer(t *testing.T, pool *pgxpool.Pool, sql string) (string, <-chan er
 	return marker, done
 }
 
+// TestUpsertEngagementAdvancesUpdatedAtMonotonically pins the companion
+// property to the read-back fix: updated_at must never move BACKWARDS.
+//
+// `now()` is transaction START time, so a transaction that begins earlier but
+// commits later stamps an EARLIER updated_at than one that already committed.
+// Reading the row inside the write's transaction (the fix above) makes that
+// transaction live longer, which widens the window — so the two changes belong
+// together. Every writer of contact_engagements.updated_at now uses
+// monotonicUpdatedAt.
+//
+// The interleaving is exact and needs no timing luck: the upsert's transaction
+// is pinned open on the contact-capacity advisory lock, so its now() is already
+// fixed; a later writer then commits a strictly greater updated_at while the
+// upsert waits. When the upsert finally runs, `now()` would take the column
+// backwards past that value.
+func TestUpsertEngagementAdvancesUpdatedAtMonotonically(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	user := newEngagementOwner(t, store, "engmono")
+	const agent, address = "raise@e.com", "partner@engmono.vc"
+	enroll(t, store, user.ID, agent, address, "prospect")
+
+	holder, holderPID := beginHolder(t, pool)
+	if _, err := holder.Exec(ctx,
+		`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`,
+		"contact-cap:"+user.ID); err != nil {
+		t.Fatalf("hold contact-cap lock: %v", err)
+	}
+
+	type upsertResult struct {
+		e   identity.ContactEngagement
+		err error
+	}
+	upserted := make(chan upsertResult, 1)
+	go func() {
+		stage := "nurture"
+		e, _, err := store.UpsertEngagement(ctx, user.ID, agent, address, &stage, nil, nil)
+		upserted <- upsertResult{e, err}
+	}()
+	// The upsert's transaction has now begun (its now() is pinned) and is
+	// parked on the advisory lock, having touched no rows yet.
+	waitForBlockedBy(t, pool, holderPID, 1)
+
+	// A later writer commits ahead of it. It needs no lock from the upsert, so
+	// this is ordinary sequential SQL, not a race.
+	var ahead time.Time
+	if err := pool.QueryRow(ctx,
+		`UPDATE contact_engagements
+		    SET updated_at = clock_timestamp()
+		  WHERE user_id = $1 AND agent_id = $2 AND address = $3
+		  RETURNING updated_at`,
+		user.ID, agent, address).Scan(&ahead); err != nil {
+		t.Fatalf("advance updated_at ahead of the parked upsert: %v", err)
+	}
+
+	if err := holder.Commit(ctx); err != nil {
+		t.Fatalf("release contact-cap lock: %v", err)
+	}
+	got := <-upserted
+	if got.err != nil {
+		t.Fatalf("UpsertEngagement: %v", got.err)
+	}
+
+	if !got.e.UpdatedAt.After(ahead) {
+		t.Errorf("updated_at = %v, want strictly after the %v a writer had already "+
+			"committed — now() is transaction START time, so this upsert walked the "+
+			"column BACKWARDS and anyone ordering or filtering on updated_at sees the "+
+			"newer write vanish", got.e.UpdatedAt, ahead)
+	}
+	// And the returned validator is the stored one, as ever.
+	reread, err := store.GetEngagement(ctx, user.ID, agent, address)
+	if err != nil {
+		t.Fatalf("re-read: %v", err)
+	}
+	if !reread.UpdatedAt.Equal(got.e.UpdatedAt) {
+		t.Errorf("stored updated_at %v, returned %v", reread.UpdatedAt, got.e.UpdatedAt)
+	}
+}
+
 // TestUpsertEngagementReturnsTheRowItCommitted is the site-1 regression.
 //
 // UpsertEngagement committed its transaction and then called GetEngagement on
@@ -138,11 +238,7 @@ func TestUpsertEngagementReturnsTheRowItCommitted(t *testing.T) {
 
 	// Hold the contact-capacity advisory lock the upsert takes before any of
 	// its writes — the one deterministic pause point inside that transaction.
-	holder, err := pool.Begin(ctx)
-	if err != nil {
-		t.Fatalf("begin holder: %v", err)
-	}
-	defer holder.Rollback(ctx) //nolint:errcheck
+	holder, holderPID := beginHolder(t, pool)
 	if _, err := holder.Exec(ctx,
 		`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`,
 		"contact-cap:"+user.ID); err != nil {
@@ -153,14 +249,13 @@ func TestUpsertEngagementReturnsTheRowItCommitted(t *testing.T) {
 		e   identity.ContactEngagement
 		err error
 	}
-	baseline := lockWaiters(t, pool)
 	upserted := make(chan upsertResult, 1)
 	go func() {
 		stage := "nurture"
 		e, _, err := store.UpsertEngagement(ctx, user.ID, agent, address, &stage, nil, nil)
 		upserted <- upsertResult{e, err}
 	}()
-	waitForExtraLockWaiter(t, pool, baseline)
+	waitForBlockedBy(t, pool, holderPID, 1)
 
 	// Queue the un-enrolment behind the upsert. It takes the same advisory
 	// lock, so it cannot start until the upsert's transaction commits — which
@@ -216,11 +311,7 @@ func TestUpdateWebhookReturnsTheRowItWrote(t *testing.T) {
 		t.Fatalf("CreateWebhook: %v", err)
 	}
 
-	holder, err := pool.Begin(ctx)
-	if err != nil {
-		t.Fatalf("begin holder: %v", err)
-	}
-	defer holder.Rollback(ctx) //nolint:errcheck
+	holder, holderPID := beginHolder(t, pool)
 	if _, err := holder.Exec(ctx, `SELECT id FROM webhooks WHERE id = $1 FOR UPDATE`, w.ID); err != nil {
 		t.Fatalf("hold webhook row: %v", err)
 	}
@@ -229,14 +320,13 @@ func TestUpdateWebhookReturnsTheRowItWrote(t *testing.T) {
 		w   *identity.Webhook
 		err error
 	}
-	baseline := lockWaiters(t, pool)
 	updated := make(chan updateResult, 1)
 	go func() {
 		mine := "mine"
 		got, err := store.UpdateWebhook(ctx, w.ID, userID, identity.WebhookUpdate{Description: &mine})
 		updated <- updateResult{got, err}
 	}()
-	waitForExtraLockWaiter(t, pool, baseline)
+	waitForBlockedBy(t, pool, holderPID, 1)
 
 	marker, racer := startRacer(t, pool,
 		"UPDATE webhooks SET description = 'racer-won' WHERE id = "+sqlLit(w.ID))
@@ -282,11 +372,7 @@ func TestUpdateTemplateReturnsTheRowItWrote(t *testing.T) {
 		t.Fatalf("CreateTemplate: %v", err)
 	}
 
-	holder, err := pool.Begin(ctx)
-	if err != nil {
-		t.Fatalf("begin holder: %v", err)
-	}
-	defer holder.Rollback(ctx) //nolint:errcheck
+	holder, holderPID := beginHolder(t, pool)
 	if _, err := holder.Exec(ctx, `SELECT id FROM templates WHERE id = $1 FOR UPDATE`, tpl.ID); err != nil {
 		t.Fatalf("hold template row: %v", err)
 	}
@@ -295,14 +381,13 @@ func TestUpdateTemplateReturnsTheRowItWrote(t *testing.T) {
 		t   *identity.Template
 		err error
 	}
-	baseline := lockWaiters(t, pool)
 	updated := make(chan updateResult, 1)
 	go func() {
 		mine := "mine"
 		got, err := store.UpdateTemplate(ctx, tpl.ID, userID, identity.TemplateUpdate{Name: &mine})
 		updated <- updateResult{got, err}
 	}()
-	waitForExtraLockWaiter(t, pool, baseline)
+	waitForBlockedBy(t, pool, holderPID, 1)
 
 	marker, racer := startRacer(t, pool,
 		"UPDATE templates SET name = 'racer-won' WHERE id = "+sqlLit(tpl.ID))
@@ -344,18 +429,17 @@ func TestUpdateAgentNameReturnsTheRowItWrote(t *testing.T) {
 	ctx := context.Background()
 	userID, agentID := trashTestSetup(t, store, "agentname-torn")
 
-	holder := lockAgentRow(t, pool, agentID)
+	holder, holderPID := lockAgentRow(t, pool, agentID)
 	type nameResult struct {
 		a   *identity.AgentIdentity
 		err error
 	}
-	baseline := lockWaiters(t, pool)
 	renamed := make(chan nameResult, 1)
 	go func() {
 		a, err := store.UpdateAgentName(ctx, agentID, userID, "mine")
 		renamed <- nameResult{a, err}
 	}()
-	waitForExtraLockWaiter(t, pool, baseline)
+	waitForBlockedBy(t, pool, holderPID, 1)
 
 	marker, racer := startRacer(t, pool,
 		"UPDATE agent_identities SET name = 'racer-won' WHERE id = "+sqlLit(agentID))
@@ -396,18 +480,17 @@ func TestUpdateAgentProtectionReturnsTheRowItWrote(t *testing.T) {
 		HITLTTLSeconds:          3600, HITLExpirationAction: identity.HITLExpirationReject,
 	}
 
-	holder := lockAgentRow(t, pool, agentID)
+	holder, holderPID := lockAgentRow(t, pool, agentID)
 	type protResult struct {
 		a   *identity.AgentIdentity
 		err error
 	}
-	baseline := lockWaiters(t, pool)
 	written := make(chan protResult, 1)
 	go func() {
 		a, err := store.UpdateAgentProtection(ctx, agentID, userID, cfg)
 		written <- protResult{a, err}
 	}()
-	waitForExtraLockWaiter(t, pool, baseline)
+	waitForBlockedBy(t, pool, holderPID, 1)
 
 	// A concurrent full-replace PUT landing right behind this one.
 	marker, racer := startRacer(t, pool,
@@ -454,18 +537,17 @@ func TestRestoreAgentReturnsTheRestoredAgent(t *testing.T) {
 		t.Fatalf("SoftDeleteAgent: %v", err)
 	}
 
-	holder := lockAgentRow(t, pool, agentID)
+	holder, holderPID := lockAgentRow(t, pool, agentID)
 	type restoreResult struct {
 		a   *identity.AgentIdentity
 		err error
 	}
-	baseline := lockWaiters(t, pool)
 	restored := make(chan restoreResult, 1)
 	go func() {
 		a, err := store.RestoreAgent(ctx, agentID, userID)
 		restored <- restoreResult{a, err}
 	}()
-	waitForExtraLockWaiter(t, pool, baseline)
+	waitForBlockedBy(t, pool, holderPID, 1)
 
 	marker, racer := startRacer(t, pool,
 		"UPDATE agent_identities SET deleted_at = now() WHERE id = "+sqlLit(agentID))
@@ -509,11 +591,7 @@ func TestRestoreMessageReturnsTheRestoredMessage(t *testing.T) {
 		t.Fatalf("SoftDeleteMessage: %v", err)
 	}
 
-	holder, err := pool.Begin(ctx)
-	if err != nil {
-		t.Fatalf("begin holder: %v", err)
-	}
-	defer holder.Rollback(ctx) //nolint:errcheck
+	holder, holderPID := beginHolder(t, pool)
 	if _, err := holder.Exec(ctx, `SELECT id FROM messages WHERE id = $1 FOR UPDATE`, msg.ID); err != nil {
 		t.Fatalf("hold message row: %v", err)
 	}
@@ -522,13 +600,12 @@ func TestRestoreMessageReturnsTheRestoredMessage(t *testing.T) {
 		m   *identity.Message
 		err error
 	}
-	baseline := lockWaiters(t, pool)
 	restored := make(chan restoreResult, 1)
 	go func() {
 		m, err := store.RestoreMessage(ctx, msg.ID, agentID)
 		restored <- restoreResult{m, err}
 	}()
-	waitForExtraLockWaiter(t, pool, baseline)
+	waitForBlockedBy(t, pool, holderPID, 1)
 
 	marker, racer := startRacer(t, pool,
 		"UPDATE messages SET deleted_at = now() WHERE id = "+sqlLit(msg.ID))
@@ -559,18 +636,14 @@ func TestRestoreMessageReturnsTheRestoredMessage(t *testing.T) {
 	}
 }
 
-func lockAgentRow(t *testing.T, pool *pgxpool.Pool, agentID string) pgx.Tx {
+func lockAgentRow(t *testing.T, pool *pgxpool.Pool, agentID string) (pgx.Tx, int) {
 	t.Helper()
-	ctx := context.Background()
-	holder, err := pool.Begin(ctx)
-	if err != nil {
-		t.Fatalf("begin holder: %v", err)
-	}
-	t.Cleanup(func() { _ = holder.Rollback(ctx) })
-	if _, err := holder.Exec(ctx, `SELECT id FROM agent_identities WHERE id = $1 FOR UPDATE`, agentID); err != nil {
+	holder, pid := beginHolder(t, pool)
+	if _, err := holder.Exec(context.Background(),
+		`SELECT id FROM agent_identities WHERE id = $1 FOR UPDATE`, agentID); err != nil {
 		t.Fatalf("hold agent row: %v", err)
 	}
-	return holder
+	return holder, pid
 }
 
 func assertAgentName(t *testing.T, pool *pgxpool.Pool, agentID, want string) {

--- a/internal/identity/protection.go
+++ b/internal/identity/protection.go
@@ -125,9 +125,18 @@ func ValidateProtectionConfig(c ProtectionConfig) error {
 // columns (the API source of truth) AND the derived scan toggle + float
 // thresholds the piguard engine reads, so the two never diverge and the engine
 // needs no change. Returns an error if the agent isn't found or not owned.
-func (s *Store) UpdateAgentProtection(ctx context.Context, agentID, userID string, c ProtectionConfig) error {
+//
+// It returns the agent AS WRITTEN, re-read INSIDE the write's transaction.
+// Reading afterwards from the pool was a torn read: the PUT is a full replace,
+// so a concurrent PUT landing between the commit and the re-read handed the
+// caller the OTHER writer's posture as the result of their own request — the
+// worst shape of this bug, because the response looks authoritative. A
+// concurrent trash likewise turned a committed write into a 500 "failed to
+// reload agent". Same recipe as UpdateEngagementIfUnchanged; the read includes
+// trashed rows for the reason given on UpdateAgentName.
+func (s *Store) UpdateAgentProtection(ctx context.Context, agentID, userID string, c ProtectionConfig) (*AgentIdentity, error) {
 	if err := ValidateProtectionConfig(c); err != nil {
-		return err
+		return nil, err
 	}
 	inB := sensitivityBands[c.InboundScanSensitivity]
 	outB := sensitivityBands[c.OutboundScanSensitivity]
@@ -142,7 +151,13 @@ func (s *Store) UpdateAgentProtection(ctx context.Context, agentID, userID strin
 		outAllow = []string{}
 	}
 
-	tag, err := s.pool.Exec(ctx,
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback(ctx)
+
+	tag, err := tx.Exec(ctx,
 		`UPDATE agent_identities SET
 		    inbound_policy = $3, inbound_allowlist = $4, inbound_policy_action = $5,
 		    inbound_scan = $6, inbound_scan_review_threshold = $7, inbound_scan_block_threshold = $8,
@@ -164,10 +179,17 @@ func (s *Store) UpdateAgentProtection(ctx context.Context, agentID, userID strin
 		c.SuppressNotifications,
 	)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if tag.RowsAffected() == 0 {
-		return fmt.Errorf("agent not found or not owned by user")
+		return nil, fmt.Errorf("agent not found or not owned by user")
 	}
-	return nil
+	a, err := loadAgentByID(ctx, tx, agentID, true)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	return a, nil
 }

--- a/internal/identity/protection_test.go
+++ b/internal/identity/protection_test.go
@@ -58,7 +58,7 @@ func TestUpdateAgentProtectionRoundTrip(t *testing.T) {
 		HITLExpirationAction:    "approve",
 		SuppressNotifications:   true,
 	}
-	if err := store.UpdateAgentProtection(ctx, agentID, userID, cfg); err != nil {
+	if _, err := store.UpdateAgentProtection(ctx, agentID, userID, cfg); err != nil {
 		t.Fatalf("UpdateAgentProtection: %v", err)
 	}
 
@@ -117,7 +117,7 @@ func TestUpdateAgentProtectionSensitivityMapping(t *testing.T) {
 			OutboundGatePolicy: "open", OutboundGateAction: "flag", OutboundScanSensitivity: tc.level,
 			HITLTTLSeconds: 604800, HITLExpirationAction: "reject",
 		}
-		if err := store.UpdateAgentProtection(ctx, agentID, userID, cfg); err != nil {
+		if _, err := store.UpdateAgentProtection(ctx, agentID, userID, cfg); err != nil {
 			t.Fatalf("%s: UpdateAgentProtection: %v", tc.level, err)
 		}
 		got, err := store.GetAgentByID(ctx, agentID)
@@ -156,7 +156,7 @@ func TestUpdateAgentProtectionValidation(t *testing.T) {
 		"allowlist over cap":             mut(func(c *identity.ProtectionConfig) { c.InboundAllowlist = makeAllowlist(1001) }),
 	}
 	for name, c := range cases {
-		if err := store.UpdateAgentProtection(ctx, agentID, userID, c); err == nil {
+		if _, err := store.UpdateAgentProtection(ctx, agentID, userID, c); err == nil {
 			t.Errorf("%s: expected validation error, got nil", name)
 		}
 	}
@@ -171,7 +171,7 @@ func TestUpdateAgentProtectionWrongOwner(t *testing.T) {
 		OutboundGatePolicy: "open", OutboundGateAction: "flag", OutboundScanSensitivity: "off",
 		HITLTTLSeconds: 604800, HITLExpirationAction: "reject",
 	}
-	if err := store.UpdateAgentProtection(ctx, agentID, "someone-else", cfg); err == nil {
+	if _, err := store.UpdateAgentProtection(ctx, agentID, "someone-else", cfg); err == nil {
 		t.Fatal("expected error updating protection for non-owner, got nil")
 	}
 }

--- a/internal/identity/review.go
+++ b/internal/identity/review.go
@@ -287,7 +287,7 @@ func (s *Store) transitionReview(ctx context.Context, messageID, agentID, newSta
 				UPDATE contact_engagements ce
 				   SET last_inbound_at = GREATEST(COALESCE(ce.last_inbound_at, m.created_at), m.created_at),
 				       last_conversation_id = COALESCE(NULLIF(m.conversation_id, ''), ce.last_conversation_id),
-				       updated_at = now()
+				       updated_at = `+monotonicUpdatedAt("ce")+`
 				  FROM messages m
 				  JOIN agent_identities ai ON ai.id = m.agent_id
 				 WHERE m.id = $1

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -1453,6 +1453,21 @@ func (s *Store) GetAgentByIDAnyState(ctx context.Context, id string) (*AgentIden
 }
 
 func (s *Store) getAgentByID(ctx context.Context, id string, includeDeleted bool) (*AgentIdentity, error) {
+	return loadAgentByID(ctx, s.pool, id, includeDeleted)
+}
+
+// agentRowQuerier is the read half of *pgxpool.Pool and pgx.Tx. It exists so
+// loadAgentByID can serve both the stand-alone getters and the write paths
+// that must re-read the agent INSIDE their own transaction.
+type agentRowQuerier interface {
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+// loadAgentByID is the one agent projection, parameterized by executor. The
+// domain JOIN (domain_verified lives on `domains`, not `agent_identities`) is
+// why the agent write paths cannot answer with a plain UPDATE … RETURNING, and
+// call this inside their own transaction instead.
+func loadAgentByID(ctx context.Context, exec agentRowQuerier, id string, includeDeleted bool) (*AgentIdentity, error) {
 	q := `SELECT a.id, a.registered_domain, a.user_id, a.name, a.public, a.created_at,
 		        a.hitl_ttl_seconds, a.hitl_expiration_action, a.suppress_notifications,
 		        COALESCE(a.inbound_policy, 'open'), a.inbound_allowlist,
@@ -1471,7 +1486,7 @@ func (s *Store) getAgentByID(ctx context.Context, id string, includeDeleted bool
 		q += ` AND a.deleted_at IS NULL`
 	}
 	a := &AgentIdentity{}
-	err := s.pool.QueryRow(ctx, q, id).Scan(&a.ID, &a.RegisteredDomain, &a.UserID, &a.Name, &a.Public, &a.CreatedAt,
+	err := exec.QueryRow(ctx, q, id).Scan(&a.ID, &a.RegisteredDomain, &a.UserID, &a.Name, &a.Public, &a.CreatedAt,
 		&a.HITLTTLSeconds, &a.HITLExpirationAction, &a.SuppressNotifications,
 		&a.InboundPolicy, &a.InboundAllowlist,
 		&a.InboundPolicyAction,
@@ -1656,24 +1671,48 @@ func ValidateAgentName(name string) error {
 	return nil
 }
 
-// UpdateAgentName sets an agent's display name for an agent owned by userID.
-// The name is a UI label only — the agent's identity is its email. Returns an
-// error if the agent isn't found or not owned.
-func (s *Store) UpdateAgentName(ctx context.Context, agentID, userID, name string) error {
+// UpdateAgentName sets an agent's display name for an agent owned by userID
+// and returns the agent AS WRITTEN. The name is a UI label only — the agent's
+// identity is its email. Returns an error if the agent isn't found or not
+// owned.
+//
+// The read-back happens INSIDE the write's transaction. Reading afterwards
+// from the pool was a torn read: the UPDATE takes the row lock, but once it
+// commits a concurrent rename could land before the re-read and the caller saw
+// the OTHER writer's name echoed back as the result of their own PATCH, while
+// a concurrent trash/delete turned a committed rename into a 500 "failed to
+// reload agent". Same recipe as UpdateEngagementIfUnchanged. The re-read
+// includes trashed rows on purpose: the row it reports is the one this
+// statement wrote, and AgentView carries deleted_at, so a racing trash is
+// reported honestly instead of as a server error.
+func (s *Store) UpdateAgentName(ctx context.Context, agentID, userID, name string) (*AgentIdentity, error) {
 	if err := ValidateAgentName(name); err != nil {
-		return err
+		return nil, err
 	}
-	tag, err := s.pool.Exec(ctx,
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback(ctx)
+
+	tag, err := tx.Exec(ctx,
 		`UPDATE agent_identities SET name = $3 WHERE id = $1 AND user_id = $2`,
 		agentID, userID, name,
 	)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if tag.RowsAffected() == 0 {
-		return fmt.Errorf("agent not found or not owned by user")
+		return nil, fmt.Errorf("agent not found or not owned by user")
 	}
-	return nil
+	a, err := loadAgentByID(ctx, tx, agentID, true)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	return a, nil
 }
 
 // Agents are joined with domain verification AND enriched with per-agent stats
@@ -1884,8 +1923,16 @@ func (s *Store) SoftDeleteAgent(ctx context.Context, agentID, userID string) err
 // hold cannot silently lapse while the inbox is trashed.
 // Returns ErrNotInTrash when the agent exists but is live, and ErrAgentNotFound
 // when it doesn't exist (or isn't the caller's).
-func (s *Store) RestoreAgent(ctx context.Context, agentID, userID string) error {
-	return s.WithTx(ctx, func(tx pgx.Tx) error {
+//
+// It returns the restored agent, read INSIDE the restore transaction. Reading
+// afterwards from the pool was a torn read: a concurrent rename could land
+// between the commit and the re-read (the response then showed the other
+// writer's name), and a concurrent re-trash made a committed restore answer
+// 500 "failed to reload agent". The in-transaction read follows the row lock
+// this transaction already holds, so it always describes this restore.
+func (s *Store) RestoreAgent(ctx context.Context, agentID, userID string) (*AgentIdentity, error) {
+	var restored *AgentIdentity
+	err := s.WithTx(ctx, func(tx pgx.Tx) error {
 		var deletedAt *time.Time
 		err := tx.QueryRow(ctx,
 			`SELECT deleted_at FROM agent_identities
@@ -1967,15 +2014,25 @@ func (s *Store) RestoreAgent(ctx context.Context, agentID, userID string) error 
 		}
 		// Give back the trash time to pending holds on the agent's LIVE
 		// messages only. Message retention itself is indefinite.
-		_, err = tx.Exec(ctx,
+		if _, err := tx.Exec(ctx,
 			`UPDATE messages
 			    SET approval_expires_at = CASE
 			          WHEN status = 'pending_review' AND approval_expires_at IS NOT NULL
 			          THEN approval_expires_at + (now() - $2::timestamptz)
 			          ELSE approval_expires_at END
-			  WHERE agent_id = $1 AND deleted_at IS NULL`, agentID, *deletedAt)
+			  WHERE agent_id = $1 AND deleted_at IS NULL`, agentID, *deletedAt); err != nil {
+			return err
+		}
+		// The LIVE projection: this transaction just cleared deleted_at, so a
+		// row is guaranteed, and finding one still proves the agent is visible
+		// again — the property the handler's post-restore read used to assert.
+		restored, err = loadAgentByID(ctx, tx, agentID, false)
 		return err
 	})
+	if err != nil {
+		return nil, err
+	}
+	return restored, nil
 }
 
 // agentPurgeBatch bounds one janitor pass of PurgeDeletedAgents: one agent
@@ -4249,6 +4306,15 @@ func (s *Store) GetMessagesByAgent(ctx context.Context, f MessageListFilter) ([]
 // the dashboard trash can open a deleted message — Gmail's "view message in
 // trash". Callers branch on DeletedAt when trash rows must not qualify.
 func (s *Store) GetMessageWithContent(ctx context.Context, messageID, agentID string) (*Message, error) {
+	return getMessageWithContent(ctx, s.pool, messageID, agentID)
+}
+
+// getMessageWithContent is GetMessageWithContent parameterized by executor, so
+// a write path (RestoreMessage) can produce its own authoritative post-write
+// view from INSIDE its transaction instead of re-reading from the pool after
+// the commit. The CTE is snapshot-safe: its outer SELECT reads the CTE's own
+// RETURNING output (`FROM upd`), never the modified table.
+func getMessageWithContent(ctx context.Context, exec agentRowQuerier, messageID, agentID string) (*Message, error) {
 	m := &Message{}
 	var authHeadersJSON []byte
 	var authentication, authVerdict []byte
@@ -4257,7 +4323,7 @@ func (s *Store) GetMessageWithContent(ctx context.Context, messageID, agentID st
 	// the detail view is a superset of the summary view, so it must carry the
 	// same webhook_status/webhook_error the list exposes. Mirrors the
 	// wd.status/wd.last_error JOIN used by GetMessagesByAgent/GetConversationByID.
-	err := s.pool.QueryRow(ctx,
+	err := exec.QueryRow(ctx,
 		`WITH upd AS (
 		   UPDATE messages SET inbox_status = CASE WHEN inbox_status = 'unread' THEN 'read' ELSE inbox_status END
 		   WHERE id = $1 AND agent_id = $2
@@ -4583,10 +4649,19 @@ func (s *Store) SoftDeleteMessage(ctx context.Context, messageID, agentID string
 }
 
 // RestoreMessage brings an indefinitely retained trashed message back to the
-// inbox. Returns ErrNotInTrash when the message exists but is live,
-// ErrMessageNotFound otherwise.
-func (s *Store) RestoreMessage(ctx context.Context, messageID, agentID string) error {
-	return s.WithTx(ctx, func(tx pgx.Tx) error {
+// inbox and returns the restored message. Returns ErrNotInTrash when the
+// message exists but is live, ErrMessageNotFound otherwise.
+//
+// The post-restore view is produced INSIDE the restore transaction. Reading it
+// afterwards from the pool was a torn read: a concurrent re-trash or purge
+// landing in the gap made a committed restore answer 500 "failed to reload
+// message", and any concurrent mutation could describe the message by state
+// this restore never produced. The in-transaction read follows the row lock
+// this transaction already holds. The detail projection still marks an unread
+// inbound message read, exactly as the handler's post-restore read did.
+func (s *Store) RestoreMessage(ctx context.Context, messageID, agentID string) (*Message, error) {
+	var restored *Message
+	err := s.WithTx(ctx, func(tx pgx.Tx) error {
 		var deletedAt *time.Time
 		var scheduledAt *time.Time
 		var deliveryStatus string
@@ -4621,9 +4696,16 @@ func (s *Store) RestoreMessage(ctx context.Context, messageID, agentID string) e
 				return err
 			}
 		}
-		_, err = tx.Exec(ctx, `UPDATE messages SET deleted_at = NULL WHERE id = $1`, messageID)
+		if _, err := tx.Exec(ctx, `UPDATE messages SET deleted_at = NULL WHERE id = $1`, messageID); err != nil {
+			return err
+		}
+		restored, err = getMessageWithContent(ctx, tx, messageID, agentID)
 		return err
 	})
+	if err != nil {
+		return nil, err
+	}
+	return restored, nil
 }
 
 // PurgeMessage permanently deletes a message that is already in the trash

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -2003,7 +2003,7 @@ func (s *Store) RestoreAgent(ctx context.Context, agentID, userID string) (*Agen
 		if _, err := tx.Exec(ctx,
 			`UPDATE contact_engagements
 			    SET notified_next_action_at = next_action_at,
-			        updated_at = now()
+			        updated_at = `+monotonicUpdatedAt("")+`
 			  WHERE user_id = $1
 			    AND agent_id = $2
 			    AND next_action_at IS NOT NULL

--- a/internal/identity/templates.go
+++ b/internal/identity/templates.go
@@ -293,21 +293,27 @@ func (s *Store) UpdateTemplate(ctx context.Context, templateID, userID string, u
 	}
 	sets = append(sets, "updated_at = GREATEST(clock_timestamp(), updated_at + interval '1 microsecond')")
 
+	// RETURNING the full row rather than RETURNING id + a separate
+	// GetTemplateByID. The follow-up read ran on its own snapshot outside this
+	// statement, so a concurrent PATCH could land in between and the caller got
+	// the OTHER writer's template echoed back as the result of their own
+	// update — and a concurrent DELETE turned a committed update into a 404
+	// template_not_found. RETURNING is evaluated on the row this statement
+	// wrote, so the response always describes this write. The not-found and
+	// alias-collision translations are unchanged (scanTemplate maps ErrNoRows
+	// to ErrTemplateNotFound).
 	query := fmt.Sprintf(
-		`UPDATE templates SET %s WHERE id = $1 AND user_id = $2 RETURNING id`,
-		joinComma(sets),
+		`UPDATE templates SET %s WHERE id = $1 AND user_id = $2 RETURNING %s`,
+		joinComma(sets), templateSelectColumns,
 	)
-	var returnedID string
-	if err := s.pool.QueryRow(ctx, query, args...).Scan(&returnedID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrTemplateNotFound
-		}
+	tp, err := scanTemplate(s.pool.QueryRow(ctx, query, args...))
+	if err != nil {
 		if isUniqueViolation(err) {
 			return nil, ErrTemplateAliasTaken
 		}
 		return nil, err
 	}
-	return s.GetTemplateByID(ctx, templateID, userID)
+	return tp, nil
 }
 
 // DeleteTemplate removes a template owned by the user. Deleting a missing

--- a/internal/identity/trash_hold_guard_test.go
+++ b/internal/identity/trash_hold_guard_test.go
@@ -232,7 +232,7 @@ func TestRestoreAgentShiftsHoldClockAndKeepsHoldPending(t *testing.T) {
 		`UPDATE messages SET approval_expires_at = now() - interval '5 minutes' WHERE id=$1`, msg.ID); err != nil {
 		t.Fatal(err)
 	}
-	if err := store.RestoreAgent(ctx, a.ID, user.ID); err != nil {
+	if _, err := store.RestoreAgent(ctx, a.ID, user.ID); err != nil {
 		t.Fatalf("RestoreAgent: %v", err)
 	}
 

--- a/internal/identity/trash_test.go
+++ b/internal/identity/trash_test.go
@@ -157,7 +157,7 @@ func TestMessageTrashLifecycle(t *testing.T) {
 	}
 
 	// Restore: back in the live list, gone from trash, DeletedAt cleared.
-	if err := store.RestoreMessage(ctx, doomed.ID, agentID); err != nil {
+	if _, err := store.RestoreMessage(ctx, doomed.ID, agentID); err != nil {
 		t.Fatalf("RestoreMessage: %v", err)
 	}
 	if _, ok := listIDs(t, store, agentID, false)[doomed.ID]; !ok {
@@ -168,14 +168,14 @@ func TestMessageTrashLifecycle(t *testing.T) {
 	}
 
 	// Restore/purge on a live message → ErrNotInTrash.
-	if err := store.RestoreMessage(ctx, doomed.ID, agentID); !errors.Is(err, identity.ErrNotInTrash) {
+	if _, err := store.RestoreMessage(ctx, doomed.ID, agentID); !errors.Is(err, identity.ErrNotInTrash) {
 		t.Errorf("RestoreMessage(live) = %v, want ErrNotInTrash", err)
 	}
 	if err := store.PurgeMessage(ctx, doomed.ID, agentID); !errors.Is(err, identity.ErrNotInTrash) {
 		t.Errorf("PurgeMessage(live) = %v, want ErrNotInTrash", err)
 	}
 	// Missing message → ErrMessageNotFound.
-	if err := store.RestoreMessage(ctx, "msg_nope", agentID); !errors.Is(err, identity.ErrMessageNotFound) {
+	if _, err := store.RestoreMessage(ctx, "msg_nope", agentID); !errors.Is(err, identity.ErrMessageNotFound) {
 		t.Errorf("RestoreMessage(missing) = %v, want ErrMessageNotFound", err)
 	}
 	if err := store.SoftDeleteMessage(ctx, "msg_nope", agentID); !errors.Is(err, identity.ErrMessageNotFound) {
@@ -332,7 +332,7 @@ func TestRestoreMessageCancelsPastDueScheduledSend(t *testing.T) {
 	if err := store.SoftDeleteMessage(ctx, message.ID, agentID); err != nil {
 		t.Fatalf("SoftDeleteMessage(future): %v", err)
 	}
-	if err := store.RestoreMessage(ctx, message.ID, agentID); err != nil {
+	if _, err := store.RestoreMessage(ctx, message.ID, agentID); err != nil {
 		t.Fatalf("RestoreMessage(future): %v", err)
 	}
 	if len(canceller.jobIDs) != 0 {
@@ -347,7 +347,7 @@ func TestRestoreMessageCancelsPastDueScheduledSend(t *testing.T) {
 	if err := store.SoftDeleteMessage(ctx, message.ID, agentID); err != nil {
 		t.Fatalf("SoftDeleteMessage(past): %v", err)
 	}
-	if err := store.RestoreMessage(ctx, message.ID, agentID); err != nil {
+	if _, err := store.RestoreMessage(ctx, message.ID, agentID); err != nil {
 		t.Fatalf("RestoreMessage(past): %v", err)
 	}
 	if got := canceller.jobIDs; len(got) != 1 || got[0] != 501 {
@@ -406,7 +406,8 @@ func TestRestoreMessageUsesCutoffAfterWaitingForRowLock(t *testing.T) {
 
 	restoreDone := make(chan error, 1)
 	go func() {
-		restoreDone <- store.RestoreMessage(ctx, message.ID, agentID)
+		_, err := store.RestoreMessage(ctx, message.ID, agentID)
+		restoreDone <- err
 	}()
 	time.Sleep(1100 * time.Millisecond)
 	if err := blocker.Commit(ctx); err != nil {
@@ -442,7 +443,7 @@ func TestRestoreMessagePreservesProviderAcceptEvidence(t *testing.T) {
 	if err := store.SoftDeleteMessage(ctx, message.ID, agentID); err != nil {
 		t.Fatalf("SoftDeleteMessage: %v", err)
 	}
-	if err := store.RestoreMessage(ctx, message.ID, agentID); err != nil {
+	if _, err := store.RestoreMessage(ctx, message.ID, agentID); err != nil {
 		t.Fatalf("RestoreMessage: %v", err)
 	}
 
@@ -487,7 +488,7 @@ func TestRestoreAgentCancelsOnlyPastDueScheduledSends(t *testing.T) {
 	if err := store.SoftDeleteAgent(ctx, agentID, userID); err != nil {
 		t.Fatalf("SoftDeleteAgent: %v", err)
 	}
-	if err := store.RestoreAgent(ctx, agentID, userID); err != nil {
+	if _, err := store.RestoreAgent(ctx, agentID, userID); err != nil {
 		t.Fatalf("RestoreAgent: %v", err)
 	}
 	if got := canceller.jobIDs; len(got) != 1 || got[0] != 502 {
@@ -544,7 +545,7 @@ func TestRestoreMessageKeepsIndefiniteRetention(t *testing.T) {
 		  WHERE id = $1`, m.ID); err != nil {
 		t.Fatalf("backdate: %v", err)
 	}
-	if err := store.RestoreMessage(ctx, m.ID, agentID); err != nil {
+	if _, err := store.RestoreMessage(ctx, m.ID, agentID); err != nil {
 		t.Fatalf("RestoreMessage: %v", err)
 	}
 	var expires *time.Time
@@ -671,7 +672,7 @@ func TestAgentTrashLifecycle(t *testing.T) {
 	}
 
 	// Restore: back everywhere, messages intact.
-	if err := store.RestoreAgent(ctx, agentID, userID); err != nil {
+	if _, err := store.RestoreAgent(ctx, agentID, userID); err != nil {
 		t.Fatalf("RestoreAgent: %v", err)
 	}
 	if _, err := store.GetAgentByID(ctx, agentID); err != nil {
@@ -681,7 +682,7 @@ func TestAgentTrashLifecycle(t *testing.T) {
 		t.Error("agent's message missing after restore")
 	}
 	// Restore on a live agent → ErrNotInTrash.
-	if err := store.RestoreAgent(ctx, agentID, userID); !errors.Is(err, identity.ErrNotInTrash) {
+	if _, err := store.RestoreAgent(ctx, agentID, userID); !errors.Is(err, identity.ErrNotInTrash) {
 		t.Errorf("RestoreAgent(live) = %v, want ErrNotInTrash", err)
 	}
 
@@ -737,7 +738,7 @@ func TestAgentTrashPausesMessageClocks(t *testing.T) {
 		t.Fatalf("messages of trashed agent survived = %d (err=%v), want 2", n, err)
 	}
 
-	if err := store.RestoreAgent(ctx, agentID, userID); err != nil {
+	if _, err := store.RestoreAgent(ctx, agentID, userID); err != nil {
 		t.Fatalf("RestoreAgent: %v", err)
 	}
 	// The inbound message remains indefinitely retained.
@@ -836,7 +837,7 @@ func TestLoadOutboundForSendSkipsTrash(t *testing.T) {
 		t.Fatalf("LoadOutboundForSend(trashed msg) = (%v, %v), want (nil, nil)", p, err)
 	}
 	// Restore the message, trash the whole AGENT → also gone.
-	if err := store.RestoreMessage(ctx, msg.ID, agentID); err != nil {
+	if _, err := store.RestoreMessage(ctx, msg.ID, agentID); err != nil {
 		t.Fatalf("RestoreMessage: %v", err)
 	}
 	if err := store.SoftDeleteAgent(ctx, agentID, userID); err != nil {

--- a/internal/identity/webhooks.go
+++ b/internal/identity/webhooks.go
@@ -185,6 +185,35 @@ func (s *Store) CreateWebhookIdem(ctx context.Context, userID, url, description 
 	return w, nil
 }
 
+// webhookColumns is the single projection every full-webhook read uses. It is
+// deliberately unqualified so the identical list also serves as an UPDATE …
+// RETURNING list, where bare column names resolve to the row's POST-update
+// values.
+const webhookColumns = `id, user_id, url, description, events, filters,
+	        signing_secret, COALESCE(signing_secret_prev, ''),
+	        signing_secret_prev_expires_at,
+	        enabled, auto_disabled_at, created_at, last_delivered_at`
+
+// scanWebhook materializes one webhookColumns row. ErrNoRows is left for the
+// caller to translate, since "no row" means not-found on a read and
+// not-found-or-not-owned on a write.
+func scanWebhook(row pgx.Row) (*Webhook, error) {
+	w := &Webhook{}
+	var filtersJSON []byte
+	if err := row.Scan(
+		&w.ID, &w.UserID, &w.URL, &w.Description, &w.Events, &filtersJSON,
+		&w.SigningSecret, &w.SigningSecretPrev,
+		&w.SigningSecretPrevExpiresAt,
+		&w.Enabled, &w.AutoDisabledAt, &w.CreatedAt, &w.LastDeliveredAt,
+	); err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(filtersJSON, &w.Filters); err != nil {
+		return nil, fmt.Errorf("unmarshal filters: %w", err)
+	}
+	return w, nil
+}
+
 // GetWebhookByID returns the webhook iff it's owned by userID. Cross-
 // user reads (or missing rows) return ErrWebhookNotFound — same
 // not-found-on-cross-user convention used elsewhere in the codebase
@@ -194,31 +223,14 @@ func (s *Store) CreateWebhookIdem(ctx context.Context, userID, url, description 
 // worker's benefit; the public API layer scrubs this field before
 // responding to GETs.
 func (s *Store) GetWebhookByID(ctx context.Context, webhookID, userID string) (*Webhook, error) {
-	w := &Webhook{}
-	var filtersJSON []byte
-	err := s.pool.QueryRow(ctx,
-		`SELECT id, user_id, url, description, events, filters,
-		        signing_secret, COALESCE(signing_secret_prev, ''),
-		        signing_secret_prev_expires_at,
-		        enabled, auto_disabled_at, created_at, last_delivered_at
-		 FROM webhooks WHERE id = $1 AND user_id = $2`,
+	w, err := scanWebhook(s.pool.QueryRow(ctx,
+		`SELECT `+webhookColumns+` FROM webhooks WHERE id = $1 AND user_id = $2`,
 		webhookID, userID,
-	).Scan(
-		&w.ID, &w.UserID, &w.URL, &w.Description, &w.Events, &filtersJSON,
-		&w.SigningSecret, &w.SigningSecretPrev,
-		&w.SigningSecretPrevExpiresAt,
-		&w.Enabled, &w.AutoDisabledAt, &w.CreatedAt, &w.LastDeliveredAt,
-	)
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrWebhookNotFound
-		}
-		return nil, err
+	))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrWebhookNotFound
 	}
-	if err := json.Unmarshal(filtersJSON, &w.Filters); err != nil {
-		return nil, fmt.Errorf("unmarshal filters: %w", err)
-	}
-	return w, nil
+	return w, err
 }
 
 // GetWebhookByIDInternal returns the webhook by ID with no ownership
@@ -231,31 +243,14 @@ func (s *Store) GetWebhookByID(ctx context.Context, webhookID, userID string) (*
 // a method name that calls out "skipping the standard authorization
 // check" so a reviewer doesn't have to read the body to know why.
 func (s *Store) GetWebhookByIDInternal(ctx context.Context, webhookID string) (*Webhook, error) {
-	w := &Webhook{}
-	var filtersJSON []byte
-	err := s.pool.QueryRow(ctx,
-		`SELECT id, user_id, url, description, events, filters,
-		        signing_secret, COALESCE(signing_secret_prev, ''),
-		        signing_secret_prev_expires_at,
-		        enabled, auto_disabled_at, created_at, last_delivered_at
-		 FROM webhooks WHERE id = $1`,
+	w, err := scanWebhook(s.pool.QueryRow(ctx,
+		`SELECT `+webhookColumns+` FROM webhooks WHERE id = $1`,
 		webhookID,
-	).Scan(
-		&w.ID, &w.UserID, &w.URL, &w.Description, &w.Events, &filtersJSON,
-		&w.SigningSecret, &w.SigningSecretPrev,
-		&w.SigningSecretPrevExpiresAt,
-		&w.Enabled, &w.AutoDisabledAt, &w.CreatedAt, &w.LastDeliveredAt,
-	)
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrWebhookNotFound
-		}
-		return nil, err
+	))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrWebhookNotFound
 	}
-	if err := json.Unmarshal(filtersJSON, &w.Filters); err != nil {
-		return nil, fmt.Errorf("unmarshal filters: %w", err)
-	}
-	return w, nil
+	return w, err
 }
 
 // Storage layer surfaces enabled and disabled rows alike; filter at the handler
@@ -485,18 +480,22 @@ func (s *Store) UpdateWebhook(ctx context.Context, webhookID, userID string, u W
 		return s.GetWebhookByID(ctx, webhookID, userID)
 	}
 
+	// RETURNING the full row rather than RETURNING id + a separate
+	// GetWebhookByID. The follow-up read ran on its own snapshot outside this
+	// statement's transaction, so a concurrent PATCH could land in between and
+	// the caller got the OTHER writer's config echoed back as the result of
+	// their own update — and a concurrent DELETE turned a committed update into
+	// a 404. RETURNING is evaluated on the row this statement wrote, so the
+	// response always describes this write.
 	query := fmt.Sprintf(
-		`UPDATE webhooks SET %s WHERE id = $1 AND user_id = $2 RETURNING id`,
-		joinComma(sets),
+		`UPDATE webhooks SET %s WHERE id = $1 AND user_id = $2 RETURNING %s`,
+		joinComma(sets), webhookColumns,
 	)
-	var returnedID string
-	if err := s.pool.QueryRow(ctx, query, args...).Scan(&returnedID); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, ErrWebhookNotFound
-		}
-		return nil, err
+	w, err := scanWebhook(s.pool.QueryRow(ctx, query, args...))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrWebhookNotFound
 	}
-	return s.GetWebhookByID(ctx, webhookID, userID)
+	return w, err
 }
 
 func joinComma(parts []string) string {

--- a/internal/usage/agents_count_test.go
+++ b/internal/usage/agents_count_test.go
@@ -199,7 +199,7 @@ func TestCountAgentsByUser_ExcludesTrashedAgents(t *testing.T) {
 		t.Fatalf("live list = %d rows, want 1 (mirror invariant)", len(list))
 	}
 	// Restore brings the slot usage back.
-	if err := idStore.RestoreAgent(ctx, "b@trashcount.example.com", user.ID); err != nil {
+	if _, err := idStore.RestoreAgent(ctx, "b@trashcount.example.com", user.ID); err != nil {
 		t.Fatalf("RestoreAgent: %v", err)
 	}
 	if n, err := usageStore.CountAgentsByUser(ctx, user.ID); err != nil || n != 2 {

--- a/internal/webhook/store_test.go
+++ b/internal/webhook/store_test.go
@@ -249,7 +249,7 @@ func TestGetPendingDeliveriesSkipsTrash(t *testing.T) {
 	}
 
 	// Restore → claimable again (the skip left the row unleased).
-	if err := identityStore.RestoreMessage(ctx, msg.ID, agent.ID); err != nil {
+	if _, err := identityStore.RestoreMessage(ctx, msg.ID, agent.ID); err != nil {
 		t.Fatalf("RestoreMessage: %v", err)
 	}
 	pending, err = deliveryStore.GetPendingDeliveries(ctx, 10)


### PR DESCRIPTION
## The class

PR #775 fixed the severe form of one bug: a data-modifying CTE whose outer SELECT ran on the pre-update statement snapshot, so an accepted conditional engagement update **committed the new state but returned the PRE-update row** — and therefore a permanently dead ETag. Its fix recipe was: do the write and the authoritative read **inside one transaction**, or **RETURN the full row from the write**.

That recipe was applied to one function. An audit found **six weaker cousins** still on `main`, all the same shape: *write, commit, then re-read from the pool*. None can permanently break a validator the way #775 did, but each leaves a real window another transaction can commit into — so the response either describes **somebody else's write**, or reports a **spurious error on a write that actually succeeded**.

All six now follow the #775 recipe.

## The six sites

| # | Site | Concrete wrong response | Approach |
|---|------|------------------------|----------|
| 1 | `identity.UpsertEngagement` (unconditional PUT path) | Commits, then `GetEngagement` on the **pool**. A `DeleteEngagement`, contact delete or import reversal in the gap → `ErrEngagementNotFound` → the handler answers **412 `precondition_failed`** (`httpapi/engagements.go`) on a request that sent **no If-Match**. `RecordInbound/OutboundActivity` (fires on every message touching that contact) can also repaint the row before a 201-created response describes it. | `RETURNING id` + read the joined row **in the same transaction** — literally the shape of `UpdateEngagementIfUnchanged`. (#775's fix comment cited this function as its model, but #775 reads inside its tx and this one did not; they agree now.) |
| 2 | `identity.UpdateAgentProtection` + handler `GetAgent` | Plain UPDATE, then a pool re-read. The PUT is a **full replace**, so a concurrent PUT hands the caller the **other writer's entire posture** as the authoritative-looking result of their own request. Concurrent trash → **500 "failed to reload agent"** after a committed write. | UPDATE + in-transaction re-read; the store now returns the agent. JOIN on `domains` for `domain_verified` rules out plain `RETURNING`. |
| 3 | Agent **PATCH** and **restore** (`httpapi/agents_write.go`, "Re-read for the authoritative post-update state") | Concurrent rename → response shows the **other** name. Concurrent trash → **500** after a committed rename. Concurrent re-trash → **500** after a committed restore. GA surface. | `UpdateAgentName` / `RestoreAgent` return the agent, read in-transaction. Restore keeps the **LIVE** projection, so it still proves the agent is visible again — the property the old post-commit re-read asserted. |
| 4 | `identity.UpdateWebhook` | `UPDATE … RETURNING id` (autocommit), then a separate `GetWebhookByID`. Concurrent PATCH → other writer's config in the response. Concurrent delete → **404 after a committed update**. | `UPDATE … RETURNING <full row>` — atomic by construction. The column list is now one shared const + `scanWebhook`, so read and RETURNING projections cannot drift. |
| 5 | `identity.UpdateTemplate` | Identical to #4; concurrent delete → **404 `template_not_found` after a committed update**. | Same: `UPDATE … RETURNING templateSelectColumns`. Alias-collision and not-found translations unchanged. |
| 6 | `identity.RestoreMessage` + handler `GetMessage` | Concurrent re-trash or purge → **500 "failed to reload message"** after a committed restore. | The restore transaction builds the detail view itself, using the **same** projection (read-marking included), so behaviour is unchanged apart from the race. |

## User-visible behaviour change

**Yes — and it is the point: the spurious 404 / 412 / 500s disappear.** A write that commits now always answers with the state it wrote, instead of occasionally answering `precondition_failed`, `not_found`, or `internal_error`. Responses also stop echoing a concurrent writer's configuration as if it were the caller's own result.

Nothing else changes:

- **No error-mapping changes for legitimate cases.** Every 404/412/409/500 that a genuinely-absent, genuinely-stale, or genuinely-live resource produces is byte-identical; only the *spurious* ones caused by the torn read are gone.
- **No response shape changes** — `make spec-check` green.
- **Lock ordering preserved.** Every added read is a plain `SELECT` taking no row locks, so the "exactly one row lock, then plain SELECTs" property #775's reviewer confirmed still holds. Checked against `DeleteImportBatch`'s contacts→engagements `FOR UPDATE` order (untouched — `UpsertEngagement` still locks agent → contacts → engagements) and against `DeleteAgent`.

Internal-only signature churn: `Deps.UpdateAgentName` / `Deps.UpdateAgentProtection` now return `*identity.AgentIdentity`; `RestoreAgent` / `RestoreMessage` move to new returning types `AgentRestoreOp` / `MessageRestoreOp`.

## Tests

New `internal/identity/post_write_read_test.go` — one DB-backed regression per site, using the blocking-interleaving technique from `contacts_reversal_test.go`:

1. a holder transaction takes the lock the write path needs;
2. the write path is started and confirmed blocked on it;
3. a **racer** is started and confirmed blocked **behind** it (lock waits are FIFO) — identified by a marker comment in its own query text, so "queued behind" is checked on that exact backend rather than a global waiter count;
4. the holder commits, so the racer lands **exactly** in the window the buggy shape leaves open.

Each racer carries no bind parameters, so pgx sends it over the simple protocol as one implicit transaction: once woken it runs *and commits* entirely server-side, while the buggy re-read still owes a client round-trip and loses. Each test also asserts the racer really landed, so a run that failed to interleave cannot pass silently.

**Pre-fix evidence** (against `origin/main`, for the three sites whose signatures did not change, 8 runs each):

| Test | Fails pre-fix | Observed failure |
|---|---|---|
| `TestUpsertEngagementReturnsTheRowItCommitted` | **8/8** | `UpsertEngagement returned engagement not found on a write that committed` |
| `TestUpdateWebhookReturnsTheRowItWrote` | **7/8** | `UpdateWebhook returned description "racer-won", want "mine"` |
| `TestUpdateTemplateReturnsTheRowItWrote` | **5/8** | `UpdateTemplate returned name "racer-won", want "mine"` |

The other four sites changed the store signature, so their tests only compile against the fix; they use the same interleaving and assert the same property.

**Post-fix:** all seven pass deterministically (6 consecutive `-count` runs, no flakes — with the fix the racer is *structurally* blocked until the read is done). `go build ./...`, `go vet ./...`, `go test ./internal/identity/ ./internal/httpapi/` green, plus `./internal/agent/ ./internal/webhook/ ./internal/usage/ ./internal/hitlworker/ ./internal/apiserver/ ./internal/contactdue/ ./internal/relay/` and `internal/e2e` compiling under `-tags integration`. `make spec-check` green.

## Also noted, NOT fixed (different class)

`UpdateWebhook`'s **re-enable cooldown is check-then-act**: a separate `SELECT auto_disabled_at` runs before the UPDATE (`internal/identity/webhooks.go`). Two racing re-enables can both pass it — harmless, since they converge on the same state — but the real exposure is the auto-disable worker setting `auto_disabled_at` **between** the check and the UPDATE, whose `enabled = true` branch then clears a cooldown that had just been armed. Folding the predicate into the UPDATE's `WHERE` needs a new not-found-vs-cooldown disambiguation branch (and interacts with the dynamic SET builder and the no-op-PATCH path), so it is not a trivially-safe change and is left for its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
