### PR TITLE
fix(httpapi): add RFC 9110 Allow header to 405 responses

### DIFF
--- a/internal/httpapi/httpapi.go
+++ b/internal/httpapi/httpapi.go
@@ -604,14 +604,48 @@ func (s *Server) routeNotFound(w http.ResponseWriter, r *http.Request) {
 	http.NotFound(w, r)
 }
 
+// allowHeaderValue derives the Allow header for a 405 response (RFC 9110
+// §15.5.6: an origin server MUST generate Allow on every 405) by asking the
+// router itself which methods route this request's path. chi v5 collects the
+// matched node's method set internally but does not expose it to a custom
+// MethodNotAllowed handler, so this re-runs the match once per HTTP method —
+// nine tree lookups on a rare error path. Probing the live routing table
+// keeps the header in lockstep with reality as routes change; nothing is
+// hardcoded per route.
+func (s *Server) allowHeaderValue(r *http.Request) string {
+	// Mirror chi's own routing-path selection: it routes on RawPath when the
+	// request URI is percent-encoded (see the WS route comment above).
+	routePath := r.URL.RawPath
+	if routePath == "" {
+		routePath = r.URL.Path
+	}
+	var allowed []string
+	for _, method := range []string{
+		http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut,
+		http.MethodPatch, http.MethodDelete, http.MethodConnect,
+		http.MethodOptions, http.MethodTrace,
+	} {
+		if s.Router.Match(chi.NewRouteContext(), method, routePath) {
+			allowed = append(allowed, method)
+		}
+	}
+	return strings.Join(allowed, ", ")
+}
+
 func (s *Server) routeMethodNotAllowed(w http.ResponseWriter, r *http.Request) {
 	if isV1Path(r.URL.Path) {
+		if allow := s.allowHeaderValue(r); allow != "" {
+			w.Header().Set("Allow", allow)
+		}
 		WriteError(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
 	if s.deps.Legacy != nil {
 		s.deps.Legacy.ServeHTTP(w, r)
 		return
+	}
+	if allow := s.allowHeaderValue(r); allow != "" {
+		w.Header().Set("Allow", allow)
 	}
 	http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
 }

--- a/internal/httpapi/httpapi.go
+++ b/internal/httpapi/httpapi.go
@@ -604,27 +604,53 @@ func (s *Server) routeNotFound(w http.ResponseWriter, r *http.Request) {
 	http.NotFound(w, r)
 }
 
+// probedMethods is the set of methods allowHeaderValue asks the router about.
+// It is exactly chi v5.3.1's built-in method table (tree.go `methodMap`),
+// including the QUERY method (RFC 10008) that chi routes via Router.Query —
+// no route registers QUERY today, so it is probed for future routes, not for
+// current ones. chi does not export that table, so this list is a mirror
+// rather than a derivation: TestProbedMethodsMatchChiMethodTable discovers
+// chi's real set at runtime and fails if the two ever diverge. Custom methods
+// added via the package-global chi.RegisterMethod are the one thing this
+// cannot track — chi exposes no way to enumerate them from here, so a caller
+// that registers one must extend this list by hand (that test will say so).
+var probedMethods = []string{
+	http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut,
+	http.MethodPatch, http.MethodDelete, http.MethodConnect,
+	http.MethodOptions, http.MethodTrace, "QUERY",
+}
+
 // allowHeaderValue derives the Allow header for a 405 response (RFC 9110
-// §15.5.6: an origin server MUST generate Allow on every 405) by asking the
-// router itself which methods route this request's path. chi v5 collects the
-// matched node's method set internally but does not expose it to a custom
-// MethodNotAllowed handler, so this re-runs the match once per HTTP method —
-// nine tree lookups on a rare error path. Probing the live routing table
-// keeps the header in lockstep with reality as routes change; nothing is
-// hardcoded per route.
+// §15.5.6: an origin server MUST generate Allow on a 405) by asking the router
+// itself which methods route this request's path. chi v5 collects the matched
+// node's method set internally but does not expose it to a custom
+// MethodNotAllowed handler, so this re-runs the match once per method in
+// probedMethods — ten tree lookups on a rare error path. Probing the live
+// routing table keeps the header in lockstep with the routes chi knows about;
+// nothing is hardcoded per route.
+//
+// An empty result is meaningful, not a failure: chi dispatches
+// MethodNotAllowedHandler with no allowed methods when the request method is
+// absent from its table (mux.go routeHTTP), so an unknown method against a
+// nonexistent path lands here with every probe missing. RFC 9110 §10.2.1
+// permits an empty Allow field value to mean "no methods are supported", which
+// is the honest answer there — callers must still set the header.
 func (s *Server) allowHeaderValue(r *http.Request) string {
 	// Mirror chi's own routing-path selection: it routes on RawPath when the
 	// request URI is percent-encoded (see the WS route comment above).
+	//
+	// chi actually consults rctx.RoutePath first and only falls back to
+	// RawPath/Path; RoutePath is populated for requests routed into a
+	// subrouter via Router.Mount. This repo mounts no subrouters, so RoutePath
+	// is always empty here and this mirror is exact — but if a Mount is ever
+	// added, this probe must consult chi.RouteContext(r.Context()).RoutePath
+	// too or it will probe the outer path and derive the wrong method set.
 	routePath := r.URL.RawPath
 	if routePath == "" {
 		routePath = r.URL.Path
 	}
 	var allowed []string
-	for _, method := range []string{
-		http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut,
-		http.MethodPatch, http.MethodDelete, http.MethodConnect,
-		http.MethodOptions, http.MethodTrace,
-	} {
+	for _, method := range probedMethods {
 		if s.Router.Match(chi.NewRouteContext(), method, routePath) {
 			allowed = append(allowed, method)
 		}
@@ -634,19 +660,21 @@ func (s *Server) allowHeaderValue(r *http.Request) string {
 
 func (s *Server) routeMethodNotAllowed(w http.ResponseWriter, r *http.Request) {
 	if isV1Path(r.URL.Path) {
-		if allow := s.allowHeaderValue(r); allow != "" {
-			w.Header().Set("Allow", allow)
-		}
+		// Set unconditionally: an empty value is a valid Allow (RFC 9110
+		// §10.2.1) and omitting the header violates §15.5.6.
+		w.Header().Set("Allow", s.allowHeaderValue(r))
 		WriteError(w, r, http.StatusMethodNotAllowed, "method_not_allowed", "method not allowed")
 		return
 	}
+	// Non-/v1 paths belong to the legacy gorilla/mux surface, which emits its
+	// own 405 without an Allow header (gorilla does not hand the allowed-method
+	// set to a MethodNotAllowedHandler). Allow coverage here therefore stops at
+	// the /v1 surface plus /u/{token}; the legacy 405s are a separate fix.
 	if s.deps.Legacy != nil {
 		s.deps.Legacy.ServeHTTP(w, r)
 		return
 	}
-	if allow := s.allowHeaderValue(r); allow != "" {
-		w.Header().Set("Allow", allow)
-	}
+	w.Header().Set("Allow", s.allowHeaderValue(r))
 	http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
 }
 

--- a/internal/httpapi/router_errors_test.go
+++ b/internal/httpapi/router_errors_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -49,6 +51,65 @@ func TestV1RouterErrorsUseCanonicalEnvelope(t *testing.T) {
 	}
 	if legacyCalls != 0 {
 		t.Fatalf("legacy handler called %d times for /v1 errors", legacyCalls)
+	}
+}
+
+// RFC 9110 §15.5.6: every 405 MUST carry an Allow header naming the methods
+// the resource does support. The header is derived by probing the live chi
+// routing table, so these expected sets are exactly the methods registered
+// for each path — if a route gains or loses a method, the assertion updates
+// with it (and this test tells you).
+func TestMethodNotAllowedCarriesAllowHeader(t *testing.T) {
+	s := New(Deps{
+		// Register the raw (non-Huma) chi WebSocket route too.
+		WSHandle: func(w http.ResponseWriter, r *http.Request, address string) {},
+	})
+
+	tests := []struct {
+		name    string
+		method  string
+		path    string
+		allowed []string
+	}{
+		// Huma-registered operation, single method.
+		{name: "huma single-method", method: http.MethodPost, path: "/v1/info", allowed: []string{http.MethodGet}},
+		// Huma-registered operations sharing one path, multiple methods.
+		{name: "huma multi-method", method: http.MethodPatch, path: "/v1/domains/example.com", allowed: []string{http.MethodGet, http.MethodDelete}},
+		// Raw chi route registered outside Huma.
+		{name: "raw chi route", method: http.MethodPost, path: "/v1/agents/a%40b.example/ws", allowed: []string{http.MethodGet}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			s.ServeHTTP(rr, httptest.NewRequest(tc.method, tc.path, nil))
+			if rr.Code != http.StatusMethodNotAllowed {
+				t.Fatalf("status = %d, want 405; body=%q", rr.Code, rr.Body.String())
+			}
+			allow := rr.Header().Get("Allow")
+			if allow == "" {
+				t.Fatalf("405 response missing Allow header (RFC 9110 §15.5.6)")
+			}
+			got := map[string]bool{}
+			for _, m := range strings.Split(allow, ",") {
+				got[strings.TrimSpace(m)] = true
+			}
+			want := map[string]bool{}
+			for _, m := range tc.allowed {
+				want[m] = true
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("Allow = %q (set %v), want exactly %v", allow, got, want)
+			}
+			// The header must not disturb the canonical JSON envelope.
+			var env ErrorEnvelope
+			if err := json.Unmarshal(rr.Body.Bytes(), &env); err != nil {
+				t.Fatalf("decode envelope: %v; body=%q", err, rr.Body.String())
+			}
+			if env.Err.Code != "method_not_allowed" {
+				t.Fatalf("error.code = %q, want method_not_allowed", env.Err.Code)
+			}
+		})
 	}
 }
 

--- a/internal/httpapi/router_errors_test.go
+++ b/internal/httpapi/router_errors_test.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/go-chi/chi/v5"
 )
 
 func TestV1RouterErrorsUseCanonicalEnvelope(t *testing.T) {
@@ -110,6 +112,64 @@ func TestMethodNotAllowedCarriesAllowHeader(t *testing.T) {
 				t.Fatalf("error.code = %q, want method_not_allowed", env.Err.Code)
 			}
 		})
+	}
+}
+
+// A method chi does not know at all never reaches the routing tree: routeHTTP
+// fails the methodMap lookup and dispatches MethodNotAllowedHandler with an
+// empty allowed-method set, so every probe misses and the derived value is "".
+// RFC 9110 §10.2.1 makes an empty Allow field value meaningful ("no methods are
+// supported"), and §15.5.6 does not permit omitting the header — so the header
+// must be present and empty, never absent.
+func TestMethodNotAllowedAlwaysCarriesAllowHeader(t *testing.T) {
+	s := New(Deps{})
+
+	rr := httptest.NewRecorder()
+	s.ServeHTTP(rr, httptest.NewRequest("BREW", "/v1/not-a-route", nil))
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want 405; body=%q", rr.Code, rr.Body.String())
+	}
+	values, present := rr.Header()["Allow"]
+	if !present {
+		t.Fatalf("405 omitted the Allow header (RFC 9110 §15.5.6); headers=%v", rr.Header())
+	}
+	if len(values) != 1 || values[0] != "" {
+		t.Fatalf("Allow = %q, want exactly one empty value", values)
+	}
+	var env ErrorEnvelope
+	if err := json.Unmarshal(rr.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode envelope: %v; body=%q", err, rr.Body.String())
+	}
+	if env.Err.Code != "method_not_allowed" {
+		t.Fatalf("error.code = %q, want method_not_allowed", env.Err.Code)
+	}
+}
+
+// probedMethods mirrors chi's unexported method table. Discover the real one at
+// runtime — Router.Handle registers a pattern under every method chi knows, and
+// Routes() reports those back by name — and fail if the mirror has drifted (chi
+// adding a method, or this repo calling the package-global chi.RegisterMethod,
+// whose custom methods the probe cannot otherwise learn about).
+func TestProbedMethodsMatchChiMethodTable(t *testing.T) {
+	r := chi.NewRouter()
+	r.Handle("/probe", http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	routes := r.Routes()
+	if len(routes) != 1 {
+		t.Fatalf("expected 1 route, got %d", len(routes))
+	}
+	chiMethods := map[string]bool{}
+	for m := range routes[0].Handlers {
+		if m == "*" { // chi's catch-all marker, not an HTTP method
+			continue
+		}
+		chiMethods[m] = true
+	}
+	probed := map[string]bool{}
+	for _, m := range probedMethods {
+		probed[m] = true
+	}
+	if !reflect.DeepEqual(chiMethods, probed) {
+		t.Fatalf("probedMethods = %v, but chi routes %v — update probedMethods", probed, chiMethods)
 	}
 }
 

--- a/internal/httpapi/unsubscribe.go
+++ b/internal/httpapi/unsubscribe.go
@@ -9,10 +9,13 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/tokencanopy/e2a/internal/identity"
 	"github.com/tokencanopy/e2a/internal/unsubscribe"
 )
 
