### PR TITLE
docs(plugins): fix stale MCP tool count in marketplace listing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
   "plugins": [
     {
       "name": "e2a",
-      "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 71 MCP tools over hosted streamable HTTP with OAuth.",
+      "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 76 MCP tools over hosted streamable HTTP with OAuth.",
       "category": "productivity",
       "source": "./plugins/e2a",
       "homepage": "https://e2a.dev"


### PR DESCRIPTION
## Summary

- `.claude-plugin/marketplace.json`'s plugin description said "71 MCP tools", but the three plugin manifests (`plugins/e2a/.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, `.cursor-plugin/plugin.json`) and `plugins/e2a/skills/e2a/SKILL.md` all say "76 MCP tools" — which matches the actual registry in `mcp/src/tools/tiers.ts` (`RUNTIME_TOOLS` = 20 entries + `ADMIN_TOOLS` = 56 entries = 76).
- `scripts/validate-plugin.mjs` only checks version-field consistency across manifests, not free-text descriptions, so this drifted silently and isn't caught by CI.
- Fixed the marketplace listing to say "76 MCP tools" to match the rest of the repo and the code-enforced tool count.

This is part of a broader documentation audit across the repo's Markdown/manifest docs; this was the one high-confidence, code-verified discrepancy found.

## Test plan

- [x] Confirmed `RUNTIME_TOOLS` (20) + `ADMIN_TOOLS` (56) = 76 in `mcp/src/tools/tiers.ts` by direct count.
- [x] Confirmed all other plugin manifests and SKILL.md already say 76 (no other file needed changing).
- Docs-only change; no code/API surface touched, so the client surface checklist doesn't apply.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LtZqGT1esNZq72Dj1egqpB)_