### PR TITLE
fix(identity): populate agent_count in LookupDomain

### DIFF
--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -52,11 +52,9 @@ type Domain struct {
 	// "probed and failed" which is captured by `verified=false` + a
 	// non-null LastCheckedAt.
 	LastCheckedAt *time.Time `json:"last_checked_at,omitempty"`
-	// AgentCount is computed at read time by ListDomainsByUser and is
-	// not a persisted column. Single-domain LookupDomain leaves it at
-	// the zero value — callers that need the count call the list path
-	// (this column-versus-aggregate split avoids changing every store
-	// signature to thread an agent-counter through).
+	// AgentCount is computed at read time by ListDomainsByUser and
+	// LookupDomain, via the same correlated subquery, and is not a
+	// persisted column.
 	AgentCount int `json:"agent_count"`
 	// DKIM keypair fields. The selector + public key
 	// are user-facing — the dashboard shows them so users can copy the
@@ -1095,13 +1093,19 @@ func (s *Store) DomainExists(ctx context.Context, domain string) (bool, error) {
 }
 
 // LookupDomain returns a domain if it exists and is owned by the given user.
+// AgentCount is populated with the same correlated subquery ListDomainsByUser
+// uses (trashed agents excluded), so the single-resource and list responses
+// agree instead of this path leaving it at the Go zero value.
 func (s *Store) LookupDomain(ctx context.Context, domain, userID string) (*Domain, error) {
 	d := &Domain{}
 	err := s.pool.QueryRow(ctx,
-		`SELECT domain, user_id, verified, verification_token, created_at, verified_at, is_primary, last_checked_at, COALESCE(dkim_selector, ''), COALESCE(dkim_public_key, ''), sending_status, COALESCE(sending_error, ''), sending_dns_records, sending_last_checked_at, COALESCE(sending_dkim_status, ''), COALESCE(sending_mail_from_status, '')
+		`SELECT domain, user_id, verified, verification_token, created_at, verified_at, is_primary, last_checked_at, COALESCE(dkim_selector, ''), COALESCE(dkim_public_key, ''), sending_status, COALESCE(sending_error, ''), sending_dns_records, sending_last_checked_at, COALESCE(sending_dkim_status, ''), COALESCE(sending_mail_from_status, ''),
+		        (SELECT count(*) FROM agent_identities a
+		           WHERE a.registered_domain = domains.domain AND a.user_id = domains.user_id
+		             AND a.deleted_at IS NULL) AS agent_count
 		 FROM domains WHERE domain = $1 AND user_id = $2`,
 		normalizeDomain(domain), userID,
-	).Scan(&d.Domain, &d.UserID, &d.Verified, &d.VerificationToken, &d.CreatedAt, &d.VerifiedAt, &d.IsPrimary, &d.LastCheckedAt, &d.DKIMSelector, &d.DKIMPublicKey, &d.SendingStatus, &d.SendingError, &d.SendingDNSRecordsJSON, &d.SendingLastCheckedAt, &d.SendingDkimStatus, &d.SendingMailFromStatus)
+	).Scan(&d.Domain, &d.UserID, &d.Verified, &d.VerificationToken, &d.CreatedAt, &d.VerifiedAt, &d.IsPrimary, &d.LastCheckedAt, &d.DKIMSelector, &d.DKIMPublicKey, &d.SendingStatus, &d.SendingError, &d.SendingDNSRecordsJSON, &d.SendingLastCheckedAt, &d.SendingDkimStatus, &d.SendingMailFromStatus, &d.AgentCount)
 	if err != nil {
 		return nil, fmt.Errorf("domain not found")
 	}

--- a/internal/identity/store_test.go
+++ b/internal/identity/store_test.go
@@ -1229,7 +1229,8 @@ func TestListDomainsByUser_ReturnsEnrichmentColumns(t *testing.T) {
 // (LookupDomain) must report the same agent_count as GET /v1/domains
 // (ListDomainsByUser) for the same domain, not the Go zero value. Also
 // checks the trashed-agent exclusion carries over, mirroring
-// TestListDomains_AgentCountExcludesTrashedAgents above.
+// TestListDomains_AgentCountExcludesTrashedAgents in
+// domain_trashed_agents_test.go.
 func TestLookupDomain_AgentCountMatchesList(t *testing.T) {
 	pool := testutil.TestDB(t)
 	store := identity.NewStore(pool)

--- a/internal/identity/store_test.go
+++ b/internal/identity/store_test.go
@@ -1225,6 +1225,58 @@ func TestListDomainsByUser_ReturnsEnrichmentColumns(t *testing.T) {
 	}
 }
 
+// TestLookupDomain_AgentCountMatchesList pins #632: GET /v1/domains/{domain}
+// (LookupDomain) must report the same agent_count as GET /v1/domains
+// (ListDomainsByUser) for the same domain, not the Go zero value. Also
+// checks the trashed-agent exclusion carries over, mirroring
+// TestListDomains_AgentCountExcludesTrashedAgents above.
+func TestLookupDomain_AgentCountMatchesList(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, err := store.CreateOrGetUser(ctx, "lookup-count@example.com", "Owner", "google-lookup-count")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	const domain = "lookupcount.example.com"
+	if _, err := store.ClaimOrCreateDomain(ctx, domain, user.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain: %v", err)
+	}
+	if _, err := store.CreateAgent(ctx, "keep@"+domain, domain, "Keep", "", "", user.ID); err != nil {
+		t.Fatalf("CreateAgent keep: %v", err)
+	}
+	trash, err := store.CreateAgent(ctx, "trash@"+domain, domain, "Trash", "", "", user.ID)
+	if err != nil {
+		t.Fatalf("CreateAgent trash: %v", err)
+	}
+	if err := store.SoftDeleteAgent(ctx, trash.ID, user.ID); err != nil {
+		t.Fatalf("SoftDeleteAgent: %v", err)
+	}
+
+	d, err := store.LookupDomain(ctx, domain, user.ID)
+	if err != nil {
+		t.Fatalf("LookupDomain: %v", err)
+	}
+	if d.AgentCount != 1 {
+		t.Errorf("LookupDomain AgentCount = %d, want 1 (one live agent, trashed one excluded)", d.AgentCount)
+	}
+
+	domains, err := store.ListDomainsByUser(ctx, user.ID, 50, time.Time{}, "")
+	if err != nil {
+		t.Fatalf("ListDomainsByUser: %v", err)
+	}
+	for _, ld := range domains {
+		if ld.Domain == domain {
+			if ld.AgentCount != d.AgentCount {
+				t.Errorf("ListDomainsByUser AgentCount = %d, LookupDomain AgentCount = %d, want equal", ld.AgentCount, d.AgentCount)
+			}
+			return
+		}
+	}
+	t.Fatalf("domain %s not found in ListDomainsByUser", domain)
+}
+
 // TestTouchDomainLastChecked_PersistsTimestamp: ensures the column
 // actually moves when called. This is the only path that writes
 // last_checked_at; without the touch, the column stays NULL even after

--- a/tests/contract/scenarios.yaml
+++ b/tests/contract/scenarios.yaml
@@ -223,6 +223,107 @@ scenarios:
             deleted: true
             domain: domain-crud.test.dev
 
+  - name: domain_agent_count
+    description: >
+      agent_count agrees between GET /v1/domains/{domain} and GET /v1/domains
+      for the same domain (#632). The single-resource path used to omit the
+      count from its SELECT, so it served Go's zero value as an authoritative
+      `0` — indistinguishable from a domain that really has no agents, on the
+      endpoint get_domain documents as the poll target after verify_domain.
+      Deliberately NOT folded into domain_crud: that scenario asserts
+      account-global collection state, so the TS runner skips it and the pin
+      would not hold across all three runners. Every precondition here is
+      established through public requests and the assertions are
+      resource-scoped (single GET plus a containment check on the list), so
+      this runs everywhere and does not care what else the account holds.
+    steps:
+      - id: register_domain
+        action: request
+        method: POST
+        path: /v1/domains
+        body:
+          domain: agentcount.test.dev
+        expect:
+          status: 201
+
+      - id: verify_domain
+        action: request
+        method: POST
+        path: /v1/domains/agentcount.test.dev/verify
+        expect:
+          status: 200
+          body_match:
+            verified: true
+
+      # Zero BEFORE any agent exists: pins that a passing agent_count is a real
+      # count and not a constant, so the post-agent assertion below cannot be
+      # satisfied by hardcoding either value.
+      - id: get_empty_domain
+        action: request
+        method: GET
+        path: /v1/domains/agentcount.test.dev
+        expect:
+          status: 200
+          body_match:
+            agent_count: 0
+
+      - id: register_agent
+        action: request
+        method: POST
+        path: /v1/agents
+        body:
+          email: bot@agentcount.test.dev
+        expect:
+          status: 201
+          body_match:
+            email: bot@agentcount.test.dev
+
+      # The #632 regression pin.
+      - id: get_domain_counts_agent
+        action: request
+        method: GET
+        path: /v1/domains/agentcount.test.dev
+        expect:
+          status: 200
+          body_match:
+            agent_count: 1
+
+      # ...and the list path reports the same number for the same domain.
+      # Containment, not index or length: the account may hold other domains.
+      - id: list_agrees_with_get
+        action: request
+        method: GET
+        path: /v1/domains
+        expect:
+          status: 200
+          body_array_contains:
+            items:
+              domain: agentcount.test.dev
+              agent_count: 1
+
+    cleanup:
+      # permanent=true is required, not tidiness: a trashed agent still holds
+      # its address and still blocks the domain delete with domain_has_agents.
+      - id: delete_agent_permanently
+        action: request
+        method: DELETE
+        path: /v1/agents/bot@agentcount.test.dev?confirm=DELETE&permanent=true
+        expect:
+          status: 200
+          body_match:
+            deleted: true
+            email: bot@agentcount.test.dev
+
+      - id: delete_domain
+        action: request
+        method: DELETE
+        path: /v1/domains/agentcount.test.dev?confirm=DELETE
+        expect:
+          status: 200
+          body_match:
+            deleted: true
+            domain: agentcount.test.dev
+
   - name: read_state_transition
     description: GET /messages/{id} marks unread messages as read
     setup:


### PR DESCRIPTION
## Summary

`GET /v1/domains/{domain}` (`LookupDomain`) always reports `agent_count: 0`, while `GET /v1/domains` (`ListDomainsByUser`) reports the correct value for the same domain. `LookupDomain`'s `SELECT`/`Scan` never included the correlated subquery `ListDomainsByUser` uses to compute `AgentCount`, so the field stayed at Go's zero value and was serialized as an authoritative `0` regardless of how many agents actually exist.

`get_domain` is the documented poll target after `verify_domain`, so this misled the two flows that read it: checking whether a domain still has agents before `delete_domain` (which rejects with `domain_has_agents`), and confirming agents were created on a freshly verified domain.

## Fix

`LookupDomain` now runs the same correlated subquery `ListDomainsByUser` uses (trashed agents excluded), so the single-resource and list responses agree. No API shape change: `agent_count` is an existing GA field, only its value on this path was wrong. Checked every production reader of `Domain.AgentCount`: only `domainViewWithRamp` (used by `GET /v1/domains/{domain}`) reads it, so the other two `LookupDomain` call sites are unaffected.

## Verification

- New regression test `TestLookupDomain_AgentCountMatchesList` (`internal/identity/store_test.go`): fails on `main` (`AgentCount = 0, want 1`), passes on this branch, both run in Docker against a real Postgres 16 instance.
- `go test ./...` passes in full (every package), plus `gofmt` and `go vet` clean.
- Did not check the live production behavior described in the issue: no access to a production account, verification is against a fresh local database.

Fixes #632
