### PR TITLE
fix(web): keep the billing page fresh while it's open

### DIFF
--- a/web/src/app/(app)/billing/page.polling.test.tsx
+++ b/web/src/app/(app)/billing/page.polling.test.tsx
@@ -1,0 +1,75 @@
+// The Billing page has to refresh itself while it sits open: usage
+// counters move whenever the account sends or receives mail, and the
+// current plan changes out-of-band when Stripe's webhook provisions an
+// upgrade. Both of its reads were focus-revalidate-only, so a user
+// watching the page saw numbers frozen at whatever they were when the
+// tab mounted.
+//
+// Mirrors the *.polling.test.tsx convention used for the pending and
+// unread hooks: assert the page hands the shared preset to useSWR, and
+// let livePolling.test.ts own the preset's actual cadence.
+
+import { render } from "@testing-library/react";
+import useSWR from "swr";
+import { billingPolling } from "../../../lib/livePolling";
+
+jest.mock("swr", () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    data: undefined,
+    error: undefined,
+    isLoading: true,
+    mutate: jest.fn(),
+  })),
+}));
+
+jest.mock("next/link", () => {
+  return function MockLink({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [k: string]: unknown;
+  }) {
+    return (
+      <a href={href} {...rest}>
+        {children}
+      </a>
+    );
+  };
+});
+
+// BILLING_API is read at module-evaluation time, so it must be set before
+// the page module is required — otherwise the plan fetch is skipped
+// entirely (null key) and there's no second call to assert on.
+process.env.NEXT_PUBLIC_BILLING_API = "https://billing.test";
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const BillingPage = require("./page").default as React.ComponentType;
+
+const mockUseSWR = useSWR as jest.MockedFunction<typeof useSWR>;
+
+beforeEach(() => {
+  mockUseSWR.mockClear();
+});
+
+describe("BillingPage polling", () => {
+  it("polls account limits on the shared billing cadence", () => {
+    render(<BillingPage />);
+
+    const call = mockUseSWR.mock.calls.find(([key]) => key === "limits");
+    expect(call).toBeDefined();
+    expect(call![2]).toEqual(expect.objectContaining(billingPolling));
+  });
+
+  it("polls the sidecar plan catalog on the shared billing cadence", () => {
+    render(<BillingPage />);
+
+    const call = mockUseSWR.mock.calls.find(
+      ([key]) => key === "https://billing.test/api/billing/plan",
+    );
+    expect(call).toBeDefined();
+    expect(call![2]).toEqual(expect.objectContaining(billingPolling));
+  });
+});

--- a/web/src/app/(app)/billing/page.refresh.test.tsx
+++ b/web/src/app/(app)/billing/page.refresh.test.tsx
@@ -191,6 +191,42 @@ describe("BillingPage — post-checkout reconciliation", () => {
     expect(window.location.search).toBe("");
   });
 
