### PR TITLE
docs(mcp): fix stale MCP tool count in Codex example

### DIFF
--- a/mcp/examples/codex/README.md
+++ b/mcp/examples/codex/README.md
@@ -2,7 +2,7 @@
 
 [Codex CLI](https://github.com/openai/codex) is OpenAI's terminal coding agent (peer to Claude Code). It speaks MCP natively — you declare servers in `~/.codex/config.toml` and Codex connects to them at session start, then surfaces their tools to whatever model you're running.
 
-Unlike the [LangChain](../langchain/), [CrewAI](../crewai/), [Google ADK](../adk/), and [OpenAI Agents SDK](../openai-agents/) examples — which are Python scripts you run — Codex is itself the agent. The "example" here is the TOML you paste into your Codex config to add e2a's MCP tools (71 total; the visible set depends on your key's scope).
+Unlike the [LangChain](../langchain/), [CrewAI](../crewai/), [Google ADK](../adk/), and [OpenAI Agents SDK](../openai-agents/) examples — which are Python scripts you run — Codex is itself the agent. The "example" here is the TOML you paste into your Codex config to add e2a's MCP tools (76 total; the visible set depends on your key's scope).
 
 Codex opens a Streamable HTTP session to the hosted endpoint at `https://api.e2a.dev/mcp` with your API key in the `Authorization: Bearer …` header — no Node toolchain on the host (works on CI runners, dev containers, remote app servers, etc.).
 


### PR DESCRIPTION
## Summary

- `mcp/examples/codex/README.md` said e2a's MCP server exposes "71 total" tools. The current count is **76** (20 runtime + 56 admin, per `mcp/src/tools/tiers.ts`), matching the sibling docs `mcp/README.md` and `mcp/examples/README.md`, which already say 76.
- Docs-only fix, found via a routine documentation audit against current code.

## Test plan

- [x] Verified 76 by counting `registerTool(` calls across `mcp/src/tools/*.ts` and cross-checking `RUNTIME_TOOLS`/`ADMIN_TOOLS` in `mcp/src/tools/tiers.ts`.
- [x] Confirmed `mcp/README.md` and `mcp/examples/README.md` both already state 76.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4DfxsAgkCUqWg75tyPhWo)_