### PR TITLE
test(cli): cover the suppressions command in the live parity suite

### DIFF
--- a/cli/test/e2e.test.ts
+++ b/cli/test/e2e.test.ts
@@ -111,7 +111,18 @@ async function apiDeleteAgentSuppression(agent: string, address: string): Promis
         headers: { Authorization: `Bearer ${KEY}` },
       },
     );
-    if (res.ok || res.status === 404) return undefined;
+    if (res.ok) return undefined;
+    if (res.status === 404) {
+      // A missing row is clean only while the agent is still live. The delete
+      // handler also returns 404 for a missing/trashed agent, in which case the
+      // durable row may still exist but is no longer manageable through it.
+      const agentRes = await fetch(`${URL_}/v1/agents/${encodeURIComponent(agent)}`, {
+        headers: { Authorization: `Bearer ${KEY}` },
+      });
+      if (agentRes.ok) return undefined;
+      return `${agent} / ${address}: suppression cleanup returned 404 and live-agent check returned ` +
+        `HTTP ${agentRes.status} ${agentRes.statusText}: ${(await agentRes.text()).slice(0, 200)}`;
+    }
     return `${agent} / ${address}: HTTP ${res.status} ${res.statusText}: ${(await res.text()).slice(0, 200)}`;
   } catch (err) {
     return `${agent} / ${address}: ${err instanceof Error ? err.message : String(err)}`;
@@ -122,13 +133,20 @@ const createdAgents: string[] = [];
 const createdAgentSuppressions: Array<{ agent: string; address: string }> = [];
 afterAll(async () => {
   const cleanupFailures: string[] = [];
+  const agentsWithSuppressionCleanupFailures = new Set<string>();
   try {
     // Suppressions must be removed while the owning agent is still live.
     for (const { agent, address } of createdAgentSuppressions) {
       const failure = await apiDeleteAgentSuppression(agent, address);
-      if (failure) cleanupFailures.push(failure);
+      if (failure) {
+        cleanupFailures.push(failure);
+        agentsWithSuppressionCleanupFailures.add(agent);
+      }
     }
     for (const a of createdAgents) {
+      // Keep the agent live when its durable suppression could not be removed;
+      // deleting it would make that row inaccessible through the API.
+      if (agentsWithSuppressionCleanupFailures.has(a)) continue;
       const failure = await apiDeleteAgent(a);
       if (failure) cleanupFailures.push(failure);
     }
@@ -327,9 +345,11 @@ describe.skipIf(!live)("cli live parity", () => {
 
     // Account-wide add is impossible by design — account entries come only from
     // bounces/complaints — so coverage exercises the agent-scoped manual block.
+    // Register cleanup before the POST: a committed write followed by a lost or
+    // malformed response is still a side effect we must attempt to remove.
+    createdAgentSuppressions.push({ agent: bot, address: blocked });
     const add = run(["suppressions", "add", blocked, "--agent", bot, "--reason", "cli e2e", "--json"]);
     expect(add.code, add.stderr).toBe(0);
-    createdAgentSuppressions.push({ agent: bot, address: blocked });
     expect(JSON.parse(add.stdout).address).toBe(blocked);
 
     const listAgent = run(["suppressions", "list", "--agent", bot, "--json"]);

--- a/cli/test/e2e.test.ts
+++ b/cli/test/e2e.test.ts
@@ -98,10 +98,36 @@ async function apiDeleteAgent(email: string): Promise<string | undefined> {
   }
 }
 
+// Agent suppressions deliberately survive both soft and permanent agent
+// deletion, so deleting only the throwaway inbox cannot clean up a failed
+// suppressions test. Remove each created row first; 404 means the happy path
+// already removed it.
+async function apiDeleteAgentSuppression(agent: string, address: string): Promise<string | undefined> {
+  try {
+    const res = await fetch(
+      `${URL_}/v1/agents/${encodeURIComponent(agent)}/suppressions/${encodeURIComponent(address)}?confirm=DELETE`,
+      {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${KEY}` },
+      },
+    );
+    if (res.ok || res.status === 404) return undefined;
+    return `${agent} / ${address}: HTTP ${res.status} ${res.statusText}: ${(await res.text()).slice(0, 200)}`;
+  } catch (err) {
+    return `${agent} / ${address}: ${err instanceof Error ? err.message : String(err)}`;
+  }
+}
+
 const createdAgents: string[] = [];
+const createdAgentSuppressions: Array<{ agent: string; address: string }> = [];
 afterAll(async () => {
   const cleanupFailures: string[] = [];
   try {
+    // Suppressions must be removed while the owning agent is still live.
+    for (const { agent, address } of createdAgentSuppressions) {
+      const failure = await apiDeleteAgentSuppression(agent, address);
+      if (failure) cleanupFailures.push(failure);
+    }
     for (const a of createdAgents) {
       const failure = await apiDeleteAgent(a);
       if (failure) cleanupFailures.push(failure);
@@ -303,6 +329,7 @@ describe.skipIf(!live)("cli live parity", () => {
     // bounces/complaints — so coverage exercises the agent-scoped manual block.
     const add = run(["suppressions", "add", blocked, "--agent", bot, "--reason", "cli e2e", "--json"]);
     expect(add.code, add.stderr).toBe(0);
+    createdAgentSuppressions.push({ agent: bot, address: blocked });
     expect(JSON.parse(add.stdout).address).toBe(blocked);
 
     const listAgent = run(["suppressions", "list", "--agent", bot, "--json"]);
@@ -311,7 +338,9 @@ describe.skipIf(!live)("cli live parity", () => {
 
     const removed = run(["suppressions", "remove", blocked, "--agent", bot, "--json"]);
     expect(removed.code, removed.stderr).toBe(0);
-    expect(run(["suppressions", "list", "--agent", bot, "--json"]).stdout).not.toContain(blocked);
+    const listAfterRemove = run(["suppressions", "list", "--agent", bot, "--json"]);
+    expect(listAfterRemove.code, listAfterRemove.stderr).toBe(0);
+    expect(listAfterRemove.stdout).not.toContain(blocked);
 
     // Account-wide list is read-only and typically empty on staging (no bounce
     // simulators there); assert it merely resolves for a bare account key.

--- a/cli/test/e2e.test.ts
+++ b/cli/test/e2e.test.ts
@@ -143,6 +143,7 @@ describe.skipIf(!live)("cli live parity", () => {
       "protection",
       "reply",
       "send",
+      "suppressions",
       "whoami",
     ]);
     recordAdvertised(commands);
@@ -287,6 +288,37 @@ describe.skipIf(!live)("cli live parity", () => {
     const setOff = run(["protection", "set", bot, "--outbound-review", "off", "--json"]);
     expect(setOff.code, setOff.stderr).toBe(0);
     recordCovered("protection");
+  });
+
+  it("suppressions: agent-scoped add → list → remove, plus account-wide list", () => {
+    const slug = Date.now().toString(36);
+    const bot = `cli-live-supp-${slug}@${DOMAIN}`;
+    const blocked = `cli-supp-blocked-${slug}@example.invalid`;
+
+    const created = run(["agents", "create", bot, "--name", "cli supp e2e", "--json"]);
+    expect(created.code, created.stderr).toBe(0);
+    createdAgents.push(bot);
+
+    // Account-wide add is impossible by design — account entries come only from
+    // bounces/complaints — so coverage exercises the agent-scoped manual block.
+    const add = run(["suppressions", "add", blocked, "--agent", bot, "--reason", "cli e2e", "--json"]);
+    expect(add.code, add.stderr).toBe(0);
+    expect(JSON.parse(add.stdout).address).toBe(blocked);
+
+    const listAgent = run(["suppressions", "list", "--agent", bot, "--json"]);
+    expect(listAgent.code, listAgent.stderr).toBe(0);
+    expect(listAgent.stdout).toContain(blocked);
+
+    const removed = run(["suppressions", "remove", blocked, "--agent", bot, "--json"]);
+    expect(removed.code, removed.stderr).toBe(0);
+    expect(run(["suppressions", "list", "--agent", bot, "--json"]).stdout).not.toContain(blocked);
+
+    // Account-wide list is read-only and typically empty on staging (no bounce
+    // simulators there); assert it merely resolves for a bare account key.
+    const listAccount = run(["suppressions", "list", "--json"]);
+    expect(listAccount.code, listAccount.stderr).toBe(0);
+
+    recordCovered("suppressions");
   });
 
   it("contacts: create/get/list/update/delete + import/imports delete + outreach tree", () => {


### PR DESCRIPTION
## Why

The v1.5.0 candidate staging run failed at **CLI command-coverage gate** (`Client surface gates (staging)`). Root cause: PR #791 added the `e2a suppressions` command group to the CLI `--help` surface but never updated `cli/test/e2e.test.ts`, which:

1. **pins the advertised top-level command catalog** — the coverage-gate *denominator* — via `expect(commands).toEqual([...])`, and
2. **records per-command coverage** via `recordCovered(...)` — the *numerator*.

Both assertions live inside `describe.skipIf(!live)`, which only runs against a live server in the **staging release pipeline**, not in offline OSS PR CI. So the drift merged green and first surfaced here. Same structural blind spot as the 2026-07-17 conformance drift: a new user-facing surface shipped without its live e2e coverage.

The CLI itself is correct — this is test drift, not a product bug.

## What

- Add `"suppressions"` to the pinned catalog. **Verified offline against the real built binary:** `parseHelpCommands(e2a --help)` now returns exactly `["agents","config","contacts","doctor","keys","listen","login","messages","protection","reply","send","suppressions","whoami"]` — matching the new pin (`MATCH: true`).
- Add a live test exercising the agent-scoped `add → list → remove` path plus the account-wide read-only `list`, calling `recordCovered("suppressions")` so the numerator matches the new denominator. Self-cleaning: the throwaway agent is registered in `createdAgents` for the shared `afterAll`.

Account-wide `add` is intentionally not exercised — account entries come only from bounces/complaints, which staging cannot generate (SES simulators are denied there).

## Verification

- `npm run build` (SDK then CLI) — clean.
- `npm run typecheck` (tsconfig.test) — clean.
- `npx vitest run` (offline unit suite) — 276 passed / 19 files.
- Catalog assertion verified against the real binary as above.
- The `skipIf(!live)` block itself can only run in the staging pipeline; re-running the v1.5.0 candidate staging run is the true validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
