### PR TITLE
fix(metrics): exclude review and schedule dwell from outbound terminal latency

### DIFF
--- a/docs/design/hitl-ttl-async-send.md
+++ b/docs/design/hitl-ttl-async-send.md
@@ -164,6 +164,15 @@ time — so a hold approved >72h after creation, during a provider outage at sen
 time, would terminate immediately instead of snoozing. Narrow edge; shared with the
 normal-send anchor, out of scope here.
 
+**F2 addendum (2026-08-04):** the same `created_at` anchor also fed the
+acceptance→terminal latency SLI, so a hold's review dwell was recorded as e2a
+latency — a reviewer clearing a queue of held messages put every one of them
+outside the 300s SLO window and burned the hosted error budget (prod alert,
+2026-08-03). The **metric** now anchors at `messages.reviewed_at` for a held
+message via `outboundsend.submissionAnchor`; `SendJob.AcceptedAt` and the 72h
+retry horizon are deliberately untouched, so F2 itself remains open as
+described above.
+
 ## Scope / non-goals
 
 - Both approve paths (TTL sweep + human endpoint). Self-sends stay on the sync

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -89,7 +89,7 @@ acceptance SLI below deliberately excludes them.
 | `e2a_outbound_attempt_duration_seconds` | histogram | — | Upstream (SES/SMTP relay) submission duration. |
 | `e2a_outbound_rate_deferred_total` | counter | — | Submissions deferred by the per-agent fire-time rate limiter (`internal/sendrate`, 60/min/agent sliding window, enforced in the send worker immediately before provider submission). A deferral snoozes the job without burning an attempt, metering, or emitting a terminal event — the message fires when the window frees capacity (re-fire spread by a deterministic per-message jitter). A sustained high rate means agents are queueing behind their own budget. Deferral loops are bounded by the 72h retry horizon, so a backlog beyond ~259,200 messages/agent/burst (60 × 60 × 72) fails its tail terminally with `send_rate_timeout` (`failed_local_retries`). |
 | `e2a_outbound_terminal_total` | counter | `outcome` | Messages reaching a terminal submission outcome, **exactly once per message**: `sent`, `failed_suppressed`, `failed_provider`, `failed_local_retries`, `failed_cancelled` (policy cancel settled by the reconciler — kept out of `failed_local_retries` so cancellations can't mask a retries-exhausted regression). A deferred final attempt is counted when the terminal reconciler settles it — as `sent` when provider-accept evidence arrived (never a false failure), else as a failure. |
-| `e2a_outbound_terminal_latency_seconds` | histogram | — | Acceptance→terminal latency per message (the terminal write's occurred_at − `messages.created_at`), observed **exactly once per message**, co-located with the `e2a_outbound_terminal_total` emission so the two share their exactly-once contract (the SNS-feedback settle path is deliberately uninstrumented for both). Provider-evidence settles use the evidence's accept time as occurred_at, so they measure acceptance→provider-accept, not acceptance→sweep. Buckets span seconds→days (the 72h retry horizon is the tail). |
+| `e2a_outbound_terminal_latency_seconds` | histogram | — | Acceptance→terminal latency per message (the terminal write's occurred_at − the **submission anchor**), observed **exactly once per message**, co-located with the `e2a_outbound_terminal_total` emission so the two share their exactly-once contract (the SNS-feedback settle path is deliberately uninstrumented for both). The anchor is `messages.created_at` for an ordinary send, and the latest of `created_at`, `scheduled_at`, and `reviewed_at` otherwise: a HITL hold anchors at the moment it was approved into the send pipeline, a scheduled send at its fire time. Neither wait is e2a latency, and charging them here made every hold approved after >5 min — and every send scheduled further out than the window — an automatic SLO miss. Provider-evidence settles use the evidence's accept time as occurred_at, so they measure anchor→provider-accept, not anchor→sweep. Buckets span seconds→days (the 72h retry horizon is the tail). |
 
 ### Webhook delivery
 
@@ -270,8 +270,11 @@ max(e2a_queue_oldest_age_seconds{queue="outbound"})
 ```
 
 **Outbound acceptance→terminal** — fraction of messages reaching a terminal
-outcome within 5 minutes of acceptance (the `le="300"` bucket edge is the
-SLO threshold):
+outcome within 5 minutes of becoming eligible to submit (the `le="300"`
+bucket edge is the SLO threshold). "Acceptance" here is the submission anchor
+in the catalog above, not raw `created_at`: a HITL hold's review dwell and a
+scheduled send's deliberate delay are outside the measurement, so a reviewer
+who takes an hour cannot burn e2a's budget:
 
 ```promql
 sum(rate(e2a_outbound_terminal_latency_seconds_bucket{le="300"}[1h]))

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -89,7 +89,7 @@ acceptance SLI below deliberately excludes them.
 | `e2a_outbound_attempt_duration_seconds` | histogram | — | Upstream (SES/SMTP relay) submission duration. |
 | `e2a_outbound_rate_deferred_total` | counter | — | Submissions deferred by the per-agent fire-time rate limiter (`internal/sendrate`, 60/min/agent sliding window, enforced in the send worker immediately before provider submission). A deferral snoozes the job without burning an attempt, metering, or emitting a terminal event — the message fires when the window frees capacity (re-fire spread by a deterministic per-message jitter). A sustained high rate means agents are queueing behind their own budget. Deferral loops are bounded by the 72h retry horizon, so a backlog beyond ~259,200 messages/agent/burst (60 × 60 × 72) fails its tail terminally with `send_rate_timeout` (`failed_local_retries`). |
 | `e2a_outbound_terminal_total` | counter | `outcome` | Messages reaching a terminal submission outcome, **exactly once per message**: `sent`, `failed_suppressed`, `failed_provider`, `failed_local_retries`, `failed_cancelled` (policy cancel settled by the reconciler — kept out of `failed_local_retries` so cancellations can't mask a retries-exhausted regression). A deferred final attempt is counted when the terminal reconciler settles it — as `sent` when provider-accept evidence arrived (never a false failure), else as a failure. |
-| `e2a_outbound_terminal_latency_seconds` | histogram | — | Acceptance→terminal latency per message (the terminal write's occurred_at − the **submission anchor**), observed **exactly once per message**, co-located with the `e2a_outbound_terminal_total` emission so the two share their exactly-once contract (the SNS-feedback settle path is deliberately uninstrumented for both). The anchor is `messages.created_at` for an ordinary send, and the latest of `created_at`, `scheduled_at`, and `reviewed_at` otherwise: a HITL hold anchors at the moment it was approved into the send pipeline, a scheduled send at its fire time. Neither wait is e2a latency, and charging them here made every hold approved after >5 min — and every send scheduled further out than the window — an automatic SLO miss. Provider-evidence settles use the evidence's accept time as occurred_at, so they measure anchor→provider-accept, not anchor→sweep. Buckets span seconds→days (the 72h retry horizon is the tail). |
+| `e2a_outbound_terminal_latency_seconds` | histogram | — | Eligibility→terminal latency per message (the terminal write's occurred_at − the **submission anchor**), observed **at most once per message**, co-located with the `e2a_outbound_terminal_total` emission so the two share their exactly-once contract (the SNS-feedback settle path is deliberately uninstrumented for both; a terminal landing before its own anchor records the count with no sample — see the SLO section). The anchor is `messages.created_at` for an ordinary send, and the latest of `created_at`, `scheduled_at`, and `reviewed_at` otherwise: a HITL hold anchors at the moment it was approved into the send pipeline, a scheduled send at its fire time. Neither wait is e2a latency, and charging them here made every hold approved after >5 min — and every send scheduled further out than the window — an automatic SLO miss. Provider-evidence settles use the evidence's accept time as occurred_at, so they measure anchor→provider-accept, not anchor→sweep. Buckets span seconds→days (the 72h retry horizon is the tail). |
 
 ### Webhook delivery
 
@@ -269,22 +269,34 @@ sum(rate(e2a_outbound_queue_wait_seconds_bucket{le="30"}[5m]))
 max(e2a_queue_oldest_age_seconds{queue="outbound"})
 ```
 
-**Outbound acceptance→terminal** — fraction of messages reaching a terminal
-outcome within 5 minutes of becoming eligible to submit (the `le="300"`
-bucket edge is the SLO threshold). "Acceptance" here is the submission anchor
-in the catalog above, not raw `created_at`: a HITL hold's review dwell and a
-scheduled send's deliberate delay are outside the measurement, so a reviewer
-who takes an hour cannot burn e2a's budget:
+**Outbound eligibility→terminal** (historically "acceptance→terminal", which
+is still the hosted alert's name — the query below is unchanged by the
+rename) — fraction of messages reaching a terminal outcome within 5 minutes of
+becoming *eligible to submit* (the `le="300"` bucket edge is the SLO
+threshold). The baseline is the submission anchor in the catalog above, not raw
+`created_at`: a HITL hold's review dwell and a scheduled send's deliberate delay
+are outside the measurement, so a reviewer who takes an hour cannot burn e2a's
+budget:
 
 ```promql
 sum(rate(e2a_outbound_terminal_latency_seconds_bucket{le="300"}[1h]))
 / sum(rate(e2a_outbound_terminal_latency_seconds_count[1h]))
 ```
 
-The histogram's exactly-once contract (one sample per message, co-located
-with `e2a_outbound_terminal_total`) is what makes this ratio a per-message
-fraction; an outage-tail message can legitimately land in the day-scale
-buckets, so alert on the ratio, not the tail.
+The histogram's per-message contract (at most one sample per message,
+co-located with `e2a_outbound_terminal_total`) is what makes this ratio a
+per-message fraction; an outage-tail message can legitimately land in the
+day-scale buckets, so alert on the ratio, not the tail. A terminal that lands
+before its own anchor — a scheduled send cancelled ahead of its fire time, or
+an approve submitted inside the app/DB clock skew — records the count with no
+latency sample, so `_count` can trail `e2a_outbound_terminal_total` slightly
+wherever holds or schedules are used. Both sides of the ratio lose the same
+sample, so the drop cannot flatter the SLI.
+
+When the anchor first ships, the reported late fraction steps down on any
+deployment using HITL or scheduled sends — those samples were never e2a
+latency. Annotate the dashboard at that release so the step is not read as a
+regression, and do not re-baseline the alert against pre-anchor history.
 
 **Webhook eventual delivery** — initial deliveries that reached a terminal
 state without an e2a-attributable failure. `endpoint_failure` is deliberately

--- a/internal/agent/outbound_async.go
+++ b/internal/agent/outbound_async.go
@@ -179,6 +179,9 @@ func (a *outboundSendStore) ClaimSend(ctx context.Context, messageID string, job
 	if p.ScheduledAt != nil {
 		sj.ScheduledAt = *p.ScheduledAt
 	}
+	if p.ReviewedAt != nil {
+		sj.ReviewedAt = *p.ReviewedAt
+	}
 	return sj, nil
 }
 

--- a/internal/agent/outbound_async_test.go
+++ b/internal/agent/outbound_async_test.go
@@ -1311,3 +1311,81 @@ func countEvents(t *testing.T, store *identity.Store, userID, eventType string) 
 	}
 	return n
 }
+
+// recordingSendMetrics captures the terminal SLI emissions of a store-backed
+// send (the outboundsend package has its own recorder for fake-store tests).
+type recordingSendMetrics struct {
+	terminals []string
+	latencies []float64
+}
+
+func (r *recordingSendMetrics) OutboundQueueWait(float64) {}
+func (r *recordingSendMetrics) OutboundTerminal(outcome string) {
+	r.terminals = append(r.terminals, outcome)
+}
+func (r *recordingSendMetrics) OutboundTerminalLatency(seconds float64) {
+	r.latencies = append(r.latencies, seconds)
+}
+func (r *recordingSendMetrics) OutboundAttempt(string, float64) {}
+func (r *recordingSendMetrics) OutboundRateDeferred()           {}
+
+// The acceptance→terminal SLI anchors a HITL hold at its approve time and a
+// scheduled send at its fire time, but the worker only ever sees those gates if
+// ClaimSend carries them out of the store payload — the messages row →
+// OutboundSendPayload → SendJob seam that lives in this package. Every
+// worker-level latency test builds SendJob by hand against a fake store, so
+// this store-backed pass is the only thing standing between a dropped field at
+// that seam and a silent return of the reviewer's dwell to e2a's error budget.
+func TestSendWorker_ClaimCarriesSubmissionGatesIntoTerminalLatency(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		label string
+		held  bool // gate the row on reviewed_at (a HITL hold) vs scheduled_at
+	}{
+		{"hitl hold anchors at approve", "gatehold", true},
+		{"scheduled send anchors at fire time", "gatesched", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			api, store, outbox, _, pool := setupAsyncAPIWithPool(t)
+			ctx := context.Background()
+			user, ag := selfAgent(t, store, tc.label)
+			res, oerr := api.DeliverOutbound(ctx, user, ag, outbound.SendRequest{
+				To: []string{"gated@external.test"}, Subject: "gated", Body: "b",
+			}, "send", "", nil, nil)
+			if oerr != nil || res == nil {
+				t.Fatalf("DeliverOutbound: res=%+v err=%+v", res, oerr)
+			}
+			// Drafted two hours ago, released into the send pipeline 30 seconds
+			// ago. Anchored at the gate the sample is ~30s; anchored at
+			// created_at it is ~2h — an automatic miss against the 300s SLO.
+			if _, err := pool.Exec(ctx,
+				`UPDATE messages
+				    SET created_at   = now() - interval '2 hours',
+				        reviewed_at  = CASE WHEN $2 THEN now() - interval '30 seconds' END,
+				        scheduled_at = CASE WHEN $2 THEN NULL ELSE now() - interval '30 seconds' END
+				  WHERE id = $1`, res.MessageID, tc.held); err != nil {
+				t.Fatalf("age the row: %v", err)
+			}
+
+			adapter := agent.NewOutboundSendStore(store, outbox, usage.NewNoopUsageTracker())
+			deliverer := fakeAsyncDeliverer{out: outboundsend.DeliverOutcome{ProviderMessageID: "ses-gated", SentAs: "relay"}}
+			rec := &recordingSendMetrics{}
+			if err := outboundsend.NewSendWorker(adapter, deliverer).WithMetrics(rec).Work(ctx, workerJob(res.MessageID, 1)); err != nil {
+				t.Fatalf("worker.Work: %v", err)
+			}
+			if len(rec.terminals) != 1 || rec.terminals[0] != "sent" {
+				t.Fatalf("terminals = %v, want [sent]", rec.terminals)
+			}
+			if len(rec.latencies) != 1 {
+				t.Fatalf("latencies = %v, want exactly one sample", rec.latencies)
+			}
+			gate := "scheduled_at"
+			if tc.held {
+				gate = "reviewed_at"
+			}
+			if got := rec.latencies[0]; got > 120 {
+				t.Errorf("terminal latency = %.0fs, want ~30s: ClaimSend must carry messages.%s into SendJob, or the SLI charges the caller's own wait to e2a", got, gate)
+			}
+		})
+	}
+}

--- a/internal/identity/delivery_store.go
+++ b/internal/identity/delivery_store.go
@@ -437,6 +437,11 @@ type OutboundSendPayload struct {
 	// ScheduledAt) so a long-scheduled send keeps the full outage-tolerant tail
 	// from its fire time instead of a horizon already blown at fire.
 	ScheduledAt *time.Time
+	// ReviewedAt is messages.reviewed_at — when a HITL hold was resolved into the
+	// send pipeline (human approve or TTL auto-approve), nil for a message that
+	// was never held. Feeds the worker's acceptance→terminal SLI anchor only, so
+	// a reviewer's dwell time is not charged to e2a's latency budget.
+	ReviewedAt *time.Time
 	// ProviderMessageID is the evidence-repaired provider id ('' when none).
 	ProviderMessageID string
 }
@@ -584,6 +589,7 @@ func (s *Store) ClaimOutboundForSend(ctx context.Context, messageID string, jobI
 		failureOccurredAt  *time.Time
 		failureAttempt     *int
 		scheduledAt        *time.Time
+		reviewedAt         *time.Time
 	)
 	var userID, registeredDomain string
 	// Lock agent first to match permanent agent deletion's lock order, then
@@ -607,14 +613,14 @@ func (s *Store) ClaimOutboundForSend(ctx context.Context, messageID string, jobI
 		        m.to_recipients, m.cc, m.bcc, m.raw_message, m.created_at,
 		        m.deleted_at, m.send_job_id, m.provider_accepted_at, COALESCE(m.provider_message_id,''),
 		        COALESCE(m.delivery_failure_source,''),COALESCE(m.delivery_failure_reason_code,''),
-		        m.delivery_failure_occurred_at,m.delivery_failure_attempt,m.scheduled_at
+		        m.delivery_failure_occurred_at,m.delivery_failure_attempt,m.scheduled_at,m.reviewed_at
 		   FROM messages m
 		  WHERE m.id = $1 AND m.agent_id = $2 AND m.direction = 'outbound'
 		  FOR UPDATE OF m`,
 		messageID, agentID,
 	).Scan(&deliveryStatus, &envelopeFrom, &sentAs, &messageType, &to, &cc, &bcc, &raw, &createdAt,
 		&deletedAt, &stampedJobID, &providerAcceptedAt, &providerMessageID,
-		&failureSource, &failureReason, &failureOccurredAt, &failureAttempt, &scheduledAt)
+		&failureSource, &failureReason, &failureOccurredAt, &failureAttempt, &scheduledAt, &reviewedAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		if err := tx.Commit(ctx); err != nil {
 			return nil, err
@@ -703,6 +709,7 @@ func (s *Store) ClaimOutboundForSend(ctx context.Context, messageID string, jobI
 		ProviderAcceptedAt: providerAcceptedAt,
 		ProviderMessageID:  providerMessageID,
 		ScheduledAt:        scheduledAt,
+		ReviewedAt:         reviewedAt,
 	}
 	if err := tx.Commit(ctx); err != nil {
 		return nil, err

--- a/internal/outboundsend/metrics.go
+++ b/internal/outboundsend/metrics.go
@@ -62,17 +62,45 @@ func (noopMetrics) OutboundRateDeferred()           {}
 // lives in this single helper so no call site can emit one without the
 // other. occurredAt is the terminal write's EFFECTIVE occurred_at (what the
 // write actually did: the provider-accept evidence time on an evidence
-// settle, the caller's observation time otherwise); acceptedAt is
-// messages.created_at. A zero timestamp or non-positive delta records the
+// settle, the caller's observation time otherwise); anchorAt is the
+// submission anchor (see submissionAnchor — messages.created_at for an
+// ordinary send). A zero timestamp or non-positive delta records the
 // count but no latency sample (same discipline as the queue-wait guard).
-func emitTerminal(m Metrics, outcome string, acceptedAt, occurredAt time.Time) {
+func emitTerminal(m Metrics, outcome string, anchorAt, occurredAt time.Time) {
 	m.OutboundTerminal(outcome)
-	if acceptedAt.IsZero() || occurredAt.IsZero() {
+	if anchorAt.IsZero() || occurredAt.IsZero() {
 		return
 	}
-	if d := occurredAt.Sub(acceptedAt); d > 0 {
+	if d := occurredAt.Sub(anchorAt); d > 0 {
 		m.OutboundTerminalLatency(d.Seconds())
 	}
+}
+
+// submissionAnchor is the acceptance→terminal SLI's baseline: the instant a
+// message became ELIGIBLE for provider submission, which is not always its
+// accept time. Two gates deliberately hold an accepted row before the pipeline
+// may touch it, and both are the caller's choice rather than e2a latency:
+//
+//   - a HITL hold sits in pending_review until a reviewer (or the TTL sweep)
+//     resolves it — reviewedAt is when it was approved into the send pipeline;
+//   - a scheduled send waits for its fire time — scheduledAt.
+//
+// Measuring from messages.created_at charged both waits to e2a's error budget,
+// so a reviewer taking six minutes, or any send scheduled further out than the
+// 300s SLO window, recorded as a miss (docs/observability.md: every target
+// measures e2a's own behavior). Taking the latest of the three mirrors
+// pastRetryHorizon's existing max(accept, scheduled) reasoning and keeps the
+// send worker and the terminal reconciler on one definition. Zero values are
+// inert — an unheld, unscheduled message anchors at acceptedAt as before.
+func submissionAnchor(acceptedAt, scheduledAt, reviewedAt time.Time) time.Time {
+	anchor := acceptedAt
+	if scheduledAt.After(anchor) {
+		anchor = scheduledAt
+	}
+	if reviewedAt.After(anchor) {
+		anchor = reviewedAt
+	}
+	return anchor
 }
 
 // terminalOutcome maps a MarkFailed call's provenance to the OutboundTerminal

--- a/internal/outboundsend/metrics.go
+++ b/internal/outboundsend/metrics.go
@@ -20,10 +20,11 @@ type Metrics interface {
 	// outcome ∈ {sent, failed_suppressed, failed_provider,
 	// failed_local_retries, failed_cancelled}.
 	OutboundTerminal(outcome string)
-	// OutboundTerminalLatency records acceptance→terminal latency for one
-	// outbound message (the terminal write's occurred_at −
-	// messages.created_at). Observed exactly once per message, co-located
-	// with OutboundTerminal so the two share their exactly-once contract.
+	// OutboundTerminalLatency records eligibility→terminal latency for one
+	// outbound message (the terminal write's occurred_at − submissionAnchor).
+	// Observed at most once per message, co-located with OutboundTerminal so
+	// the two share their exactly-once contract; a terminal whose occurred_at
+	// precedes its anchor records the count with no latency sample.
 	OutboundTerminalLatency(seconds float64)
 	// OutboundAttempt records one submission attempt to the upstream relay.
 	// outcome ∈ {success, temporary_failure, permanent_failure}.
@@ -66,6 +67,15 @@ func (noopMetrics) OutboundRateDeferred()           {}
 // submission anchor (see submissionAnchor — messages.created_at for an
 // ordinary send). A zero timestamp or non-positive delta records the
 // count but no latency sample (same discipline as the queue-wait guard).
+//
+// A gated row can reach that guard for real, where an ordinary send never
+// could: a scheduled send cancelled BEFORE its fire time settles ahead of its
+// own anchor, and an approve submitted within the app/DB clock skew can too
+// (anchorAt comes from Postgres now(), occurredAt from this process). Dropping
+// those is deliberate — the message never became eligible, and the drop is
+// pessimistic for the SLI because it removes a fast sample from both sides of
+// the ratio. It does mean the histogram's _count can trail
+// e2a_outbound_terminal_total slightly wherever holds or schedules are used.
 func emitTerminal(m Metrics, outcome string, anchorAt, occurredAt time.Time) {
 	m.OutboundTerminal(outcome)
 	if anchorAt.IsZero() || occurredAt.IsZero() {

--- a/internal/outboundsend/metrics_test.go
+++ b/internal/outboundsend/metrics_test.go
@@ -396,3 +396,88 @@ func TestSendWorker_TerminalLatencyMarkFailedSettlesSentUsesWriteTime(t *testing
 		t.Errorf("latency = %.1fs, want ~60s (the write's effective occurred_at − accepted_at)", got)
 	}
 }
+
+// A HITL hold sits in pending_review until a human (or the TTL sweep) resolves
+// it. That dwell is the reviewer's time, not e2a's, and measuring it from
+// messages.created_at put every hold approved more than 5 minutes after
+// drafting outside the acceptance→terminal SLO window — the failure mode that
+// burned the prod error budget on 2026-08-03.
+func TestSendWorker_TerminalLatencyExcludesHumanReviewDwell(t *testing.T) {
+	j := acceptedJob("msg_1")
+	j.AcceptedAt = time.Now().Add(-2 * time.Hour)
+	j.ReviewedAt = time.Now().Add(-30 * time.Second)
+	st := &fakeStore{job: j}
+	dl := &fakeDeliverer{out: outboundsend.DeliverOutcome{ProviderMessageID: "ses-1", SentAs: "relay"}}
+	rec := &recordingMetrics{}
+	if err := outboundsend.NewSendWorker(st, dl).WithMetrics(rec).Work(context.Background(), job("msg_1", 1)); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	if len(rec.latencies) != 1 {
+		t.Fatalf("latencies = %v, want exactly one sample", rec.latencies)
+	}
+	if got := rec.latencies[0]; got < 25 || got > 35 {
+		t.Errorf("terminal latency = %.1fs, want ~30s (occurred_at − reviewed_at); a 2h hold must not be charged to e2a", got)
+	}
+}
+
+// A scheduled send waits for its fire time by construction, so anchoring at
+// created_at made every send scheduled further out than the 300s window a
+// guaranteed SLO miss. Same defect class as the HITL hold above.
+func TestSendWorker_TerminalLatencyExcludesScheduledDelay(t *testing.T) {
+	j := acceptedJob("msg_1")
+	j.AcceptedAt = time.Now().Add(-48 * time.Hour)
+	j.ScheduledAt = time.Now().Add(-30 * time.Second)
+	st := &fakeStore{job: j}
+	dl := &fakeDeliverer{out: outboundsend.DeliverOutcome{ProviderMessageID: "ses-1", SentAs: "relay"}}
+	rec := &recordingMetrics{}
+	if err := outboundsend.NewSendWorker(st, dl).WithMetrics(rec).Work(context.Background(), job("msg_1", 1)); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	if len(rec.latencies) != 1 {
+		t.Fatalf("latencies = %v, want exactly one sample", rec.latencies)
+	}
+	if got := rec.latencies[0]; got < 25 || got > 35 {
+		t.Errorf("terminal latency = %.1fs, want ~30s (occurred_at − scheduled_at)", got)
+	}
+}
+
+// The ordinary path must be untouched: an unheld, unscheduled message still
+// measures from accept, so the SLI keeps reporting real pipeline latency.
+func TestSendWorker_TerminalLatencyUnheldMessageStillAnchorsAtAccept(t *testing.T) {
+	j := acceptedJob("msg_1")
+	j.AcceptedAt = time.Now().Add(-90 * time.Second)
+	st := &fakeStore{job: j}
+	dl := &fakeDeliverer{out: outboundsend.DeliverOutcome{ProviderMessageID: "ses-1", SentAs: "relay"}}
+	rec := &recordingMetrics{}
+	if err := outboundsend.NewSendWorker(st, dl).WithMetrics(rec).Work(context.Background(), job("msg_1", 1)); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	if len(rec.latencies) != 1 {
+		t.Fatalf("latencies = %v, want exactly one sample", rec.latencies)
+	}
+	if got := rec.latencies[0]; got < 85 || got > 95 {
+		t.Errorf("terminal latency = %.1fs, want ~90s — zero reviewed_at/scheduled_at must be inert", got)
+	}
+}
+
+// A hold whose send then fails is measured the same way: the reviewer's dwell
+// is excluded from the failure's latency sample too, so the two terminal arms
+// cannot disagree about what "acceptance" means.
+func TestSendWorker_TerminalLatencyExcludesReviewDwellOnFailureOutcome(t *testing.T) {
+	j := acceptedJob("msg_1")
+	j.AcceptedAt = time.Now().Add(-2 * time.Hour)
+	j.ReviewedAt = time.Now().Add(-30 * time.Second)
+	st := &fakeStore{job: j, suppressed: []string{"blocked@example.com"}}
+	dl := &fakeDeliverer{out: outboundsend.DeliverOutcome{}}
+	rec := &recordingMetrics{}
+	err := outboundsend.NewSendWorker(st, dl).WithMetrics(rec).Work(context.Background(), job("msg_1", 1))
+	if err == nil {
+		t.Fatal("Work: want a cancel error for a suppressed recipient")
+	}
+	if len(rec.latencies) != 1 {
+		t.Fatalf("latencies = %v, want exactly one sample", rec.latencies)
+	}
+	if got := rec.latencies[0]; got < 25 || got > 35 {
+		t.Errorf("terminal latency = %.1fs, want ~30s (occurred_at − reviewed_at)", got)
+	}
+}

--- a/internal/outboundsend/reconcile_test.go
+++ b/internal/outboundsend/reconcile_test.go
@@ -422,6 +422,51 @@ func TestTerminalReconcileWorker_RecordsTerminalLatencyPerSettledRow(t *testing.
 	}
 }
 
+// The reconciler reads its own gates out of SQL, so the shared anchor helper
+// being correct proves nothing about the sweep path: only a store-backed pass
+// shows that the candidate query actually selects reviewed_at/scheduled_at and
+// that the emit site uses them. A held row stranded by a dead job is exactly
+// the population that burned the error budget on 2026-08-03 — settled minutes
+// after a review that may have taken hours.
+func TestTerminalReconcileWorker_TerminalLatencyExcludesReviewAndScheduleDwell(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	adapter := agent.NewOutboundSendStore(store,
+		webhookpub.NewOutbox(pool, webhookpub.StaticFlag(true)), usage.NewNoopUsageTracker())
+
+	f := newTerminalFixture(t, pool, store, adapter)
+	heldID := f.seed(t, "lat-held", "accepted", "discarded", false)
+	scheduledID := f.seed(t, "lat-scheduled", "accepted", "discarded", false)
+	// Both drafted three hours ago and released into the pipeline 30 seconds
+	// before their job died. A discarded row settles at its finalized_at, so
+	// pinning each gate off that column makes the gate-anchored latency exactly
+	// ~30s — where the created_at anchor would record hours.
+	for _, tc := range []struct{ id, column string }{
+		{heldID, "reviewed_at"},
+		{scheduledID, "scheduled_at"},
+	} {
+		gate := `(SELECT r.finalized_at - interval '30 seconds' FROM river_job r WHERE r.id = m.send_job_id)`
+		if _, err := f.pool.Exec(context.Background(),
+			`UPDATE messages m SET created_at = now() - interval '3 hours', `+tc.column+` = `+gate+` WHERE m.id=$1`, tc.id); err != nil {
+			t.Fatalf("gate %s on %s: %v", tc.column, tc.id, err)
+		}
+	}
+
+	rec := &recordingMetrics{}
+	worker := outboundsend.NewTerminalReconcileWorker(pool, adapter).WithMetrics(rec)
+	if err := worker.Work(context.Background(), &river.Job[outboundsend.TerminalReconcileArgs]{}); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	if len(rec.terminals) != 2 || len(rec.latencies) != 2 {
+		t.Fatalf("terminals=%v latencies=%v, want one of each per settled row", rec.terminals, rec.latencies)
+	}
+	for _, got := range rec.latencies {
+		if got < 25 || got > 35 {
+			t.Errorf("reconciled terminal latency = %.0fs, want ~30s (settle − the gate); the sweep must anchor at reviewed_at/scheduled_at, not created_at", got)
+		}
+	}
+}
+
 func TestTerminalReconcileWorker_ReconcilesOnlyTerminalJobs(t *testing.T) {
 	pool := testutil.TestDB(t)
 	store := identity.NewStore(pool)

--- a/internal/outboundsend/terminal_reconcile.go
+++ b/internal/outboundsend/terminal_reconcile.go
@@ -77,13 +77,29 @@ type terminalCandidate struct {
 	attempt                  int
 	state                    string
 	finalizedAt              *time.Time
-	acceptedAt               time.Time // messages.created_at — the latency SLI baseline
+	acceptedAt               time.Time  // messages.created_at
+	scheduledAt              *time.Time // messages.scheduled_at (nil unless scheduled)
+	reviewedAt               *time.Time // messages.reviewed_at (nil unless HITL-held)
 	failureSource            delivery.FailureSource
 	detail                   string
 	failureReason            string
 	failureOccurredAt        *time.Time
 	failureAttempt           *int
 	failureBlockedRecipients []string
+}
+
+// submissionAnchor is this candidate's acceptance→terminal SLI baseline — the
+// same definition the send worker uses, so a message settled by the reconciler
+// and one settled inline are measured identically.
+func (c terminalCandidate) submissionAnchor() time.Time {
+	var scheduledAt, reviewedAt time.Time
+	if c.scheduledAt != nil {
+		scheduledAt = *c.scheduledAt
+	}
+	if c.reviewedAt != nil {
+		reviewedAt = *c.reviewedAt
+	}
+	return submissionAnchor(c.acceptedAt, scheduledAt, reviewedAt)
 }
 
 func (w *TerminalReconcileWorker) Work(ctx context.Context, _ *river.Job[TerminalReconcileArgs]) error {
@@ -98,7 +114,7 @@ func (w *TerminalReconcileWorker) Work(ctx context.Context, _ *river.Job[Termina
 		        COALESCE(r.attempt, 0),
 		        CASE WHEN r.id IS NULL THEN 'missing' ELSE r.state::text END,
 		        r.finalized_at,
-		        m.created_at,
+		        m.created_at, m.scheduled_at, m.reviewed_at,
 		        COALESCE(m.delivery_failure_source,''),COALESCE(m.delivery_detail,''),COALESCE(m.delivery_failure_reason_code,''),
 		        m.delivery_failure_occurred_at,m.delivery_failure_attempt,m.delivery_failure_blocked_recipients
 		   FROM messages m
@@ -122,7 +138,7 @@ func (w *TerminalReconcileWorker) Work(ctx context.Context, _ *river.Job[Termina
 	candidates := make([]terminalCandidate, 0)
 	for rows.Next() {
 		var candidate terminalCandidate
-		if err := rows.Scan(&candidate.messageID, &candidate.jobID, &candidate.attempt, &candidate.state, &candidate.finalizedAt, &candidate.acceptedAt, &candidate.failureSource, &candidate.detail, &candidate.failureReason, &candidate.failureOccurredAt, &candidate.failureAttempt, &candidate.failureBlockedRecipients); err != nil {
+		if err := rows.Scan(&candidate.messageID, &candidate.jobID, &candidate.attempt, &candidate.state, &candidate.finalizedAt, &candidate.acceptedAt, &candidate.scheduledAt, &candidate.reviewedAt, &candidate.failureSource, &candidate.detail, &candidate.failureReason, &candidate.failureOccurredAt, &candidate.failureAttempt, &candidate.failureBlockedRecipients); err != nil {
 			return err
 		}
 		candidates = append(candidates, candidate)
@@ -185,9 +201,9 @@ func (w *TerminalReconcileWorker) Work(ctx context.Context, _ *river.Job[Termina
 		// acceptance→sweep.
 		switch settled {
 		case delivery.StatusFailed:
-			emitTerminal(w.metrics, terminalOutcome(source, reason, candidate.failureBlockedRecipients), candidate.acceptedAt, settledAt)
+			emitTerminal(w.metrics, terminalOutcome(source, reason, candidate.failureBlockedRecipients), candidate.submissionAnchor(), settledAt)
 		case delivery.StatusSent:
-			emitTerminal(w.metrics, terminalSent, candidate.acceptedAt, settledAt)
+			emitTerminal(w.metrics, terminalSent, candidate.submissionAnchor(), settledAt)
 		}
 		if w.ramp != nil {
 			if err := w.ramp.Resolve(ctx, candidate.messageID); err != nil {

--- a/internal/outboundsend/terminal_reconcile_internal_test.go
+++ b/internal/outboundsend/terminal_reconcile_internal_test.go
@@ -25,3 +25,54 @@ func TestTerminalReconcilePeriodicConstructor_RoutesToMaintenance(t *testing.T) 
 		t.Errorf("TerminalReconcileArgs.Kind() = %q, want outbound_terminal_reconcile", got)
 	}
 }
+
+func TestSubmissionAnchor(t *testing.T) {
+	accept := time.Date(2026, 8, 3, 22, 0, 0, 0, time.UTC)
+	later := accept.Add(2 * time.Hour)
+	earlier := accept.Add(-2 * time.Hour)
+
+	tests := []struct {
+		name                              string
+		acceptedAt, scheduledAt, reviewed time.Time
+		want                              time.Time
+	}{
+		{"ordinary send anchors at accept", accept, time.Time{}, time.Time{}, accept},
+		{"hitl hold anchors at approve", accept, time.Time{}, later, later},
+		{"scheduled send anchors at fire time", accept, later, time.Time{}, later},
+		{"held and scheduled take the latest gate", accept, later, later.Add(time.Hour), later.Add(time.Hour)},
+		{"a gate before accept is inert", accept, earlier, earlier, accept},
+		{"zero accept with a hold still anchors at approve", time.Time{}, time.Time{}, later, later},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := submissionAnchor(tt.acceptedAt, tt.scheduledAt, tt.reviewed); !got.Equal(tt.want) {
+				t.Errorf("submissionAnchor = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+// The reconciler and the send worker must agree on the baseline, or a message
+// settled by the sweep is measured differently from one settled inline.
+func TestTerminalCandidateSubmissionAnchor_MatchesWorkerDefinition(t *testing.T) {
+	accept := time.Date(2026, 8, 3, 22, 0, 0, 0, time.UTC)
+	reviewed := accept.Add(90 * time.Minute)
+	c := terminalCandidate{acceptedAt: accept, reviewedAt: &reviewed}
+	j := &SendJob{AcceptedAt: accept, ReviewedAt: reviewed}
+	if got, want := c.submissionAnchor(), j.submissionAnchor(); !got.Equal(want) {
+		t.Errorf("reconciler anchor = %s, worker anchor = %s; the two paths must agree", got, want)
+	}
+	if got := c.submissionAnchor(); !got.Equal(reviewed) {
+		t.Errorf("anchor = %s, want the approve time %s", got, reviewed)
+	}
+}
+
+// A nil scheduled_at/reviewed_at (the overwhelmingly common row) must not be
+// dereferenced and must leave the accept anchor untouched.
+func TestTerminalCandidateSubmissionAnchor_NilTimestamps(t *testing.T) {
+	accept := time.Date(2026, 8, 3, 22, 0, 0, 0, time.UTC)
+	c := terminalCandidate{acceptedAt: accept}
+	if got := c.submissionAnchor(); !got.Equal(accept) {
+		t.Errorf("anchor = %s, want %s for a row with no gates", got, accept)
+	}
+}

--- a/internal/outboundsend/worker.go
+++ b/internal/outboundsend/worker.go
@@ -107,6 +107,12 @@ type SendJob struct {
 	// outage-tolerant tail from its fire time, instead of a horizon already blown
 	// the moment it first runs.
 	ScheduledAt time.Time
+	// ReviewedAt is messages.reviewed_at — when a HITL hold was resolved into the
+	// send pipeline (human approve or TTL auto-approve), zero for a message that
+	// was never held. Consumed ONLY by submissionAnchor for the latency SLI; the
+	// retry horizon deliberately still measures from AcceptedAt, so the F2
+	// limitation in docs/design/hitl-ttl-async-send.md is unchanged by this field.
+	ReviewedAt time.Time
 	// ProviderAccepted is set when authoritatively correlated provider-accept
 	// evidence (an SNS-verified, header- or provider-id-matched SES
 	// notification) has been recorded for this message: the provider already
@@ -132,6 +138,14 @@ func (j *SendJob) pastRetryHorizon() bool {
 		start = j.ScheduledAt
 	}
 	return !start.IsZero() && time.Since(start) > sendRetryHorizon
+}
+
+// submissionAnchor is this job's acceptance→terminal SLI baseline — see the
+// package helper. Held and scheduled sends anchor at the moment they became
+// eligible to submit, not at accept, so a reviewer's dwell time and a
+// deliberate schedule delay stay out of e2a's error budget.
+func (j *SendJob) submissionAnchor() time.Time {
+	return submissionAnchor(j.AcceptedAt, j.ScheduledAt, j.ReviewedAt)
 }
 
 // alreadyDone reports whether the message has already been submitted to the
@@ -349,7 +363,7 @@ func (w *SendWorker) Work(ctx context.Context, job *river.Job[OutboundSendArgs])
 		// earlier attempt; only the settle lands here. occurredAt is the
 		// provider-accept evidence time, so the latency measures
 		// acceptance→provider-accept, not acceptance→settle.
-		emitTerminal(w.metrics, terminalSent, j.AcceptedAt, observedAt)
+		emitTerminal(w.metrics, terminalSent, j.submissionAnchor(), observedAt)
 		if w.ramp != nil && j.rampEligible() {
 			return w.ramp.Confirm(ctx, j.MessageID)
 		}
@@ -373,13 +387,13 @@ func (w *SendWorker) Work(ctx context.Context, job *river.Job[OutboundSendArgs])
 		observedAt = time.Now().UTC()
 		if rerr != nil {
 			if isPermanentRampError(rerr) {
-				if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, j.AcceptedAt, observedAt, "sending_ramp_invalid: "+rerr.Error(), delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionCancelled, nil); err != nil {
+				if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, j.submissionAnchor(), observedAt, "sending_ramp_invalid: "+rerr.Error(), delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionCancelled, nil); err != nil {
 					return err
 				}
 				return river.JobCancel(rerr)
 			}
 			if j.pastRetryHorizon() {
-				if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, j.AcceptedAt, observedAt, "ramp_capacity_timeout: "+rerr.Error(), delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionLocalRetriesExhausted, nil); err != nil {
+				if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, j.submissionAnchor(), observedAt, "ramp_capacity_timeout: "+rerr.Error(), delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionLocalRetriesExhausted, nil); err != nil {
 					return err
 				}
 				_ = w.ramp.Release(ctx, j.MessageID)
@@ -393,7 +407,7 @@ func (w *SendWorker) Work(ctx context.Context, job *river.Job[OutboundSendArgs])
 		}
 		if !decision.Allowed {
 			if j.pastRetryHorizon() {
-				if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, j.AcceptedAt, observedAt, "ramp_capacity_timeout", delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionLocalRetriesExhausted, nil); err != nil {
+				if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, j.submissionAnchor(), observedAt, "ramp_capacity_timeout", delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionLocalRetriesExhausted, nil); err != nil {
 					return err
 				}
 				if err := w.ramp.Release(ctx, j.MessageID); err != nil {
@@ -429,7 +443,7 @@ func (w *SendWorker) Work(ctx context.Context, job *river.Job[OutboundSendArgs])
 			// Fail toward retry, never toward an unthrottled submit: the
 			// provider is never exposed because the limiter is down.
 			if j.pastRetryHorizon() {
-				if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, j.AcceptedAt, observedAt, "send_rate_timeout: "+rerr.Error(), delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionLocalRetriesExhausted, nil); err != nil {
+				if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, j.submissionAnchor(), observedAt, "send_rate_timeout: "+rerr.Error(), delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionLocalRetriesExhausted, nil); err != nil {
 					return err
 				}
 				if w.ramp != nil && j.rampEligible() {
@@ -445,7 +459,7 @@ func (w *SendWorker) Work(ctx context.Context, job *river.Job[OutboundSendArgs])
 		}
 		if !decision.Allowed {
 			if j.pastRetryHorizon() {
-				if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, j.AcceptedAt, observedAt, "send_rate_timeout", delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionLocalRetriesExhausted, nil); err != nil {
+				if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, j.submissionAnchor(), observedAt, "send_rate_timeout", delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionLocalRetriesExhausted, nil); err != nil {
 					return err
 				}
 				if w.ramp != nil && j.rampEligible() {
@@ -485,7 +499,7 @@ func (w *SendWorker) Work(ctx context.Context, job *river.Job[OutboundSendArgs])
 	}
 	if len(suppressed) > 0 {
 		supErr := fmt.Errorf("recipient_suppressed: %s%s", strings.Join(suppressed, ", "), outbound.SuppressionRemediation(j.AgentID))
-		if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, j.AcceptedAt, observedAt, supErr.Error(), delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionCancelled, suppressed); err != nil {
+		if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, j.submissionAnchor(), observedAt, supErr.Error(), delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionCancelled, suppressed); err != nil {
 			return err
 		}
 		if w.ramp != nil && j.rampEligible() {
@@ -524,7 +538,7 @@ func (w *SendWorker) Work(ctx context.Context, job *river.Job[OutboundSendArgs])
 		// contract — emitTerminal emits count and latency together, here and
 		// everywhere else, and the SNS-feedback path stays uninstrumented
 		// for both.
-		emitTerminal(w.metrics, terminalSent, j.AcceptedAt, observedAt)
+		emitTerminal(w.metrics, terminalSent, j.submissionAnchor(), observedAt)
 		if w.ramp != nil && j.rampEligible() {
 			if err := w.ramp.Confirm(ctx, j.MessageID); err != nil {
 				return fmt.Errorf("confirm sending ramp: %w", err)
@@ -537,7 +551,7 @@ func (w *SendWorker) Work(ctx context.Context, job *river.Job[OutboundSendArgs])
 	// Provenance 'provider': SES itself refused this submission, so the §3.1
 	// correction never revives it.
 	if out.Permanent {
-		if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, j.AcceptedAt, observedAt, out.Err.Error(), delivery.FailureSourceProvider, messagelifecycle.ReasonSubmissionProviderRejected, nil); err != nil {
+		if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, j.submissionAnchor(), observedAt, out.Err.Error(), delivery.FailureSourceProvider, messagelifecycle.ReasonSubmissionProviderRejected, nil); err != nil {
 			return err
 		}
 		if w.ramp != nil && j.rampEligible() {
@@ -554,7 +568,7 @@ func (w *SendWorker) Work(ctx context.Context, job *river.Job[OutboundSendArgs])
 	// (provenance 'local': the provider never confirmed a rejection).
 	if out.Outage {
 		if j.pastRetryHorizon() {
-			if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, j.AcceptedAt, observedAt, out.Err.Error(), delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionLocalRetriesExhausted, nil); err != nil {
+			if err := w.markFailed(ctx, j.MessageID, job.ID, job.Attempt, j.submissionAnchor(), observedAt, out.Err.Error(), delivery.FailureSourceLocal, messagelifecycle.ReasonSubmissionLocalRetriesExhausted, nil); err != nil {
 				return err
 			}
 			if w.ramp != nil && j.rampEligible() {
@@ -661,7 +675,7 @@ const (
 	terminalWriteBackoff = 150 * time.Millisecond
 )
 
-func (w *SendWorker) markFailed(ctx context.Context, messageID string, jobID int64, attempt int, acceptedAt, occurredAt time.Time, detail string, source delivery.FailureSource, reason messagelifecycle.ReasonCode, blockedRecipients []string) error {
+func (w *SendWorker) markFailed(ctx context.Context, messageID string, jobID int64, attempt int, anchorAt, occurredAt time.Time, detail string, source delivery.FailureSource, reason messagelifecycle.ReasonCode, blockedRecipients []string) error {
 	var err error
 	for i := 0; i < terminalWriteRetries; i++ {
 		var settled delivery.Status
@@ -678,9 +692,9 @@ func (w *SendWorker) markFailed(ctx context.Context, messageID string, jobID int
 			// latency reports what the write did, not what the caller asked.
 			switch settled {
 			case delivery.StatusFailed:
-				emitTerminal(w.metrics, terminalOutcome(source, reason, blockedRecipients), acceptedAt, settledAt)
+				emitTerminal(w.metrics, terminalOutcome(source, reason, blockedRecipients), anchorAt, settledAt)
 			case delivery.StatusSent:
-				emitTerminal(w.metrics, terminalSent, acceptedAt, settledAt)
+				emitTerminal(w.metrics, terminalSent, anchorAt, settledAt)
 			}
 			return nil
 		}

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -114,13 +114,16 @@ type Metrics interface {
 	// when it settles.
 	OutboundTerminal(outcome string)
 
-	// OutboundTerminalLatency records acceptance→terminal latency for
-	// one outbound message (the terminal write's occurred_at −
-	// messages.created_at). Observed exactly once per message,
-	// co-located with the OutboundTerminal emission so the two share
-	// their exactly-once contract (the SNS-feedback settle path stays
-	// uninstrumented for both — see the guard comment at the worker's
-	// MarkSent emit in internal/outboundsend).
+	// OutboundTerminalLatency records eligibility→terminal latency for
+	// one outbound message (the terminal write's occurred_at − the
+	// submission anchor: messages.created_at for an ordinary send, the
+	// approve or fire time for a held or scheduled one). Observed at most
+	// once per message, co-located with the OutboundTerminal emission so
+	// the two share their exactly-once contract (the SNS-feedback settle
+	// path stays uninstrumented for both — see the guard comment at the
+	// worker's MarkSent emit in internal/outboundsend). A terminal whose
+	// occurred_at precedes its anchor records the count with no latency
+	// sample, so the two can legitimately diverge for gated rows.
 	OutboundTerminalLatency(seconds float64)
 
 	// OutboundAttempt records one submission attempt to the upstream

--- a/internal/telemetry/prom.go
+++ b/internal/telemetry/prom.go
@@ -222,7 +222,7 @@ func NewProm(build string) *Prom {
 		}, []string{"outcome"}),
 		outTerminalLat: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Name:    "e2a_outbound_terminal_latency_seconds",
-			Help:    "Outbound acceptance→terminal latency per message (terminal occurred_at - messages.created_at), observed exactly once per message.",
+			Help:    "Outbound eligibility→terminal latency per message (terminal occurred_at - the submission anchor: the latest of messages.created_at, scheduled_at and reviewed_at), observed exactly once per message.",
 			Buckets: longBuckets,
 		}),
 		outAttempts: prometheus.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
## Summary

`e2a_outbound_terminal_latency_seconds` measured from `messages.created_at`, so any wait the *caller* deliberately asked for was recorded as e2a latency. A HITL hold sits in `pending_review` until a human (or the TTL sweep) resolves it — `ApproveAndAccept` updates the row in place and never touches `created_at` — so an approved hold's sample carried the reviewer's entire dwell. Every hold approved more than 5 minutes after drafting was an automatic miss against the "terminal within 5 min of acceptance ≥ 99%" SLO in `docs/observability.md`. Scheduled sends have the same defect: any send scheduled further out than the window missed it by construction.

This is the same class of error the webhook eventual-delivery SLI already avoids by excluding `endpoint_failure` — the target measures e2a's own behavior, and a reviewer taking an hour is not e2a being slow.

It burned the hosted error budget for real: on 2026-08-03 a reviewer clearing a queue of held messages put a cluster of them past the 300s bucket and paged the prod `outbound acceptance→terminal latency` alert at 11.46% against a 1% budget.

The fix introduces `submissionAnchor(acceptedAt, scheduledAt, reviewedAt)` — the latest of the three, i.e. the instant the message became *eligible* to submit. Both terminal emission paths use it (the send worker inline, and the terminal reconciler for stranded rows) so a message settled by the sweep is measured identically to one settled inline. Taking the latest of the gates mirrors `pastRetryHorizon`'s existing `max(accept, scheduled)` reasoning.

## Operational risk

Observability-only. No change to send, retry, or terminal outcomes, and no API or client surface is touched.

- Zero/nil `scheduled_at` and `reviewed_at` are inert, so an ordinary send still anchors at `created_at` and the SLI keeps reporting real pipeline latency. That path has an explicit regression test.
- `SendJob.AcceptedAt` and the 72h retry horizon are deliberately **not** changed. That is F2 in `docs/design/hitl-ttl-async-send.md` and stays open; an addendum there records the split so the two anchors don't get conflated later.
- The reconciler's query gains two nullable columns (`scheduled_at`, `reviewed_at`) on a query already reading that row — no new scan, no index implication.
- Rollback is a plain revert; nothing persists.

Once released, the hosted `outbound_terminal_latency` alert query needs no change — it becomes correct as written. Expect the reported late fraction on that SLI to drop for any deployment using HITL or scheduled sends, because those samples were never e2a latency to begin with.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet` clean on `internal/outboundsend`, `internal/identity`, `internal/agent`
- [x] `go test -short ./internal/outboundsend/ ./internal/identity/ ./internal/agent/ ./internal/telemetry/` — all pass
- [x] New tests fail without the fix (verified by reverting the anchor to `j.AcceptedAt`); the unchanged-ordinary-send test correctly still passes
- [x] Review dwell excluded on the **sent** arm and the **failure** arm, so the two terminal paths can't disagree about what "acceptance" means
- [x] Reconciler and worker anchors asserted equal for the same row
- [x] `submissionAnchor` table test: gate ordering, a gate before accept is inert, zero accept with a hold
- [ ] After merge: confirm on staging that a HITL-approved send lands in a low bucket rather than one reflecting the hold duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016zA4AGZSEVk9jdBfyCkL1v

---
_Generated by [Claude Code](https://claude.ai/code/session_016zA4AGZSEVk9jdBfyCkL1v)_