### PR TITLE
fix(identity): populate agent_count on same-owner domain re-claim

### DIFF
--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -52,9 +52,9 @@ type Domain struct {
 	// "probed and failed" which is captured by `verified=false` + a
 	// non-null LastCheckedAt.
 	LastCheckedAt *time.Time `json:"last_checked_at,omitempty"`
-	// AgentCount is computed at read time by ListDomainsByUser and
-	// LookupDomain, via the same correlated subquery, and is not a
-	// persisted column.
+	// AgentCount is computed at read time — ListDomainsByUser,
+	// LookupDomain, and ClaimOrCreateDomain's existing-row branch run
+	// the same correlated subquery — and is not a persisted column.
 	AgentCount int `json:"agent_count"`
 	// DKIM keypair fields. The selector + public key
 	// are user-facing — the dashboard shows them so users can copy the
@@ -864,10 +864,19 @@ func (s *Store) ClaimOrCreateDomain(ctx context.Context, domain, userID string) 
 	}
 
 	d := &Domain{}
+	// A same-owner re-claim is idempotent and returns this existing row, which
+	// POST /v1/domains serializes through the same view as GET — so AgentCount
+	// must be the real count (same correlated subquery as LookupDomain /
+	// ListDomainsByUser, trashed agents excluded), not the Go zero value
+	// (#811). The INSERT branch below deliberately omits it: a brand-new row
+	// cannot have agents, so its zero is genuinely correct.
 	err = tx.QueryRow(ctx,
-		`SELECT domain, user_id, verified, verification_token, created_at, verified_at, is_primary, last_checked_at, COALESCE(dkim_selector, ''), COALESCE(dkim_public_key, ''), sending_status, COALESCE(sending_error, ''), sending_dns_records, sending_last_checked_at, COALESCE(sending_dkim_status, ''), COALESCE(sending_mail_from_status, '')
+		`SELECT domain, user_id, verified, verification_token, created_at, verified_at, is_primary, last_checked_at, COALESCE(dkim_selector, ''), COALESCE(dkim_public_key, ''), sending_status, COALESCE(sending_error, ''), sending_dns_records, sending_last_checked_at, COALESCE(sending_dkim_status, ''), COALESCE(sending_mail_from_status, ''),
+		        (SELECT count(*) FROM agent_identities a
+		           WHERE a.registered_domain = domains.domain AND a.user_id = domains.user_id
+		             AND a.deleted_at IS NULL) AS agent_count
 		 FROM domains WHERE domain = $1`, domain,
-	).Scan(&d.Domain, &d.UserID, &d.Verified, &d.VerificationToken, &d.CreatedAt, &d.VerifiedAt, &d.IsPrimary, &d.LastCheckedAt, &d.DKIMSelector, &d.DKIMPublicKey, &d.SendingStatus, &d.SendingError, &d.SendingDNSRecordsJSON, &d.SendingLastCheckedAt, &d.SendingDkimStatus, &d.SendingMailFromStatus)
+	).Scan(&d.Domain, &d.UserID, &d.Verified, &d.VerificationToken, &d.CreatedAt, &d.VerifiedAt, &d.IsPrimary, &d.LastCheckedAt, &d.DKIMSelector, &d.DKIMPublicKey, &d.SendingStatus, &d.SendingError, &d.SendingDNSRecordsJSON, &d.SendingLastCheckedAt, &d.SendingDkimStatus, &d.SendingMailFromStatus, &d.AgentCount)
 	if errors.Is(err, pgx.ErrNoRows) {
 		err = tx.QueryRow(ctx,
 			`INSERT INTO domains (domain, user_id, verified, verification_token, dkim_selector, dkim_public_key, dkim_private_key)

--- a/internal/identity/store_test.go
+++ b/internal/identity/store_test.go
@@ -1278,6 +1278,58 @@ func TestLookupDomain_AgentCountMatchesList(t *testing.T) {
 	t.Fatalf("domain %s not found in ListDomainsByUser", domain)
 }
 
+// TestClaimOrCreateDomain_ReclaimPopulatesAgentCount pins #811: a same-owner
+// re-claim is idempotent and returns the existing row, which POST /v1/domains
+// serializes through the same view as GET /v1/domains/{domain} — so its
+// AgentCount must be the real count (trashed agents excluded, mirroring
+// TestLookupDomain_AgentCountMatchesList), not the Go zero value. The
+// first-claim assertion also pins the INSERT branch's genuine zero, so a
+// passing count is a real count and not a constant.
+func TestClaimOrCreateDomain_ReclaimPopulatesAgentCount(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, err := store.CreateOrGetUser(ctx, "reclaim-count@example.com", "Owner", "google-reclaim-count")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	const domain = "reclaimcount.example.com"
+	first, err := store.ClaimOrCreateDomain(ctx, domain, user.ID)
+	if err != nil {
+		t.Fatalf("ClaimOrCreateDomain (create): %v", err)
+	}
+	if first.AgentCount != 0 {
+		t.Errorf("fresh claim AgentCount = %d, want 0 (brand-new row cannot have agents)", first.AgentCount)
+	}
+	if _, err := store.CreateAgent(ctx, "keep@"+domain, domain, "Keep", "", "", user.ID); err != nil {
+		t.Fatalf("CreateAgent keep: %v", err)
+	}
+	trash, err := store.CreateAgent(ctx, "trash@"+domain, domain, "Trash", "", "", user.ID)
+	if err != nil {
+		t.Fatalf("CreateAgent trash: %v", err)
+	}
+	if err := store.SoftDeleteAgent(ctx, trash.ID, user.ID); err != nil {
+		t.Fatalf("SoftDeleteAgent: %v", err)
+	}
+
+	reclaimed, err := store.ClaimOrCreateDomain(ctx, domain, user.ID)
+	if err != nil {
+		t.Fatalf("ClaimOrCreateDomain (re-claim): %v", err)
+	}
+	if reclaimed.AgentCount != 1 {
+		t.Errorf("re-claim AgentCount = %d, want 1 (one live agent, trashed one excluded)", reclaimed.AgentCount)
+	}
+
+	looked, err := store.LookupDomain(ctx, domain, user.ID)
+	if err != nil {
+		t.Fatalf("LookupDomain: %v", err)
+	}
+	if looked.AgentCount != reclaimed.AgentCount {
+		t.Errorf("LookupDomain AgentCount = %d, re-claim AgentCount = %d, want equal", looked.AgentCount, reclaimed.AgentCount)
+	}
+}
+
 // TestTouchDomainLastChecked_PersistsTimestamp: ensures the column
 // actually moves when called. This is the only path that writes
 // last_checked_at; without the touch, the column stays NULL even after

--- a/tests/contract/scenarios.yaml
+++ b/tests/contract/scenarios.yaml
@@ -225,9 +225,10 @@ scenarios:
 
   - name: domain_agent_count
     description: >
-      agent_count agrees between GET /v1/domains/{domain} and GET /v1/domains
-      for the same domain (#632). The single-resource path used to omit the
-      count from its SELECT, so it served Go's zero value as an authoritative
+      agent_count agrees between GET /v1/domains/{domain}, GET /v1/domains,
+      and an idempotent re-register via POST /v1/domains for the same domain
+      (#632, #811). The single-resource and claim paths used to omit the count
+      from their SELECTs, so they served Go's zero value as an authoritative
       `0` — indistinguishable from a domain that really has no agents, on the
       endpoint get_domain documents as the poll target after verify_domain.
       Deliberately NOT folded into domain_crud: that scenario asserts
@@ -285,6 +286,21 @@ scenarios:
         path: /v1/domains/agentcount.test.dev
         expect:
           status: 200
+          body_match:
+            agent_count: 1
+
+      # The #811 regression pin: re-registering an owned domain is idempotent
+      # (201, existing row returned), and that row must carry the real count —
+      # the claim path used to leave the field at the Go zero value, serving
+      # the same false 0 that #632 fixed on the GET path.
+      - id: reregister_counts_agent
+        action: request
+        method: POST
+        path: /v1/domains
+        body:
+          domain: agentcount.test.dev
+        expect:
+          status: 201
           body_match:
             agent_count: 1
 

--- a/tests/contract/scenarios.yaml
+++ b/tests/contract/scenarios.yaml
@@ -293,6 +293,12 @@ scenarios:
       # (201, existing row returned), and that row must carry the real count —
       # the claim path used to leave the field at the Go zero value, serving
       # the same false 0 that #632 fixed on the GET path.
+      #
+      # `verified` is pinned alongside the count because idempotent means the
+      # EXISTING row, untouched: the read/insert split returns it as-is, but a
+      # future rewrite into `INSERT … ON CONFLICT DO UPDATE` would silently
+      # reset verification on every re-register and agent_count alone would
+      # still pass. The domain is verified two steps above, so this is free.
       - id: reregister_counts_agent
         action: request
         method: POST
@@ -303,6 +309,7 @@ scenarios:
           status: 201
           body_match:
             agent_count: 1
+            verified: true
 
       # ...and the list path reports the same number for the same domain.
       # Containment, not index or length: the account may hold other domains.


### PR DESCRIPTION
## Summary

`POST /v1/domains` returns `agent_count: 0` when re-registering a domain the caller already owns, even when the domain has live agents. A same-owner claim is idempotent (the cross-account guard is `user_id IS DISTINCT FROM $2`), so the endpoint returns the *existing* row — but `ClaimOrCreateDomain`'s existing-row `SELECT` never computed `AgentCount`, and `handleRegisterDomain` renders the result through the same `domainViewWithRamp` as `GET /v1/domains/{domain}`, so the Go zero value was serialized as an authoritative `0`.

This is the residual of #632 (fixed for `LookupDomain` in #806) on the register path, filed as #811.

## Fix

The existing-row branch of `ClaimOrCreateDomain` now runs the same correlated subquery `LookupDomain` and `ListDomainsByUser` use (trashed agents excluded), so all three endpoints that serialize a domain agree. The `INSERT … RETURNING` branch is deliberately untouched: a brand-new row cannot have agents, so its zero is genuinely correct.

No API shape change: `agent_count` is an existing required GA field; only its value on this path was wrong. (#811's option 1 — making the field `*int` so a forgotten subquery serializes as absent — would kill the class, but it drops a required field from the GA `/v1` shape, which the compat gate exists to prevent, so this PR takes option 2.)

## Verification

All against a real Postgres 16 instance in Docker:

- New store regression test `TestClaimOrCreateDomain_ReclaimPopulatesAgentCount` (`internal/identity/store_test.go`): fails pre-fix (`re-claim AgentCount = 0, want 1`), passes with the fix. Also pins the fresh-claim zero and agreement with `LookupDomain`.
- New `reregister_counts_agent` step on the `domain_agent_count` contract scenario (`tests/contract/scenarios.yaml`) — the extension point #811 names. Fails pre-fix (`agent_count = 0 (float64), want 1`), passes with the fix, via the Go runner; the step is runner-agnostic YAML with resource-scoped assertions, matching the scenario's existing constraints.
- `internal/identity`, `internal/httpapi`, `tests/contract` pass in full, plus `internal/sendramp` / `internal/apiserver` / `internal/contactdue` (whose tests call `ClaimOrCreateDomain` as setup). `gofmt` and `go vet` clean.
- TS/Python contract runners not run locally (need a wired live server); the Go runner passes and CI runs all three.

Fixes #811

🤖 Generated with [Claude Code](https://claude.com/claude-code)