### PR TITLE
test(e2e-prod): response-schema validation — suite records, gate validates

### DIFF
--- a/tests/e2e-prod/README.md
+++ b/tests/e2e-prod/README.md
@@ -45,15 +45,25 @@ npm run test:unit:gates  # gate unit tests (python3 -m unittest test_gates -v)
 ```
 
 `test:unit:gates` is deliberately NOT chained into `test:unit`: the harness
-tests are pure Node, while the gate tests drive the three Python coverage
-gates (`coverage_gate.py`, `event_coverage_gate.py`, `mcp_coverage_gate.py`)
-as subprocesses against synthetic shard directories, and need `python3` +
-PyYAML. Run both in environments that have them.
+tests are pure Node, while the gate tests drive the Python coverage gates
+(`coverage_gate.py`, `event_coverage_gate.py`, `mcp_coverage_gate.py`,
+`response_schema_gate.py`) as subprocesses against synthetic shard
+directories, and need `python3` + PyYAML (+ `jsonschema` for the
+response-schema gate — its tests skip without it). Run both in environments
+that have them.
 
-The three gates fail closed on uncovered surface: every /v1 operationId
-(coverage_gate.py), every webhook event type (event_coverage_gate.py), and
-every advertised MCP tool (mcp_coverage_gate.py) must be exercised by a live
-run. Suite `30-contacts-outreach.test.ts` owns the contacts/outreach surface
+The three coverage gates fail closed on uncovered surface: every /v1
+operationId (coverage_gate.py), every webhook event type
+(event_coverage_gate.py), and every advertised MCP tool
+(mcp_coverage_gate.py) must be exercised by a live run.
+
+A fourth gate, `response_schema_gate.py` (`npm run coverage:gate:responses`,
+needs `pip install jsonschema`), validates every response BODY the run
+received — all statuses, error envelopes included — against the OpenAPI
+response schemas. The suite records samples (`harness/responses.ts` →
+`reports/response-samples/`); the gate validates them, because the suite
+itself is zero-dependency and cannot carry a JSON-Schema validator. It is not
+yet wired into the release pipeline as a blocking gate. Suite `30-contacts-outreach.test.ts` owns the contacts/outreach surface
 for all three: the 11 contacts operationIds (REST), the 11 contact MCP
 tools, and the `contact.due` event (dual-assertion emission, same bar as
 `21-webhook-events.test.ts`).

--- a/tests/e2e-prod/harness/client.ts
+++ b/tests/e2e-prod/harness/client.ts
@@ -1,5 +1,6 @@
 import { loadEnv, type ProdEnv } from "./env.ts";
 import { recordRequest } from "./coverage.ts";
+import { recordResponse } from "./responses.ts";
 import { recordTarget } from "./target.ts";
 
 export interface RawResponse<T = unknown> {
@@ -93,6 +94,10 @@ export class ApiClient {
         parsed = null;
       }
     }
+    // Record the full response as a sample for response_schema_gate.py — ALL
+    // statuses, unlike recordRequest above (see harness/responses.ts for why
+    // the two channels deliberately differ).
+    recordResponse(method, url.pathname, res.status, parsed, raw, res.headers.get("content-type") ?? "");
     const out: RawResponse<T> = {
       status: res.status,
       ok: res.ok,

--- a/tests/e2e-prod/harness/responses.ts
+++ b/tests/e2e-prod/harness/responses.ts
@@ -1,0 +1,98 @@
+import { writeFileSync, mkdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+// Response-sample recorder — the raw material for response_schema_gate.py.
+//
+// The suites assert hand-picked body fields; nothing here (or anywhere in the
+// zero-dependency suite) validates a live response against the OpenAPI response
+// schemas. Doing that in-process would need a JSON-Schema validator, i.e. an
+// npm dependency the suite deliberately does not have — so the split is: the
+// SUITE RECORDS, the GATE VALIDATES. This module captures every ApiClient
+// response as an (method, path, status, body) sample; the Python gate maps each
+// sample to its operationId, resolves the spec's response schema, and validates
+// there (where CI already installs Python deps for coverage_gate.py).
+//
+// Unlike harness/coverage.ts this records ALL statuses, not just 2xx — the
+// spec's per-op `default` response documents the error envelope, so every 401
+// auth-probe and 422 validation-rejection the suites already provoke is a free
+// conformance check on the error contract. The 2xx-only filter over in
+// coverage.ts is about not over-claiming COVERAGE; it stays untouched — this is
+// a separate channel with a separate question ("was the body well-shaped?",
+// not "did the op run?").
+//
+// Sample kinds:
+//   json     — body parsed as JSON; recorded verbatim for validation.
+//   empty    — zero-length body. The gate decides whether that's legal for the
+//              documented response (in today's spec it never is: every response
+//              documents application/json content).
+//   nonjson  — non-empty body that failed JSON.parse; only a bounded prefix is
+//              recorded, for diagnosis. Always suspicious against this spec.
+//   oversized — body above SAMPLE_MAX_BYTES; recorded without the body so one
+//              huge attachment payload can't bloat the shard. The gate counts
+//              these as skipped, never as passes.
+//
+// Shards live in reports/response-samples/ (own SUBDIR, same reasoning as
+// reports/coverage/: consolidate.ts reads reports/*.json as {findings} objects
+// and would choke on a bare array). One shard per suite-file process, flushed
+// on 'exit' (same guarantees and same safe-false-FAIL SIGKILL caveat as
+// coverage.ts); `pretest` clears the dir so a prior run's samples can't leak
+// into a later run's verdict.
+const SAMPLES_DIR = fileURLToPath(new URL("../reports/response-samples/", import.meta.url));
+
+// Bound on the RAW body size we embed in a shard. Big enough for every real
+// list/object response the suites see; small enough that an attachment-data
+// body can't turn a shard into a multi-megabyte artifact.
+const SAMPLE_MAX_BYTES = 262144; // 256 KiB
+
+export interface ResponseSample {
+  method: string;
+  path: string;
+  status: number;
+  contentType: string;
+  kind: "json" | "empty" | "nonjson" | "oversized";
+  body?: unknown; // present only for kind "json"
+  rawPrefix?: string; // present only for kind "nonjson", bounded
+  rawLength?: number; // present for "nonjson" and "oversized"
+}
+
+const samples: ResponseSample[] = [];
+let installed = false;
+
+export function recordResponse(
+  method: string,
+  pathname: string,
+  status: number,
+  parsedBody: unknown,
+  raw: string,
+  contentType: string,
+): void {
+  const base = { method: method.toUpperCase(), path: pathname, status, contentType };
+  if (raw.length === 0) {
+    samples.push({ ...base, kind: "empty" });
+  } else if (raw.length > SAMPLE_MAX_BYTES) {
+    samples.push({ ...base, kind: "oversized", rawLength: raw.length });
+  } else if (parsedBody === null && !isJsonNull(raw)) {
+    samples.push({ ...base, kind: "nonjson", rawPrefix: raw.slice(0, 200), rawLength: raw.length });
+  } else {
+    samples.push({ ...base, kind: "json", body: parsedBody });
+  }
+  if (!installed) {
+    installed = true;
+    process.on("exit", () => {
+      if (samples.length === 0) return;
+      try {
+        mkdirSync(SAMPLES_DIR, { recursive: true });
+        writeFileSync(`${SAMPLES_DIR}${process.pid}.json`, JSON.stringify(samples));
+      } catch {
+        /* best-effort: sampling is advisory, must never fail a suite */
+      }
+    });
+  }
+}
+
+// ApiClient parses leniently (parse failure → body null), so a null parsedBody
+// is ambiguous between "the literal JSON null" and "not JSON at all". Only the
+// raw text can disambiguate.
+function isJsonNull(raw: string): boolean {
+  return raw.trim() === "null";
+}

--- a/tests/e2e-prod/package.json
+++ b/tests/e2e-prod/package.json
@@ -4,15 +4,16 @@
   "type": "module",
   "scripts": {
     "smoke": "node smoke.ts",
-    "pretest": "rm -rf reports/coverage reports/mcp-coverage reports/event-coverage reports/target",
+    "pretest": "rm -rf reports/coverage reports/mcp-coverage reports/event-coverage reports/response-samples reports/target",
     "test": "node --test --test-concurrency=1 --test-reporter=spec suites/*.test.ts",
-    "pretest:prod": "rm -rf reports/coverage reports/mcp-coverage reports/event-coverage reports/target",
+    "pretest:prod": "rm -rf reports/coverage reports/mcp-coverage reports/event-coverage reports/response-samples reports/target",
     "test:prod": "node --test --test-concurrency=1 --test-reporter=spec suites/*.test.ts suites/prod/*.test.ts",
     "test:unit": "node --test harness/*.test.ts",
     "test:unit:gates": "python3 -m unittest test_gates -v",
     "coverage:gate": "python3 coverage_gate.py",
     "coverage:gate:mcp": "python3 mcp_coverage_gate.py",
     "coverage:gate:events": "python3 event_coverage_gate.py",
+    "coverage:gate:responses": "python3 response_schema_gate.py",
     "coverage": "npm test; npm run coverage:gate",
     "report:gate": "node consolidate.ts",
     "typecheck": "tsc --noEmit"

--- a/tests/e2e-prod/response_schema_gate.py
+++ b/tests/e2e-prod/response_schema_gate.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Response-schema conformance gate.
+
+Every response body the e2e-prod suite received must validate against the
+OpenAPI response schema for its (operation, status) — or the gate fails. This
+closes the gap the other gates leave open: coverage_gate.py proves an operation
+RAN, the suites assert hand-picked fields, but nothing proved the full body
+SHAPE matches api/openapi.yaml (the drift-gated SSOT). A field the server stops
+returning, a type that changes under a wrong status, or an error path that
+returns a bare string instead of the envelope — none of that was caught.
+
+The suite itself stays zero-dependency (node: builtins only — the ops pipeline
+runs it with no `npm install`), so validation cannot happen in-process. The
+split is: the SUITE RECORDS, this GATE VALIDATES.
+
+Inputs:
+  - reports/response-samples/*.json : shards written by harness/responses.ts,
+    each a JSON array of {method, path, status, contentType, kind, body}
+    samples — ALL statuses, not just 2xx (the per-op `default` response
+    documents the error envelope, so every 401/404/422 the suites provoke is a
+    free check on the error contract).
+  - api/openapi.yaml : the operation catalog + response schemas.
+
+Maps each sample to the most-specific matching operationId (same matcher as
+coverage_gate.py), picks the response schema for its exact status (falling back
+to the op's `default`), resolves $refs against components, and validates with
+`jsonschema` (Draft 2020-12 — the spec declares openapi 3.1.0).
+
+What counts as a violation:
+  - a JSON body that fails its schema (missing required field, wrong type, …);
+  - an empty or non-JSON body where the spec documents application/json
+    content (in today's spec: every documented response);
+  - a status the spec neither documents nor covers with a `default`.
+Responses are deliberately open (`additionalProperties: true` on the response
+schemas) — EXTRA fields are not violations, and `format` stays annotation-only
+(per the 2020-12 default), so no format false-positives.
+
+What does not affect the verdict:
+  - samples on non-/v1 paths (billing, OAuth, /api/health — out of the
+    operationId scope, reported for visibility like coverage_gate.py);
+  - `oversized` samples the recorder bounded (counted as skipped, never as
+    passes).
+
+Usage: python3 response_schema_gate.py [--openapi PATH] [--reports DIR]
+Exit 0 = every sample valid (or allowlisted); 1 = violation(s); 2 = usage/IO
+error (including "no shards" — an absent run must never read as a pass).
+"""
+import argparse
+import glob
+import json
+import os
+import sys
+from collections import defaultdict
+
+from coverage_gate import load_ops, match_op
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+# (operationId, status) pairs whose violations we knowingly tolerate, keyed
+# "operationId <status>", with the reason. Keep this SHORT and justified —
+# every entry is a live spec/implementation mismatch we are choosing to ship.
+ALLOWLIST: dict[str, str] = {}
+
+
+def load_spec(openapi_path):
+    try:
+        import yaml
+    except ImportError:
+        print("response_schema_gate: PyYAML required (pip install pyyaml)", file=sys.stderr)
+        sys.exit(2)
+    with open(openapi_path) as f:
+        return yaml.safe_load(f)
+
+
+def response_entry(op, status):
+    """The response object documented for `status`, or the op's `default`.
+
+    Returns (entry, label) where label is the spec key that matched ("200",
+    "default", …), or (None, None) when the spec has no answer for the status —
+    itself a violation category, since a caller has nothing to code against."""
+    responses = op.get("responses") or {}
+    if str(status) in responses:
+        return responses[str(status)], str(status)
+    if "default" in responses:
+        return responses["default"], "default"
+    return None, None
+
+
+def make_validator(schema, components, cache, cache_key):
+    """A Draft 2020-12 validator for `schema`, with $refs resolvable.
+
+    The spec's $refs are all document-internal ("#/components/schemas/…"), so
+    wrapping the schema as {"allOf": [schema], "components": …} makes every ref
+    resolve against the wrapped document itself — no external registry, and the
+    stray "components" key is an unknown keyword the validator ignores."""
+    import jsonschema
+
+    if cache_key not in cache:
+        wrapped = {"allOf": [schema], "components": components}
+        cache[cache_key] = jsonschema.Draft202012Validator(wrapped)
+    return cache[cache_key]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--openapi", default=os.path.join(HERE, "../../api/openapi.yaml"))
+    ap.add_argument("--reports", default=os.path.join(HERE, "reports", "response-samples"))
+    args = ap.parse_args()
+
+    try:
+        import jsonschema  # noqa: F401
+    except ImportError:
+        print("response_schema_gate: jsonschema required (pip install jsonschema)", file=sys.stderr)
+        return 2
+
+    if not os.path.exists(args.openapi):
+        print(f"response_schema_gate: openapi spec not found: {args.openapi}", file=sys.stderr)
+        return 2
+
+    spec = load_spec(args.openapi)
+    ops = load_ops(args.openapi)  # (METHOD, [template segments], operationId)
+    all_ids = {opid for _, _, opid in ops}
+    ops_by_id = {}
+    for path, item in (spec.get("paths") or {}).items():
+        for method, op in (item or {}).items():
+            if isinstance(op, dict) and "operationId" in op:
+                ops_by_id[op["operationId"]] = op
+    components = spec.get("components") or {}
+
+    # An allowlist entry naming an operationId the spec no longer has is a
+    # silent hole (renamed/removed op) — fail loudly, same as the other gates.
+    stale = {key for key in ALLOWLIST if key.split(" ")[0] not in all_ids}
+    if stale:
+        print(
+            f"response_schema_gate: allowlist entries not in the spec (renamed/removed?): {sorted(stale)}",
+            file=sys.stderr,
+        )
+        return 2
+
+    shards = glob.glob(os.path.join(args.reports, "*.json"))
+    if not shards:
+        print(
+            f"response_schema_gate: no response-sample shards in {args.reports} — did the suite run?",
+            file=sys.stderr,
+        )
+        return 2
+    samples = []
+    for shard in shards:
+        with open(shard) as f:
+            samples.extend(json.load(f))
+
+    validators = {}
+    validated = 0
+    skipped_oversized = 0
+    non_v1 = set()
+    ops_sampled = set()
+    # (opid, status, message) → [count, example path]. Grouped so a violation
+    # repeated across 40 list calls reads as one line, not 40.
+    violations = defaultdict(lambda: [0, ""])
+
+    def record_violation(opid, status, message, path):
+        group = violations[(opid, status, message)]
+        group[0] += 1
+        group[1] = group[1] or path
+
+    for s in samples:
+        method, path, status = s["method"], s["path"], s["status"]
+        try:
+            opid = match_op(method, path.strip("/").split("/"), ops)
+        except ValueError as e:
+            print(f"response_schema_gate: {e}", file=sys.stderr)
+            return 2
+        if not opid:
+            non_v1.add(f"{method} {path}")
+            continue
+        ops_sampled.add(opid)
+        if s["kind"] == "oversized":
+            skipped_oversized += 1
+            continue
+        entry, label = response_entry(ops_by_id[opid], status)
+        if entry is None:
+            record_violation(opid, status, "status not documented for this operation (no `default` either)", path)
+            continue
+        content = (entry.get("content") or {}).get("application/json")
+        if content is None or "schema" not in content:
+            # A response documented WITHOUT a JSON body: only an empty body conforms.
+            if s["kind"] != "empty":
+                record_violation(opid, status, f"spec documents no application/json content for {label}, got a body", path)
+            else:
+                validated += 1
+            continue
+        if s["kind"] == "empty":
+            record_violation(opid, status, f"empty body where spec documents application/json ({label})", path)
+            continue
+        if s["kind"] == "nonjson":
+            preview = (s.get("rawPrefix") or "").replace("\n", "\\n")[:80]
+            record_violation(opid, status, f"non-JSON body where spec documents application/json ({label}): {preview!r}", path)
+            continue
+        validator = make_validator(content["schema"], components, validators, (opid, label))
+        errors = sorted(validator.iter_errors(s.get("body")), key=lambda e: str(e.json_path))
+        if errors:
+            for e in errors:
+                record_violation(opid, status, f"[{label} schema] {e.json_path}: {e.message[:200]}", path)
+        else:
+            validated += 1
+
+    allowlisted_groups = {k: v for k, v in violations.items() if f"{k[0]} {k[1]}" in ALLOWLIST}
+    failing_groups = {k: v for k, v in violations.items() if f"{k[0]} {k[1]}" not in ALLOWLIST}
+    unused_allowlist = set(ALLOWLIST) - {f"{k[0]} {k[1]}" for k in allowlisted_groups}
+
+    print(f"OpenAPI operations : {len(all_ids)}  (/v1 operationId scope)")
+    print(f"Operations sampled : {len(ops_sampled)}")
+    print(f"Samples            : {len(samples)}  ({len(shards)} shard(s); valid: {validated}, "
+          f"oversized-skipped: {skipped_oversized}, unmapped non-/v1 paths: {len(non_v1)})")
+    print(f"Allowlisted groups : {len(allowlisted_groups)} "
+          + (str(sorted(f'{k[0]} {k[1]}' for k in allowlisted_groups)) if allowlisted_groups else ""))
+    if unused_allowlist:
+        # Not fatal (a partial run may simply not have hit the op), but visible —
+        # an entry that never fires across full runs should be removed.
+        print(f"Allowlist entries with no observed violation this run: {sorted(unused_allowlist)}")
+    if non_v1:
+        for pair in sorted(non_v1)[:10]:
+            print(f"    non-/v1: {pair}")
+
+    if failing_groups:
+        print(f"\nVIOLATIONS ({len(failing_groups)} group(s), "
+              f"{sum(v[0] for v in failing_groups.values())} sample(s)):")
+        for (opid, status, message), (count, example) in sorted(failing_groups.items()):
+            print(f"  - {opid} {status} ({count}x, e.g. {example})")
+            print(f"      {message}")
+        print("\nGATE: FAIL — the above response(s) do not conform to api/openapi.yaml. "
+              "Fix the server or the spec, or add an ALLOWLIST entry with a justification.")
+        return 1
+
+    print("\nGATE: PASS — every sampled response body conforms to its OpenAPI response schema.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/e2e-prod/test_gates.py
+++ b/tests/e2e-prod/test_gates.py
@@ -1,4 +1,4 @@
-"""Unit tests for the three coverage gates, run as SUBPROCESSES against
+"""Unit tests for the coverage gates, run as SUBPROCESSES against
 synthetic shard directories in a temp dir.
 
 Nothing is imported from the gates themselves: each test drives the real CLI
@@ -174,6 +174,79 @@ class EventCoverageGateTest(unittest.TestCase):
         write_shard(self.reports, "1.json", sorted(self.required))
         proc = run_gate("event_coverage_gate.py", *self.args)
         self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+
+
+def _has_jsonschema() -> bool:
+    try:
+        import jsonschema  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+@unittest.skipUnless(_has_jsonschema(), "response_schema_gate needs jsonschema (pip install jsonschema)")
+class ResponseSchemaGateTest(unittest.TestCase):
+    """Drives response_schema_gate.py with synthetic samples against the real
+    spec. The violating cases exist to prove the gate can actually FAIL — a
+    validator that never rejects is worse than none."""
+
+    # getAccount has no documented 401, so a 401 sample validates against the
+    # op's `default` → ErrorEnvelope (error.code/message/request_id required).
+    VALID_ERROR = {"error": {"code": "unauthorized", "message": "no", "request_id": "req_1"}}
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.reports = Path(self._tmp.name) / "response-samples"
+        self.args = ("--openapi", str(OPENAPI), "--reports", str(self.reports))
+
+    def sample(self, status: int, body: object, kind: str = "json") -> dict:
+        s = {"method": "GET", "path": "/v1/account", "status": status, "contentType": "application/json", "kind": kind}
+        if kind == "json":
+            s["body"] = body
+        return s
+
+    def test_conformant_samples_pass(self) -> None:
+        write_shard(self.reports, "1.json", [self.sample(401, self.VALID_ERROR)])
+        proc = run_gate("response_schema_gate.py", *self.args)
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        self.assertIn("GATE: PASS", proc.stdout)
+
+    def test_missing_required_field_fails_closed(self) -> None:
+        # error.request_id is required by ErrorBody — dropping it must fail.
+        body = {"error": {"code": "unauthorized", "message": "no"}}
+        write_shard(self.reports, "1.json", [self.sample(401, body)])
+        proc = run_gate("response_schema_gate.py", *self.args)
+        self.assertEqual(proc.returncode, 1, proc.stdout + proc.stderr)
+        self.assertIn("getAccount", proc.stdout)
+        self.assertIn("request_id", proc.stdout)
+
+    def test_wrong_type_fails_closed(self) -> None:
+        body = {"error": {"code": 401, "message": "no", "request_id": "req_1"}}  # code must be a string
+        write_shard(self.reports, "1.json", [self.sample(401, body)])
+        proc = run_gate("response_schema_gate.py", *self.args)
+        self.assertEqual(proc.returncode, 1, proc.stdout + proc.stderr)
+        self.assertIn("getAccount", proc.stdout)
+
+    def test_extra_fields_are_not_violations(self) -> None:
+        # Responses are deliberately open (additionalProperties: true).
+        body = {"error": {**self.VALID_ERROR["error"], "hint": "extra"}, "extra_top": 1}
+        write_shard(self.reports, "1.json", [self.sample(401, body)])
+        proc = run_gate("response_schema_gate.py", *self.args)
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+
+    def test_non_json_body_fails_closed(self) -> None:
+        s = self.sample(401, None, kind="nonjson")
+        s["rawPrefix"] = "<html>upstream error page</html>"
+        write_shard(self.reports, "1.json", [s])
+        proc = run_gate("response_schema_gate.py", *self.args)
+        self.assertEqual(proc.returncode, 1, proc.stdout + proc.stderr)
+        self.assertIn("non-JSON", proc.stdout)
+
+    def test_no_shards_is_not_a_pass(self) -> None:
+        proc = run_gate("response_schema_gate.py", *self.args)
+        self.assertEqual(proc.returncode, 2, proc.stdout + proc.stderr)
 
 
 class McpCoverageGateTest(unittest.TestCase):


### PR DESCRIPTION
## What

Closes the audited conformance gap: **nothing validated live response bodies against `api/openapi.yaml`** — `harness/client.ts` checks status codes, suites assert hand-picked fields, and `harness/coverage.ts` records 2xx pairs only. A dropped required field, a wrong type, or an error path returning a bare string instead of the envelope all shipped invisibly.

The suite is deliberately zero-dependency (the ops release pipeline runs it with no `npm install`), so validation cannot happen in-process. The split: **the suite records, the gate validates.**

- **`harness/responses.ts`** (new) — records every `ApiClient` response as a `{method, path, status, contentType, kind, body}` sample in `reports/response-samples/` (per-pid shards, same `exit`-flush + `pretest`-clean pattern as `coverage.ts`). Records **all statuses**, not just 2xx: every op documents `default` → `ErrorEnvelope`, so each 401/404/422 the suites already provoke is a free error-contract check. The coverage channel's 2xx-only filter is untouched — coverage answers "did the op run?", this answers "was the body well-shaped?".
- **`response_schema_gate.py`** (new) — maps each sample to its operationId with `coverage_gate.py`'s matcher, picks the response schema for the exact status (falling back to `default`), resolves `$ref`s against `components`, validates under Draft 2020-12 (the spec is OpenAPI 3.1). Needs `jsonschema` alongside the existing `pyyaml`. Extra fields are **not** violations (responses are deliberately `additionalProperties: true`, and `format` stays annotation-only); missing required fields, wrong types, empty/non-JSON bodies where JSON is documented, and undocumented statuses **are**. House gate contract: exit 2 on no-shards/inconclusive (never 0), 1 on violations, 0 clean; empty `ALLOWLIST` with the stale-entry check.
- `harness/client.ts` — one `recordResponse(...)` call after body parse.
- `package.json` — `coverage:gate:responses` script; `pretest` clears the new shard dir.
- `test_gates.py` — 6 new subprocess tests (skip cleanly without `jsonschema`), including explicit proof the gate can FAIL: missing required field, wrong type, and non-JSON body each exit 1; extra fields exit 0; no shards exit 2.

## Measured against live staging (partial run, 2026-08-02)

Suites 01–13 against `api-staging.e2a.dev` (run cut short deliberately; a Free-plan account capped agent-heavy paths). **379 samples, 13 shards, 28/72 operations sampled (274× 2xx + 105× 4xx), 360 valid, 1 violating sample:**

```
VIOLATIONS (1 group(s), 1 sample(s)):
  - getAgent 404 (1x, e.g. /v1/agents/..%2F..%2Fetc%2Fpasswd)
      non-JSON body where spec documents application/json (default): 'Not Found'