@@ -21,6 +24,29 @@ const (
 	publicUnsubscribeCSP     = "default-src 'none'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'"
 	rfc8058OneClickBody      = "List-Unsubscribe=One-Click"
 )
+
+// publicUnsubscribeHandlers is the single source of truth for the methods
+// /u/{token} serves. It drives both the dispatch in handlePublicUnsubscribe
+// and the Allow header on that route's 405, so the two cannot drift apart.
+// The /v1 405s derive Allow by probing the routing table instead; that cannot
+// work here because this route is registered for every method (root.Handle),
+// so the router would answer "all of them".
+var publicUnsubscribeHandlers = map[string]func(*Server, http.ResponseWriter, *http.Request, *identity.UnsubscribeScope){
+	http.MethodGet:  (*Server).servePublicUnsubscribeForm,
+	http.MethodPost: (*Server).servePublicUnsubscribeSubmit,
+}
+
+// publicUnsubscribeAllow is the RFC 9110 §15.5.6 Allow value for this route,
+// derived from publicUnsubscribeHandlers. Sorted so the value is stable (map
+// iteration order is not); RFC 9110 §10.2.1 gives the order no meaning.
+var publicUnsubscribeAllow = func() string {
+	methods := make([]string, 0, len(publicUnsubscribeHandlers))
+	for m := range publicUnsubscribeHandlers {
+		methods = append(methods, m)
+	}
+	sort.Strings(methods)
+	return strings.Join(methods, ", ")
+}()
 
 var (
 	unsubscribeConfirmPage = template.Must(template.New("unsubscribe-confirm").Parse(`<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Unsubscribe</title></head><body><main><h1>Unsubscribe</h1><p>Stop emails sent by {{.}}?</p><form method="post"><button type="submit" name="confirm" value="unsubscribe">Unsubscribe</button></form></main></body></html>`))
@@ -69,44 +95,47 @@ func (s *Server) handlePublicUnsubscribe(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	switch r.Method {
-	case http.MethodGet:
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.WriteHeader(http.StatusOK)
-		if err := unsubscribeConfirmPage.Execute(w, scope.AgentID); err != nil {
-			log.Printf("[unsubscribe] confirmation render failed: %v", err)
-		}
-	case http.MethodPost:
-		rfc, ok := parsePublicUnsubscribePOST(w, r)
-		if !ok {
-			writePublicUnsubscribeError(w, http.StatusBadRequest)
-			return
-		}
-		if s.deps.AddAgentSuppressionFromTokenScope == nil {
-			writePublicUnsubscribeError(w, http.StatusInternalServerError)
-			return
-		}
-		if _, _, err := s.deps.AddAgentSuppressionFromTokenScope(r.Context(), *scope, s.deps.AgentSuppressionAddedHook); err != nil {
-			log.Printf("[unsubscribe] suppression insert failed")
-			writePublicUnsubscribeError(w, http.StatusInternalServerError)
-			return
-		}
-		if rfc {
-			w.WriteHeader(http.StatusOK)
-			return
-		}
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.WriteHeader(http.StatusOK)
-		if err := unsubscribeSuccessPage.Execute(w, nil); err != nil {
-			log.Printf("[unsubscribe] success render failed: %v", err)
-		}
-	default:
-		// RFC 9110 §15.5.6: a 405 must carry Allow. This route is registered
-		// on the router for all methods (root.Handle), so the method set
-		// cannot be derived from the routing table — the switch above is the
-		// source of truth.
-		w.Header().Set("Allow", "GET, POST")
+	handle, ok := publicUnsubscribeHandlers[r.Method]
+	if !ok {
+		// RFC 9110 §15.5.6: a 405 must carry Allow.
+		w.Header().Set("Allow", publicUnsubscribeAllow)
 		writePublicUnsubscribeError(w, http.StatusMethodNotAllowed)
+		return
+	}
+	handle(s, w, r, scope)
+}
+
+func (s *Server) servePublicUnsubscribeForm(w http.ResponseWriter, r *http.Request, scope *identity.UnsubscribeScope) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	if err := unsubscribeConfirmPage.Execute(w, scope.AgentID); err != nil {
+		log.Printf("[unsubscribe] confirmation render failed: %v", err)
+	}
+}
+
+func (s *Server) servePublicUnsubscribeSubmit(w http.ResponseWriter, r *http.Request, scope *identity.UnsubscribeScope) {
+	rfc, ok := parsePublicUnsubscribePOST(w, r)
+	if !ok {
+		writePublicUnsubscribeError(w, http.StatusBadRequest)
+		return
+	}
+	if s.deps.AddAgentSuppressionFromTokenScope == nil {
+		writePublicUnsubscribeError(w, http.StatusInternalServerError)
+		return
+	}
+	if _, _, err := s.deps.AddAgentSuppressionFromTokenScope(r.Context(), *scope, s.deps.AgentSuppressionAddedHook); err != nil {
+		log.Printf("[unsubscribe] suppression insert failed")
+		writePublicUnsubscribeError(w, http.StatusInternalServerError)
+		return
+	}
+	if rfc {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	if err := unsubscribeSuccessPage.Execute(w, nil); err != nil {
+		log.Printf("[unsubscribe] success render failed: %v", err)
 	}
 }
 

--- a/internal/httpapi/unsubscribe.go
+++ b/internal/httpapi/unsubscribe.go
@@ -101,6 +101,11 @@ func (s *Server) handlePublicUnsubscribe(w http.ResponseWriter, r *http.Request)
 			log.Printf("[unsubscribe] success render failed: %v", err)
 		}
 	default:
+		// RFC 9110 §15.5.6: a 405 must carry Allow. This route is registered
+		// on the router for all methods (root.Handle), so the method set
+		// cannot be derived from the routing table — the switch above is the
+		// source of truth.
+		w.Header().Set("Allow", "GET, POST")
 		writePublicUnsubscribeError(w, http.StatusMethodNotAllowed)
 	}
 }