+  // The reconcile deadline is stamped once, into a ref, when the window
+  // opens — deliberately not a local recomputed on every run of the effect
+  // that owns the interval. That effect depends on SWR's bound mutators; if
+  // a future SWR returned a fresh identity per render, a recomputed deadline
+  // would be pushed forward on every re-render and the timeout would never
+  // be reached, leaving this polling the billing sidecar indefinitely.
+  //
+  // This pins the wall-clock boundary from both sides: it must still be
+  // waiting just before the window elapses, and must have given up just
+  // after. A deadline that drifts fails the second assertion.
+  it("holds the reconcile window to wall-clock time, then gives up", async () => {
+    window.history.replaceState({}, "", "/billing?status=success");
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText(/Finalizing your upgrade/i)).toBeInTheDocument(),
+    );
+
+    // Just inside the window, after many poll ticks and the re-renders
+    // each resolved read causes — still waiting.
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(19000);
+    });
+    expect(screen.getByText(/Finalizing your upgrade/i)).toBeInTheDocument();
+    expect(screen.queryByText(/hasn't appeared yet/i)).not.toBeInTheDocument();
+
+    // Just past it — given up, on schedule rather than whenever the effect
+    // last happened to re-run.
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(3000);
+    });
+    await waitFor(() =>
+      expect(screen.getByText(/hasn't appeared yet/i)).toBeInTheDocument(),
+    );
+  });
+
   it("gives up with an explanation when the webhook never lands", async () => {
     window.history.replaceState({}, "", "/billing?status=success");
     renderPage();

--- a/web/src/app/(app)/billing/page.refresh.test.tsx
+++ b/web/src/app/(app)/billing/page.refresh.test.tsx
@@ -1,0 +1,233 @@
+// Freshness behavior of the Billing page.
+//
+// Two customer-visible defects are pinned here:
+//
+//  1. The visible "Refresh" button only revalidated the usage read. The
+//     plan label, the "Current" badge, and every tier CTA come from the
+//     sidecar catalog, which it never refetched — so a user who had just
+//     upgraded clicked Refresh, saw their old plan, and concluded the
+//     page was broken.
+//
+//  2. Stripe Checkout returns the user to /billing?status=success via a
+//     full page load. That load races the asynchronous
+//     checkout.session.completed webhook that provisions the new limits,
+//     and the redirect usually wins. Nothing on the page ever re-read
+//     afterwards, so the old plan rendered until a manual reload.
+
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { SWRConfig } from "swr";
+
+jest.mock("next/link", () => {
+  return function MockLink({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [k: string]: unknown;
+  }) {
+    return (
+      <a href={href} {...rest}>
+        {children}
+      </a>
+    );
+  };
+});
+
+// Set before requiring the page: BILLING_API is captured at module
+// evaluation, and without it there is no sidecar catalog to reconcile.
+process.env.NEXT_PUBLIC_BILLING_API = "https://billing.test";
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const BillingPage = require("./page").default as React.ComponentType;
+
+const PLAN_URL = "https://billing.test/api/billing/plan";
+
+const CATALOG = [
+  {
+    code: "free",
+    display_name: "Free",
+    monthly_price_cents: 0,
+    max_agents: 3,
+    max_domains: 1,
+    max_messages_month: 3000,
+    max_storage_bytes: 1 << 30,
+  },
+  {
+    code: "pro",
+    display_name: "Pro",
+    monthly_price_cents: 2000,
+    max_agents: 25,
+    max_domains: 10,
+    max_messages_month: 50000,
+    max_storage_bytes: 10 * (1 << 30),
+  },
+];
+
+const FREE_LIMITS = {
+  plan_code: "free",
+  limits: {
+    max_agents: 3,
+    max_domains: 1,
+    max_messages_month: 3000,
+    max_storage_bytes: 1 << 30,
+  },
+  usage: { agents: 1, domains: 0, messages_month: 120, storage_bytes: 1024 },
+  upgrade_url: "",
+};
+
+// Pre-webhook: Stripe has taken the money but the sidecar hasn't
+// provisioned yet, so it still reports the free tier as current.
+const PENDING_PLAN = {
+  catalog: CATALOG,
+  current: { code: "free", status: "inactive", has_stripe_customer: true },
+};
+
+// Post-webhook: limits provisioned, subscription active.
+const ACTIVE_PLAN = {
+  catalog: CATALOG,
+  current: { code: "pro", status: "active", has_stripe_customer: true },
+};
+
+const mockFetch = jest.fn();
+
+// Mutable staging so a test can flip what the sidecar returns
+// mid-reconcile, the way the webhook landing does in production.
+let limitsPayload: unknown = FREE_LIMITS;
+let planPayload: unknown = PENDING_PLAN;
+
+beforeEach(() => {
+  limitsPayload = FREE_LIMITS;
+  planPayload = PENDING_PLAN;
+  mockFetch.mockReset();
+  mockFetch.mockImplementation((url: string) => {
+    if (url === "/v1/account") {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(limitsPayload) });
+    }
+    if (url === PLAN_URL) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(planPayload) });
+    }
+    return Promise.resolve({ ok: false, text: () => Promise.resolve("404") });
+  });
+  global.fetch = mockFetch;
+  window.history.replaceState({}, "", "/billing");
+});
+
+function renderPage() {
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      <BillingPage />
+    </SWRConfig>,
+  );
+}
+
+const countCallsTo = (url: string) =>
+  mockFetch.mock.calls.filter(([u]) => u === url).length;
+
+describe("BillingPage — manual refresh", () => {
+  it("revalidates the plan catalog as well as usage", async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText("Plans")).toBeInTheDocument());
+    const planCallsBefore = countCallsTo(PLAN_URL);
+    const limitsCallsBefore = countCallsTo("/v1/account");
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+
+    // Both reads must move. Refreshing usage while leaving the plan
+    // cached is what made the button look like it did nothing after an
+    // upgrade.
+    await waitFor(() =>
+      expect(countCallsTo(PLAN_URL)).toBeGreaterThan(planCallsBefore),
+    );
+    expect(countCallsTo("/v1/account")).toBeGreaterThan(limitsCallsBefore);
+  });
+});
+
+describe("BillingPage — post-checkout reconciliation", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("re-reads the sidecar until the upgrade webhook lands, then shows the new plan", async () => {
+    window.history.replaceState({}, "", "/billing?status=success");
+    renderPage();
+
+    // Lands on the pre-webhook state: still Free, with a notice telling
+    // the user the upgrade is being finalized rather than silently
+    // showing them the plan they just paid to leave.
+    await waitFor(() =>
+      expect(screen.getByText(/Finalizing your upgrade/i)).toBeInTheDocument(),
+    );
+    const callsAfterMount = countCallsTo(PLAN_URL);
+
+    // The webhook hasn't landed yet — the page must keep asking.
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(2000);
+    });
+    expect(countCallsTo(PLAN_URL)).toBeGreaterThan(callsAfterMount);
+
+    // Webhook lands between polls.
+    planPayload = ACTIVE_PLAN;
+    limitsPayload = { ...FREE_LIMITS, plan_code: "pro" };
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(2000);
+    });
+
+    await waitFor(() => expect(screen.getByText("Current")).toBeInTheDocument());
+    expect(screen.queryByText(/Finalizing your upgrade/i)).not.toBeInTheDocument();
+
+    // And it stops once resolved — no unbounded polling of the sidecar.
+    const callsAfterResolve = countCallsTo(PLAN_URL);
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(6000);
+    });
+    expect(countCallsTo(PLAN_URL)).toBe(callsAfterResolve);
+
+    // The marker is consumed so a later remount (or a Back navigation)
+    // doesn't restart the reconcile loop.
+    expect(window.location.search).toBe("");
+  });
+
+  it("gives up with an explanation when the webhook never lands", async () => {
+    window.history.replaceState({}, "", "/billing?status=success");
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText(/Finalizing your upgrade/i)).toBeInTheDocument(),
+    );
+
+    // Past the reconcile window with the sidecar still reporting free.
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(21000);
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText(/hasn't appeared yet/i)).toBeInTheDocument(),
+    );
+    expect(screen.queryByText(/Finalizing your upgrade/i)).not.toBeInTheDocument();
+
+    // Stopped polling rather than hammering the sidecar forever.
+    const callsAfterGiveUp = countCallsTo(PLAN_URL);
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(6000);
+    });
+    expect(countCallsTo(PLAN_URL)).toBe(callsAfterGiveUp);
+  });
+
+  it("does not reconcile on an ordinary visit", async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByText("Plans")).toBeInTheDocument());
+    const callsAfterMount = countCallsTo(PLAN_URL);
+
+    expect(screen.queryByText(/Finalizing your upgrade/i)).not.toBeInTheDocument();
+
+    // Well inside the 30s background cadence: nothing extra should fire.
+    await act(async () => {
+      await jest.advanceTimersByTimeAsync(6000);
+    });
+    expect(countCallsTo(PLAN_URL)).toBe(callsAfterMount);
+  });
+});

