### PR TITLE
docs(plugins): fix tether SKILL.md exit-code contradiction for ask

### DIFF
--- a/plugins/e2a/skills/tether/SKILL.md
+++ b/plugins/e2a/skills/tether/SKILL.md
@@ -114,8 +114,9 @@ or put the agent key + inbox in `~/.e2a-tether.env` and leave the CLI config alo
 > `pending_review` means the message was held for approval; a terminal `failed`
 > means the server persisted a delivery failure. `tether.sh` detects both on
 > every send: an affected intro makes `start` **refuse to arm**, and an affected
-> `update`/`ask` exits non-zero (**2** = held, **5** = terminal failure) so the
-> session never mistakes either for a delivered message. A terminal failure is
+> `update`/`ask` exits non-zero — held is **2** for `update`, **4** for `ask`;
+> terminal failure is **5** for both — so the session never mistakes either for
+> a delivered message. A terminal failure is
 > **not** retryable — the server already recorded an outcome for that message
 > id, so re-sending risks a duplicate. Inspect it with `e2a messages get <id>`.
 


### PR DESCRIPTION
## Summary

- `plugins/e2a/skills/tether/SKILL.md` had a self-contradictory claim about `tether.sh` exit codes: the summary near the top said both `update` and `ask` exit **2** when a send is held for review, but the `ask`-specific section further down (and the actual `tether.sh` behavior) says `ask` exits **4** in that case, not 2. Only `update`'s held case is exit 2 (`tether.sh:187`); `ask`'s held case is exit 4 (`tether.sh:290`). Terminal-failure exit 5 is correct for both.
- Docs-only fix, found via a routine documentation audit against current code.

## Test plan

- [x] Verified against `plugins/e2a/skills/tether/tether.sh`: `update`'s `pending_review` path exits 2 (line 187), `ask`'s exits 4 (line 290), both terminal-`failed` paths exit 5 (lines 178, 284).
- [x] Confirmed the corrected text now matches the file's own later "exit 4 = held for review" statement for `ask`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4DfxsAgkCUqWg75tyPhWo)_