--- a/internal/httpapi/unsubscribe_test.go
+++ b/internal/httpapi/unsubscribe_test.go
@@ -34,6 +34,14 @@ type publicUnsubscribeFixture struct {
 
 func newPublicUnsubscribeServer(t *testing.T, mutate func(*Deps, *publicUnsubscribeFixture)) (*httptest.Server, *publicUnsubscribeFixture) {
 	t.Helper()
+	handler, fixture := newPublicUnsubscribeHandler(t, mutate)
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return srv, fixture
+}
+
+func newPublicUnsubscribeHandler(t *testing.T, mutate func(*Deps, *publicUnsubscribeFixture)) (http.Handler, *publicUnsubscribeFixture) {
+	t.Helper()
 	fixture := &publicUnsubscribeFixture{
 		rows:  make(map[string]identity.AgentSuppression),
 		scope: identity.UnsubscribeScope{UserID: "u_1", AgentID: "sender@example.com", Address: "recipient@example.net"},
@@ -76,9 +84,7 @@ func newPublicUnsubscribeServer(t *testing.T, mutate func(*Deps, *publicUnsubscr
 	if mutate != nil {
 		mutate(&deps, fixture)
 	}
-	srv := httptest.NewServer(New(deps))
-	t.Cleanup(srv.Close)
-	return srv, fixture
+	return New(deps), fixture
 }
 
 func assertPublicUnsubscribeSecurityHeaders(t *testing.T, resp *http.Response) {
@@ -335,6 +341,38 @@ func TestPublicUnsubscribeUnsupportedMethodHasSecurityHeaders(t *testing.T) {
 	}
 	if want := map[string]bool{http.MethodGet: true, http.MethodPost: true}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("Allow = %q (set %v), want exactly %v", resp.Header.Get("Allow"), got, want)
+	}
+}
+
+// TestPublicUnsubscribeMethodCoverage sweeps every method chi can route against
+// /u/{token}. Unlike the /v1 405s, this route's Allow cannot be derived from
+// the routing table (it is registered for all methods), so it is driven by
+// publicUnsubscribeHandlers instead — this asserts, method by method, that the
+// dispatch table and the advertised Allow actually agree.
+func TestPublicUnsubscribeMethodCoverage(t *testing.T) {
+	handler, _ := newPublicUnsubscribeHandler(t, nil)
+	for _, method := range probedMethods {
+		t.Run(method, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, httptest.NewRequest(method, "/u/"+publicUnsubscribeToken, nil))
+			if _, served := publicUnsubscribeHandlers[method]; served {
+				// Served methods must never 405 (POST here has no body and so
+				// gets a 400 — the point is only that it reached the handler).
+				if rr.Code == http.StatusMethodNotAllowed {
+					t.Fatalf("%s is in publicUnsubscribeHandlers but got 405", method)
+				}
+				if allow := rr.Header().Get("Allow"); allow != "" {
+					t.Fatalf("%s: non-405 response carries Allow = %q", method, allow)
+				}
+				return
+			}
+			if rr.Code != http.StatusMethodNotAllowed {
+				t.Fatalf("%s status = %d, want 405; body=%q", method, rr.Code, rr.Body.String())
+			}
+			if allow := rr.Header().Get("Allow"); allow != "GET, POST" {
+				t.Fatalf("%s: Allow = %q, want %q", method, allow, "GET, POST")
+			}
+		})
 	}
 }
 

--- a/internal/httpapi/unsubscribe_test.go
+++ b/internal/httpapi/unsubscribe_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -323,6 +324,17 @@ func TestPublicUnsubscribeUnsupportedMethodHasSecurityHeaders(t *testing.T) {
 	resp, _ := doPublicUnsubscribe(t, srv.Client(), http.MethodPut, srv.URL+"/u/"+publicUnsubscribeToken, "application/x-www-form-urlencoded", "confirm=unsubscribe")
 	if resp.StatusCode != http.StatusMethodNotAllowed {
 		t.Fatalf("PUT status = %d, want 405", resp.StatusCode)
+	}
+	// RFC 9110 §15.5.6: the 405 must name the supported methods. This raw
+	// handler serves exactly GET and POST.
+	got := map[string]bool{}
+	for _, m := range strings.Split(resp.Header.Get("Allow"), ",") {
+		if m = strings.TrimSpace(m); m != "" {
+			got[m] = true
+		}
+	}
+	if want := map[string]bool{http.MethodGet: true, http.MethodPost: true}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Allow = %q (set %v), want exactly %v", resp.Header.Get("Allow"), got, want)
 	}
 }
 