--- a/web/src/app/(app)/billing/page.test.tsx
+++ b/web/src/app/(app)/billing/page.test.tsx
@@ -26,6 +26,7 @@ const mockFetch = jest.fn();
 beforeEach(() => {
   mockFetch.mockReset();
   global.fetch = mockFetch;
+  window.history.replaceState({}, "", "/billing");
 });
 
 // Wraps the page in a fresh SWR provider per test so cached responses
@@ -105,6 +106,25 @@ describe("BillingPage", () => {
     // its tier cards must not render.
     expect(screen.queryByText("Plans")).not.toBeInTheDocument();
     expect(screen.queryByText("Scale")).not.toBeInTheDocument();
+  });
+
+  it("ignores a checkout marker when no billing sidecar is configured", async () => {
+    // Post-checkout reconciliation waits on the sidecar's plan read to
+    // report an active subscription. With no sidecar there is no such
+    // read, so a stray ?status=success must not park the page on a
+    // "finalizing your upgrade" notice that can never resolve — a
+    // self-host install has no checkout to come back from.
+    window.history.replaceState({}, "", "/billing?status=success");
+    stageLimits({
+      plan_code: "default",
+      limits: { max_agents: 1, max_domains: 1, max_messages_month: 1, max_storage_bytes: 1 },
+      usage: { agents: 0, domains: 0, messages_month: 0, storage_bytes: 0 },
+      upgrade_url: "",
+    });
+    renderPage();
+
+    await waitFor(() => screen.getByText(/Default/i));
+    expect(screen.queryByText(/Finalizing your upgrade/i)).not.toBeInTheDocument();
   });
 
   it("renders error state when the API returns non-2xx", async () => {

--- a/web/src/app/(app)/billing/page.tsx
+++ b/web/src/app/(app)/billing/page.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useState } from "react";
 import useSWR from "swr";
+import { billingPolling } from "../../../lib/livePolling";
+import { limitsKey } from "../../../lib/swrKeys";
 import { PageShell } from "../../components/loft/PageShell";
 
 // LimitsInfo matches the LimitsView shape returned by GET /v1/account.
@@ -116,6 +118,24 @@ const QUOTA_DIMS: { label: string; format: (p: PlanEntry) => string }[] = [
   { label: "Messages / mo", format: (p) => formatNumber(p.max_messages_month) },
   { label: "Storage", format: (p) => formatBytes(p.max_storage_bytes) },
 ];
+
+// Stripe Checkout returns the user to CHECKOUT_SUCCESS_URL
+// (/billing?status=success) as a full page load. That load races the
+// asynchronous checkout.session.completed webhook that provisions the new
+// limits, and the redirect normally wins — so the first read still reports
+// the old plan. Re-read on a short interval until the sidecar says the
+// subscription is active, then stop.
+//
+// "active" is a sound completion signal here because Checkout is only
+// reachable from a non-subscribed state; existing subscribers change plans
+// through the Stripe portal, which returns to /billing with no marker.
+const RECONCILE_INTERVAL_MS = 2000;
+const RECONCILE_TIMEOUT_MS = 20000;
+
+// idle    — ordinary visit, background polling only.
+// pending — just came back from Checkout, waiting on the webhook.
+// timeout — waited RECONCILE_TIMEOUT_MS and it still hasn't landed.
+type ReconcileState = "idle" | "pending" | "timeout";
 
 // pctTone picks the bar color based on how close to the cap the user
 // is. <70% neutral, 70-90% warning, >=90% danger. Tones reuse existing
@@ -235,9 +255,14 @@ function PlanCard({
 }
 
 export default function BillingPage() {
+  // Both reads poll: usage counters move as the account sends and
+  // receives, and the plan changes out-of-band when Stripe's webhook
+  // provisions an upgrade. Focus revalidation alone left the page frozen
+  // for anyone who simply kept it open.
   const { data, error, isLoading, mutate } = useSWR<LimitsInfo>(
-    "limits",
+    limitsKey,
     fetchLimits,
+    billingPolling,
   );
 
   // The plan catalog comes from the sidecar's source of truth. Gated on
@@ -250,6 +275,7 @@ export default function BillingPage() {
   } = useSWR<PlanInfo>(
     BILLING_API ? `${BILLING_API}/api/billing/plan` : null,
     fetchPlan,
+    billingPolling,
   );
 
   // Track which specific button is in flight so it can show "Opening…"
@@ -311,6 +337,59 @@ export default function BillingPage() {
     window.addEventListener("pageshow", onShow);
     return () => window.removeEventListener("pageshow", onShow);
   }, [mutate, mutatePlan]);
+
+  const [reconcile, setReconcile] = useState<ReconcileState>("idle");
+
+  // Consume the ?status marker Stripe redirected us back with. Read from
+  // window.location rather than useSearchParams() because this route is
+  // part of a static export — useSearchParams() would force the whole
+  // page under a Suspense boundary to prerender. The marker is stripped
+  // immediately: it has been used, and leaving it in the URL would
+  // restart the reconcile loop on every remount or Back navigation.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const status = params.get("status");
+    if (!status) return;
+    params.delete("status");
+    const qs = params.toString();
+    window.history.replaceState(
+      {},
+      "",
+      `${window.location.pathname}${qs ? `?${qs}` : ""}`,
+    );
+    // `cancel` needs no reconcile — nothing was provisioned. Clearing the
+    // marker above is the whole handling.
+    //
+    // The BILLING_API guard matters because reconciliation resolves on the
+    // sidecar's plan read: with no sidecar that read never happens, so a
+    // stray marker would park the page on a notice that can never clear.
+    if (status === "success" && BILLING_API) setReconcile("pending");
+  }, []);
+
+  // Poll both reads until the webhook lands or the window elapses. This
+  // is deliberately separate from the background `billingPolling`
+  // cadence: 30s is fine for idle drift, far too slow for someone
+  // staring at the page they just paid on.
+  useEffect(() => {
+    if (reconcile !== "pending") return;
+    const deadline = Date.now() + RECONCILE_TIMEOUT_MS;
+    const id = setInterval(() => {
+      if (Date.now() >= deadline) {
+        setReconcile("timeout");
+        return;
+      }
+      void mutate();
+      void mutatePlan();
+    }, RECONCILE_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [reconcile, mutate, mutatePlan]);
+
+  // Webhook landed — stop polling and let the page render normally.
+  useEffect(() => {
+    if (reconcile === "pending" && planData?.current.status === "active") {
+      setReconcile("idle");
+    }
+  }, [reconcile, planData]);
 
   // Compute usage percentages once data is loaded. Guard zero limits
   // (treat as 0% rather than NaN/Infinity) so a misconfigured row with
@@ -394,6 +473,40 @@ export default function BillingPage() {
           }}
         >
           Couldn&apos;t load your limits. {String(error.message ?? error)}
+        </div>
+      )}
+
+      {/* Post-checkout reconciliation. Rendered outside the `data` gate so
+          it shows even if the usage read is slow or failing — the user
+          just paid, and silence is the worst response. A late webhook
+          that lands after we gave up still clears the notice, because the
+          background poll keeps running. */}
+      {reconcile === "pending" && (
+        <div
+          className="rounded-lg border px-4 py-3 text-sm mb-6"
+          style={{
+            borderColor: "var(--border)",
+            background: "var(--bg-elev)",
+            color: "var(--fg-muted)",
+          }}
+          role="status"
+        >
+          Finalizing your upgrade… your new plan will appear here in a moment.
+        </div>
+      )}
+      {reconcile === "timeout" && planData?.current.status !== "active" && (
+        <div
+          className="rounded-lg border px-4 py-3 text-sm mb-6"
+          style={{
+            borderColor: "var(--border)",
+            background: "var(--bg-elev)",
+            color: "var(--fg-muted)",
+          }}
+          role="status"
+        >
+          Your payment went through, but the new plan hasn&apos;t appeared yet.
+          It usually lands within a minute — this page keeps checking, or use
+          Refresh below.
         </div>
       )}
 