```

Root cause (verified by curl + config): Caddy URI-normalizes `..%2F..` so the path escapes `/v1/*` and hits the api-host allowlist catch-all (`respond "Not Found" 404` — ops `Caddyfile.staging`/`Caddyfile`), so the request never reaches the app. The server's own `routeNotFound` correctly returns the JSON envelope for real `/v1` paths (control: bogus agent → JSON `not_found` + `x-request-id`). The attribution to `getAgent` is a recorder artifact (the client-side pathname keeps `%2F` encoded, so it maps as one segment); the finding itself — the hosted edge answers some `/v1`-looking requests with a non-envelope plain-text 404 — is real, and is an edge-config question for e2a-ops, not a server bug.

Every app-generated response sampled — including all 105 error responses — conformed. Not sampled (suites 14+ not reached): templates, webhooks, reviews (mostly), api-keys, contacts, suppressions, trash, attachments, starter templates.

## Not in this PR

- **Not wired into the ops release pipeline, not blocking.** Wiring is a later `e2a-ops` PR (`pip install jsonschema` next to the existing `pyyaml` step + running `coverage:gate:responses`). The measured violation rate (1 infra-layer finding, 0 app-layer, across 379 samples) suggests it can block with at most one justified allowlist entry once the remaining 44 ops have been measured on a full staging-gate run.

## Verification

- `npm run typecheck` clean; `node --test harness/*.test.ts` 18/18.
- `python3 -m unittest test_gates -v` 12/12 (venv with pyyaml + jsonschema).
- Synthetic-violation proof the gate can fail:

```
VIOLATIONS (2 group(s), 2 sample(s)):
  - getAccount 401 (1x, e.g. /v1/account)
      [default schema] $.error.code: 401 is not of type 'string'
  - getAccount 401 (1x, e.g. /v1/account)
      [default schema] $.error: 'request_id' is a required property

GATE: FAIL — the above response(s) do not conform to api/openapi.yaml. Fix the server or the spec, or add an ALLOWLIST entry with a justification.
```

- Missing/empty shard dir → exit 2 with "no response-sample shards … did the suite run?" (never a vacuous pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)