### PR TITLE
feat(web): add /mcp landing page, structured data, and llms-full.txt

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -144,6 +144,7 @@ The Next.js dashboard ships as a static export, so its config is inlined at buil
 | `NEXT_PUBLIC_AGENTS_DOMAIN` | Shared mail domain shown in landing-page code samples (e.g. `agents.example.com`). When empty, samples fall back to `your-domain.com`. |
 | `NEXT_PUBLIC_FEEDBACK_EMAIL` | Address shown on the feedback form. Empty hides the "or email us at …" line. |
 | `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION` | Google Search Console token. Only emitted into `<head>` when set, so forks don't inherit upstream's property. |
+| `NEXT_PUBLIC_PRICING_PATH` | Site-relative path of the pricing page, when the deployment serves one (the hosted deployment sets `/pricing`). Only used to add the page to the sitemap. Leave empty if there is no pricing route — a sitemap entry that 404s is a crawl-quality problem. |
 | `NEXT_PUBLIC_E2A_SIGN_IN_URL` | Sign-in door for the dashboard's "Sign in" links. Default: `/api/auth/login` (legacy Google OAuth). Set to `/api/auth/oidc/login` to make the generic OIDC door the default — only when the server runs with `E2A_OIDC_ENABLED=true`, otherwise the link 404s. Button copy follows: "Sign in with Google" for the legacy door, provider-neutral "Sign in" otherwise. |
 
 ## MCP HTTP server

