### PR TITLE
docs: make v1.5.0 the /v1 GA compatibility baseline

### DIFF
--- a/docs/api-compatibility-gate.md
+++ b/docs/api-compatibility-gate.md
@@ -23,23 +23,23 @@ event- or error-specific schema lookup.
 
 ## Freeze baseline
 
-The cumulative pre-release `/v1` freeze anchor is commit
-`af5d3c7486db76cf7e62ba18763b47e4a5b95b35`, the mainline contract immediately
-before the strict GA policy was enabled. This intentionally comes after the
-pre-GA bounds program; an earlier gate-introduction commit would make those
-approved pre-freeze request bounds look retroactively breaking. Until the first
-explicitly announced API GA release tag exists, release audits compare the
-candidate against this anchor as well as the normal pull-request base:
+**`/v1` went generally available with `v1.5.0` (2026-08-02).** That tag is the
+compatibility baseline: release audits compare the candidate against the most
+recent GA tag, in addition to the normal pull-request base.
 
 ```sh
-make openapi-compat-check \
-  OPENAPI_BASE=af5d3c7486db76cf7e62ba18763b47e4a5b95b35:api/openapi.yaml
+make openapi-compat-check OPENAPI_BASE=v1.5.0:api/openapi.yaml
 ```
 
 Existing `v1.0.x` tags are application/cherry-pick releases that predate the
-API contract freeze; they are not `/v1` compatibility baselines. The first
-official API GA tag supersedes the commit anchor, and every later release must
-compare against the most recent GA tag.
+API contract freeze; they are not `/v1` compatibility baselines.
+
+Superseded — kept because audits of pre-GA history still need it: before a GA
+tag existed, the anchor was commit `af5d3c7486db76cf7e62ba18763b47e4a5b95b35`,
+the mainline contract immediately before the strict GA policy was enabled. It
+deliberately sits after the pre-GA bounds program, because an earlier
+gate-introduction commit would make those approved pre-freeze request bounds
+look retroactively breaking.
 
 ## Policy
 


### PR DESCRIPTION
`/v1` went GA with **v1.5.0** on 2026-08-02, which fires a trigger the doc set for itself:

> The first official API GA tag supersedes the commit anchor, and every later release must compare against the most recent GA tag.

So release audits should now compare against `v1.5.0`, not the pre-release freeze anchor `af5d3c74`.

## What changed

The baseline command becomes:

```sh
make openapi-compat-check OPENAPI_BASE=v1.5.0:api/openapi.yaml
```

**Verified it actually runs** — a doc that prescribes a command should prescribe one that works:

```
bash scripts/check-openapi-compat.sh "v1.5.0:api/openapi.yaml" "api/openapi.yaml"
No changes detected
```

(Correct: v1.5.0 was cut from `main` and nothing has touched the spec since.)

## What was kept, and why

The old anchor stays, explicitly marked superseded. Two reasons: audits reaching back into pre-GA history still need it, and its rationale isn't reconstructible from the commit alone — it deliberately sits *after* the pre-GA bounds program, because an earlier gate-introduction commit would make those approved pre-freeze bounds look retroactively breaking. Deleting it would lose that.

## Scope note

This baseline is a **manual release-audit instruction, not automation**. CI compares against `github.event.pull_request.base.sha` and `github.event.before`; the anchor was never referenced by any workflow or the Makefile (`git grep af5d3c74` matches this doc only). So this changes what a human runs during a release audit, and nothing in the automated gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)