### PR TITLE
fix(ci): publish CLI on dedicated cli-v* tag, not product v* tag

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,8 +1,14 @@
 name: Publish CLI
 
+# Dedicated tag, NOT the product "v*" release tag: the CLI depends on
+# @e2a/sdk, and the SDKs publish on their own ts-sdk-v* / python-v* tags
+# pushed after the product tag. Publishing the CLI from "v*" therefore
+# always raced ahead of the SDK it was built against (observed on v1.5.0:
+# @e2a/cli@2.2.0 hit npm ~4 minutes before @e2a/sdk@5.5.0). Push cli-v*
+# after ts-sdk-v* so the SDK is installable first.
 on:
   push:
-    tags: ["v*"]
+    tags: ["cli-v*"]
   workflow_dispatch:
 
 concurrency:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -437,7 +437,10 @@ manually on every API change even though the template won't remind you.
 - **Publishing** (all tag/dispatch-triggered GitHub workflows):
   - Python SDK: bump `sdks/python/pyproject.toml` version, tag `python-v*`.
   - TS SDK: bump `sdks/typescript/package.json` version, tag `ts-sdk-v*`.
-  - CLI: bump `cli/package.json` version, then GitHub release publish or
-    `gh workflow run "Publish CLI" --ref main`.
+  - CLI: bump `cli/package.json` version, tag `cli-v*` (or
+    `gh workflow run "Publish CLI" --ref main`). Deliberately NOT the
+    product `v*` tag: the CLI depends on `@e2a/sdk`, so push `cli-v*`
+    only after `ts-sdk-v*` — publishing from the product tag raced the
+    CLI onto npm before its SDK existed.
   - MCP: hosted-only — `publish-mcp-http.yml` pushes the HTTP image on tag;
     npm publish is retired.


### PR DESCRIPTION
## Summary

Release-ordering hazard: `publish-cli.yml` triggered on the product `v*` release tag, but the CLI depends on `@e2a/sdk` (`cli/package.json` declares `"@e2a/sdk": "^5.0.0"`), and the SDKs publish on their own `ts-sdk-v*` / `python-v*` tags pushed **after** the product tag. So the CLI was always published before the SDK version it was built against.

**Observed live on v1.5.0:** `@e2a/cli@2.2.0` hit npm ~4 minutes before `@e2a/sdk@5.5.0`. It was benign only because CLI 2.2.0 happens to use no 5.5.0-only API — every method it calls existed in 5.4.0. A future CLI that genuinely needed a new SDK method would be installable-and-broken during that window.

## Change

- Trigger switched to a dedicated `cli-v*` tag, matching the SDK pattern exactly. `workflow_dispatch` retained; `test` job, npm-OIDC setup, `--provenance`, and concurrency group unchanged.
- `AGENTS.md` publishing section updated to document the new tag and the ordering rationale.

## New release step

Publishing the CLI now requires pushing `cli-v<version>` (after `ts-sdk-v*`), or dispatching the workflow — it no longer happens automatically on a product release. No other workflow publishes the CLI on `v*` (verified: `build-image.yml` and `publish-mcp-http.yml` only push container images).

Possible follow-up (not in this PR, to stay consistent with the SDK workflows, which also lack it): a tag-vs-`package.json` version guard across all three publish workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)