--- a/plugins/e2a/docs/llms.txt
+++ b/plugins/e2a/docs/llms.txt
@@ -8,6 +8,7 @@
 ## Start here
 
 - [setup.md](https://e2a.dev/setup.md): What e2a is, how an agent connects (one MCP command), and what it can do. Read this first.
+- [llms-full.txt](https://e2a.dev/llms-full.txt): Every document below, inlined into one file. Fetch this instead if you would rather read the whole corpus in a single request.
 
 ## Connecting & auth
 
@@ -22,6 +23,7 @@
 ## MCP & plugin
 
 - [Agent plugin + skills](https://github.com/tokencanopy/e2a/tree/main/plugins/e2a): The `e2a` plugin bundles the hosted MCP server config and agent guidance for Claude Code, Codex, and Cursor.
+- [MCP overview](https://e2a.dev/mcp): Per-client connection instructions (Claude Code, Codex, Cursor/Windsurf/Claude Desktop, VS Code + Copilot), what the agent can do once connected, and how an agent-owned inbox differs from a mailbox integration.
 - MCP endpoint: `https://api.e2a.dev/mcp` (Streamable HTTP, OAuth 2.1). Add with `claude mcp add --transport http --scope user e2a https://api.e2a.dev/mcp`, then run `/mcp` to authorize (`--scope user` installs it globally; drop it for current-directory only). Per-client config (Cursor, VS Code, Codex, …) is in [setup.md](https://e2a.dev/setup.md).
 
 ## Source

--- a/scripts/sync-agent-docs.mjs
+++ b/scripts/sync-agent-docs.mjs
@@ -12,6 +12,43 @@ export const AGENT_DOC_MIRRORS = [
   ["plugins/e2a/docs/llms.txt", "web/public/llms.txt"],
 ];
 
+// llms.txt is an index: it tells a model which documents exist and where to
+// fetch them. That costs a retrieval round trip the model may not take, and
+// some crawlers never follow the links at all. llms-full.txt is the whole
+// corpus inlined so a single fetch is enough to answer from.
+//
+// Derived, not mirrored — it has no canonical source file of its own, so it is
+// built here and committed like the mirrors, which keeps `--check` honest.
+export const LLMS_FULL_TARGET = "web/public/llms-full.txt";
+
+export const LLMS_FULL_SOURCES = [
+  ["plugins/e2a/docs/setup.md", "https://e2a.dev/setup.md"],
+  ["plugins/e2a/docs/auth.md", "https://e2a.dev/auth.md"],
+  ["plugins/e2a/docs/sdk.md", "https://e2a.dev/sdk.md"],
+  ["plugins/e2a/docs/templates.md", "https://e2a.dev/templates.md"],
+];
+
+const LLMS_FULL_HEADER = `# e2a — full documentation
+
+> e2a is an authenticated email gateway for AI agents: it gives an agent its
+> own verified email inbox to send, receive, reply, and forward, with SPF/DKIM
+> verification on inbound. Connect over a hosted MCP server (OAuth 2.1, no API
+> key), the REST API, or the TypeScript/Python SDKs.
+
+This file inlines the full e2a documentation set so it can be read in one
+fetch. The per-document originals are linked above each section, and the
+complete API contract is at https://e2a.dev/v1/openapi.yaml. Source:
+https://github.com/tokencanopy/e2a (Apache-2.0).
+`;
+
+/** Builds the llms-full.txt body from the canonical docs. */
+export function composeLlmsFull(documents) {
+  const sections = documents.map(
+    ({ url, body }) => `<!-- source: ${url} -->\n\n${body.trim()}\n`,
+  );
+  return `${LLMS_FULL_HEADER}\n---\n\n${sections.join("\n---\n\n")}`;
+}
+
 const usage = "usage: node scripts/sync-agent-docs.mjs [--check]";
 
 export function parseArgs(args) {
@@ -21,41 +58,74 @@ export function parseArgs(args) {
   throw new Error(usage);
 }
 
+async function readCanonical(repoRoot, source) {
+  try {
+    return await readFile(join(repoRoot, source));
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      throw new Error(`missing canonical agent doc: ${source}`);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Writes `expected` to `target`, or records a mismatch when checking.
+ * Returns a mismatch string, or null when the target is already correct.
+ */
+async function reconcile({ repoRoot, target, expected, check, describe, log }) {
+  let existing;
+  try {
+    existing = await readFile(join(repoRoot, target));
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+
+  if (existing?.equals(expected)) return null;
+
+  if (check) {
+    return `${existing === undefined ? "missing" : "stale"} ${describe}: ${target}`;
+  }
+
+  const targetPath = join(repoRoot, target);
+  await mkdir(dirname(targetPath), { recursive: true });
+  await writeFile(targetPath, expected);
+  log(`wrote ${target}`);
+  return null;
+}
+
 export async function syncAgentDocs({ repoRoot, check, log = console.log }) {
   const mismatches = [];
 
   for (const [source, target] of AGENT_DOC_MIRRORS) {
-    let canonical;
-    try {
-      canonical = await readFile(join(repoRoot, source));
-    } catch (error) {
-      if (error?.code === "ENOENT") {
-        throw new Error(`missing canonical agent doc: ${source}`);
-      }
-      throw error;
-    }
-
-    let hosted;
-    try {
-      hosted = await readFile(join(repoRoot, target));
-    } catch (error) {
-      if (error?.code !== "ENOENT") throw error;
-    }
-
-    if (hosted?.equals(canonical)) continue;
-
-    if (check) {
-      mismatches.push(
-        `${hosted === undefined ? "missing" : "stale"} hosted agent doc: ${target}`,
-      );
-      continue;
-    }
-
-    const targetPath = join(repoRoot, target);
-    await mkdir(dirname(targetPath), { recursive: true });
-    await writeFile(targetPath, canonical);
-    log(`synced ${source} -> ${target}`);
+    const canonical = await readCanonical(repoRoot, source);
+    const mismatch = await reconcile({
+      repoRoot,
+      target,
+      expected: canonical,
+      check,
+      describe: "hosted agent doc",
+      log: () => log(`synced ${source} -> ${target}`),
+    });
+    if (mismatch) mismatches.push(mismatch);
   }
+
+  const documents = [];
+  for (const [source, url] of LLMS_FULL_SOURCES) {
+    documents.push({
+      url,
+      body: (await readCanonical(repoRoot, source)).toString("utf8"),
+    });
+  }
+  const llmsFull = await reconcile({
+    repoRoot,
+    target: LLMS_FULL_TARGET,
+    expected: Buffer.from(composeLlmsFull(documents), "utf8"),
+    check,
+    describe: "generated corpus",
+    log,
+  });
+  if (llmsFull) mismatches.push(llmsFull);
 
   if (mismatches.length > 0) {
     throw new Error(mismatches.join("\n"));

--- a/scripts/sync-agent-docs.test.mjs
+++ b/scripts/sync-agent-docs.test.mjs
@@ -6,6 +6,8 @@ import { afterEach, test } from "node:test";
 
 import {
   AGENT_DOC_MIRRORS,
+  LLMS_FULL_SOURCES,
+  LLMS_FULL_TARGET,
   parseArgs,
   syncAgentDocs,
 } from "./sync-agent-docs.mjs";
@@ -85,6 +87,34 @@ test("sync fails clearly when a canonical source is missing", async () => {
     syncAgentDocs({ repoRoot, check: false, log: () => {} }),
     /missing canonical agent doc: plugins\/e2a\/docs\/setup\.md/,
   );
+});
+
+test("sync inlines every corpus source into llms-full.txt", async () => {
+  const repoRoot = await fixture();
+
+  await syncAgentDocs({ repoRoot, check: false, log: () => {} });
+
+  const full = await readFile(join(repoRoot, LLMS_FULL_TARGET), "utf8");
+  for (const [source, url] of LLMS_FULL_SOURCES) {
+    const body = await readFile(join(repoRoot, source), "utf8");
+    assert.ok(full.includes(`<!-- source: ${url} -->`), `missing marker for ${url}`);
+    assert.ok(full.includes(body.trim()), `missing body of ${source}`);
+  }
+  await assert.doesNotReject(
+    syncAgentDocs({ repoRoot, check: true, log: () => {} }),
+  );
+});
+
+test("check reports a stale llms-full.txt without rewriting it", async () => {
+  const repoRoot = await fixture();
+  await syncAgentDocs({ repoRoot, check: false, log: () => {} });
+  await writeFile(join(repoRoot, LLMS_FULL_TARGET), "stale\n");
+
+  await assert.rejects(
+    syncAgentDocs({ repoRoot, check: true, log: () => {} }),
+    /stale generated corpus: web\/public\/llms-full\.txt/,
+  );
+  assert.equal(await readFile(join(repoRoot, LLMS_FULL_TARGET), "utf8"), "stale\n");
 });
 
 test("parseArgs accepts check mode and rejects unknown options", () => {

--- a/web/.env.example
+++ b/web/.env.example
@@ -23,6 +23,12 @@ NEXT_PUBLIC_FEEDBACK_EMAIL=
 # <head> when set, so forks don't accidentally inherit upstream's property.
 NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=
 
+# Optional. Site-relative path of the pricing page, when the deployment has
+# one. Pricing isn't part of this app — the hosted deployment serves it from
+# a separate route and sets this to /pricing so the sitemap can advertise it.
+# Leave empty if there's no pricing page; a sitemap entry that 404s hurts.
+NEXT_PUBLIC_PRICING_PATH=
+
 # Optional. Sign-in door the dashboard's "Sign in" links point at. Defaults
 # to /api/auth/login (legacy Google OAuth), which every deployment has.
 # Set to /api/auth/oidc/login to make the generic OIDC door the default —

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -49,6 +49,10 @@ ARG NEXT_PUBLIC_SITE_NAME=
 ARG NEXT_PUBLIC_AGENTS_DOMAIN=
 ARG NEXT_PUBLIC_FEEDBACK_EMAIL=
 ARG NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=
+# Empty means this deployment has no pricing page, so the sitemap omits it.
+# The hosted deployment serves /pricing from the ops repo through Caddy and
+# sets this to /pricing; staging and self-hosts leave it unset.
+ARG NEXT_PUBLIC_PRICING_PATH=
 # Empty disables the dashboard's Upgrade / Manage Billing affordances —
 # self-host deployments without a paid tier leave this unset. The
 # hosted deployment sets it to the dashboard's own origin (e.g.
@@ -67,6 +71,7 @@ ENV NEXT_PUBLIC_SITE_URL=$NEXT_PUBLIC_SITE_URL \
     NEXT_PUBLIC_AGENTS_DOMAIN=$NEXT_PUBLIC_AGENTS_DOMAIN \
     NEXT_PUBLIC_FEEDBACK_EMAIL=$NEXT_PUBLIC_FEEDBACK_EMAIL \
     NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=$NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION \
+    NEXT_PUBLIC_PRICING_PATH=$NEXT_PUBLIC_PRICING_PATH \
     NEXT_PUBLIC_BILLING_API=$NEXT_PUBLIC_BILLING_API \
     NEXT_PUBLIC_E2A_SIGN_IN_URL=$NEXT_PUBLIC_E2A_SIGN_IN_URL
 

--- a/web/public/llms-full.txt
+++ b/web/public/llms-full.txt
@@ -1,0 +1,725 @@
+# e2a — full documentation
+
+> e2a is an authenticated email gateway for AI agents: it gives an agent its
+> own verified email inbox to send, receive, reply, and forward, with SPF/DKIM
+> verification on inbound. Connect over a hosted MCP server (OAuth 2.1, no API
+> key), the REST API, or the TypeScript/Python SDKs.
+
+This file inlines the full e2a documentation set so it can be read in one
+fetch. The per-document originals are linked above each section, and the
+complete API contract is at https://e2a.dev/v1/openapi.yaml. Source:
+https://github.com/tokencanopy/e2a (Apache-2.0).
+
+---
+
+<!-- source: https://e2a.dev/setup.md -->
+
+# Set up e2a
+
+e2a gives an AI agent its own real email inbox: a verified address it can send
+from, receive to, and use for multi-turn conversations. The inbox belongs to
+the agent—not to a human whose mailbox the agent reads.
+
+This guide connects e2a, selects or creates an inbox, and verifies that it is
+ready. Most setups use the shared `agents.e2a.dev` domain and require no DNS
+configuration.
+
+> **Two hosts.** Documentation (`setup.md`, `auth.md`, `sdk.md`,
+> `openapi.yaml`, and `llms.txt`) lives on `e2a.dev`. The REST API and MCP
+> server live on `api.e2a.dev`. Use `https://api.e2a.dev/mcp` for MCP and
+> `https://api.e2a.dev/v1/...` for REST.
+
+## 1. Connect your client
+
+The hosted MCP endpoint is `https://api.e2a.dev/mcp`. Interactive clients use
+OAuth in the browser, so you do not need to paste an API key.
+
+### Claude Code
+
+```sh
+claude mcp add --transport http --scope user e2a https://api.e2a.dev/mcp
+```
+
+Run `/mcp` in Claude Code and authorize e2a in the browser. `--scope user`
+makes e2a available in every project; omit it to configure only the current
+project.
+
+### OpenAI Codex
+
+Add the server:
+
+```sh
+codex mcp add e2a --url https://api.e2a.dev/mcp
+```
+
+Then authorize it:
+
+```sh
+codex mcp login e2a
+```
+
+### Cursor / Windsurf / Claude Desktop
+
+Add the endpoint to the client's MCP configuration:
+
+```json
+{
+  "mcpServers": {
+    "e2a": { "url": "https://api.e2a.dev/mcp" }
+  }
+}
+```
+
+Complete the OAuth prompt when the client opens it.
+
+### VS Code with GitHub Copilot
+
+Add `.vscode/mcp.json` with the `servers` key:
+
+```json
+{
+  "servers": {
+    "e2a": {
+      "type": "http",
+      "url": "https://api.e2a.dev/mcp"
+    }
+  }
+}
+```
+
+For Goose, Zed, and other MCP clients, use the same Streamable HTTP endpoint.
+Ready-to-paste configurations are available in the
+[client examples](https://github.com/tokencanopy/e2a/tree/main/plugins/e2a/clients).
+
+### Headless Codex or CI
+
+When a browser-based OAuth flow is unavailable, read an account API key from
+the environment:
+
+```sh
+codex mcp add e2a \
+  --url https://api.e2a.dev/mcp \
+  --bearer-token-env-var E2A_API_KEY
+```
+
+For autonomous OAuth registration, follow the OAuth 2.1 Dynamic Client
+Registration flow in [auth.md](https://e2a.dev/auth.md).
+
+### REST or SDK
+
+If your client does not use MCP, follow [sdk.md](https://e2a.dev/sdk.md) for
+TypeScript, Python, and raw REST examples. The complete API contract is
+[openapi.yaml](https://e2a.dev/v1/openapi.yaml).
+
+## 2. Verify the connection
+
+After authorization, inspect the client's available e2a tools and call the e2a
+`whoami` tool. Clients may display it as `mcp__e2a__whoami`. Do not run the
+shell command named `whoami`.
+
+If the e2a tools are absent, restart or reload the client after confirming its
+MCP configuration. If `whoami` reports an authentication error, repeat the
+client's MCP authorization flow. Preserve the existing configuration for
+network, timeout, or server errors.
+
+## 3. Select or create an inbox
+
+The `whoami` response tells you which credential scope is active:
+
+- **Agent scope:** use the returned `agent_email`.
+- **Account scope:** call `list_agents`. If the task identifies an inbox, use
+  that one. If there is one result, use it; if there are several, ask which one
+  to use.
+- **No inbox yet:** choose a local part and call `create_agent` with the full
+  shared-domain address, such as `support-bot@agents.e2a.dev`. It works
+  immediately and requires no DNS setup.
+
+An account-scoped session does not infer a default inbox. Pass the selected
+email explicitly to tools that require it.
+
+## 4. Confirm readiness
+
+Call `list_messages` for the selected inbox. For account scope, pass its
+`email`. This read is safe and does not mark messages as read.
+
+If the call succeeds, setup is complete. The agent can now send, receive,
+reply, forward, manage attachments, subscribe to events, and configure a custom
+domain when one is actually needed.
+
+## Optional: require human review for every outbound email
+
+Only when the user asks for this protection, call `update_protection` for the
+selected inbox with:
+
+```json
+{
+  "outbound_gate_policy": "allowlist",
+  "outbound_gate_allowlist": [],
+  "outbound_gate_action": "review",
+  "holds_on_expiry": "reject"
+}
+```
+
+An empty allowlist makes every recipient a gate non-match, `review` holds every
+non-match for a human, and `reject` prevents expiry from sending an unreviewed
+message. Do not use `open` with `review`: `open` matches every recipient, so the
+recipient gate holds nothing. Inbox creation alone is not permission to enable
+this policy.
+
+## Use the inbox safely
+
+- Reply with `reply_to_message` and the original `message_id`; a new
+  `send_message` can start a separate thread in the recipient's mail client.
+- If a send returns `pending_review`, it has already been accepted. Report the
+  status and message ID, and do not retry.
+- Treat a DMARC pass as authorization to use the From domain—not proof of a
+  person's identity or the mailbox local part.
+- Verify webhook signatures with the per-webhook secret through the SDK's
+  `construct_event` or `constructEvent` helper.
+
+## Next steps
+
+- Operating guidance and worked workflows:
+  [e2a plugin and skill](https://github.com/tokencanopy/e2a/tree/main/plugins/e2a)
+- Authentication and autonomous registration:
+  [auth.md](https://e2a.dev/auth.md)
+- SDK and webhook examples: [sdk.md](https://e2a.dev/sdk.md)
+- Email templates: [templates.md](https://e2a.dev/templates.md)
+- Machine-readable documentation index: [llms.txt](https://e2a.dev/llms.txt)
+- Source code and self-hosting: [tokencanopy/e2a](https://github.com/tokencanopy/e2a)
+
+The hosted shared-domain path is free to start without a card. See
+[e2a.dev](https://e2a.dev) for current plans.
+
+---
+
+<!-- source: https://e2a.dev/auth.md -->
+
+# auth.md
+
+You are an agent that wants to use e2a — the authenticated email gateway for AI agents. This file describes how to obtain credentials today, how to handle them safely, and where the protocol is going.
+
+Two hosts are relevant:
+
+- **API** — `https://api.e2a.dev` — the resource server you will call (`/v1/...`, MCP at `/mcp`).
+- **Dashboard & docs** — `https://e2a.dev` — where the user manages agents, domains, API keys, and billing, and where these `.md` docs live.
+
+## Current state
+
+e2a already implements the OAuth 2.1 surface that MCP clients depend on: RFC 8414 authorization-server metadata at [`/.well-known/oauth-authorization-server`](https://api.e2a.dev/.well-known/oauth-authorization-server), RFC 7591 Dynamic Client Registration at `/oauth2/register` (rate-limited per IP), `authorization_code` + `refresh_token` grants with PKCE S256, RFC 7009 revocation, and RFC 6750 Bearer challenges on 401s. MCP clients can register and onboard without any human-supplied secret — the user only sees a browser consent screen.
+
+e2a also implements the first pieces of the WorkOS [auth.md](https://github.com/workos/auth.md) autonomous-agent flow: a JSON Web Key Set at `/.well-known/jwks.json`, an `agent_auth` block in the AS metadata, and a bootstrap endpoint (`POST /agent/identity`) that exchanges an agent-scoped API key for a long-lived identity assertion, redeemable at `/oauth2/token` via `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer` for a short-lived access token. Still missing: an RFC 9728 protected-resource metadata document, ID-JAG assertion intake from third parties, and the email-OTP claim ceremony. See [Agent identity](#agent-identity) for where we're heading — because every e2a agent has an end-to-end-verified email address, e2a is positioned to act as an identity provider in this protocol, and that's the direction we're building.
+
+## Use the existing tooling first
+
+Before you do anything credential-shaped, check whether the user has already wired e2a into your environment. Most of the time they have, and you should not be handling credentials (API keys or OAuth tokens) yourself.
+
+1. **e2a MCP server** — if you are an MCP client (Claude, Cursor, Codex, ChatGPT, etc.), e2a's MCP server is hosted: point your MCP client at the Streamable HTTP endpoint `https://api.e2a.dev/mcp` (OAuth 2.1 — no key pasted) to get inbox, send, reply, agents, and domains as tools. Repository: `https://github.com/tokencanopy/e2a/tree/main/mcp`.
+2. **e2a agent skill** — a guidance document covering inbox patterns, idempotency, attachment handling, and webhook verification. Load it before calling the API directly so you don't relearn the gotchas on the user's dime.
+3. **e2a CLI** — if you are running shell commands, prefer `e2a` over hand-rolled `curl`. It handles auth resolution, retries, and non-interactive flags. Install: `npm i -g @e2a/cli`. Repository: `https://github.com/tokencanopy/e2a/tree/main/cli`.
+
+If any of these is already configured, use it and stop. Do not ask the user for an API key you do not need.
+
+## Credentials
+
+Authenticated `/v1/...` endpoints accept two credential shapes, dispatched by token prefix:
+
+- **OAuth access token** (`ate2a_…`, refresh `rte2a_…`) — issued by the e2a OAuth server to a registered client after the user consents in a browser. Use this if you are an MCP client.
+- **API key** (`e2a_acct_…` for account scope, `e2a_agt_…` for a single-agent scope) — issued through the dashboard, CLI, or account API and supplied to your environment out of band. Use this if you are a CLI, script, server-side integration, or direct API consumer.
+
+Both are presented as `Authorization: Bearer <credential>`.
+
+### Path A — MCP client via OAuth DCR
+
+If you are an MCP client, you do not need an API key. Run the standard discovery + DCR + authorization-code flow:
+
+1. **Discover** — `GET https://api.e2a.dev/.well-known/oauth-authorization-server`. Read `registration_endpoint`, `authorization_endpoint`, `token_endpoint`, and `scopes_supported` (`agent` and `account`).
+2. **Register** — `POST` your client metadata to `registration_endpoint` (RFC 7591), including `scope: "agent"` for agent-only access or `scope: "agent account"` to make workspace-admin consent eligible. Account scope is eligible only when every registered redirect URI is HTTPS or an HTTP loopback URI. Omitting `scope` registers the full ceiling the redirect URIs allow. You'll receive a `client_id`; token endpoint auth method is `none` because you are a public client.
+3. **Authorize** — redirect the user to `authorization_endpoint` with `response_type=code`, your `client_id`, `redirect_uri`, a space-delimited scope matching the registered access (`scope=agent` or `scope=agent account`, query-encoded), and PKCE S256 (`code_challenge`, `code_challenge_method=S256`). The user logs in and chooses the exact grant.
+4. **Token exchange** — `POST` `code` + `code_verifier` to `token_endpoint`. You receive `access_token` (prefix `ate2a_…`) and `refresh_token`.
+5. **Use** — present the access token as a bearer; refresh with the refresh token before `expires_in`.
+
+Access tokens carry the user identity that consented to your client; every `/v1/...` call is scoped to that user.
+
+### Path B — Direct API consumer via API key
+
+The user issues an API key from the e2a dashboard and supplies it to you through a secure channel — never by pasting it into chat.
+
+#### How to pick the key up
+
+Look for it in this order. Stop at the first one that exists:
+
+1. `E2A_API_KEY` in your process environment.
+2. A project `.env` file the user has told you to read.
+3. The user's CLI config at `~/.e2a/config.json` (populated via `e2a login`; used automatically when you invoke the `e2a` CLI).
+
+If you're invoking the e2a MCP server, you don't pick the key up at all — the server reads `E2A_API_KEY` from its own environment (set in the MCP client's `env` block) and you call tools through it.
+
+If none of the above is set and you genuinely need a key, **do not ask the user to paste it into the conversation**. Instead, tell them to:
+
+- Create one in the e2a dashboard.
+- Put it in `E2A_API_KEY` in their shell, `.env`, MCP client config, or run `e2a login` to populate `~/.e2a/config.json` — whichever matches how they invoke you.
+- Resume the task once it is set.
+
+This keeps the key out of your transcript, out of any logs the user shares, and out of the model provider's training data.
+
+API keys may have an optional hard expiry chosen at creation; a key created
+without `expires_at` does not expire automatically. Treat a `401` on a
+previously-working key as expiry or revocation: drop it from memory and ask the
+user to refresh whichever source you read it from.
+
+### How to use the credential
+
+Whether `access_token` or `api_key`, present it as a bearer token. The message surface is agent-scoped — the sending agent is in the path (URL-encode the `@`), so there is no `from` field in the body. Example send:
+
+```http
+POST /v1/agents/bot%40agents.e2a.dev/messages HTTP/1.1
+Host: api.e2a.dev
+Authorization: Bearer $CREDENTIAL
+Content-Type: application/json
+Idempotency-Key: <UUIDv4>
+
+{
+  "to": ["alice@example.com"],
+  "subject": "Hello from your agent",
+  "text": "Plain-text body. Required.",
+  "html": "<p>Optional HTML alternative.</p>"
+}
+```
+
+For a literal send, `subject` and the plain-text `text` body are required; the
+HTML alternative is optional. A template send uses `template_id` or
+`template_alias` instead and must omit literal `subject`, `text`, and `html`.
+
+Read the credential from the environment at the moment of the call. Do not copy it into variables you log, do not echo it back to the user, do not include it in commit messages, PR descriptions, error reports, or screenshots. If you are running a shell command, never interpolate the credential inline — reference the environment variable so it does not appear in command history.
+
+Set an `Idempotency-Key` (UUIDv4 recommended) per logical operation on side-effectful calls such as sends and replies. Reuse the **same** key on transport retries (network failures, timeouts) — the server replays the original response. Same key with a different body returns `422`; a genuinely new operation needs a fresh key.
+
+### Handling `pending_review`
+
+If a send, reply, or forward returns **`202 Accepted`** with
+`status: "pending_review"`, the server accepted the message but did not dispatch
+it:
+
+```json
+{
+  "message_id": "msg_abc123",
+  "status": "pending_review",
+  "approval_expires_at": "2026-05-28T13:00:00Z"
+}
+```
+
+Do not retry the send — another call can queue a duplicate. Surface the status,
+`message_id`, and `approval_expires_at` to the calling user, then stop.
+
+### Errors
+
+| Status | Where | Meaning | What to do |
+| --- | --- | --- | --- |
+| `400` | send, reply | Missing `subject` or `text`; malformed recipient; CRLF in subject. | Fix the payload before retrying. |
+| `401` first use | any | Credential missing, malformed, revoked, or for a different environment. | Ask the user to confirm the value in their `E2A_API_KEY` / config is current and active in the dashboard. MCP clients should restart at discovery. |
+| `401` on previously-working credential | any | Revoked or rotated. | Drop the cached value. API-key consumers re-read from the same source you loaded it from. MCP clients refresh, then re-run the authorization-code flow if refresh fails. |
+| `403` | send, reply | Agent's sending domain is not verified. | Ask the user to register and verify the domain in the dashboard (`POST /v1/domains` then `POST /v1/domains/{domain}/verify`). |
+| `409` | send, reply, approve | An in-flight request with this `Idempotency-Key` is still being processed, or the message is no longer in the expected state. | Wait and re-poll `GET /v1/agents/{address}/messages/{id}`. |
+| `422` | send, reply | `Idempotency-Key` reused with a different body. | Mint a fresh key for the new payload. |
+| `429` | any | Rate limited (60 sends/agent/minute; 200 agent registrations/IP/hour on `/v1/agents`). | Back off; honor `Retry-After` (delay-seconds form). |
+
+The `WWW-Authenticate` header on 401 responses tells you whether the failing credential was an OAuth token (carries RFC 6750 §3.1 `error="invalid_token"` params) or an API key (bare `Bearer realm="e2a"`). MCP clients should branch on this.
+
+## Agent identity
+
+This section describes e2a's bet on where agent auth is heading. The bootstrap identity endpoint below is shipped (behind an opt-in signing-key config); third-party ID-JAG consumption and the email-loop claim ceremony are still direction, not shipped surface. If you are implementing today, use the credential paths above for anything beyond the identity bootstrap.
+
+Every e2a agent has a stable, verified email address. The owner proved control of the domain (via DNS records and a verification token), and e2a evaluates SPF, DKIM, and DMARC on every inbound message routed to that agent. Equivalently for agents on the shared `agents.e2a.dev` domain, e2a is the authoritative issuer. **The agent's email is not a label — it's an identity claim e2a stands behind.**
+
+We are building two pieces on top of this:
+
+### e2a as an identity provider
+
+e2a already operates as an OAuth issuer at `https://api.e2a.dev` (see AS metadata above), publishes a JSON Web Key Set at `https://api.e2a.dev/.well-known/jwks.json`, and lets an agent bootstrap a long-lived identity assertion from its API key via `POST /agent/identity`, redeemable for a short-lived access token at `/oauth2/token`. The remaining work is issuing audience-bound [ID-JAG](https://datatracker.ietf.org/doc/draft-ietf-oauth-identity-assertion-authz-grant/) assertions (`urn:ietf:params:oauth:token-type:id-jag`) that a *third-party* service can verify, with:
+
+- `iss` = `https://api.e2a.dev`
+- `sub` = the agent's verified email
+- `email` / `email_verified: true`
+- `aud` = the third-party service the agent is registering with
+- Short `exp` (≤5 minutes), fresh `jti`
+
+Any auth.md-implementing service that adds e2a to its trust list will be able to onboard an e2a agent without an OTP ceremony — the agent's e2a identity vouches for it. e2a's contribution is an identity rooted in a verifiable email address, stable across agent runtimes.
+
+If you operate an agent service and want to accept e2a-issued assertions, watch for `iss: https://api.e2a.dev` to land in the WorkOS reference trust list, or open an issue at `https://github.com/tokencanopy/e2a/issues` to pre-register.
+
+### Email-loop claim completion (proposed)
+
+The WorkOS auth.md OTP ceremony assumes a human reads a 6-digit code back to the agent. For agents that have an e2a inbox, we are prototyping an inbox-driven completion:
+
+1. The third-party service sends a single-click approval mail to the user.
+2. The user clicks "confirm".
+3. The service emails a confirmation to the agent's e2a inbox.
+4. The agent receives the confirmation via WebSocket or webhook and posts to `/agent/auth/claim/complete`.
+
+No code reading, no copy-paste, no transcript leakage. This is uniquely possible for e2a because the agent's mailbox is part of the product. We will publish a flow extension when the prototype is stable; if you are building an auth.md service and want to support this from day one, open an issue at `https://github.com/tokencanopy/e2a/issues`.
+
+## Discovery
+
+What e2a publishes today:
+
+- **RFC 8414 authorization-server metadata** at [`https://api.e2a.dev/.well-known/oauth-authorization-server`](https://api.e2a.dev/.well-known/oauth-authorization-server) — advertises `authorization_endpoint`, `token_endpoint`, `registration_endpoint`, `revocation_endpoint`, supported grants (`authorization_code`, `refresh_token`), PKCE (`S256`), and the RFC 9207 `iss` parameter. Request the `agent` scope (`account` for workspace-admin access).
+- **RFC 6750 Bearer challenges** on every 401 from `/v1/...` — `WWW-Authenticate: Bearer realm="e2a"` for unknown/missing credentials, plus RFC 6750 §3.1 error params for OAuth-bearer failures.
+
+What e2a publishes for the autonomous-agent path today (gated behind an opt-in signing-key config; see [Agent identity](#agent-identity)):
+
+- An `agent_auth` block in the AS metadata (`identity_endpoint`, `jwks_uri`, and related fields).
+- A JSON Web Key Set at `/.well-known/jwks.json`.
+- A bootstrap endpoint, `POST /agent/identity`, that mints an identity assertion from an agent-scoped API key — e2a's adaptation of the flow (the bootstrap credential is a domain-verified agent-scoped key, not an ownerless self-registration).
+
+What's missing for full auth.md compliance:
+
+- An RFC 9728 protected-resource metadata document at `/.well-known/oauth-protected-resource`, and `resource_metadata="..."` parameter on the WWW-Authenticate challenge so agents can auto-discover it.
+- ID-JAG assertion intake so third-party services can register e2a-issued assertions (the `anonymous` and `identity_assertion + id-jag` flows from the spec).
+- The email-OTP claim ceremony (see [Email-loop claim completion](#email-loop-claim-completion-proposed)).
+
+When these land, this document will be updated and the AS metadata will carry the canonical machine-readable description.
+
+## Revocation
+
+The user revokes API keys in the e2a dashboard. OAuth access tokens are revoked via `POST /oauth2/revoke` (RFC 7009) or by the user disconnecting the client in the dashboard. Either way, you will discover revocation as a `401` on a previously-working credential — drop it and re-acquire from the same source you loaded it from. Once e2a issues ID-JAGs, providers will be able to POST logout tokens to a `revocation_uri` advertised in AS metadata; that is not in scope for the current credential paths.
+
+## References
+
+- WorkOS [auth.md protocol](https://workos.com/auth-md) — the open spec this document follows
+- [github.com/workos/auth.md](https://github.com/workos/auth.md) — reference implementation
+- e2a [OpenAPI contract](https://e2a.dev/v1/openapi.yaml) — full reference for the endpoints above
+
+---
+
+<!-- source: https://e2a.dev/sdk.md -->
+
+# sdk.md
+
+Typed clients for the e2a REST API + webhook verification, for when you're
+driving e2a from your own code (a webhook handler, a worker) rather than over
+MCP. Two SDKs, same surface.
+
+- **TypeScript** — `@e2a/sdk` (npm) · [README](https://github.com/tokencanopy/e2a/blob/main/sdks/typescript/README.md)
+- **Python** — `e2a` (PyPI) · [README](https://github.com/tokencanopy/e2a/blob/main/sdks/python/README.md)
+
+Prefer a typed client; if you're calling the REST API raw, see
+[Raw REST](#raw-rest-without-an-sdk) below. The exhaustive contract is
+https://e2a.dev/v1/openapi.yaml, and the auth model (API key vs OAuth) is in
+https://e2a.dev/auth.md.
+
+## Install
+
+```bash
+npm install @e2a/sdk        # TypeScript / Node
+pip install e2a             # Python (async)
+```
+
+## Quick start
+
+### TypeScript
+
+```ts
+import { E2AClient } from "@e2a/sdk";
+
+const client = new E2AClient({ apiKey: process.env.E2A_API_KEY });
+const messageId = "msg_..."; // an inbound message id from a webhook, WebSocket, or list call
+
+// Send; if status is pending_review, report it and do not retry.
+const result = await client.messages.send("bot@agents.e2a.dev", {
+  to: ["person@example.com"],
+  subject: "Hello from my agent",
+  text: "This was sent by an AI agent via e2a.",
+});
+
+// Reply in-thread to an inbound message
+await client.messages.reply("bot@agents.e2a.dev", messageId, {
+  text: "Thanks — handled.",
+});
+```
+
+### Python
+
+```python
+import os
+from e2a.v1 import AsyncE2AClient
+
+async with AsyncE2AClient(api_key=os.environ["E2A_API_KEY"]) as client:
+    message_id = "msg_..."  # an inbound message id from a webhook, WebSocket, or list call
+    await client.messages.send("bot@agents.e2a.dev", {
+        "to": ["person@example.com"],
+        "subject": "Hello from my agent",
+        "text": "This was sent by an AI agent via e2a.",
+    })
+
+    await client.messages.reply("bot@agents.e2a.dev", message_id, {
+        "text": "Thanks — handled.",
+    })
+```
+
+## Receiving mail (webhook → facade → reply)
+
+The webhook delivery is a metadata trigger; the inbound facade validates its
+fetch keys, hydrates the parsed message, and binds reply/forward/attachments.
+Always **verify the signature** first — `construct_event` parses + checks the
+HMAC and throws on a bad/forged/replayed delivery.
+
+### TypeScript
+
+```ts
+import { constructEvent, E2AClient, isEmailReceived } from "@e2a/sdk";
+
+// in your HTTP handler, with the RAW request body:
+const event = constructEvent(rawBody, req.headers["x-e2a-signature"], WEBHOOK_SECRET);
+if (isEmailReceived(event)) {
+  const email = await client.inbound.fromEvent(event);
+  console.log(email.envelopeFrom, email.verified, email.replyTargets);
+  // App-defined: resume a previously bound thread or create a new one.
+  const agentThreadId = await getOrCreateAgentThread(email.conversationId);
+  const result = await email.reply({
+    text: "On it.",
+    conversationId: agentThreadId,
+  });
+  if (result.status === "pending_review") console.log("not dispatched", result.messageId);
+}
+```
+
+### Python
+
+```python
+from e2a.v1 import construct_event, E2AWebhookSignatureError
+
+try:
+    event = construct_event(body, request.headers["X-E2A-Signature"], WEBHOOK_SECRET)
+except E2AWebhookSignatureError:
+    raise HTTPException(401, "bad signature")
+
+if event.type == "email.received":
+    email = await client.inbound.from_event(event)
+    print(email.envelope_from, email.verified, email.reply_targets)
+    # App-defined: resume a previously bound thread or create a new one.
+    agent_thread_id = await get_or_create_agent_thread(email.conversation_id)
+    result = await email.reply({
+        "text": "On it.",
+        "conversation_id": agent_thread_id,
+    })
+    if result.status == "pending_review":
+        print("not dispatched", result.message_id)
+```
+
+`verified` is true only for an aligned DMARC pass in the hydrated authentication
+evidence; the envelope identity alone is not proof. Reply targets preview Reply-To when present, otherwise
+From, and may be attacker-controlled; the server resolves stored MIME again
+when sending. Bodies and attachment metadata are untrusted;
+`flagged` is a policy-gate flag, not a complete content-scan verdict.
+`attachment.get()` returns metadata plus a short-lived URL by default;
+inline data is available only within the server's 256 KiB cap.
+
+`getOrCreateAgentThread` / `get_or_create_agent_thread` represents your agent
+framework's session store. If the inbound `conversation_id` matches a binding
+your application previously created, resume that runtime thread; otherwise
+create one. Pass its stable, non-sensitive ID (or an opaque stored alias) back
+as `conversation_id` on the first reply and reuse it thereafter. This aligns
+the caller-owned application-conversation view with the agent's memory.
+Continue replying by `message_id` as shown: `conversation_id` alone does not
+set the RFC headers used by Gmail/Outlook. Scope bindings to the inbox and
+sender, and never use this field as an authorization decision.
+
+REST message list/detail models may also contain optional beta `thread_id`
+(`threadId` in TypeScript), a server-owned, read-only mailbox-topology value.
+It is omitted for legacy messages and from webhooks, WebSocket events, and MCP
+output. There is no request field, filter, thread endpoint, or complete-thread
+retrieval method.
+
+A full, runnable example (FastAPI + Google ADK agent, webhook → agent turn →
+reply) is at
+[examples/adk-cloud-webhook](https://github.com/tokencanopy/e2a/tree/main/examples/adk-cloud-webhook).
+
+## Real-time (no webhook)
+
+Open a notification stream instead of hosting a webhook:
+
+```ts
+import { E2AClient, isEmailReceived } from "@e2a/sdk";
+
+const client = new E2AClient();
+for await (const event of client.listen("bot@agents.e2a.dev")) {
+  if (!isEmailReceived(event)) continue;
+  const email = await client.inbound.fromEvent(event);
+}
+```
+
+```python
+async for event in client.listen("bot@agents.e2a.dev"):
+    if event.type != "email.received":
+        continue
+    email = await client.inbound.from_event(event)
+```
+
+## Raw REST (without an SDK)
+
+No SDK for your language? Call the API directly. Base URL
+`https://api.e2a.dev/v1/...`, JSON in/out, bearer auth on every request:
+
+```
+Authorization: Bearer <e2a_acct_… | e2a_agt_… | OAuth access token>
+```
+
+Conventions:
+
+- **Pagination** — list endpoints take `?cursor=` and return `next_cursor`
+  (null when exhausted).
+- **Errors** — non-2xx bodies are `{"error": {"code", "message", "request_id"}}`;
+  branch on the machine `code`.
+- **Idempotency** — sends (`send`/`reply`/`forward`) accept an
+  `Idempotency-Key` header; a retried call replays instead of double-sending.
+- **Scopes** — account keys manage agents/domains/keys; agent keys are
+  pinned to one inbox.
+
+The endpoint map, exact request/response bodies, enums, and error codes are all
+in the OpenAPI 3.1 contract — generated from the live handlers and checked for
+drift in CI: **https://e2a.dev/v1/openapi.yaml**. The core resources are `agents`
+(inboxes), `messages` (send/reply/forward/get/list/attachments), `domains`,
+`webhooks`, `events`, and `account`.
+
+---
+
+<!-- source: https://e2a.dev/templates.md -->
+
+# Email templates (beta)
+
+> **Beta.** Templates are unstable — their shape may change before they are
+> declared stable. The canonical contract is [`api/openapi.yaml`](https://e2a.dev/v1/openapi.yaml).
+
+## Using a coding agent?
+
+Copy this prompt into your coding agent:
+
+> Help me set up e2a email templates using https://api.e2a.dev/mcp
+
+Templates are reusable email sources — a subject, a plain-text body, and an
+optional HTML body — stored on your account and **rendered server-side at send
+time**. Instead of composing subject/body in your agent code, you reference a
+template by alias and pass the variable values:
+
+- `POST /v1/templates` — create (or copy a starter with `from_starter`)
+- `GET/PATCH/DELETE /v1/templates/{id}` — manage
+- `POST /v1/templates/validate` — dry-run sources + render a preview without persisting
+- `GET /v1/starter-templates` / `GET /v1/starter-templates/{alias}` — the read-only starter catalog
+
+The dashboard surface lives at **/templates** (list, edit, starter gallery, and
+a rendered preview with an HTML/text tab switch and light/dark toggle).
+
+## Syntax
+
+Template syntax is intentionally minimal — variable interpolation only, no
+loops, no conditionals, no partials:
+
+| Form | Behavior |
+|---|---|
+| `{{variable}}` | Interpolates the value. In the **HTML part** the value is HTML-escaped; in the subject and plain-text parts it is inserted as-is. |
+| `{{{variable}}}` | Raw insertion (HTML part): the value is inserted **without escaping**. For pre-rendered HTML fragments only — see the warning below. |
+
+Missing variables render as **empty strings**. Variable names match
+`[A-Za-z_][A-Za-z0-9_.]*` — dot paths into nested objects are supported
+(e.g. `order_id`, `items_html`, `customer.name`).
+
+**Reserved-section note:** anything that is not a `{{…}}` / `{{{…}}}` slot is
+literal template text and is emitted verbatim — including `{` and `}`
+characters in CSS or code samples. Only the double/triple-brace forms are
+interpreted; there is no escape sequence and no other directive syntax.
+
+## Sending with a template
+
+Reference the template by its per-account alias (`template_alias`) or id
+(`template_id`) — mutually exclusive with literal `subject`/`text`/`html` —
+and pass the variables in `template_data`:
+
+```bash
+curl -X POST https://api.e2a.dev/v1/agents/billing-bot%40agents.e2a.dev/messages \
+  -H "Authorization: Bearer $E2A_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": ["customer@example.com"],
+    "template_alias": "receipt",
+    "template_data": {
+      "company_name": "Acme",
+      "support_email": "support@acme.com",
+      "company_address": "100 Main St, San Francisco, CA 94105",
+      "order_id": "ORD-10432",
+      "order_date": "July 2, 2026",
+      "items_html": "<tr><td style=\"padding:8px 0;\">1x Pro plan (monthly)</td><td style=\"padding:8px 0;\" align=\"right\">$29.00</td></tr>",
+      "items_text": "1x Pro plan (monthly) — $29.00",
+      "total": "$29.00",
+      "receipt_url": "https://app.acme.com/receipts/ORD-10432"
+    }
+  }'
+```
+
+> **Wire change.** To make room for the template shape, `subject` and `text`
+> moved from schema-required to handler-enforced on
+> `POST /v1/agents/{email}/messages`. A literal send that omits them now
+> returns **400 `invalid_request`** where it previously returned a **422**
+> schema-validation error. Sends that include them are unaffected.
+
+## Starter templates
+
+The deployment ships a read-only catalog of pre-built, ISP-friendly starters
+(responsive tables, dark-mode support, CAN-SPAM footer). `POST /v1/templates`
+with `{"from_starter": "<alias>"}` copies the master **verbatim** into your
+library (name/alias default to the starter's and may be overridden); edit the
+copy freely afterwards.
+
+| Alias | Purpose | Variables |
+|---|---|---|
+| `welcome` | Warm, brief welcome with a single primary CTA | `company_name`, `support_email`, `company_address`, `preheader`*, `recipient_name`, `cta_url`, `cta_label` |
+| `verify-code` | Terse one-time verification code (selectable monospace chip, no button) | `company_name`, `support_email`, `company_address`, `preheader`*, `code`, `expires_minutes` |
+| `password-reset` | Security-neutral password reset with one reset button and expiry notice | `company_name`, `support_email`, `company_address`, `preheader`*, `action_url`, `expires_minutes` |
+| `receipt` | Order receipt with a line-item table and hosted-receipt link | `company_name`, `support_email`, `company_address`, `preheader`*, `order_id`, `order_date`, **`items_html`** (raw), `items_text`, `total`, `receipt_url` |
+| `agent-status` | Numbers-first status report from an automated agent | `company_name`, `support_email`, `company_address`, `preheader`*, `agent_name`, `run_summary`, **`sections_html`** (raw), `sections_text`, `dashboard_url` |
+| `daily-digest` | Recurring daily summary with an unsubscribe link | `company_name`, `support_email`, `company_address`, `preheader`*, `agent_name`, `date`, `headline`, **`sections_html`** (raw), `sections_text`, `dashboard_url`, **`unsubscribe_html`** (raw) |
+| `approval-request` | Human approval request with Approve/Reject buttons and expiry | `company_name`, `support_email`, `company_address`, `preheader`*, `agent_name`, `action_summary`, **`details_html`** (raw), `details_text`, `approve_url`, `reject_url`, `expires_at` |
+
+\* optional; **bold** = raw (`{{{…}}}`) slot. `GET /v1/starter-templates`
+returns the authoritative per-variable metadata (required/raw flags,
+descriptions, example values usable directly as `template_data`).
+
+## The `{{{items_html}}}` fragment pattern
+
+Several starters take a **raw HTML fragment** for their repeated content (line
+items, report sections, key-value rows). The template owns the surrounding
+table and styling; your agent supplies only the inner rows, pre-rendered with
+inline styles:
+
+```json
+{
+  "items_html": "<tr><td style=\"padding:8px 0;font-family:'Helvetica Neue',Arial,sans-serif;font-size:14px;color:#1F2430;\">1x Pro plan (monthly)</td><td style=\"padding:8px 0;font-size:14px;color:#1F2430;\" align=\"right\">$29.00</td></tr><tr><td style=\"padding:8px 0;font-size:14px;color:#1F2430;\">1x Extra seat</td><td style=\"padding:8px 0;font-size:14px;color:#1F2430;\" align=\"right\">$10.00</td></tr>",
+  "items_text": "1x Pro plan (monthly) — $29.00\n1x Extra seat — $10.00"
+}
+```
+
+> **Warning — escape user content in raw slots.** `{{{…}}}` inserts the value
+> into the HTML part **without escaping**. If any part of the fragment comes
+> from user- or third-party-controlled data (product names, memo lines,
+> addresses), HTML-escape those substrings *before* building the fragment —
+> e.g. a product name `Widget <img src=x onerror=…>` must be inserted as
+> `Widget &lt;img src=x onerror=…&gt;`. Never pass untrusted input to a raw
+> slot; use the escaped `{{…}}` form wherever a plain string will do. Always
+> fill the matching `*_text` variable too, so the plain-text part carries the
+> same content.
+
+## Approval-request URLs: **require a confirmation page**
+
+**`approve_url` and `reject_url` MUST land on a page that requires an explicit
+human click to take effect — never on a state-changing GET.** Corporate
+mail-security scanners (Safe Links, spam filters, previewers) **fetch every
+link in an email** before or after delivery. If your approve/reject URL
+mutates state directly on GET, a scanner will silently approve or reject the
+action with no human involved. Serve a confirmation page at those URLs and
+perform the actual approve/reject on a POST from that page's button. (One-time
+tokens alone do not save you — the scanner's GET consumes the token.)
+
+## See also
+
+- [`docs/api.md`](https://github.com/tokencanopy/e2a/blob/main/docs/api.md) — REST surface overview and conventions
+- [`api/openapi.yaml`](https://e2a.dev/v1/openapi.yaml) — the canonical machine-readable contract

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -8,6 +8,7 @@
 ## Start here
 
 - [setup.md](https://e2a.dev/setup.md): What e2a is, how an agent connects (one MCP command), and what it can do. Read this first.
+- [llms-full.txt](https://e2a.dev/llms-full.txt): Every document below, inlined into one file. Fetch this instead if you would rather read the whole corpus in a single request.
 
 ## Connecting & auth
 
@@ -22,6 +23,7 @@
 ## MCP & plugin
 
 - [Agent plugin + skills](https://github.com/tokencanopy/e2a/tree/main/plugins/e2a): The `e2a` plugin bundles the hosted MCP server config and agent guidance for Claude Code, Codex, and Cursor.
+- [MCP overview](https://e2a.dev/mcp): Per-client connection instructions (Claude Code, Codex, Cursor/Windsurf/Claude Desktop, VS Code + Copilot), what the agent can do once connected, and how an agent-owned inbox differs from a mailbox integration.
 - MCP endpoint: `https://api.e2a.dev/mcp` (Streamable HTTP, OAuth 2.1). Add with `claude mcp add --transport http --scope user e2a https://api.e2a.dev/mcp`, then run `/mcp` to authorize (`--scope user` installs it globally; drop it for current-directory only). Per-client config (Cursor, VS Code, Codex, …) is in [setup.md](https://e2a.dev/setup.md).
 
 ## Source

--- a/web/src/app/blog/PostSchema.tsx
+++ b/web/src/app/blog/PostSchema.tsx
@@ -1,0 +1,23 @@
+import { JsonLd } from "../components/JsonLd";
+import { blogPosting, breadcrumbs } from "../../lib/jsonld";
+import type { Post } from "./posts";
+
+/**
+ * Per-post structured data. Without this a post inherits only the root
+ * SoftwareApplication node, so search and answer engines see a product page
+ * where an article is — no byline, no publish date, no article body signal.
+ */
+export function PostSchema({ post }: { post: Post }) {
+  return (
+    <JsonLd
+      data={[
+        blogPosting(post),
+        breadcrumbs([
+          { name: "e2a", path: "/" },
+          { name: "Blog", path: "/blog" },
+          { name: post.title, path: `/blog/${post.slug}` },
+        ]),
+      ]}
+    />
+  );
+}

--- a/web/src/app/blog/email-agent-with-google-adk/page.mdx
+++ b/web/src/app/blog/email-agent-with-google-adk/page.mdx
@@ -1,4 +1,5 @@
 import { getPost } from "../posts";
+import { PostSchema } from "../PostSchema";
 
 export const post = getPost("email-agent-with-google-adk");
 
@@ -19,6 +20,8 @@ export const metadata = {
     description: post.description,
   },
 };
+
+<PostSchema post={post} />
 
 <div style={{ fontSize: 11, color: "#A89A8A", fontFamily: "'IBM Plex Mono', monospace", marginBottom: 6 }}>
   {new Date(post.date + "T00:00:00Z").toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric", timeZone: "UTC" })} · {post.readingMinutes} min read

--- a/web/src/app/blog/email-for-openclaw-agents/page.mdx
+++ b/web/src/app/blog/email-for-openclaw-agents/page.mdx
@@ -1,4 +1,5 @@
 import { getPost } from "../posts";
+import { PostSchema } from "../PostSchema";
 
 export const post = getPost("email-for-openclaw-agents");
 
@@ -19,6 +20,8 @@ export const metadata = {
     description: post.description,
   },
 };
+
+<PostSchema post={post} />
 
 <div style={{ fontSize: 11, color: "#A89A8A", fontFamily: "'IBM Plex Mono', monospace", marginBottom: 6 }}>
   {new Date(post.date + "T00:00:00Z").toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric", timeZone: "UTC" })} · {post.readingMinutes} min read

--- a/web/src/app/blog/human-in-the-loop-for-agent-email/page.mdx
+++ b/web/src/app/blog/human-in-the-loop-for-agent-email/page.mdx
@@ -1,4 +1,5 @@
 import { getPost } from "../posts";
+import { PostSchema } from "../PostSchema";
 
 export const post = getPost("human-in-the-loop-for-agent-email");
 
@@ -19,6 +20,8 @@ export const metadata = {
     description: post.description,
   },
 };
+
+<PostSchema post={post} />
 
 <div style={{ fontSize: 11, color: "#A89A8A", fontFamily: "'IBM Plex Mono', monospace", marginBottom: 6 }}>
   {new Date(post.date + "T00:00:00Z").toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric", timeZone: "UTC" })} · {post.readingMinutes} min read

--- a/web/src/app/blog/send-email-from-python-agent/page.mdx
+++ b/web/src/app/blog/send-email-from-python-agent/page.mdx
@@ -1,4 +1,5 @@
 import { getPost } from "../posts";
+import { PostSchema } from "../PostSchema";
 
 export const post = getPost("send-email-from-python-agent");
 
@@ -19,6 +20,8 @@ export const metadata = {
     description: post.description,
   },
 };
+
+<PostSchema post={post} />
 
 <div style={{ fontSize: 11, color: "#A89A8A", fontFamily: "'IBM Plex Mono', monospace", marginBottom: 6 }}>
   {new Date(post.date + "T00:00:00Z").toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric", timeZone: "UTC" })} · {post.readingMinutes} min read

--- a/web/src/app/components/JsonLd.tsx
+++ b/web/src/app/components/JsonLd.tsx
@@ -1,0 +1,25 @@
+import type { JsonLdNode } from "../../lib/jsonld";
+
+/**
+ * Renders one or more JSON-LD nodes as <script type="application/ld+json">.
+ *
+ * The `<` escape guards against a string field (a post title, an FAQ answer)
+ * closing the script tag early — JSON.stringify does not escape it, and the
+ * browser's HTML parser ends the script at the first literal `</script`.
+ */
+export function JsonLd({ data }: { data: JsonLdNode | JsonLdNode[] }) {
+  const nodes = Array.isArray(data) ? data : [data];
+  return (
+    <>
+      {nodes.map((node, i) => (
+        <script
+          key={i}
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(node).replace(/</g, "\\u003c"),
+          }}
+        />
+      ))}
+    </>
+  );
+}

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -6,7 +6,9 @@ import "@e2a/ui/styles.css";
 import "./globals.css";
 import { AuthProvider } from "./components/AuthProvider";
 import { ThemeProvider } from "./components/ThemeProvider";
+import { JsonLd } from "./components/JsonLd";
 import { SITE_URL, SITE_NAME, GOOGLE_SITE_VERIFICATION } from "../lib/site";
+import { organization, softwareApplication, website } from "../lib/jsonld";
 
 const inter = Inter({
   variable: "--f-ui",
@@ -92,20 +94,13 @@ export const metadata: Metadata = {
   },
 };
 
-const jsonLd = {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  name: SITE_NAME,
-  description: ROOT_DESC,
-  url: SITE_URL,
-  applicationCategory: "DeveloperApplication",
-  operatingSystem: "Any",
-  offers: {
-    "@type": "Offer",
-    price: "0",
-    priceCurrency: "USD",
-  },
-};
+// Site-wide structured data. The Organization node carries an @id that every
+// other page's schema references, so publisher identity is stated once.
+const rootJsonLd = [
+  organization(),
+  website(),
+  softwareApplication(ROOT_DESC),
+];
 
 export default function RootLayout({
   children,
@@ -119,10 +114,7 @@ export default function RootLayout({
       suppressHydrationWarning
     >
       <body className="min-h-screen flex flex-col">
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
-        />
+        <JsonLd data={rootJsonLd} />
         <AuthProvider>
           <ThemeProvider>
             {children}

--- a/web/src/app/mcp/page.tsx
+++ b/web/src/app/mcp/page.tsx
@@ -1,0 +1,477 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { SITE_URL } from "../../lib/site";
+import { JsonLd } from "../components/JsonLd";
+import { breadcrumbs, faqPage, howTo, type FaqEntry } from "../../lib/jsonld";
+
+// Deliberately a server component with no "use client". Everything on this
+// page must exist in the static HTML: answer engines and most crawlers never
+// run our JavaScript, and this route's whole job is to be quotable.
+
+const TITLE = "Email over MCP — give your AI agent a real inbox";
+const DESC =
+  "Connect Claude Code, Codex, Cursor, or any MCP client to a real, authenticated email address in one command. OAuth 2.1, no API key, SPF/DKIM-verified inbound.";
+
+const MCP_URL = "https://api.e2a.dev/mcp";
+
+export const metadata: Metadata = {
+  title: { absolute: `${TITLE} — e2a` },
+  description: DESC,
+  alternates: { canonical: "/mcp" },
+  keywords: [
+    "email mcp server",
+    "mcp server for email",
+    "claude code email mcp",
+    "codex email mcp",
+    "cursor email mcp",
+    "give ai agent email address mcp",
+    "agent inbox mcp",
+  ],
+  openGraph: {
+    title: TITLE,
+    description: DESC,
+    url: `${SITE_URL}/mcp`,
+    type: "website",
+    images: [{ url: "/og-image.png", width: 1200, height: 630 }],
+  },
+  twitter: { card: "summary_large_image", title: TITLE, description: DESC },
+};
+
+// Each answer is written to survive being quoted on its own, with no
+// surrounding page. That is the unit an answer engine actually lifts.
+const FAQ: FaqEntry[] = [
+  {
+    question: "How do I give my AI agent an email address?",
+    answer:
+      "Add the e2a MCP server to your agent's client and authorize it in the browser. In Claude Code that is a single command: `claude mcp add --transport http --scope user e2a https://api.e2a.dev/mcp`, then `/mcp` to authorize. The agent gets its own address on agents.e2a.dev — or on a domain you own — and can send, receive, reply, and forward mail from that moment on.",
+  },
+  {
+    question: "Do I need an API key to use the e2a MCP server?",
+    answer:
+      "No. The hosted MCP server at https://api.e2a.dev/mcp uses OAuth 2.1 with Dynamic Client Registration (RFC 7591) and PKCE, so an interactive client registers itself and completes authorization in the browser with no secret to paste. API keys exist for headless and CI use, where a browser flow is not available.",
+  },
+  {
+    question: "Which MCP clients does e2a work with?",
+    answer:
+      "Any client that speaks Streamable HTTP MCP. e2a is tested with Claude Code, OpenAI Codex, Cursor, Windsurf, Claude Desktop, and VS Code with GitHub Copilot. All of them point at the same endpoint, https://api.e2a.dev/mcp; only the configuration syntax differs.",
+  },
+  {
+    question: "How is this different from connecting an agent to Gmail?",
+    answer:
+      "A Gmail integration lets an agent read a human's mailbox. With e2a the inbox belongs to the agent itself: it has its own verified sending identity, so recipients can tell agent mail apart from yours, and revoking it does not touch your personal mail. e2a also verifies SPF, DKIM, and DMARC on every inbound message and hands the agent that authentication evidence, which a mailbox integration does not.",
+  },
+  {
+    question: "Can I review what the agent sends before it goes out?",
+    answer:
+      "Yes. Human-in-the-loop approval can be enabled per agent. When it is on, an outbound send is held and you get an approve or reject prompt — in the dashboard, the CLI, or straight from your own inbox — and the message only leaves once you approve it.",
+  },
+  {
+    question: "Is e2a open source?",
+    answer:
+      "Yes. The core is Apache-2.0 at github.com/tokencanopy/e2a — Go backend, SMTP relay, TypeScript and Python SDKs, CLI, MCP server, and dashboard — and can be self-hosted against your own Postgres and outbound relay. e2a.dev is the hosted version of that same codebase.",
+  },
+];
+
+const CLIENTS: {
+  id: string;
+  name: string;
+  intro: string;
+  lang: string;
+  code: string;
+  after?: string;
+}[] = [
+  {
+    id: "claude-code",
+    name: "Claude Code",
+    intro: "One command, then authorize in the browser.",
+    lang: "sh",
+    code: `claude mcp add --transport http --scope user e2a ${MCP_URL}`,
+    after:
+      "Run /mcp in Claude Code and authorize e2a. --scope user makes it available in every project; omit it to configure only the current one.",
+  },
+  {
+    id: "codex",
+    name: "OpenAI Codex",
+    intro: "Add the server, then log in.",
+    lang: "sh",
+    code: `codex mcp add e2a --url ${MCP_URL}\ncodex mcp login e2a`,
+  },
+  {
+    id: "cursor",
+    name: "Cursor · Windsurf · Claude Desktop",
+    intro: "Add the endpoint to the client's MCP configuration.",
+    lang: "json",
+    code: `{
+  "mcpServers": {
+    "e2a": { "url": "${MCP_URL}" }
+  }
+}`,
+    after: "Complete the OAuth prompt when the client opens it.",
+  },
+  {
+    id: "vscode",
+    name: "VS Code with GitHub Copilot",
+    intro: "Add .vscode/mcp.json with the servers key.",
+    lang: "json",
+    code: `{
+  "servers": {
+    "e2a": {
+      "type": "http",
+      "url": "${MCP_URL}"
+    }
+  }
+}`,
+  },
+];
+
+const HOW_TO = howTo({
+  name: "Give an AI agent an email address over MCP",
+  description:
+    "Connect an MCP client to the hosted e2a server so the agent has its own authenticated inbox.",
+  steps: [
+    {
+      name: "Add the MCP server",
+      text: `Point your MCP client at ${MCP_URL} over Streamable HTTP. In Claude Code: claude mcp add --transport http --scope user e2a ${MCP_URL}`,
+    },
+    {
+      name: "Authorize in the browser",
+      text: "Trigger the client's authorization flow (/mcp in Claude Code, codex mcp login e2a in Codex). e2a uses OAuth 2.1 with Dynamic Client Registration, so there is no API key to paste.",
+    },
+    {
+      name: "Claim an inbox",
+      text: "Pick a slug on the shared agents.e2a.dev domain, or verify a domain you own with a DNS TXT record. The agent now has an address it can send from and receive to.",
+    },
+    {
+      name: "Send and receive",
+      text: "Ask the agent to send a message and reply to it from your own mail client. Inbound arrives with SPF, DKIM, and DMARC results attached and a stable conversation_id that threads the exchange.",
+    },
+  ],
+});
+
+export default function McpPage() {
+  return (
+    <div
+      className="min-h-screen"
+      style={{
+        background: "var(--bg)",
+        color: "var(--fg)",
+        fontFamily: "var(--f-ui)",
+      }}
+    >
+      <JsonLd
+        data={[
+          faqPage(FAQ),
+          HOW_TO,
+          breadcrumbs([
+            { name: "e2a", path: "/" },
+            { name: "MCP", path: "/mcp" },
+          ]),
+        ]}
+      />
+
+      <nav
+        className="sticky top-0 z-50"
+        style={{
+          background: "var(--bg)",
+          borderBottom: "1px solid var(--border)",
+        }}
+      >
+        <div className="max-w-[760px] mx-auto flex items-center justify-between px-6 md:px-8 py-3.5">
+          <Link
+            href="/"
+            className="font-mono font-bold text-[15px]"
+            style={{ color: "var(--fg)", letterSpacing: "-0.02em" }}
+          >
+            e2a
+          </Link>
+          <div className="flex items-center gap-4">
+            <Link href="/blog" className="text-[13px]" style={{ color: "var(--fg-muted)" }}>
+              Blog
+            </Link>
+            <Link href="/api-docs" className="text-[13px]" style={{ color: "var(--fg-muted)" }}>
+              Docs
+            </Link>
+            <Link
+              href="/get-started"
+              className="inline-flex items-center gap-1.5 px-3.5 py-1.5 text-[13px] font-medium"
+              style={{
+                background: "var(--fg)",
+                color: "var(--bg)",
+                borderRadius: "var(--r-md)",
+              }}
+            >
+              Start building <span className="font-mono">→</span>
+            </Link>
+          </div>
+        </div>
+      </nav>
+
+      <main className="max-w-[720px] mx-auto px-6 md:px-8 py-14 md:py-[56px] pb-20">
+        <p
+          className="font-mono text-[11px] mb-3"
+          style={{ color: "var(--fg-subtle)", letterSpacing: "0.08em" }}
+        >
+          MCP SERVER
+        </p>
+        <h1
+          className="text-[34px] md:text-[40px] font-semibold leading-[1.12] mb-5"
+          style={{ letterSpacing: "-0.025em" }}
+        >
+          Email over MCP — give your AI agent a real inbox
+        </h1>
+
+        {/* The lede is the extractable answer. Keep it self-contained: state
+            what the product does, for whom, and what it costs to start. */}
+        <p className="text-[17px] leading-[1.6]" style={{ color: "var(--fg-muted)" }}>
+          e2a is an MCP server that gives an AI agent its own authenticated email
+          address. Connect Claude Code, Codex, Cursor, or any Streamable HTTP MCP
+          client in one command and the agent can send, receive, reply, and
+          forward real mail — with SPF/DKIM-verified inbound and an optional
+          approval hold before anything leaves. OAuth 2.1, no API key, free tier.
+        </p>
+
+        <Endpoint />
+
+        <Section id="connect" title="How do I connect my MCP client?">
+          <P>
+            Point the client at <Code>{MCP_URL}</Code> over Streamable HTTP and
+            authorize in the browser. e2a uses OAuth 2.1 with Dynamic Client
+            Registration, so the client registers itself — there is no key to
+            paste and no secret to store.
+          </P>
+          {CLIENTS.map((c) => (
+            <div key={c.id} className="mt-7">
+              <h3 className="text-[15px] font-semibold mb-1.5">{c.name}</h3>
+              <p className="text-[14px] mb-2.5" style={{ color: "var(--fg-muted)" }}>
+                {c.intro}
+              </p>
+              <Pre lang={c.lang}>{c.code}</Pre>
+              {c.after ? (
+                <p className="text-[13.5px] mt-2.5" style={{ color: "var(--fg-muted)" }}>
+                  {c.after}
+                </p>
+              ) : null}
+            </div>
+          ))}
+          <P className="mt-7">
+            For Goose, Zed, and other MCP clients, use the same endpoint.
+            Ready-to-paste configurations live in the{" "}
+            <A href="https://github.com/tokencanopy/e2a/tree/main/plugins/e2a/clients">
+              client examples
+            </A>
+            . For headless or CI runs where no browser is available, pass an
+            account API key instead — see{" "}
+            <A href="https://e2a.dev/setup.md">setup.md</A>.
+          </P>
+        </Section>
+
+        <Section id="capabilities" title="What can the agent do once it is connected?">
+          <P>
+            The MCP server exposes the full mail surface as tools, so the agent
+            works in its inbox the way a person works in theirs:
+          </P>
+          <ul className="mt-3 space-y-2 text-[15px]" style={{ color: "var(--fg-muted)" }}>
+            {[
+              ["Send and reply", "Compose new mail, reply in-thread, forward, and attach files."],
+              ["Read inbound", "List conversations and messages, and pull attachments."],
+              ["Manage identity", "Create agents, claim a slug, or register and verify a custom domain."],
+              ["Route and screen", "Suppressions, contacts, templates, and webhooks for downstream systems."],
+            ].map(([label, body]) => (
+              <li key={label} className="flex gap-2.5">
+                <span style={{ color: "var(--fg-subtle)" }}>—</span>
+                <span>
+                  <strong style={{ color: "var(--fg)" }}>{label}.</strong> {body}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </Section>
+
+        <Section id="different" title="How is this different from a Gmail MCP server?">
+          <P>
+            A Gmail integration lets an agent read a human&rsquo;s mailbox. With
+            e2a <em>the inbox is the agent</em> — it has its own verified sending
+            identity, so recipients can tell agent mail from yours, and revoking
+            it never touches your personal mail.
+          </P>
+          <P className="mt-3.5">
+            Every inbound message is checked for SPF, DKIM, and DMARC before the
+            agent sees it, and the result is handed over as structured evidence
+            rather than a header the agent has to parse and trust. Optional
+            prompt-injection and phishing screening runs on the same path, and
+            human-in-the-loop approval can hold any outbound send until you
+            approve it from the dashboard, the CLI, or your own inbox.
+          </P>
+        </Section>
+
+        <Section id="faq" title="Frequently asked questions">
+          <div className="mt-1">
+            {FAQ.map((f) => (
+              <div
+                key={f.question}
+                className="py-4"
+                style={{ borderTop: "1px solid var(--border)" }}
+              >
+                <h3 className="text-[15px] font-semibold mb-1.5">{f.question}</h3>
+                <p className="text-[14.5px] leading-[1.6]" style={{ color: "var(--fg-muted)" }}>
+                  {f.answer}
+                </p>
+              </div>
+            ))}
+          </div>
+        </Section>
+
+        <div
+          className="mt-12 p-6"
+          style={{
+            border: "1px solid var(--border)",
+            borderRadius: "var(--r-lg)",
+            background: "var(--surface, transparent)",
+          }}
+        >
+          <h2 className="text-[17px] font-semibold mb-1.5">Give your agent an inbox</h2>
+          <p className="text-[14.5px] mb-4" style={{ color: "var(--fg-muted)" }}>
+            Free tier, no card. Add the server, authorize, and send your first
+            message in about a minute.
+          </p>
+          <Link
+            href="/get-started"
+            className="inline-flex items-center gap-1.5 px-4 py-2 text-[14px] font-medium"
+            style={{
+              background: "var(--fg)",
+              color: "var(--bg)",
+              borderRadius: "var(--r-md)",
+            }}
+          >
+            Start building <span className="font-mono">→</span>
+          </Link>
+        </div>
+      </main>
+
+      <footer
+        className="max-w-[720px] mx-auto flex justify-between px-6 md:px-8 py-5"
+        style={{ borderTop: "1px solid var(--border)" }}
+      >
+        <span
+          className="font-mono font-bold text-[13px]"
+          style={{ color: "var(--fg)", letterSpacing: "-0.02em" }}
+        >
+          e2a
+        </span>
+        <span className="font-mono text-[12px]" style={{ color: "var(--fg-subtle)" }}>
+          Apache 2.0
+        </span>
+      </footer>
+    </div>
+  );
+}
+
+function Endpoint() {
+  return (
+    <div
+      className="mt-7 flex flex-wrap items-baseline gap-x-3 gap-y-1 px-4 py-3"
+      style={{
+        border: "1px solid var(--border)",
+        borderRadius: "var(--r-md)",
+      }}
+    >
+      <span
+        className="font-mono text-[11px]"
+        style={{ color: "var(--fg-subtle)", letterSpacing: "0.06em" }}
+      >
+        ENDPOINT
+      </span>
+      <code className="font-mono text-[13.5px]" style={{ color: "var(--fg)" }}>
+        {MCP_URL}
+      </code>
+      <span className="font-mono text-[11.5px]" style={{ color: "var(--fg-subtle)" }}>
+        Streamable HTTP · OAuth 2.1
+      </span>
+    </div>
+  );
+}
+
+function Section({
+  id,
+  title,
+  children,
+}: {
+  id: string;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section id={id} className="mt-12 scroll-mt-20">
+      {/* Question-shaped H2 with the answer immediately below it — the shape
+          both featured snippets and LLM extraction key off. */}
+      <h2
+        className="text-[22px] font-semibold mb-3.5 leading-[1.25]"
+        style={{ letterSpacing: "-0.015em" }}
+      >
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+function P({
+  children,
+  className = "",
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <p
+      className={`text-[15px] leading-[1.65] ${className}`}
+      style={{ color: "var(--fg-muted)" }}
+    >
+      {children}
+    </p>
+  );
+}
+
+function A({ href, children }: { href: string; children: React.ReactNode }) {
+  const external = href.startsWith("http");
+  return (
+    <a
+      href={href}
+      style={{ color: "var(--fg)", textDecoration: "underline" }}
+      {...(external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+    >
+      {children}
+    </a>
+  );
+}
+
+function Code({ children }: { children: React.ReactNode }) {
+  return (
+    <code
+      className="font-mono text-[13.5px] px-1.5 py-0.5"
+      style={{
+        background: "var(--border)",
+        borderRadius: "4px",
+        color: "var(--fg)",
+      }}
+    >
+      {children}
+    </code>
+  );
+}
+
+function Pre({ lang, children }: { lang: string; children: string }) {
+  return (
+    <pre
+      className="overflow-x-auto px-4 py-3.5 text-[12.5px] leading-[1.65] font-mono"
+      style={{
+        background: "var(--ink)",
+        border: "1px solid var(--ink-border)",
+        borderRadius: "var(--r-lg)",
+        color: "var(--ink-fg)",
+      }}
+    >
+      <code data-lang={lang}>{children}</code>
+    </pre>
+  );
+}

--- a/web/src/app/sitemap.test.ts
+++ b/web/src/app/sitemap.test.ts
@@ -1,0 +1,61 @@
+// The sitemap reads NEXT_PUBLIC_PRICING_PATH through site.ts, which resolves
+// env vars at module load (Next.js inlines them at build time). Each scenario
+// therefore re-imports the module tree fresh.
+
+const ENV_KEY = "NEXT_PUBLIC_PRICING_PATH";
+
+function loadSitemap(): () => Array<{ url: string; priority?: number }> {
+  let mod: { default: () => Array<{ url: string; priority?: number }> } | undefined;
+  jest.isolateModules(() => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    mod = require("./sitemap");
+  });
+  if (!mod) throw new Error("failed to load ./sitemap");
+  return mod.default;
+}
+
+function urls(): string[] {
+  return loadSitemap()().map((entry) => entry.url);
+}
+
+describe("sitemap", () => {
+  const original = process.env[ENV_KEY];
+
+  afterEach(() => {
+    if (original === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = original;
+  });
+
+  it("omits pricing when the deployment has no pricing route", () => {
+    delete process.env[ENV_KEY];
+    // Staging and self-hosts don't serve /pricing — advertising it there would
+    // put a 404 in the sitemap.
+    expect(urls().some((u) => u.endsWith("/pricing"))).toBe(false);
+  });
+
+  it("advertises pricing at the configured path when the deployment serves one", () => {
+    process.env[ENV_KEY] = "/pricing";
+    const entries = loadSitemap()();
+    const pricing = entries.find((e) => e.url.endsWith("/pricing"));
+    expect(pricing).toBeDefined();
+    // Commercial intent — should not rank below the blog.
+    expect(pricing?.priority).toBeGreaterThanOrEqual(0.8);
+  });
+
+  it("includes the MCP landing page and every blog post", () => {
+    delete process.env[ENV_KEY];
+    const found = urls();
+    expect(found.some((u) => u.endsWith("/mcp"))).toBe(true);
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { posts } = require("./blog/posts") as typeof import("./blog/posts");
+    for (const post of posts) {
+      expect(found.some((u) => u.endsWith(`/blog/${post.slug}`))).toBe(true);
+    }
+  });
+
+  it("emits no duplicate URLs", () => {
+    process.env[ENV_KEY] = "/pricing";
+    const found = urls();
+    expect(new Set(found).size).toBe(found.length);
+  });
+});

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from "next";
 import { posts } from "./blog/posts";
-import { SITE_URL } from "../lib/site";
+import { PRICING_PATH, SITE_URL } from "../lib/site";
 
 // Required for static export (output: "export")
 export const dynamic = "force-static";
@@ -9,6 +9,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const now = new Date();
   const staticRoutes: Array<{ path: string; changeFrequency: "daily" | "weekly" | "monthly"; priority: number }> = [
     { path: "/", changeFrequency: "weekly", priority: 1.0 },
+    { path: "/mcp", changeFrequency: "weekly", priority: 0.9 },
     { path: "/docs", changeFrequency: "weekly", priority: 0.8 },
     { path: "/docs/python", changeFrequency: "weekly", priority: 0.8 },
     { path: "/python-sdk", changeFrequency: "weekly", priority: 0.7 },
@@ -16,6 +17,15 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: "/blog", changeFrequency: "weekly", priority: 0.7 },
     { path: "/get-started", changeFrequency: "monthly", priority: 0.6 },
   ];
+  // Only advertised when the deployment actually serves a pricing route —
+  // see PRICING_PATH. Commercial-intent page, so it ranks above the blog.
+  if (PRICING_PATH) {
+    staticRoutes.push({
+      path: PRICING_PATH,
+      changeFrequency: "monthly",
+      priority: 0.9,
+    });
+  }
   const blogRoutes = posts.map((p) => ({
     path: `/blog/${p.slug}`,
     changeFrequency: "monthly" as const,

--- a/web/src/lib/jsonld.test.ts
+++ b/web/src/lib/jsonld.test.ts
@@ -1,0 +1,81 @@
+import {
+  ORGANIZATION_ID,
+  blogPosting,
+  breadcrumbs,
+  faqPage,
+  howTo,
+  organization,
+  softwareApplication,
+  website,
+} from "./jsonld";
+
+describe("structured data", () => {
+  it("states publisher identity once and references it by @id", () => {
+    // Duplicating the Organization node per page is how publisher metadata
+    // drifts. Everything else should point at the one @id.
+    expect(organization()["@id"]).toBe(ORGANIZATION_ID);
+    expect(website().publisher).toEqual({ "@id": ORGANIZATION_ID });
+    expect(softwareApplication("desc").publisher).toEqual({
+      "@id": ORGANIZATION_ID,
+    });
+  });
+
+  it("builds a BlogPosting with absolute URLs and an ISO publish date", () => {
+    const node = blogPosting({
+      title: "Send real email from a Python AI agent",
+      description: "A minimal walkthrough.",
+      date: "2026-04-13",
+      author: "e2a",
+      slug: "send-email-from-python-agent",
+    });
+
+    expect(node["@type"]).toBe("BlogPosting");
+    expect(node.datePublished).toBe("2026-04-13T00:00:00.000Z");
+    expect(String(node.url)).toMatch(/\/blog\/send-email-from-python-agent$/);
+    expect(String(node.url)).toMatch(/^https?:\/\//);
+    expect(node.mainEntityOfPage).toEqual({
+      "@type": "WebPage",
+      "@id": node.url,
+    });
+  });
+
+  it("maps FAQ entries to Question/acceptedAnswer pairs in order", () => {
+    const node = faqPage([
+      { question: "Do I need an API key?", answer: "No — OAuth 2.1." },
+      { question: "Is it open source?", answer: "Yes, Apache-2.0." },
+    ]);
+
+    expect(node["@type"]).toBe("FAQPage");
+    expect(node.mainEntity).toEqual([
+      {
+        "@type": "Question",
+        name: "Do I need an API key?",
+        acceptedAnswer: { "@type": "Answer", text: "No — OAuth 2.1." },
+      },
+      {
+        "@type": "Question",
+        name: "Is it open source?",
+        acceptedAnswer: { "@type": "Answer", text: "Yes, Apache-2.0." },
+      },
+    ]);
+  });
+
+  it("numbers HowTo steps and breadcrumbs from one", () => {
+    const steps = howTo({
+      name: "Connect",
+      description: "Connect an MCP client.",
+      steps: [
+        { name: "Add", text: "Add the server." },
+        { name: "Authorize", text: "Authorize in the browser." },
+      ],
+    }).step as Array<{ position: number }>;
+    expect(steps.map((s) => s.position)).toEqual([1, 2]);
+
+    const crumbs = breadcrumbs([
+      { name: "e2a", path: "/" },
+      { name: "MCP", path: "/mcp" },
+    ]).itemListElement as Array<{ position: number; item: string }>;
+    expect(crumbs.map((c) => c.position)).toEqual([1, 2]);
+    expect(crumbs[1].item).toMatch(/\/mcp$/);
+  });
+});

--- a/web/src/lib/jsonld.ts
+++ b/web/src/lib/jsonld.ts
@@ -1,0 +1,169 @@
+// Structured-data builders for the marketing surface.
+//
+// Two audiences read this output and they want different things. Search engines
+// use it for rich results (breadcrumbs, FAQ accordions, article bylines).
+// Answer engines use it as a pre-parsed summary of the page — a question/answer
+// pair in FAQPage schema is the single most quotable unit we can publish,
+// because it needs no extraction step.
+//
+// Every builder returns a plain object. Render it with <JsonLd data={...} />.
+// Keep the shapes minimal: a field we cannot keep true is worse than an absent
+// one, since stale structured data is a manual-action risk on the SEO side and
+// a wrong-answer risk on the AEO side.
+
+import { SITE_NAME, SITE_URL } from "./site";
+
+/** Loose JSON-LD node. Values are whatever schema.org allows at that key. */
+export type JsonLdNode = Record<string, unknown>;
+
+/** Absolute URL for a site-relative path. Schema.org wants absolute URLs. */
+function abs(path: string): string {
+  return path.startsWith("http") ? path : `${SITE_URL}${path}`;
+}
+
+/**
+ * The publisher behind every page. Referenced by @id from other nodes so the
+ * organization is described once rather than duplicated per page.
+ */
+export const ORGANIZATION_ID = `${SITE_URL}/#organization`;
+
+export function organization(): JsonLdNode {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "@id": ORGANIZATION_ID,
+    name: SITE_NAME,
+    url: SITE_URL,
+    logo: abs("/logo-wordmark.svg"),
+    description:
+      "e2a gives AI agents a real, authenticated email address — SPF/DKIM-verified inbound, HMAC-signed webhook and WebSocket delivery, and an HTTP API for outbound.",
+    sameAs: [
+      "https://github.com/tokencanopy/e2a",
+      "https://www.npmjs.com/package/@e2a/sdk",
+      "https://pypi.org/project/e2a/",
+    ],
+    parentOrganization: {
+      "@type": "Organization",
+      name: "Token Canopy",
+      url: "https://tokencanopy.com",
+    },
+  };
+}
+
+export function website(): JsonLdNode {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "@id": `${SITE_URL}/#website`,
+    name: SITE_NAME,
+    url: SITE_URL,
+    publisher: { "@id": ORGANIZATION_ID },
+    inLanguage: "en-US",
+  };
+}
+
+export function softwareApplication(description: string): JsonLdNode {
+  return {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name: SITE_NAME,
+    description,
+    url: SITE_URL,
+    applicationCategory: "DeveloperApplication",
+    operatingSystem: "Any",
+    publisher: { "@id": ORGANIZATION_ID },
+    // The free tier is real and requires no card, so a zero-price Offer is
+    // accurate. Paid tiers are described on /pricing, which carries its own
+    // Offer nodes rather than restating dollar amounts here where they would
+    // drift out of sync with billing.
+    offers: {
+      "@type": "Offer",
+      price: "0",
+      priceCurrency: "USD",
+    },
+  };
+}
+
+export type BlogPostingInput = {
+  title: string;
+  description: string;
+  /** ISO date string (YYYY-MM-DD). */
+  date: string;
+  author: string;
+  slug: string;
+};
+
+export function blogPosting(post: BlogPostingInput): JsonLdNode {
+  const published = new Date(`${post.date}T00:00:00Z`).toISOString();
+  const url = abs(`/blog/${post.slug}`);
+  return {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: post.title,
+    description: post.description,
+    datePublished: published,
+    // We do not track per-post revisions, so modified mirrors published rather
+    // than claiming a freshness we cannot substantiate.
+    dateModified: published,
+    author: { "@type": "Organization", name: post.author, url: SITE_URL },
+    publisher: { "@id": ORGANIZATION_ID },
+    url,
+    mainEntityOfPage: { "@type": "WebPage", "@id": url },
+    image: abs("/og-image.png"),
+    inLanguage: "en-US",
+  };
+}
+
+export type FaqEntry = { question: string; answer: string };
+
+/**
+ * FAQPage schema. The `answer` strings should be self-contained prose — an
+ * answer engine may quote one in isolation, with no surrounding page context.
+ */
+export function faqPage(entries: readonly FaqEntry[]): JsonLdNode {
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: entries.map((e) => ({
+      "@type": "Question",
+      name: e.question,
+      acceptedAnswer: { "@type": "Answer", text: e.answer },
+    })),
+  };
+}
+
+export type HowToStepInput = { name: string; text: string };
+
+export function howTo(input: {
+  name: string;
+  description: string;
+  steps: readonly HowToStepInput[];
+}): JsonLdNode {
+  return {
+    "@context": "https://schema.org",
+    "@type": "HowTo",
+    name: input.name,
+    description: input.description,
+    step: input.steps.map((s, i) => ({
+      "@type": "HowToStep",
+      position: i + 1,
+      name: s.name,
+      text: s.text,
+    })),
+  };
+}
+
+export type Crumb = { name: string; path: string };
+
+export function breadcrumbs(crumbs: readonly Crumb[]): JsonLdNode {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: crumbs.map((c, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name: c.name,
+      item: abs(c.path),
+    })),
+  };
+}

--- a/web/src/lib/site.ts
+++ b/web/src/lib/site.ts
@@ -33,6 +33,16 @@ export const FEEDBACK_EMAIL = process.env.NEXT_PUBLIC_FEEDBACK_EMAIL || "";
 export const GOOGLE_SITE_VERIFICATION =
   process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION || "";
 
+// Site-relative path of the pricing page, when the deployment has one.
+//
+// Pricing is NOT part of this app. The hosted deployment serves it from the
+// private ops repo via a Caddy route, because tier numbers and dollar amounts
+// are hosted-service concerns the OSS repo doesn't own. Staging has no such
+// route and neither does a self-host. So the sitemap must only advertise
+// /pricing where it actually resolves — an unset value means "no pricing page",
+// and listing a 404 in a sitemap is a crawl-quality problem, not a no-op.
+export const PRICING_PATH = process.env.NEXT_PUBLIC_PRICING_PATH || "";
+
 // Sign-in entry point for the dashboard's "Sign in" links. Defaults to the
 // legacy Google OAuth door, which every self-host deployment has. The hosted
 // deployment bakes in NEXT_PUBLIC_E2A_SIGN_IN_URL=/api/auth/oidc/login at


### PR DESCRIPTION
## Why

e2a.dev ranks fine for its own name, but is absent from the unbranded queries people actually type when shopping for this category. Two searches, run before writing any code:

- **"email API for AI agents / give your agent an email address"** — results are AgentMail, Robotomail, AgentsMail, Mailtrap, Nylas, and a stack of competitor-authored "N best email APIs for AI agents compared" listicles. e2a appears nowhere.
- **"MCP server email agent claude code"** — Resend, Composio, UseJunior. e2a appears nowhere, despite MCP being the fastest path to adoption.

Those listicles are what answer engines quote when someone asks what to use, so the category shortlist is being written without us on it. Two fixable causes: there are only 11 URLs to rank, and the pages that do exist carry almost no machine-readable summary of what they say.

This PR is the plumbing half of the fix. It does not attempt comparison content, which should wait for GA.

## What changed

**`/mcp` landing page.** The MCP install path is the fastest route to adoption and had no page at all. Deliberately a server component with no `"use client"` — answer engines and most crawlers never run our JavaScript, and this route's entire job is to be quotable. Question-shaped H2s with self-contained answers, per-client setup for Claude Code, Codex, Cursor/Windsurf/Claude Desktop, and VS Code + Copilot. All commands taken from `plugins/e2a/docs/setup.md` rather than written fresh.

**`src/lib/jsonld.ts`.** Typed builders for Organization, WebSite, SoftwareApplication, BlogPosting, FAQPage, HowTo, and BreadcrumbList, rendered through a `<JsonLd>` component that escapes `<` so a post title or FAQ answer can't close the script tag early. Publisher identity is now stated once and referenced by `@id` instead of being restated per page. The four blog posts previously inherited only the root SoftwareApplication node — a product schema where an article is.

**`web/public/llms-full.txt`.** `llms.txt` is an index: it tells a model which documents exist, which costs a retrieval round trip the model may not take. `llms-full.txt` inlines the corpus so a single fetch is enough. Generated from the canonical `plugins/e2a/docs/*.md` by `sync-agent-docs.mjs` and committed, so `--check` catches drift the same way it does for the mirrors.

**Sitemap.** Adds `/mcp`. Adds `/pricing` gated behind a new `NEXT_PUBLIC_PRICING_PATH` — that page is served outside this app and only exists on the hosted deployment, so staging and self-hosts must not advertise a URL that 404s for them.

## Verification

- 731/731 web tests pass, including 8 new ones covering the schema builders and the sitemap's env gating (present with the var set, absent without, no duplicate URLs).
- 7/7 `sync-agent-docs` tests pass, including two new ones asserting every corpus source is inlined and that `--check` reports a stale `llms-full.txt` without rewriting it. Re-running the generator is idempotent.
- `scripts/check-repository-text-integrity.sh` passes.
- eslint clean on all new and changed files.
- Production build succeeds. Confirmed in `out/`: `mcp.html` carries FAQPage + HowTo + BreadcrumbList and has the install commands in static HTML; blog posts carry BlogPosting + BreadcrumbList; the sitemap contains `/pricing` when built with the var and omits it without.

Two pre-existing `tsc` errors in `AgentHeader.test.tsx` and `onboarding/state.test.ts` (a `DashboardAgent.id` property) are unrelated to this change and left alone.

## Not in this PR

`/docs`, `/docs/python`, and `/python-sdk` are client-side redirect stubs whose rendered body is a loading string — but they sit in the sitemap at priority 0.8/0.7. Three of eleven sitemap URLs are effectively empty. Whether to give them content or drop them is a site-architecture call, so it is flagged rather than fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)