@@ -533,7 +646,14 @@ export default function BillingPage() {
 
             <div className="pt-2">
               <button
-                onClick={() => mutate()}
+                onClick={() => {
+                  // Both reads, not just usage. The plan label, the
+                  // "Current" badge and every tier CTA come from the
+                  // sidecar catalog — refreshing usage alone made the
+                  // button look broken to anyone who had just upgraded.
+                  void mutate();
+                  void mutatePlan();
+                }}
                 className="text-xs text-muted hover:text-foreground transition"
               >
                 Refresh

--- a/web/src/app/(app)/billing/page.tsx
+++ b/web/src/app/(app)/billing/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import useSWR from "swr";
 import { billingPolling } from "../../../lib/livePolling";
 import { limitsKey } from "../../../lib/swrKeys";
@@ -370,11 +370,26 @@ export default function BillingPage() {
   // is deliberately separate from the background `billingPolling`
   // cadence: 30s is fine for idle drift, far too slow for someone
   // staring at the page they just paid on.
+  // The deadline lives in a ref, not a local, so it is set ONCE when the
+  // reconcile window opens and survives any re-run of this effect. A local
+  // would be recomputed on every re-run, and this effect depends on `mutate`
+  // and `mutatePlan` — SWR's bound mutators, which are referentially stable
+  // in v2 but are not ours to guarantee. If a future SWR ever returned a
+  // fresh identity per render, a recomputed deadline would push the timeout
+  // permanently out of reach and this would poll the billing sidecar
+  // forever. The ref makes termination depend only on wall-clock time.
+  const reconcileDeadlineRef = useRef<number | null>(null);
+
   useEffect(() => {
-    if (reconcile !== "pending") return;
-    const deadline = Date.now() + RECONCILE_TIMEOUT_MS;
+    if (reconcile !== "pending") {
+      // Leaving the window (resolved, timed out, or unmounted) clears the
+      // deadline so a subsequent reconcile starts a fresh one.
+      reconcileDeadlineRef.current = null;
+      return;
+    }
+    reconcileDeadlineRef.current ??= Date.now() + RECONCILE_TIMEOUT_MS;
     const id = setInterval(() => {
-      if (Date.now() >= deadline) {
+      if (Date.now() >= (reconcileDeadlineRef.current ?? 0)) {
         setReconcile("timeout");
         return;
       }

--- a/web/src/lib/livePolling.test.ts
+++ b/web/src/lib/livePolling.test.ts
@@ -1,4 +1,9 @@
-import { inboxPolling, pendingPolling, unreadPolling } from './livePolling';
+import {
+  billingPolling,
+  inboxPolling,
+  pendingPolling,
+  unreadPolling,
+} from './livePolling';
 
 describe('live polling configuration', () => {
   it('polls inbox data every 10 seconds only while visible and online', () => {
@@ -20,6 +25,19 @@ describe('live polling configuration', () => {
   it('polls unread data every 15 seconds only while visible and online', () => {
     expect(unreadPolling).toEqual({
       refreshInterval: 15000,
+      refreshWhenHidden: false,
+      refreshWhenOffline: false,
+    });
+  });
+
+  // Billing usage counters move whenever the account sends or receives,
+  // so the page must refresh itself while it sits open. 30s is slower
+  // than the inbox cadence on purpose — nobody watches a storage bar the
+  // way they watch a message list, and this fetch also hits the external
+  // sidecar.
+  it('polls billing data every 30 seconds only while visible and online', () => {
+    expect(billingPolling).toEqual({
+      refreshInterval: 30000,
       refreshWhenHidden: false,
       refreshWhenOffline: false,
     });

--- a/web/src/lib/livePolling.ts
+++ b/web/src/lib/livePolling.ts
@@ -11,3 +11,15 @@ export const unreadPolling = {
   refreshWhenHidden: false,
   refreshWhenOffline: false,
 } as const;
+
+// Billing usage counters move whenever the account sends or receives, and
+// the current plan changes out-of-band when Stripe's webhook provisions an
+// upgrade — so the page has to refresh itself while it sits open. Slower
+// than the inbox cadence deliberately: nobody watches a storage bar the
+// way they watch a message list, and one of these reads leaves the OSS
+// server for the external billing sidecar.
+export const billingPolling = {
+  refreshInterval: 30000,
+  refreshWhenHidden: false,
+  refreshWhenOffline: false,
+} as const;

--- a/web/src/lib/swrKeys.test.ts
+++ b/web/src/lib/swrKeys.test.ts
@@ -19,9 +19,14 @@ import useSWR from "swr";
 import {
   accountUnreadKey,
   agentUnreadKey,
+  agentsKey,
+  domainsKey,
   invalidateAgentUnread,
+  invalidateAgents,
+  invalidateDomains,
   invalidateMessageDetail,
   invalidateMessageLifecycle,
+  limitsKey,
   messageDetailKey,
   messageLifecycleKey,
 } from "./swrKeys";
@@ -56,6 +61,58 @@ describe("invalidateAgentUnread", () => {
       expect(accountFetcher).toHaveBeenCalledTimes(2);
     });
     expect(otherFetcher).toHaveBeenCalledTimes(1);
+  });
+});
+
+// Inbox count and domain count are two of the four usage dimensions the
+// Billing page meters, so an agent/domain mutation makes the billing
+// usage bars stale. Folding the limits invalidation into the agent and
+// domain helpers (rather than asking every call site to remember a
+// second call) is what keeps that from silently rotting: /billing read a
+// key nothing in the app ever invalidated.
+describe("limitsKey", () => {
+  it("uses the cache key the Billing page reads account limits under", () => {
+    expect(limitsKey).toBe("limits");
+  });
+});
+
+// Both helpers are exercised against a SINGLE limits subscriber in one
+// test rather than split in two: limitsKey is a fixed string, and SWR's
+// request-dedup window is global and outlives the per-test cache reset in
+// jest.setup.ts — so a second test mounting the same key would have its
+// mount fetch silently suppressed and assert nothing.
+describe("limits invalidation", () => {
+  it("revalidates account limits from both agent and domain mutations", async () => {
+    const agentsFetcher = jest.fn().mockResolvedValue([]);
+    const domainsFetcher = jest.fn().mockResolvedValue([]);
+    const limitsFetcher = jest.fn().mockResolvedValue({ plan_code: "free" });
+    renderHook(() => useSWR(agentsKey, agentsFetcher));
+    renderHook(() => useSWR(domainsKey, domainsFetcher));
+    renderHook(() => useSWR(limitsKey, limitsFetcher));
+    await waitFor(() => {
+      expect(agentsFetcher).toHaveBeenCalledTimes(1);
+      expect(domainsFetcher).toHaveBeenCalledTimes(1);
+      expect(limitsFetcher).toHaveBeenCalledTimes(1);
+    });
+
+    // Creating or trashing an inbox changes usage.agents, so an open
+    // Billing tab must not keep rendering the pre-mutation count.
+    await act(async () => {
+      await invalidateAgents();
+    });
+    await waitFor(() => {
+      expect(agentsFetcher).toHaveBeenCalledTimes(2);
+      expect(limitsFetcher).toHaveBeenCalledTimes(2);
+    });
+
+    // Same for usage.domains after a domain is registered or removed.
+    await act(async () => {
+      await invalidateDomains();
+    });
+    await waitFor(() => {
+      expect(domainsFetcher).toHaveBeenCalledTimes(2);
+      expect(limitsFetcher).toHaveBeenCalledTimes(3);
+    });
   });
 });
 

--- a/web/src/lib/swrKeys.ts
+++ b/web/src/lib/swrKeys.ts
@@ -19,6 +19,12 @@ export const domainsKey = "domains";
 export const pendingMessagesKey = "pending-messages";
 export const accountUnreadKey = "account-unread";
 
+// Account plan + entitlements + month-to-date usage (GET /v1/account),
+// read by the Billing page. Inbox count and domain count are two of the
+// four metered dimensions, so agent and domain mutations invalidate this
+// too — see invalidateAgents / invalidateDomains below.
+export const limitsKey = "limits";
+
 // Trash views (soft-deleted resources, restorable ~30 days).
 // deletedAgentsKey backs the account-wide /trash page
 // (GET /v1/agents?deleted=true); agentTrashKey backs the per-inbox
@@ -100,7 +106,16 @@ export const webhookDeliveriesKey = (
 // list — which carries the per-agent enrichment fields the dashboard
 // renders — needs to refetch.
 export function invalidateAgents() {
-  return mutate(agentsKey);
+  return Promise.all([mutate(agentsKey), invalidateLimits()]);
+}
+
+// Account limits carry the metered usage the Billing page renders. It's
+// folded into the agent and domain helpers rather than left for each call
+// site to remember, because a missed call here is invisible: the bars just
+// keep showing a pre-mutation count. Cheap when nothing reads it — SWR
+// only refetches keys that have a live subscriber.
+export function invalidateLimits() {
+  return mutate(limitsKey);
 }
 
 // After approve / reject the user-wide pending list needs to drop
@@ -168,7 +183,7 @@ export function invalidateAgentUnread(email: string) {
 }
 
 export function invalidateDomains() {
-  return mutate(domainsKey);
+  return Promise.all([mutate(domainsKey), invalidateLimits()]);
 }
 
 // After an inbox is trashed / restored / purged, the account-wide trash


### PR DESCRIPTION
## Summary

A customer reported that the Billing page doesn't show up-to-date state unless they click something or manually reload. Both of its reads (`GET /v1/account` and the sidecar's `/api/billing/plan`) were focus-revalidate-only, so usage counters and the current plan froze at whatever they were when the tab mounted.

The sharper half is the post-checkout path: Stripe returns the user to `/billing?status=success` as a full page load, which races the asynchronous `checkout.session.completed` webhook that provisions the new limits. The redirect normally wins, and nothing on the page ever re-read afterwards — so the plan they just paid to leave rendered until a manual reload. The visible **Refresh** button didn't rescue it either: it revalidated usage but never the sidecar catalog, which is what supplies the plan label, the "Current" badge, and every tier CTA.

Found during a broader audit of dashboard refresh behavior. The remaining finding from that audit — a set of pages that fetch once on mount with no SWR at all (`/api-keys`, `/webhooks`, `/templates`, `/contacts`, …) — is deliberately left for a separate PR.

## What changes

- **Poll both reads** on a new `billingPolling` preset (30s, not while hidden or offline). Slower than the 10s inbox cadence on purpose: nobody watches a storage bar the way they watch a message list, and one of these reads leaves the OSS server for the external sidecar.
- **Refresh revalidates the catalog too**, not just usage.
- **Post-checkout reconciliation**: re-read every 2s for up to 20s until the sidecar reports an active subscription, with a "Finalizing your upgrade…" notice while waiting and a plain explanation if it times out. The `?status` marker is consumed and stripped on mount so a Back navigation can't restart the loop.
- **`limitsKey` is now a named key**, and `invalidateAgents()` / `invalidateDomains()` fan out to it — inbox count and domain count are two of the four metered dimensions, so an open Billing tab no longer shows pre-mutation counts.

Two design notes for the reviewer:

- The marker is read from `window.location` rather than `useSearchParams()`. The latter would force the whole route under a Suspense boundary to prerender; `/billing` still exports as static content this way.
- `status === "active"` is a sound completion signal because Checkout is only reachable from a non-subscribed state — existing subscribers change plans through the Stripe portal, which returns with no marker. Reconciliation is additionally gated on `BILLING_API` so a stray marker on a self-host install can't park the page on a notice that never clears.

## Client surface checklist

Not applicable — web-dashboard only. No API handler, migration, spec, SDK, CLI, or MCP change; no `/v1` surface is touched.

## Operational risk

Low, and read-only. No schema, auth, or send-path changes. The one new outbound behavior is polling: two extra GETs per open Billing tab per 30s, suppressed while the tab is hidden or offline, plus a bounded burst of at most ~10 extra reads in the 20s after a checkout return. Reconciliation is time-boxed and self-terminating in every branch — resolved, timed out, or unmounted — so there is no path to unbounded polling of the billing sidecar. Rollback is a plain revert.

## Test plan

Written test-first: each behavior below was confirmed failing for the right reason before the implementation landed.

- [x] `lib/livePolling.test.ts` — billing cadence is 30s, not while hidden or offline
- [x] `lib/swrKeys.test.ts` — agent and domain invalidation both revalidate the limits key
- [x] `billing/page.polling.test.tsx` — both reads receive the shared preset
- [x] `billing/page.refresh.test.tsx` — Refresh revalidates the catalog as well as usage
- [x] `billing/page.refresh.test.tsx` — reconcile re-reads until the webhook lands, shows the new plan, then stops; marker is consumed
- [x] `billing/page.refresh.test.tsx` — gives up with an explanation and stops polling when the webhook never lands
- [x] `billing/page.refresh.test.tsx` — no reconcile on an ordinary visit
- [x] `billing/page.test.tsx` — a stray marker is ignored when no sidecar is configured
- [x] Full web suite green (741 tests, 91 suites), `npm run lint` clean, `npm run build` clean with `/billing` still prerendered static
- [ ] After merge: confirm on staging that a real Checkout return resolves to the new plan without a manual reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)