### PR TITLE
fix(relay): deflake TestSMTPInboundMetric_RejectedLineTooLong

### DIFF
--- a/internal/relay/metrics_test.go
+++ b/internal/relay/metrics_test.go
@@ -463,19 +463,24 @@ func TestSMTPInboundMetric_RejectedLineTooLong(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DATA: %v", err)
 	}
-	// A single 160KiB line — over the 128KiB cap, small enough that the
-	// unread remainder after the server aborts fits in loopback socket
-	// buffers (the server reads ~128KiB before erroring).
+	// A single 160KiB line — over the 128KiB cap. The server aborts the
+	// connection mid-transfer, so depending on socket buffering the client
+	// may see the reset during Write, or only at Close, or (if the reset
+	// races the last flush) not as the 554 text at all. None of that is
+	// what's under test: a mid-write reset is itself evidence the server
+	// aborted, and the authoritative assertion is the
+	// rejected_line_too_long metric below, which runs on every path.
 	body := "From: sender@ext.test\r\nTo: " + agentEmail + "\r\nSubject: too long\r\n\r\n" +
 		strings.Repeat("y", 160*1024)
-	if _, err := w.Write([]byte(body)); err != nil {
-		t.Fatalf("write body: %v", err)
-	}
+	_, werr := w.Write([]byte(body))
 	cerr := w.Close()
-	if cerr == nil {
+	if werr == nil && cerr == nil {
 		t.Fatal("DATA with a 160KiB line succeeded; want 554 too-long-line rejection")
 	}
-	if !strings.Contains(cerr.Error(), "554") || !strings.Contains(cerr.Error(), "too long a line") {
+	// Only when the write went through cleanly is Close guaranteed to carry
+	// the SMTP-level rejection; after a mid-write reset it may return a bare
+	// connection error instead.
+	if werr == nil && (!strings.Contains(cerr.Error(), "554") || !strings.Contains(cerr.Error(), "too long a line")) {
 		t.Fatalf("DATA close error = %v, want 554 too-long-line", cerr)
 	}
 


### PR DESCRIPTION
## Problem

`TestSMTPInboundMetric_RejectedLineTooLong` (added in #773) intermittently reds the Go coverage gate and blocks unrelated PRs:

```
--- FAIL: TestSMTPInboundMetric_RejectedLineTooLong (0.78s)
    metrics_test.go:472: write body: write tcp 127.0.0.1:34262->127.0.0.1:38673: write: connection reset by peer
```

Seen on main `fddf0edf` ([job](https://github.com/tokencanopy/e2a/actions/runs/30732251784/job/91454593936)). It is flaky, not broken — the same test on recent main: `25356292` pass, `bfeec71e` pass, `81e8ce87` pass, `fddf0edf` fail (~1 in 4 in that sample).

## Root cause

The test writes a single 160KiB line to exercise the 128KiB `MaxLineLength` cap. The server hits the cap partway through and resets the connection. Whether the client finishes its `Write` before the RST arrives depends on socket buffering and scheduling — `make cover` runs packages at `-p 4` on a loaded runner, which is exactly when it loses. The old comment even conceded the assumption ('small enough that the unread remainder … fits in loopback socket buffers'). When the write lost the race, `t.Fatalf("write body: …")` fired before the real assertion was ever reached.

## Fix

Remove the timing dependency instead of re-tuning the body size (a bigger/smaller buffer just moves the threshold and stays racy):

- A `w.Write` error is no longer fatal — a mid-write reset is itself evidence the server aborted the transaction. It's captured instead.
- The test fails only if **both** the write and `w.Close()` succeed — the genuine 'server wrongly accepted a 160KiB line' condition.
- The 554 / 'too long a line' text assertion applies only when the write completed cleanly; after a mid-write reset, `Close` may surface a bare connection error rather than the SMTP text.
- The deterministic, server-side proof remains `assertSingleOutcome(t, metrics, "rejected_line_too_long", false)` — the actual thing under test, independent of wire timing, and it runs on every path.

## Verification

- `go test ./internal/relay -run TestSMTPInboundMetric_RejectedLineTooLong -count=30` — ok (30/30)
- `go test ./internal/relay -run TestSMTPInboundMetric -count=10 -p 4` — ok
- `go test ./internal/relay -count=1` (whole package) — ok
- Regression check: temporarily raised `MaxLineLength` to 512KiB in `server.go` → test fails with `DATA with a 160KiB line succeeded; want 554 too-long-line rejection`; restored → passes. The flake is fixed without neutering the assertion.
- `gofmt -l` clean, `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)