### PR DESCRIPTION
## Finding

A Schemathesis run against live staging found **all 22 tested paths return 405 without an `Allow` header**. RFC 9110 §15.5.6: an origin server MUST generate `Allow` on a 405 listing the target resource's supported methods.

## Scope of this fix

**The `/v1` surface plus the public unsubscribe route `/u/{token}` — not the whole server.** Non-`/v1` paths delegate to the legacy gorilla/mux surface (`Deps.Legacy`), whose `MethodNotAllowedHandler` still omits `Allow`; gorilla does not hand the allowed-method set to that handler, so fixing it is a separate change. A comment in `routeMethodNotAllowed` records the boundary.

## Where the covered 405s originate

1. **Router-level** — chi's `MethodNotAllowed` hook (`internal/httpapi/httpapi.go`, `routeMethodNotAllowed`). This covers every Huma-registered operation *and* the raw chi routes (`root.Get(...)`: WS upgrade, attachment download), since humachi registers operations on the same chi mux.
2. **Handler-level** — the public unsubscribe handler (`/u/{token}`, `internal/httpapi/unsubscribe.go`) is registered via `root.Handle` (all methods) and emits its own 405.

## Fix

- `routeMethodNotAllowed` derives the method set by probing the live routing table (`Router.Match` per HTTP method, mirroring chi's own RawPath-vs-Path selection). chi v5.3.1 collects the matched node's methods internally (`rctx.methodsAllowed`) but does not expose them to a custom handler, so the probe is the drift-proof alternative — nothing is hardcoded per route. Ten tree lookups on a rare error path.
- **The header is set unconditionally, including when the derived set is empty.** chi's `routeHTTP` dispatches `MethodNotAllowedHandler` with *no* allowed methods when the request method is absent from its internal table, so an unknown method on a nonexistent path (`BREW /v1/not-a-route`) lands in the handler with every probe missing. RFC 9110 §10.2.1 makes an empty `Allow` field value meaningful ("no methods are supported"), and §15.5.6 does not permit omitting the header — so the empty value goes out rather than the header being dropped.
- **`QUERY` is probed** (chi v5.3.1 `tree.go` `mQUERY`, `Router.Query`). No route registers it today, so this is forward-looking. The probe list is a named `probedMethods` var guarded by a test that discovers chi's real method table at runtime and fails if the mirror drifts. Custom methods registered through the package-global `chi.RegisterMethod` cannot be enumerated from here; the comment says so rather than claiming the header tracks the router unconditionally.
- **The `/u/{token}` `Allow` is structural, not a literal.** The method switch is now a dispatch map (`publicUnsubscribeHandlers`) that both routes the request and derives the `Allow` value, so the advertised set and the served set cannot diverge.
- The JSON error envelope is untouched — `code: method_not_allowed`, body byte-identical before/after (Content-Length 115 in every dump below).

## Before / after (verbatim wire dumps, raw TCP against a local server)

Before (`origin/main`) — no `Allow` at all:
```
--- POST /v1/info HTTP/1.1 ---
HTTP/1.1 405 Method Not Allowed
Content-Type: application/json
X-Content-Type-Options: nosniff
X-Request-Id: req_0cd1c80a817da78a7bb97033
Content-Length: 115

--- BREW /v1/not-a-route HTTP/1.1 ---
HTTP/1.1 405 Method Not Allowed
Content-Type: application/json
X-Content-Type-Options: nosniff
X-Request-Id: req_38f911e85e88d07803e966a6
Content-Length: 115
```

After:
```
--- POST /v1/info HTTP/1.1 ---
HTTP/1.1 405 Method Not Allowed
Allow: GET
Content-Type: application/json
X-Content-Type-Options: nosniff
X-Request-Id: req_e9306ac1d351e0ddda98bc13
Content-Length: 115

--- BREW /v1/not-a-route HTTP/1.1 ---
HTTP/1.1 405 Method Not Allowed
Allow: 
Content-Type: application/json
X-Content-Type-Options: nosniff
X-Request-Id: req_a4ac863b10e213ed86fabfc1
Content-Length: 115
```

(`PATCH /v1/domains/example.com` → `Allow: GET, DELETE`.)

## Tests

- `TestMethodNotAllowedCarriesAllowHeader` — single-method Huma op (`POST /v1/info` → `GET`), multi-method Huma path (`PATCH /v1/domains/{domain}` → `GET, DELETE`), raw chi route (`POST /v1/agents/{email}/ws` → `GET`); order-insensitive exact-set comparison + envelope/`code` assertions. `method_not_allowed` previously had no black-box coverage.
- `TestMethodNotAllowedAlwaysCarriesAllowHeader` — regression for the empty case: `BREW /v1/not-a-route` must carry `Allow` **present and empty**, never absent.
- `TestProbedMethodsMatchChiMethodTable` — discovers chi's method table at runtime (`Router.Handle` registers every method chi knows; `Routes()` reports them by name) and fails if `probedMethods` drifts.
- `TestPublicUnsubscribeMethodCoverage` — sweeps every chi-routable method against `/u/{token}`, asserting the served pair never 405s and every other method 405s with `Allow: GET, POST`.

## Latent note

The probe mirrors chi's RawPath-then-Path selection, but chi's `routeHTTP` checks `rctx.RoutePath` first. Nothing calls `Router.Mount` in this repo, so `RoutePath` is never populated and the mirror is exact today — a comment records what to change if a subrouter is ever mounted.

## Spec

The OpenAPI spec documents 405 only in the error-catalog extension (per-code statuses), not as per-operation response objects — there is no response to declare the header on, so no spec change. `make spec-check` clean.

## Verification

- `go build ./...` clean
- `go test ./internal/httpapi/ -count=1` — ok (full package)
- `gofmt -l` / `go vet ./internal/httpapi/` clean
- `make spec-check` clean (spec unchanged → no SDK regen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
