### PR TITLE
fix(web): replace the undefined --surface token on /mcp and /billing

### DIFF
--- a/web/src/app/(app)/billing/page.tsx
+++ b/web/src/app/(app)/billing/page.tsx
@@ -185,10 +185,20 @@ function PlanCard({
     <div
       className="rounded-lg border p-4 flex flex-col gap-3"
       style={{
-        // The current tier gets the accent border + a tinted surface so
-        // it reads as "you are here" at a glance.
+        // The current tier is marked by the accent border and the "Current"
+        // badge. It deliberately shares --bg-elev with the other tiers: the
+        // surface scale has no step above --bg-elev that keeps its direction
+        // in both themes (--bg-panel is lighter than --bg-elev in light mode
+        // but darker in dark mode), so a background distinction here would
+        // read as "raised" on one theme and "recessed" on the other.
+        //
+        // This previously read `isCurrent ? "var(--surface)" : "var(--bg-elev)"`.
+        // --surface is defined nowhere, so with no fallback the declaration was
+        // invalid at computed-value time and background-color fell back to its
+        // initial value, transparent — the current tier was the ONLY card with
+        // no surface at all, inverting the hierarchy it was meant to signal.
         borderColor: isCurrent ? "var(--accent)" : "var(--border)",
-        background: isCurrent ? "var(--surface)" : "var(--bg-elev)",
+        background: "var(--bg-elev)",
       }}
       aria-current={isCurrent ? "true" : undefined}
     >
@@ -408,7 +418,7 @@ export default function BillingPage() {
             className="rounded-xl border p-5"
             style={{
               borderColor: "var(--border)",
-              background: "var(--surface)",
+              background: "var(--bg-panel)",
             }}
           >
             <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
@@ -447,7 +457,7 @@ export default function BillingPage() {
           {BILLING_API && (
             <section
               className="rounded-xl border p-5 space-y-4"
-              style={{ borderColor: "var(--border)", background: "var(--surface)" }}
+              style={{ borderColor: "var(--border)", background: "var(--bg-panel)" }}
             >
               <div>
                 <div className="text-xs uppercase tracking-wide text-muted">
@@ -494,7 +504,7 @@ export default function BillingPage() {
             className="rounded-xl border p-5 space-y-5"
             style={{
               borderColor: "var(--border)",
-              background: "var(--surface)",
+              background: "var(--bg-panel)",
             }}
           >
             <div>

--- a/web/src/app/mcp/page.tsx
+++ b/web/src/app/mcp/page.tsx
@@ -326,7 +326,7 @@ export default function McpPage() {
           style={{
             border: "1px solid var(--border)",
             borderRadius: "var(--r-lg)",
-            background: "var(--surface, transparent)",
+            background: "var(--bg-elev)",
           }}
         >
           <h2 className="text-[17px] font-semibold mb-1.5">Give your agent an inbox</h2>
@@ -450,8 +450,8 @@ function Code({ children }: { children: React.ReactNode }) {
     <code
       className="font-mono text-[13.5px] px-1.5 py-0.5"
       style={{
-        background: "var(--border)",
-        borderRadius: "4px",
+        background: "var(--bg-sunken)",
+        borderRadius: "var(--r-sm)",
         color: "var(--fg)",
       }}
     >


### PR DESCRIPTION
## Summary

Follow-up to #807. `--surface` is **defined nowhere in the repo** — not in `web/src/app/globals.css`, not in `design-system/src/tokens.css`. Every reference to it resolved to nothing. This PR removes the last of them, across two pages.

### `/mcp` (marketing page)

| Before | After | Why |
|---|---|---|
| `var(--surface, transparent)` | `var(--bg-elev)` | the fallback won, so the "Give your agent an inbox" card rendered with no background at all |
| `var(--border)` (as a `<code>` background) | `var(--bg-sunken)` | a border color used as a fill — `--bg-sunken` is the token that means "recessed surface" |
| `borderRadius: "4px"` | `var(--r-sm)` | hardcoded; `--r-sm` is defined as exactly `4px`, so a no-op today that stays correct if the scale moves |

### `/billing` (dashboard)

Four bare `var(--surface)` uses, no fallback — so each declaration was invalid at computed-value time and `background-color` fell back to its initial value, `transparent`.

The `PlanCard` case **inverted the hierarchy it was meant to signal.** It read:

```tsx
background: isCurrent ? "var(--surface)" : "var(--bg-elev)",
```

with the comment "the current tier gets the accent border + a tinted surface so it reads as 'you are here' at a glance." In practice the current tier was the *only* card with no surface at all, while every tier the user was **not** on sat on `--bg-elev` and read as raised. Measured computed backgrounds:

| | page | siblings | **current tier** |
|---|---|---|---|
| light | `#FAF7F2` | `#F2ECE2` | **`rgba(0,0,0,0)`** |
| dark | `#13110E` | `#221F1B` | **`rgba(0,0,0,0)`** |

Worst in dark mode, where `--bg-elev` is ~79% brighter than the page, so the plan you're paying for renders as a hole between the two you aren't. The accent border and "Current" badge were the only things rescuing it, which is why this survived review.

**The fix:**

- The three section backgrounds → `--bg-panel`, matching the **82** other uses of that token across the dashboard (vs 18 `--bg-elev`, and only these 3 `--surface`).
- The current `PlanCard` now shares `--bg-elev` with its siblings, distinguished by its accent border and badge alone.

That second choice is deliberate and worth flagging: **the surface scale has no step above `--bg-elev` that keeps its direction in both themes.** `--bg-panel` is lighter than `--bg-elev` in light mode (`#FFFFFF` vs `#F2ECE2`) but *darker* in dark mode (`#1A1714` vs `#221F1B`), so using it for the current card would read "raised" on one theme and "recessed" on the other. `--bg-sunken` is recessed in both. Rather than invent a token or ship a theme-dependent hierarchy, the background distinction is dropped and the border carries the signal. If the design wants the current tier visually elevated, that needs a new token — a design decision, not a bug fix.

## Provenance

The `/mcp` commit was written during another session and ended up on an unrelated branch; this PR is where it belongs. The `/billing` commit was added here afterwards, replacing what was originally scoped as a separate follow-up — same root cause, same one-line class of fix, and no reviewer benefit in splitting it.

## Client surface checklist

Not applicable — style values on two pages. No API, migration, spec, SDK, CLI, or MCP change.

## Operational risk

None. Presentational only, no runtime behavior, no API or auth surface. Rollback is a plain revert.

Verified `git merge-tree --write-tree` against #808 (which also touches `billing/page.tsx`): **auto-merges cleanly, no conflicts** — #808's changes are in the SWR hooks and render body, these are in the style blocks.

## Test plan

- [x] Confirmed `--surface` is defined in neither `globals.css` nor `tokens.css`
- [x] Confirmed `--bg-elev`, `--bg-sunken`, `--bg-panel`, `--r-sm` are all defined in both, with light and dark values
- [x] Measured computed `background-color` on every plan card in both themes — reproduced `rgba(0,0,0,0)` on the current tier, confirmed a real color after the fix
- [x] Rendered both states in a browser against the real `globals.css` in light and dark
- [x] `npm run lint` in `web/` — clean
- [x] `npm test` in `web/` — 731 pass, 89 suites
- [x] `npm run build` in `web/` — clean, `/mcp` and `/billing` both still prerender static
- [x] `git merge-tree` against #808 — no conflict

## Not fixed here

Nothing detects this class of bug. `var(--x)` references in **TSX inline style objects** are invisible to stylelint (it parses CSS and CSS-in-JS template literals, not React style props), and stylelint has no built-in undefined-custom-property rule anyway — it's an open request, and the related detection is same-file only. A repo-local guard script that cross-references every `var(--x)` against the token definitions would kill the class permanently and fits the existing `scripts/check-*.mjs` idiom. Worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
