### PR TITLE
fix(api): stop charging the domain cap for an idempotent re-register, with contract coverage

### DIFF
--- a/cmd/e2a-contract-server/main.go
+++ b/cmd/e2a-contract-server/main.go
@@ -29,7 +29,14 @@ func main() {
 		log.Fatalf("contract server health check failed: %v", err)
 	}
 
-	envContent := fmt.Sprintf("E2A_TEST_BASE_URL=%s\nE2A_TEST_API_KEY=%s\n", srv.BaseURL, srv.APIKey)
+	// E2A_TEST_CAPPED_API_KEY authenticates the secondary account seeded with
+	// testutil.CappedLimits. Scenarios that assert quota enforcement run as
+	// that account; CI sources this file with `set -a`, so the runners pick it
+	// up with no workflow change.
+	envContent := fmt.Sprintf(
+		"E2A_TEST_BASE_URL=%s\nE2A_TEST_API_KEY=%s\nE2A_TEST_CAPPED_API_KEY=%s\n",
+		srv.BaseURL, srv.APIKey, srv.CappedAPIKey,
+	)
 	if envFile != "" {
 		if err := os.WriteFile(envFile, []byte(envContent), 0o600); err != nil {
 			log.Fatalf("write env file: %v", err)

--- a/internal/httpapi/domains.go
+++ b/internal/httpapi/domains.go
@@ -483,7 +483,27 @@ func (s *Server) handleRegisterDomain(ctx context.Context, in *registerDomainInp
 	if s.deps.SharedDomain != "" && strings.EqualFold(normalized, s.deps.SharedDomain) {
 		return nil, NewError(http.StatusBadRequest, "reserved_domain", "reserved domain")
 	}
-	if s.deps.EnforceDomainCreate != nil {
+	// The create cap applies to creates. A same-owner claim is idempotent —
+	// ClaimOrCreateDomain returns the existing row untouched — so charging it
+	// against max_domains 402s a caller for re-POSTing a domain they already
+	// hold, naming a resource the request would not have consumed.
+	//
+	// "Already owned" is decided by the same user-scoped lookup GET uses, so
+	// this cannot become a bypass: another account's row is invisible to it
+	// and stays charged (then rejected by the claim as a conflict), and a
+	// parent/child claim is a genuinely new row that no exact-match lookup
+	// finds. Anything other than a clean hit — dep unwired, lookup failed,
+	// nil row — falls through to enforcing, so a limit is never skipped by
+	// accident. The check is deliberately outside the claim transaction: it
+	// is the same non-transactional shape the cap already had, so two racing
+	// creates could still both pass, exactly as before this change.
+	alreadyOwned := false
+	if s.deps.LookupDomain != nil {
+		if existing, lookupErr := s.deps.LookupDomain(ctx, normalized, user.ID); lookupErr == nil && existing != nil {
+			alreadyOwned = true
+		}
+	}
+	if !alreadyOwned && s.deps.EnforceDomainCreate != nil {
 		if err := s.deps.EnforceDomainCreate(ctx, user.ID); err != nil {
 			if env, ok := limitEnvelope(err); ok {
 				return nil, env

--- a/internal/httpapi/domains_limit_test.go
+++ b/internal/httpapi/domains_limit_test.go
@@ -1,0 +1,75 @@
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/tokencanopy/e2a/internal/identity"
+)
+
+// POST /v1/domains is idempotent for a domain the caller already owns: the
+// claim returns the existing row rather than creating one (#811). Charging
+// that no-op against max_domains 402s a caller for re-POSTing a domain they
+// already hold — the SDK retry, the re-run of a provisioning script, the
+// dashboard's "register" on a domain already in the list all fail once the
+// account sits at its cap, and the error names a resource the request would
+// not have consumed. The create limit belongs on creates.
+func TestRegisterDomainAtCapAllowsReclaimOfOwnedDomain(t *testing.T) {
+	srv := testServer(t)
+	// "acme.com" is a domain the shared LookupDomain fake reports as owned;
+	// "overcap" authenticates as u_overcap, whom EnforceDomainCreate rejects.
+	code, body := postJSON(t, srv.URL+"/v1/domains", "overcap", map[string]any{"domain": "acme.com"})
+	if code != 201 {
+		t.Fatalf("re-register of an owned domain at cap = %d %v, want 201 (creates nothing, so the create cap does not apply)", code, body)
+	}
+	if body["domain"] != "acme.com" {
+		t.Errorf("domain = %v, want acme.com", body["domain"])
+	}
+}
+
+// The skip is scoped to domains the caller actually owns, so it cannot become
+// a way to bypass the cap: LookupDomain filters on user_id, so another
+// account's domain is not "already owned" and stays charged (and would then
+// be rejected as a conflict by the claim itself).
+func TestRegisterDomainAtCapStillChargesAnotherAccountsDomain(t *testing.T) {
+	srv := testServer(t, func(d *Deps) {
+		d.LookupDomain = func(ctx context.Context, domain, userID string) (*identity.Domain, error) {
+			// User-scoped exactly like the store: only the owner sees the row.
+			if domain == "someone-elses.com" && userID == "u_other" {
+				return &identity.Domain{Domain: domain, Verified: true}, nil
+			}
+			return nil, errors.New("domain not found")
+		}
+	})
+	code, body := postJSON(t, srv.URL+"/v1/domains", "overcap", map[string]any{"domain": "someone-elses.com"})
+	if code != 402 || errCode(body) != "limit_exceeded" {
+		t.Fatalf("want 402 limit_exceeded for a domain the caller does not own, got %d %v", code, body)
+	}
+}
+
+// Fail-safe: an unwired lookup means we cannot tell a create from a re-claim,
+// so the cap is enforced. A missing dependency must never silently disable a
+// limit.
+func TestRegisterDomainAtCapEnforcesWhenLookupUnavailable(t *testing.T) {
+	srv := testServer(t, func(d *Deps) { d.LookupDomain = nil })
+	code, body := postJSON(t, srv.URL+"/v1/domains", "overcap", map[string]any{"domain": "acme.com"})
+	if code != 402 || errCode(body) != "limit_exceeded" {
+		t.Fatalf("want 402 limit_exceeded when LookupDomain is unwired, got %d %v", code, body)
+	}
+}
+
+// A lookup that fails for a reason other than "not found" must not be read as
+// "already owned" — the store collapses every failure into one error, so an
+// unreachable database would otherwise open the cap.
+func TestRegisterDomainAtCapEnforcesWhenLookupErrors(t *testing.T) {
+	srv := testServer(t, func(d *Deps) {
+		d.LookupDomain = func(ctx context.Context, domain, userID string) (*identity.Domain, error) {
+			return nil, errors.New("connection refused")
+		}
+	})
+	code, body := postJSON(t, srv.URL+"/v1/domains", "overcap", map[string]any{"domain": "acme.com"})
+	if code != 402 || errCode(body) != "limit_exceeded" {
+		t.Fatalf("want 402 limit_exceeded when the lookup fails, got %d %v", code, body)
+	}
+}

--- a/internal/httpapi/domains_limit_test.go
+++ b/internal/httpapi/domains_limit_test.go
@@ -17,14 +17,17 @@ import (
 // not have consumed. The create limit belongs on creates.
 func TestRegisterDomainAtCapAllowsReclaimOfOwnedDomain(t *testing.T) {
 	srv := testServer(t)
-	// "acme.com" is a domain the shared LookupDomain fake reports as owned;
-	// "overcap" authenticates as u_overcap, whom EnforceDomainCreate rejects.
-	code, body := postJSON(t, srv.URL+"/v1/domains", "overcap", map[string]any{"domain": "acme.com"})
+	// "capped-owned.com" is owned by u_overcap ALONE in the shared fake, and
+	// "overcap" authenticates as u_overcap — whom EnforceDomainCreate rejects.
+	// A singly-owned domain is deliberate: it is only found when the handler
+	// passes the authenticated caller's id, so this assertion fails if the
+	// scoping is dropped (passing "") or aimed at the wrong account.
+	code, body := postJSON(t, srv.URL+"/v1/domains", "overcap", map[string]any{"domain": "capped-owned.com"})
 	if code != 201 {
 		t.Fatalf("re-register of an owned domain at cap = %d %v, want 201 (creates nothing, so the create cap does not apply)", code, body)
 	}
-	if body["domain"] != "acme.com" {
-		t.Errorf("domain = %v, want acme.com", body["domain"])
+	if body["domain"] != "capped-owned.com" {
+		t.Errorf("domain = %v, want capped-owned.com", body["domain"])
 	}
 }
 
@@ -32,19 +35,18 @@ func TestRegisterDomainAtCapAllowsReclaimOfOwnedDomain(t *testing.T) {
 // a way to bypass the cap: LookupDomain filters on user_id, so another
 // account's domain is not "already owned" and stays charged (and would then
 // be rejected as a conflict by the claim itself).
+//
+// This runs against the SHARED ownership-aware fake, not a local override, and
+// that is the point: "other-account.com" is owned by u_1 alone, so the request
+// below only 402s if the handler passes the AUTHENTICATED caller's id. An
+// earlier version of this test used a domain no fake matched for anyone, which
+// meant it exercised the fake's not-found branch and passed even with the
+// scoping removed — the mutation it exists to catch.
 func TestRegisterDomainAtCapStillChargesAnotherAccountsDomain(t *testing.T) {
-	srv := testServer(t, func(d *Deps) {
-		d.LookupDomain = func(ctx context.Context, domain, userID string) (*identity.Domain, error) {
-			// User-scoped exactly like the store: only the owner sees the row.
-			if domain == "someone-elses.com" && userID == "u_other" {
-				return &identity.Domain{Domain: domain, Verified: true}, nil
-			}
-			return nil, errors.New("domain not found")
-		}
-	})
-	code, body := postJSON(t, srv.URL+"/v1/domains", "overcap", map[string]any{"domain": "someone-elses.com"})
+	srv := testServer(t)
+	code, body := postJSON(t, srv.URL+"/v1/domains", "overcap", map[string]any{"domain": "other-account.com"})
 	if code != 402 || errCode(body) != "limit_exceeded" {
-		t.Fatalf("want 402 limit_exceeded for a domain the caller does not own, got %d %v", code, body)
+		t.Fatalf("want 402 limit_exceeded for a domain owned by another account, got %d %v", code, body)
 	}
 }
 
@@ -53,7 +55,7 @@ func TestRegisterDomainAtCapStillChargesAnotherAccountsDomain(t *testing.T) {
 // limit.
 func TestRegisterDomainAtCapEnforcesWhenLookupUnavailable(t *testing.T) {
 	srv := testServer(t, func(d *Deps) { d.LookupDomain = nil })
-	code, body := postJSON(t, srv.URL+"/v1/domains", "overcap", map[string]any{"domain": "acme.com"})
+	code, body := postJSON(t, srv.URL+"/v1/domains", "overcap", map[string]any{"domain": "capped-owned.com"})
 	if code != 402 || errCode(body) != "limit_exceeded" {
 		t.Fatalf("want 402 limit_exceeded when LookupDomain is unwired, got %d %v", code, body)
 	}
@@ -68,7 +70,7 @@ func TestRegisterDomainAtCapEnforcesWhenLookupErrors(t *testing.T) {
 			return nil, errors.New("connection refused")
 		}
 	})
-	code, body := postJSON(t, srv.URL+"/v1/domains", "overcap", map[string]any{"domain": "acme.com"})
+	code, body := postJSON(t, srv.URL+"/v1/domains", "overcap", map[string]any{"domain": "capped-owned.com"})
 	if code != 402 || errCode(body) != "limit_exceeded" {
 		t.Fatalf("want 402 limit_exceeded when the lookup fails, got %d %v", code, body)
 	}

--- a/internal/httpapi/operations_test.go
+++ b/internal/httpapi/operations_test.go
@@ -351,24 +351,7 @@ func testServer(t *testing.T, opts ...func(*Deps)) *httptest.Server {
 			}
 			return nil, errors.New("not found")
 		},
-		LookupDomain: func(ctx context.Context, domain, userID string) (*identity.Domain, error) {
-			switch domain {
-			case "acme.com":
-				return &identity.Domain{Domain: domain, Verified: true, VerificationToken: "e2a-verify=tok", IsPrimary: true}, nil
-			case "pending.com":
-				return &identity.Domain{Domain: domain, Verified: false}, nil
-			case "busy.com":
-				return &identity.Domain{Domain: domain, Verified: true}, nil
-			case "fresh.com":
-				// Registered, TXT published, not yet marked verified.
-				return &identity.Domain{Domain: domain, Verified: false, VerificationToken: "e2a-verify=fresh"}, nil
-			case "nomx.com":
-				// Registered, ownership TXT published, but the inbound MX is missing.
-				return &identity.Domain{Domain: domain, Verified: false, VerificationToken: "e2a-verify=nomx"}, nil
-			default:
-				return nil, errors.New("not registered")
-			}
-		},
+		LookupDomain: fakeLookupDomain,
 		ListDomains: func(ctx context.Context, userID string, limit int, afterCreatedAt time.Time, afterDomain string) ([]identity.Domain, error) {
 			return []identity.Domain{{Domain: "acme.com", Verified: true, VerificationToken: "e2a-verify=tok", IsPrimary: true, AgentCount: 2}}, nil
 		},
@@ -893,4 +876,41 @@ func TestLegacyFallback(t *testing.T) {
 	if resp.Header.Get("X-Request-Id") == "" {
 		t.Error("legacy fallback should still carry X-Request-Id")
 	}
+}
+
+// fakeLookupDomain mirrors identity.Store.LookupDomain's USER SCOPING
+// (`WHERE domain = $1 AND user_id = $2`). Modeling ownership matters: a fake
+// that switched on the domain alone — as this one used to — cannot observe
+// WHICH user id a handler passes, so it silently passes even when a handler
+// drops the scoping entirely. That scoping is what keeps the domain-create cap
+// from being bypassable (#819), so it needs a fake that can fail.
+//
+// Every account in the harness owns the shared fixtures, preserving the old
+// behavior for tests that authenticate as either user. "other-account.com" is
+// owned by u_1 ALONE and exists so a cross-account lookup has something real to
+// miss on.
+func fakeLookupDomain(ctx context.Context, domain, userID string) (*identity.Domain, error) {
+	shared := map[string]identity.Domain{
+		"acme.com":    {Domain: domain, Verified: true, VerificationToken: "e2a-verify=tok", IsPrimary: true},
+		"pending.com": {Domain: domain, Verified: false},
+		"busy.com":    {Domain: domain, Verified: true},
+		// Registered, TXT published, not yet marked verified.
+		"fresh.com": {Domain: domain, Verified: false, VerificationToken: "e2a-verify=fresh"},
+		// Registered, ownership TXT published, but the inbound MX is missing.
+		"nomx.com": {Domain: domain, Verified: false, VerificationToken: "e2a-verify=nomx"},
+	}
+	if row, ok := shared[domain]; ok {
+		return &row, nil
+	}
+	// Singly-owned fixtures. These are what let a test observe the user id:
+	// each is invisible to every account but its owner, so a handler that
+	// passes "" — or any other account's id — misses.
+	soleOwner := map[string]string{
+		"other-account.com": "u_1",
+		"capped-owned.com":  "u_overcap",
+	}
+	if owner, ok := soleOwner[domain]; ok && owner == userID {
+		return &identity.Domain{Domain: domain, Verified: true}, nil
+	}
+	return nil, errors.New("not registered")
 }

--- a/internal/testutil/contract_server.go
+++ b/internal/testutil/contract_server.go
@@ -25,10 +25,38 @@ import (
 	"github.com/tokencanopy/e2a/internal/ws"
 )
 
+// CappedLimits are the plan caps of the secondary account described on
+// ContractServer.CappedAPIKey. One slot per create-limited resource is the
+// smallest cap that can express BOTH directions of enforcement: a scenario can
+// consume the slot (success), be refused at the cap (402), free it, and
+// succeed again — proving the limit is a cap and not an unconditional refusal.
+var CappedLimits = limits.Limits{
+	PlanCode:         "contract_capped",
+	MaxAgents:        1,
+	MaxDomains:       1,
+	MaxMessagesMonth: 1,
+	MaxStorageBytes:  1 << 20,
+	UpgradeURL:       "https://e2a.dev/upgrade",
+}
+
 type ContractServer struct {
-	BaseURL    string
-	APIKey     string
-	UserID     string
+	BaseURL string
+	APIKey  string
+	UserID  string
+	// CappedAPIKey authenticates a SECOND account seeded with CappedLimits,
+	// so scenarios can exercise quota enforcement without touching the
+	// primary account's generous caps.
+	//
+	// A separate account rather than a "set the caps" scenario step: caps are
+	// account-global, and the TS and Python runners silently ignore setup keys
+	// they do not recognize, so a cap lowered for one scenario and restored by
+	// a cleanup step that some runner skipped would 402 every scenario after
+	// it. Nothing here is mutable, so nothing can leak. It also means the
+	// enforcer's limits cache needs no special handling: the row is written
+	// before the server accepts its first request and never changes, so there
+	// is no staleness window for a scenario to race.
+	CappedAPIKey string
+	CappedUserID string
 	DBPool     *pgxpool.Pool
 	Store      *identity.Store
 	WSHub      *ws.Hub
@@ -62,9 +90,12 @@ func StartContractServer(ctx context.Context, dbURL string) (*ContractServer, er
 	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
 	noopUsage := usage.NewNoopUsageTracker()
 
-	// Limits/usage/webhook components the /v1 Deps bind to. Caps are set
-	// generously so contract scenarios exercise contract shape, not quota
-	// enforcement (the 402 limit paths have dedicated httpapi unit tests).
+	// Limits/usage/webhook components the /v1 Deps bind to. These DEFAULTS are
+	// generous on purpose: they apply to the primary contract account, whose
+	// scenarios exercise contract shape and must never trip a quota. Quota
+	// enforcement is exercised by the separate capped account seeded at the
+	// bottom of this function (CappedAPIKey) — an account_limits row overrides
+	// these defaults for that user alone.
 	usageStore := usage.NewStore(pool)
 	enforcer := limits.NewEnforcer(limits.NewStore(pool), usageStore, limits.Defaults{
 		PlanCode: "contract_test", MaxAgents: 100000, MaxDomains: 100000,
@@ -186,10 +217,42 @@ func StartContractServer(ctx context.Context, dbURL string) (*ContractServer, er
 		return nil, err
 	}
 
+	// The capped account. Seeded here, before the first request is served, so
+	// its account_limits row is already in place the first time the enforcer
+	// resolves it — no cache invalidation, no warm-up, no race.
+	cappedUser, err := store.CreateOrGetUser(ctx, "capped@test.dev", "Contract Capped", "google-contract-capped")
+	if err != nil {
+		_ = smtpServer.Close()
+		_ = httpServer.Shutdown(context.Background())
+		_ = httpLn.Close()
+		wsHub.Close()
+		pool.Close()
+		return nil, err
+	}
+	if err := limits.NewStore(pool).Upsert(ctx, cappedUser.ID, CappedLimits); err != nil {
+		_ = smtpServer.Close()
+		_ = httpServer.Shutdown(context.Background())
+		_ = httpLn.Close()
+		wsHub.Close()
+		pool.Close()
+		return nil, err
+	}
+	cappedKey, err := store.CreateAPIKey(ctx, cappedUser.ID, "contract-capped-key", nil)
+	if err != nil {
+		_ = smtpServer.Close()
+		_ = httpServer.Shutdown(context.Background())
+		_ = httpLn.Close()
+		wsHub.Close()
+		pool.Close()
+		return nil, err
+	}
+
 	return &ContractServer{
-		BaseURL:    "http://" + httpLn.Addr().String(),
-		APIKey:     key.PlaintextKey,
-		UserID:     user.ID,
+		BaseURL:      "http://" + httpLn.Addr().String(),
+		APIKey:       key.PlaintextKey,
+		UserID:       user.ID,
+		CappedAPIKey: cappedKey.PlaintextKey,
+		CappedUserID: cappedUser.ID,
 		DBPool:     pool,
 		Store:      store,
 		WSHub:      wsHub,

--- a/internal/testutil/contract_server.go
+++ b/internal/testutil/contract_server.go
@@ -26,13 +26,19 @@ import (
 )
 
 // CappedLimits are the plan caps of the secondary account described on
-// ContractServer.CappedAPIKey. One slot per create-limited resource is the
-// smallest cap that can express BOTH directions of enforcement: a scenario can
-// consume the slot (success), be refused at the cap (402), free it, and
-// succeed again — proving the limit is a cap and not an unconditional refusal.
+// ContractServer.CappedAPIKey. Caps are small enough that a scenario can
+// consume the slots, be refused at the cap (402), free one, and succeed again
+// — proving the limit is a cap and not an unconditional refusal — and
+// deliberately DIFFERENT per resource, so no single hardcoded number can
+// satisfy every assertion about the 402 envelope.
+//
+// Only the fields limits.Store.Upsert writes are capped here. max_webhooks,
+// max_templates and max_contacts are separate columns this row does not touch,
+// so the capped account still inherits their generous schema defaults; a
+// future scenario covering those caps has to extend the row first.
 var CappedLimits = limits.Limits{
 	PlanCode:         "contract_capped",
-	MaxAgents:        1,
+	MaxAgents:        2,
 	MaxDomains:       1,
 	MaxMessagesMonth: 1,
 	MaxStorageBytes:  1 << 20,
@@ -57,13 +63,13 @@ type ContractServer struct {
 	// is no staleness window for a scenario to race.
 	CappedAPIKey string
 	CappedUserID string
-	DBPool     *pgxpool.Pool
-	Store      *identity.Store
-	WSHub      *ws.Hub
-	SMTPAddr   string
-	httpServer *http.Server
-	httpLn     net.Listener
-	smtpServer *relay.Server
+	DBPool       *pgxpool.Pool
+	Store        *identity.Store
+	WSHub        *ws.Hub
+	SMTPAddr     string
+	httpServer   *http.Server
+	httpLn       net.Listener
+	smtpServer   *relay.Server
 }
 
 func StartContractServer(ctx context.Context, dbURL string) (*ContractServer, error) {
@@ -253,13 +259,13 @@ func StartContractServer(ctx context.Context, dbURL string) (*ContractServer, er
 		UserID:       user.ID,
 		CappedAPIKey: cappedKey.PlaintextKey,
 		CappedUserID: cappedUser.ID,
-		DBPool:     pool,
-		Store:      store,
-		WSHub:      wsHub,
-		SMTPAddr:   smtpAddr,
-		httpServer: httpServer,
-		httpLn:     httpLn,
-		smtpServer: smtpServer,
+		DBPool:       pool,
+		Store:        store,
+		WSHub:        wsHub,
+		SMTPAddr:     smtpAddr,
+		httpServer:   httpServer,
+		httpLn:       httpLn,
+		smtpServer:   smtpServer,
 	}, nil
 }
 

--- a/sdks/python/tests/test_contract.py
+++ b/sdks/python/tests/test_contract.py
@@ -3,6 +3,10 @@
 Runs against a live test server. Requires env vars:
   E2A_TEST_BASE_URL  — test server URL (e.g. http://localhost:8080)
   E2A_TEST_API_KEY   — valid API key for the test user
+  E2A_TEST_CAPPED_API_KEY — optional; key for the contract server's secondary
+    account, seeded with tiny plan caps. Scenarios asserting quota enforcement
+    run as that account and skip without it (a deployed staging target has no
+    capped account to offer).
 
 The runner drives the server over raw HTTP (a thin scenario interpreter, not
 the ergonomic client):
@@ -42,6 +46,7 @@ from e2a.v1.generated.models import PageMessageLifecycleTransition
 
 BASE_URL = os.environ.get("E2A_TEST_BASE_URL", "")
 API_KEY = os.environ.get("E2A_TEST_API_KEY", "")
+CAPPED_API_KEY = os.environ.get("E2A_TEST_CAPPED_API_KEY", "")
 
 # tests/test_contract.py -> sdks/python/tests/ -> sdks/python/ -> sdks/ -> repo root
 SCENARIOS_PATH = Path(__file__).resolve().parents[3] / "tests" / "contract" / "scenarios.yaml"
@@ -130,6 +135,17 @@ def values_equal(json_val: Any, yaml_val: Any) -> bool:
 
 STORE_ACTIONS = {"inject_message", "verify_and_retry"}
 
+CAPPED_KEY_PLACEHOLDER = "{capped_api_key}"
+
+
+def scenario_needs_capped_account(sc: dict[str, Any]) -> bool:
+    """True when the scenario authenticates as the capped-plan account.
+
+    Those scenarios need a cap they can actually reach, which only the contract
+    server's seeded secondary account provides.
+    """
+    return CAPPED_KEY_PLACEHOLDER in json_mod.dumps(sc)
+
 
 def scenario_needs_store(sc: dict[str, Any]) -> bool:
     setup = sc.get("setup") or []
@@ -159,6 +175,10 @@ class Runner:
             "future_rfc3339": future.isoformat().replace("+00:00", "Z"),
             "scenario_token": uuid.uuid4().hex[:12],
         }
+        # Bound only when supplied: scenarios needing it skip otherwise, so an
+        # empty bearer token can never reach the wire as a confusing 401.
+        if CAPPED_API_KEY:
+            self.vars["capped_api_key"] = CAPPED_API_KEY
         self._http = httpx.Client(base_url=base_url, timeout=30)
 
     def close(self):
@@ -980,6 +1000,46 @@ def test_scheduled_send_scenario_is_self_cleaning_and_projection_complete():
     ]
 
 
+def test_limits_scenario_shape():
+    """Always-on guard for the quota scenario.
+
+    The live quota run skips without a capped key (a deployed target has no
+    capped account), so this shape test is what keeps that skip from decaying
+    into zero coverage. It fails if the scenario is deleted, stops using the
+    capped account, or loses either direction of enforcement.
+    """
+    scenario = _scenario_by_name("account_limits_enforced")
+    assert scenario_needs_capped_account(scenario)
+
+    steps = {step["id"]: step for step in scenario["steps"]}
+
+    # Refused AT the cap, with the machine-readable envelope an SDK needs to
+    # say WHICH quota stopped the caller.
+    refused = steps["second_domain_hits_the_cap"]["expect"]
+    assert refused["status"] == 402
+    assert refused["body_match"]["error.code"] == "limit_exceeded"
+    assert refused["body_match"]["error.details.resource"] == "domains"
+    assert refused["body_match"]["error.details.limit"] == 1
+    assert steps["second_agent_hits_the_cap"]["expect"]["body_match"][
+        "error.details.resource"
+    ] == "agents"
+
+    # ...and allowed when it should be. Without these, a server that 402'd
+    # unconditionally would satisfy every assertion above.
+    assert steps["reregister_owned_domain_at_cap_is_allowed"]["expect"]["status"] == 201
+    assert (
+        steps["agent_create_succeeds_again_after_freeing_a_slot"]["expect"]["status"]
+        == 201
+    )
+
+    # The capped account holds one slot per resource, so a leak puts the NEXT
+    # run at its cap on step one.
+    assert [step["id"] for step in scenario["cleanup"]] == [
+        "delete_agent_permanently",
+        "delete_domain",
+    ]
+
+
 @pytest.fixture(params=_scenario_ids() if SCENARIOS_PATH.exists() else [])
 def scenario(request):
     return _scenario_by_name(request.param)
@@ -989,6 +1049,11 @@ def scenario(request):
 def test_contract_scenario(scenario):
     if scenario_needs_store(scenario):
         pytest.skip(f"scenario {scenario['name']}: requires store access (inject_message/verify_domain)")
+    # No capped account on this target (e.g. a deployed server) → no reachable
+    # cap. The Go runner always has one, and test_limits_scenario_shape below
+    # runs everywhere, so this skip cannot silently become zero coverage.
+    if scenario_needs_capped_account(scenario) and not CAPPED_API_KEY:
+        pytest.skip(f"scenario {scenario['name']}: needs E2A_TEST_CAPPED_API_KEY")
 
     runner = Runner(BASE_URL, API_KEY, scenario)
     try:

--- a/sdks/python/tests/test_contract.py
+++ b/sdks/python/tests/test_contract.py
@@ -143,8 +143,22 @@ def scenario_needs_capped_account(sc: dict[str, Any]) -> bool:
 
     Those scenarios need a cap they can actually reach, which only the contract
     server's seeded secondary account provides.
+
+    Inspects auth_override VALUES specifically. Dumping the whole scenario and
+    substring-matching looks equivalent and is not: the scenario's own
+    description mentions the placeholder in prose, so a blob match stays true
+    even if every auth_override is switched back to the primary account —
+    exactly the regression this is meant to detect. (It also avoids serializing
+    arbitrary YAML scalars, which JSON cannot always encode.)
     """
-    return CAPPED_KEY_PLACEHOLDER in json_mod.dumps(sc)
+    overrides = [sc.get("auth_override")]
+    for key in ("steps", "cleanup", "setup"):
+        for step in sc.get(key) or []:
+            if isinstance(step, dict):
+                overrides.append(step.get("auth_override"))
+    return any(
+        isinstance(o, str) and CAPPED_KEY_PLACEHOLDER in o for o in overrides
+    )
 
 
 def scenario_needs_store(sc: dict[str, Any]) -> bool:
@@ -1014,15 +1028,27 @@ def test_limits_scenario_shape():
     steps = {step["id"]: step for step in scenario["steps"]}
 
     # Refused AT the cap, with the machine-readable envelope an SDK needs to
-    # say WHICH quota stopped the caller.
+    # say WHICH quota stopped the caller — including the upgrade affordance,
+    # which is omitempty and so vanishes silently if the server drops it.
     refused = steps["second_domain_hits_the_cap"]["expect"]
     assert refused["status"] == 402
     assert refused["body_match"]["error.code"] == "limit_exceeded"
     assert refused["body_match"]["error.details.resource"] == "domains"
     assert refused["body_match"]["error.details.limit"] == 1
-    assert steps["second_agent_hits_the_cap"]["expect"]["body_match"][
-        "error.details.resource"
-    ] == "agents"
+    assert refused["body_match"]["error.details.current"] == 1
+    assert refused["body_match"]["error.details.plan_code"] == "contract_capped"
+    assert (
+        refused["body_match"]["error.details.upgrade_url"]
+        == "https://e2a.dev/upgrade"
+    )
+
+    # A second resource with a DIFFERENT cap: no single hardcoded number can
+    # satisfy both refusals.
+    agent_refused = steps["third_agent_hits_the_cap"]["expect"]
+    assert agent_refused["status"] == 402
+    assert agent_refused["body_match"]["error.details.resource"] == "agents"
+    assert agent_refused["body_match"]["error.details.limit"] == 2
+    assert agent_refused["body_match"]["error.details.current"] == 2
 
     # ...and allowed when it should be. Without these, a server that 402'd
     # unconditionally would satisfy every assertion above.
@@ -1032,10 +1058,14 @@ def test_limits_scenario_shape():
         == 201
     )
 
-    # The capped account holds one slot per resource, so a leak puts the NEXT
-    # run at its cap on step one.
+    # Cleanup must remove EVERY agent the scenario can create, including the
+    # one the happy path deletes mid-scenario: steps stop at the first failure,
+    # so a failure in between would otherwise strand it and put the next run at
+    # its cap on an early step.
     assert [step["id"] for step in scenario["cleanup"]] == [
-        "delete_agent_permanently",
+        "delete_agent_1",
+        "delete_agent_2",
+        "delete_agent_3",
         "delete_domain",
     ]
 

--- a/sdks/typescript/test/v1/contract.test.ts
+++ b/sdks/typescript/test/v1/contract.test.ts
@@ -4,6 +4,10 @@
  * Runs against a live test server. Requires env vars:
  *   E2A_TEST_BASE_URL  — test server URL (e.g. http://localhost:8080)
  *   E2A_TEST_API_KEY   — valid API key for the test user
+ *   E2A_TEST_CAPPED_API_KEY — optional; key for the contract server's
+ *     secondary account, seeded with tiny plan caps. Scenarios that assert
+ *     quota enforcement run as that account and skip without it (a deployed
+ *     staging target has no capped account to offer).
  *
  * The runner drives the server over raw HTTP (a thin scenario interpreter,
  * not the ergonomic client) plus {@link WSListener} for WebSocket steps.
@@ -29,6 +33,15 @@ import type { PageMessageLifecycleTransition } from "../../src/v1/index.js";
 // When the isolated CF zone + SMTP port are configured, store-dependent scenarios
 // are SEEDED over the API (verified domains + real inbound) instead of skipped.
 const SEED = seedEnabled();
+
+// The contract server's capped-account key (see the header). Absent when the
+// runner is pointed at a deployed server, which has no such account.
+const CAPPED_API_KEY = process.env.E2A_TEST_CAPPED_API_KEY;
+
+/** True when the scenario authenticates as the capped account anywhere. */
+function scenarioNeedsCappedAccount(sc: Scenario): boolean {
+  return JSON.stringify(sc).includes("{capped_api_key}");
+}
 
 it("parses the generated message lifecycle page contract", () => {
   const page = ObjectSerializer.deserialize(
@@ -100,6 +113,45 @@ it("keeps the managed-unsubscribe scenario self-cleaning and lifecycle-observabl
   });
 
   expect(scenario!.steps.map((step) => step.id)).not.toContain("delete_agent_permanently");
+  expect(scenario!.cleanup?.map((step) => step.id)).toEqual([
+    "delete_agent_permanently",
+    "delete_domain",
+  ]);
+});
+
+// Always-on: the live quota run skips without a capped key (deployed targets
+// have no capped account), so this shape test is what keeps that skip from
+// decaying into zero coverage. It fails if the scenario is deleted, stops using
+// the capped account, or loses either direction of enforcement.
+it("keeps the account-limits scenario pinned to both directions of enforcement", () => {
+  const scenario = loadScenarios().find((c) => c.name === "account_limits_enforced");
+  expect(scenario).toBeDefined();
+  expect(scenarioNeedsCappedAccount(scenario!)).toBe(true);
+
+  const steps = new Map(scenario!.steps.map((step) => [step.id, step]));
+
+  // Refused AT the cap, with the machine-readable envelope an SDK needs to say
+  // WHICH quota stopped the caller.
+  expect(steps.get("second_domain_hits_the_cap")?.expect).toMatchObject({
+    status: 402,
+    body_match: {
+      "error.code": "limit_exceeded",
+      "error.details.resource": "domains",
+      "error.details.limit": 1,
+    },
+  });
+  expect(steps.get("second_agent_hits_the_cap")?.expect).toMatchObject({
+    status: 402,
+    body_match: { "error.details.resource": "agents" },
+  });
+
+  // ...and allowed when it should be. Without these, a server that 402'd
+  // unconditionally would satisfy every assertion above.
+  expect(steps.get("reregister_owned_domain_at_cap_is_allowed")?.expect?.status).toBe(201);
+  expect(steps.get("agent_create_succeeds_again_after_freeing_a_slot")?.expect?.status).toBe(201);
+
+  // The capped account holds one slot per resource, so a leak puts the NEXT
+  // run at its cap on step one.
   expect(scenario!.cleanup?.map((step) => step.id)).toEqual([
     "delete_agent_permanently",
     "delete_domain",
@@ -717,6 +769,9 @@ class Runner {
     future.setUTCMilliseconds(0);
     this.vars.future_rfc3339 = future.toISOString().replace(".000Z", "Z");
     this.vars.scenario_token = randomBytes(6).toString("hex");
+    // Only bind when present: scenarios needing it are skipped otherwise, so a
+    // silently-empty bearer token can never reach the wire as a confusing 401.
+    if (CAPPED_API_KEY) this.vars.capped_api_key = CAPPED_API_KEY;
     this.api = new RawApi(apiKey, baseUrl);
     this.seeder = SEED ? new Seeder(baseUrl, apiKey) : null;
   }
@@ -1115,7 +1170,15 @@ describe.skipIf(!baseUrl || !apiKey)("Contract scenarios", () => {
   for (const sc of scenarios) {
     // Store-dependent scenarios run when SEED supplies their preconditions over
     // the API; otherwise they skip. Account-global scenarios skip regardless.
-    const skip = ACCOUNT_GLOBAL.has(sc.name) || (scenarioNeedsStore(sc) && !SEED);
+    // Quota scenarios need the capped account; without its key there is no way
+    // to reach a cap on a live server, so they skip. The Go runner owns the
+    // contract server in-process and always has it, and the always-on shape
+    // test below fails if the scenario is ever deleted or defanged — so a skip
+    // here can never quietly become zero coverage.
+    const skip =
+      ACCOUNT_GLOBAL.has(sc.name) ||
+      (scenarioNeedsStore(sc) && !SEED) ||
+      (scenarioNeedsCappedAccount(sc) && !CAPPED_API_KEY);
 
     (skip ? it.skip : it)(
       sc.name,

--- a/sdks/typescript/test/v1/contract.test.ts
+++ b/sdks/typescript/test/v1/contract.test.ts
@@ -38,9 +38,22 @@ const SEED = seedEnabled();
 // runner is pointed at a deployed server, which has no such account.
 const CAPPED_API_KEY = process.env.E2A_TEST_CAPPED_API_KEY;
 
-/** True when the scenario authenticates as the capped account anywhere. */
+/**
+ * True when the scenario authenticates as the capped account anywhere.
+ *
+ * Inspects auth_override VALUES specifically. Stringifying the whole scenario
+ * looks equivalent and is not: the scenario's own description mentions
+ * {capped_api_key} in prose, so a blob match stays true even if every
+ * auth_override is switched back to the primary account — exactly the
+ * regression this is meant to detect.
+ */
 function scenarioNeedsCappedAccount(sc: Scenario): boolean {
-  return JSON.stringify(sc).includes("{capped_api_key}");
+  const overrides = [
+    sc.auth_override,
+    ...(sc.steps ?? []).map((s) => s.auth_override),
+    ...(sc.cleanup ?? []).map((s) => s.auth_override),
+  ];
+  return overrides.some((o) => typeof o === "string" && o.includes("{capped_api_key}"));
 }
 
 it("parses the generated message lifecycle page contract", () => {
@@ -131,18 +144,29 @@ it("keeps the account-limits scenario pinned to both directions of enforcement",
   const steps = new Map(scenario!.steps.map((step) => [step.id, step]));
 
   // Refused AT the cap, with the machine-readable envelope an SDK needs to say
-  // WHICH quota stopped the caller.
+  // WHICH quota stopped the caller — including the upgrade affordance, which is
+  // omitempty and so vanishes silently if the server stops sending it.
   expect(steps.get("second_domain_hits_the_cap")?.expect).toMatchObject({
     status: 402,
     body_match: {
       "error.code": "limit_exceeded",
       "error.details.resource": "domains",
       "error.details.limit": 1,
+      "error.details.current": 1,
+      "error.details.plan_code": "contract_capped",
+      "error.details.upgrade_url": "https://e2a.dev/upgrade",
     },
   });
-  expect(steps.get("second_agent_hits_the_cap")?.expect).toMatchObject({
+
+  // A second resource with a DIFFERENT cap: no single hardcoded number can
+  // satisfy both refusals.
+  expect(steps.get("third_agent_hits_the_cap")?.expect).toMatchObject({
     status: 402,
-    body_match: { "error.details.resource": "agents" },
+    body_match: {
+      "error.details.resource": "agents",
+      "error.details.limit": 2,
+      "error.details.current": 2,
+    },
   });
 
   // ...and allowed when it should be. Without these, a server that 402'd
@@ -150,10 +174,14 @@ it("keeps the account-limits scenario pinned to both directions of enforcement",
   expect(steps.get("reregister_owned_domain_at_cap_is_allowed")?.expect?.status).toBe(201);
   expect(steps.get("agent_create_succeeds_again_after_freeing_a_slot")?.expect?.status).toBe(201);
 
-  // The capped account holds one slot per resource, so a leak puts the NEXT
-  // run at its cap on step one.
+  // Cleanup must remove EVERY agent the scenario can create, including the one
+  // the happy path deletes mid-scenario: steps stop at the first failure, so a
+  // failure in between would otherwise strand it and put the next run at its
+  // cap on an early step.
   expect(scenario!.cleanup?.map((step) => step.id)).toEqual([
-    "delete_agent_permanently",
+    "delete_agent_1",
+    "delete_agent_2",
+    "delete_agent_3",
     "delete_domain",
   ]);
 });

--- a/tests/contract/contract_test.go
+++ b/tests/contract/contract_test.go
@@ -134,6 +134,9 @@ type testEnv struct {
 	wsHub   *ws.Hub
 	apiKey  string
 	userID  string
+	// cappedAPIKey authenticates the contract server's secondary account,
+	// seeded with testutil.CappedLimits, that quota scenarios run as.
+	cappedAPIKey string
 }
 
 func setupEnv(t *testing.T) *testEnv {
@@ -157,6 +160,8 @@ func setupEnv(t *testing.T) *testEnv {
 		wsHub:   cs.WSHub,
 		apiKey:  cs.APIKey,
 		userID:  cs.UserID,
+
+		cappedAPIKey: cs.CappedAPIKey,
 	}
 }
 
@@ -350,6 +355,7 @@ func TestRunnerInitializesDynamicScenarioVars(t *testing.T) {
 func (r *runner) resolve(s string) string {
 	s = strings.ReplaceAll(s, "{base_url}", r.env.baseURL)
 	s = strings.ReplaceAll(s, "{api_key}", r.env.apiKey)
+	s = strings.ReplaceAll(s, "{capped_api_key}", r.env.cappedAPIKey)
 	for k, v := range r.vars {
 		s = strings.ReplaceAll(s, "{"+k+"}", v)
 	}
@@ -917,16 +923,104 @@ func loadScenarios(t *testing.T) []scenario {
 	return sf.Scenarios
 }
 
+// requireCappedKey fails a scenario that asks for the capped account when the
+// harness cannot supply it. Deliberately a failure and not a skip: a quota
+// scenario that quietly stops running is indistinguishable from one that
+// passes, which is exactly how limit coverage would rot back to zero.
+func requireCappedKey(t *testing.T, env *testEnv, sc scenario) {
+	t.Helper()
+	if env.cappedAPIKey == "" && scenarioUsesCappedKey(t, sc) {
+		t.Fatalf("scenario %s uses %s but the contract server supplied no capped API key", sc.Name, cappedKeyPlaceholder)
+	}
+}
+
+// scenarioUsesCappedKey reports whether the scenario authenticates as the
+// capped-plan account anywhere.
+func scenarioUsesCappedKey(t *testing.T, sc scenario) bool {
+	t.Helper()
+	raw, err := yaml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("marshal scenario %s: %v", sc.Name, err)
+	}
+	return strings.Contains(string(raw), cappedKeyPlaceholder)
+}
+
+const cappedKeyPlaceholder = "{capped_api_key}"
+
 func TestScenarios(t *testing.T) {
 	scenarios := loadScenarios(t)
 	for _, sc := range scenarios {
 		sc := sc
 		t.Run(sc.Name, func(t *testing.T) {
 			env := setupEnv(t)
+			requireCappedKey(t, env, sc)
 			r := newRunner(env, sc)
 			t.Cleanup(func() { r.cleanup(t) })
 			r.executeSetup(t)
 			r.executeSteps(t)
 		})
+	}
+}
+
+// TestLimitsScenarioShape is the Go half of the always-on guard the TS and
+// Python runners also carry. The live quota run can skip in those runners when
+// no capped key is supplied (a deployed target has no capped account); this
+// pins the scenario's shape everywhere, so a deletion or a defanged assertion
+// fails the build even where the live run does not execute.
+func TestLimitsScenarioShape(t *testing.T) {
+	var sc scenario
+	for _, candidate := range loadScenarios(t) {
+		if candidate.Name == "account_limits_enforced" {
+			sc = candidate
+			break
+		}
+	}
+	if sc.Name == "" {
+		t.Fatal("scenario account_limits_enforced not found — quota enforcement would have no live coverage in any runner")
+	}
+	if !scenarioUsesCappedKey(t, sc) {
+		t.Fatalf("scenario %s no longer authenticates as the capped account, so it cannot reach a cap", sc.Name)
+	}
+
+	steps := map[string]step{}
+	for _, s := range sc.Steps {
+		steps[s.ID] = s
+	}
+
+	// Refused AT the cap, carrying the fields an SDK needs to say WHICH quota
+	// stopped the caller.
+	refused, ok := steps["second_domain_hits_the_cap"]
+	if !ok || refused.Expect == nil || refused.Expect.Status != 402 {
+		t.Fatalf("second_domain_hits_the_cap must expect 402, got %+v", refused.Expect)
+	}
+	for path, want := range map[string]interface{}{
+		"error.code":             "limit_exceeded",
+		"error.details.resource": "domains",
+		"error.details.limit":    1,
+	} {
+		if got := refused.Expect.BodyMatch[path]; fmt.Sprint(got) != fmt.Sprint(want) {
+			t.Errorf("second_domain_hits_the_cap body_match[%q] = %v, want %v", path, got, want)
+		}
+	}
+	if got := steps["second_agent_hits_the_cap"].Expect.BodyMatch["error.details.resource"]; fmt.Sprint(got) != "agents" {
+		t.Errorf("second_agent_hits_the_cap resource = %v, want agents (a second resource proves one wired quota is not standing in for all four)", got)
+	}
+
+	// ...and allowed when it should be. Without these a server that 402'd
+	// unconditionally would satisfy every assertion above.
+	for _, id := range []string{"reregister_owned_domain_at_cap_is_allowed", "agent_create_succeeds_again_after_freeing_a_slot"} {
+		if s, ok := steps[id]; !ok || s.Expect == nil || s.Expect.Status != 201 {
+			t.Errorf("%s must expect 201, got %+v", id, s.Expect)
+		}
+	}
+
+	// The capped account holds one slot per resource, so anything left behind
+	// puts the NEXT run at its cap on the very first step.
+	var cleanupIDs []string
+	for _, c := range sc.Cleanup {
+		cleanupIDs = append(cleanupIDs, c.ID)
+	}
+	if len(cleanupIDs) != 2 || cleanupIDs[0] != "delete_agent_permanently" || cleanupIDs[1] != "delete_domain" {
+		t.Errorf("cleanup = %v, want [delete_agent_permanently delete_domain]", cleanupIDs)
 	}
 }

--- a/tests/contract/contract_test.go
+++ b/tests/contract/contract_test.go
@@ -936,13 +936,27 @@ func requireCappedKey(t *testing.T, env *testEnv, sc scenario) {
 
 // scenarioUsesCappedKey reports whether the scenario authenticates as the
 // capped-plan account anywhere.
+//
+// It inspects auth_override VALUES specifically. Substring-matching a
+// serialized dump of the whole scenario looks equivalent and is not: the
+// scenario's own description mentions {capped_api_key} in prose, so a dump
+// match stays true even if every auth_override is switched back to the primary
+// account — which is exactly the regression this is supposed to detect.
 func scenarioUsesCappedKey(t *testing.T, sc scenario) bool {
 	t.Helper()
-	raw, err := yaml.Marshal(sc)
-	if err != nil {
-		t.Fatalf("marshal scenario %s: %v", sc.Name, err)
+	overrides := []*string{sc.AuthOverride}
+	for _, s := range sc.Steps {
+		overrides = append(overrides, s.AuthOverride)
 	}
-	return strings.Contains(string(raw), cappedKeyPlaceholder)
+	for _, s := range sc.Cleanup {
+		overrides = append(overrides, s.AuthOverride)
+	}
+	for _, o := range overrides {
+		if o != nil && strings.Contains(*o, cappedKeyPlaceholder) {
+			return true
+		}
+	}
+	return false
 }
 
 const cappedKeyPlaceholder = "{capped_api_key}"
@@ -986,41 +1000,79 @@ func TestLimitsScenarioShape(t *testing.T) {
 	for _, s := range sc.Steps {
 		steps[s.ID] = s
 	}
+	// Every lookup below is ok-checked: an indexed miss on a renamed step would
+	// otherwise nil-panic instead of reporting which pin broke.
+	matched := func(id string) map[string]interface{} {
+		t.Helper()
+		s, ok := steps[id]
+		if !ok || s.Expect == nil {
+			t.Fatalf("step %s is missing or has no expect block", id)
+		}
+		return s.Expect.BodyMatch
+	}
+	wantStatus := func(id string, want int) {
+		t.Helper()
+		s, ok := steps[id]
+		if !ok || s.Expect == nil {
+			t.Fatalf("step %s is missing or has no expect block", id)
+		}
+		if s.Expect.Status != want {
+			t.Errorf("step %s status = %d, want %d", id, s.Expect.Status, want)
+		}
+	}
 
 	// Refused AT the cap, carrying the fields an SDK needs to say WHICH quota
-	// stopped the caller.
-	refused, ok := steps["second_domain_hits_the_cap"]
-	if !ok || refused.Expect == nil || refused.Expect.Status != 402 {
-		t.Fatalf("second_domain_hits_the_cap must expect 402, got %+v", refused.Expect)
-	}
+	// stopped the caller — including the upgrade affordance, which is omitempty
+	// and so disappears silently if the server stops sending it.
+	wantStatus("second_domain_hits_the_cap", 402)
+	domainRefusal := matched("second_domain_hits_the_cap")
 	for path, want := range map[string]interface{}{
-		"error.code":             "limit_exceeded",
-		"error.details.resource": "domains",
-		"error.details.limit":    1,
+		"error.code":                "limit_exceeded",
+		"error.details.resource":    "domains",
+		"error.details.limit":       1,
+		"error.details.current":     1,
+		"error.details.plan_code":   "contract_capped",
+		"error.details.upgrade_url": "https://e2a.dev/upgrade",
 	} {
-		if got := refused.Expect.BodyMatch[path]; fmt.Sprint(got) != fmt.Sprint(want) {
+		if got := domainRefusal[path]; fmt.Sprint(got) != fmt.Sprint(want) {
 			t.Errorf("second_domain_hits_the_cap body_match[%q] = %v, want %v", path, got, want)
 		}
 	}
-	if got := steps["second_agent_hits_the_cap"].Expect.BodyMatch["error.details.resource"]; fmt.Sprint(got) != "agents" {
-		t.Errorf("second_agent_hits_the_cap resource = %v, want agents (a second resource proves one wired quota is not standing in for all four)", got)
+
+	// A second resource with a DIFFERENT cap, so no single hardcoded number can
+	// satisfy both refusals and one wired quota cannot stand in for all of them.
+	wantStatus("third_agent_hits_the_cap", 402)
+	agentRefusal := matched("third_agent_hits_the_cap")
+	for path, want := range map[string]interface{}{
+		"error.details.resource": "agents",
+		"error.details.limit":    2,
+		"error.details.current":  2,
+	} {
+		if got := agentRefusal[path]; fmt.Sprint(got) != fmt.Sprint(want) {
+			t.Errorf("third_agent_hits_the_cap body_match[%q] = %v, want %v", path, got, want)
+		}
 	}
 
 	// ...and allowed when it should be. Without these a server that 402'd
 	// unconditionally would satisfy every assertion above.
-	for _, id := range []string{"reregister_owned_domain_at_cap_is_allowed", "agent_create_succeeds_again_after_freeing_a_slot"} {
-		if s, ok := steps[id]; !ok || s.Expect == nil || s.Expect.Status != 201 {
-			t.Errorf("%s must expect 201, got %+v", id, s.Expect)
-		}
-	}
+	wantStatus("reregister_owned_domain_at_cap_is_allowed", 201)
+	wantStatus("agent_create_succeeds_again_after_freeing_a_slot", 201)
 
-	// The capped account holds one slot per resource, so anything left behind
-	// puts the NEXT run at its cap on the very first step.
+	// Cleanup must remove EVERY agent the scenario can create, including the one
+	// the happy path deletes mid-scenario: steps stop at the first failure, so a
+	// failure in between would otherwise strand it and put the next run at its
+	// cap on an early step.
 	var cleanupIDs []string
 	for _, c := range sc.Cleanup {
 		cleanupIDs = append(cleanupIDs, c.ID)
 	}
-	if len(cleanupIDs) != 2 || cleanupIDs[0] != "delete_agent_permanently" || cleanupIDs[1] != "delete_domain" {
-		t.Errorf("cleanup = %v, want [delete_agent_permanently delete_domain]", cleanupIDs)
+	want := []string{"delete_agent_1", "delete_agent_2", "delete_agent_3", "delete_domain"}
+	if len(cleanupIDs) != len(want) {
+		t.Fatalf("cleanup = %v, want %v", cleanupIDs, want)
+	}
+	for i := range want {
+		if cleanupIDs[i] != want[i] {
+			t.Errorf("cleanup[%d] = %s, want %s", i, cleanupIDs[i], want[i])
+		}
 	}
 }

--- a/tests/contract/scenarios.yaml
+++ b/tests/contract/scenarios.yaml
@@ -2030,3 +2030,141 @@ scenarios:
           status: 404
           body_match:
             "error.code": contact_not_found
+
+  - name: account_limits_enforced
+    description: >
+      Plan caps are enforced on the create paths and surface as a 402
+      limit_exceeded envelope carrying the resource, the cap, and the current
+      usage — the fields an SDK needs to tell a caller WHICH quota stopped
+      them and by how much. Everything here runs as a SECOND, permanently
+      capped account (auth_override with {capped_api_key}) that the contract
+      server seeds at startup with max_domains 1 / max_agents 1. Nothing
+      mutates a cap, so this scenario cannot leak enforcement into the ones
+      that follow — which is the whole reason the caps are a separate account
+      instead of a limits-seeding step: both the TS and Python runners
+      silently ignore setup keys they do not recognize, so a "reset the caps"
+      cleanup that one runner skipped would 402 every later scenario.
+      Until this existed, no limit path in the product was covered by any
+      live-server test in any language (the contract server deliberately set
+      caps to 100000, per the comment in testutil.StartContractServer).
+    steps:
+      # The capped account starts empty, so its single domain slot is free.
+      - id: first_domain_fits_the_cap
+        action: request
+        method: POST
+        path: /v1/domains
+        auth_override: "Bearer {capped_api_key}"
+        body:
+          domain: capped-{scenario_token}.test.dev
+        expect:
+          status: 201
+          body_match:
+            domain: capped-{scenario_token}.test.dev
+
+      # The cap bites, and says so in a machine-readable way: an SDK surfacing
+      # only "402" leaves the caller guessing which of four quotas they hit.
+      - id: second_domain_hits_the_cap
+        action: request
+        method: POST
+        path: /v1/domains
+        auth_override: "Bearer {capped_api_key}"
+        body:
+          domain: capped-2-{scenario_token}.test.dev
+        expect:
+          status: 402
+          body_match:
+            "error.code": limit_exceeded
+            "error.details.resource": domains
+            "error.details.limit": 1
+            "error.details.current": 1
+
+      # The exemption (#811 / #819): a same-owner re-register creates nothing —
+      # the claim returns the existing row — so the CREATE cap must not apply
+      # to it. Pre-fix this 402'd, failing an SDK retry of a request the server
+      # had already satisfied. This step is the reason the account is capped at
+      # exactly 1: the account is provably AT its cap on the line above.
+      - id: reregister_owned_domain_at_cap_is_allowed
+        action: request
+        method: POST
+        path: /v1/domains
+        auth_override: "Bearer {capped_api_key}"
+        body:
+          domain: capped-{scenario_token}.test.dev
+        expect:
+          status: 201
+          body_match:
+            domain: capped-{scenario_token}.test.dev
+
+      # A DIFFERENT resource, so a passing suite cannot come from one quota
+      # being wired while the others are not. The shared domain needs no
+      # verification, so the agent cap is reachable over pure HTTP in every
+      # runner.
+      - id: first_agent_fits_the_cap
+        action: request
+        method: POST
+        path: /v1/agents
+        auth_override: "Bearer {capped_api_key}"
+        body:
+          email: capped-bot-{scenario_token}@agents.e2a.dev
+        expect:
+          status: 201
+          body_match:
+            email: capped-bot-{scenario_token}@agents.e2a.dev
+
+      - id: second_agent_hits_the_cap
+        action: request
+        method: POST
+        path: /v1/agents
+        auth_override: "Bearer {capped_api_key}"
+        body:
+          email: capped-bot-2-{scenario_token}@agents.e2a.dev
+        expect:
+          status: 402
+          body_match:
+            "error.code": limit_exceeded
+            "error.details.resource": agents
+            "error.details.limit": 1
+            "error.details.current": 1
+
+      # The cap is a cap, not a wall: freeing the slot makes the create work
+      # again. Without this, a server that 402'd unconditionally would pass
+      # every assertion above.
+      - id: agent_slot_frees_on_delete
+        action: request
+        method: DELETE
+        path: /v1/agents/capped-bot-{scenario_token}@agents.e2a.dev?confirm=DELETE&permanent=true
+        auth_override: "Bearer {capped_api_key}"
+        expect:
+          status: 200
+          body_match:
+            deleted: true
+
+      - id: agent_create_succeeds_again_after_freeing_a_slot
+        action: request
+        method: POST
+        path: /v1/agents
+        auth_override: "Bearer {capped_api_key}"
+        body:
+          email: capped-bot-2-{scenario_token}@agents.e2a.dev
+        expect:
+          status: 201
+
+    cleanup:
+      # Self-cleaning is load-bearing here, not tidiness: the capped account
+      # has exactly one slot per resource, so anything left behind puts the
+      # NEXT run at its cap on the very first step.
+      - id: delete_agent_permanently
+        action: request
+        method: DELETE
+        path: /v1/agents/capped-bot-2-{scenario_token}@agents.e2a.dev?confirm=DELETE&permanent=true
+        auth_override: "Bearer {capped_api_key}"
+        expect:
+          status: 200
+
+      - id: delete_domain
+        action: request
+        method: DELETE
+        path: /v1/domains/capped-{scenario_token}.test.dev?confirm=DELETE
+        auth_override: "Bearer {capped_api_key}"
+        expect:
+          status: 200

--- a/tests/contract/scenarios.yaml
+++ b/tests/contract/scenarios.yaml
@@ -2034,9 +2034,14 @@ scenarios:
   - name: account_limits_enforced
     description: >
       Plan caps are enforced on the create paths and surface as a 402
-      limit_exceeded envelope carrying the resource, the cap, and the current
-      usage — the fields an SDK needs to tell a caller WHICH quota stopped
-      them and by how much. Everything here runs as a SECOND, permanently
+      limit_exceeded envelope carrying the resource, the cap, the plan code and
+      the upgrade URL — the fields an SDK needs to tell a caller WHICH quota
+      stopped them and how to get out of it. The two resources carry DIFFERENT
+      caps (domains 1, agents 2) so a single hardcoded number cannot satisfy
+      both. `current` is asserted too, but note it is NOT independently proven
+      here: at the moment of refusal `current == limit` by definition of the
+      `count >= cap` check, so only an over-cap account (a downgrade) could
+      distinguish them. Tracked separately. Everything here runs as a SECOND, permanently
       capped account (auth_override with {capped_api_key}) that the contract
       server seeds at startup with max_domains 1 / max_agents 1. Nothing
       mutates a cap, so this scenario cannot leak enforcement into the ones
@@ -2077,6 +2082,12 @@ scenarios:
             "error.details.resource": domains
             "error.details.limit": 1
             "error.details.current": 1
+            # The upgrade affordance is the whole point of a 402: without a
+            # plan code and a URL the caller hits a paywall with nowhere to go.
+            # Both are `omitempty`, so dropping them server-side is invisible
+            # unless something asserts them.
+            "error.details.plan_code": contract_capped
+            "error.details.upgrade_url": https://e2a.dev/upgrade
 
       # The exemption (#811 / #819): a same-owner re-register creates nothing —
       # the claim returns the existing row — so the CREATE cap must not apply
@@ -2095,8 +2106,9 @@ scenarios:
           body_match:
             domain: capped-{scenario_token}.test.dev
 
-      # A DIFFERENT resource, so a passing suite cannot come from one quota
-      # being wired while the others are not. The shared domain needs no
+      # A DIFFERENT resource with a DIFFERENT cap, so a passing suite cannot
+      # come from one quota being wired while the others are not, nor from a
+      # hardcoded "1" anywhere in the envelope. The shared domain needs no
       # verification, so the agent cap is reachable over pure HTTP in every
       # runner.
       - id: first_agent_fits_the_cap
@@ -2111,7 +2123,7 @@ scenarios:
           body_match:
             email: capped-bot-{scenario_token}@agents.e2a.dev
 
-      - id: second_agent_hits_the_cap
+      - id: second_agent_fits_the_cap
         action: request
         method: POST
         path: /v1/agents
@@ -2119,12 +2131,23 @@ scenarios:
         body:
           email: capped-bot-2-{scenario_token}@agents.e2a.dev
         expect:
+          status: 201
+
+      - id: third_agent_hits_the_cap
+        action: request
+        method: POST
+        path: /v1/agents
+        auth_override: "Bearer {capped_api_key}"
+        body:
+          email: capped-bot-3-{scenario_token}@agents.e2a.dev
+        expect:
           status: 402
           body_match:
             "error.code": limit_exceeded
             "error.details.resource": agents
-            "error.details.limit": 1
-            "error.details.current": 1
+            "error.details.limit": 2
+            "error.details.current": 2
+            "error.details.plan_code": contract_capped
 
       # The cap is a cap, not a wall: freeing the slot makes the create work
       # again. Without this, a server that 402'd unconditionally would pass
@@ -2145,26 +2168,42 @@ scenarios:
         path: /v1/agents
         auth_override: "Bearer {capped_api_key}"
         body:
-          email: capped-bot-2-{scenario_token}@agents.e2a.dev
+          email: capped-bot-3-{scenario_token}@agents.e2a.dev
         expect:
           status: 201
 
     cleanup:
       # Self-cleaning is load-bearing here, not tidiness: the capped account
-      # has exactly one slot per resource, so anything left behind puts the
-      # NEXT run at its cap on the very first step.
-      - id: delete_agent_permanently
+      # has a handful of slots, so anything left behind puts the NEXT run at
+      # its cap on an early step — and a scenario that fails at step one with
+      # "the cap fired on the first create" reads exactly like a product bug.
+      #
+      # EVERY agent the scenario can create is deleted here, including
+      # capped-bot-1, which the happy path already removed in
+      # agent_slot_frees_on_delete: steps stop at the first failure, so a
+      # failure between that create and that delete would otherwise strand it.
+      # These carry no `expect` precisely so an already-deleted agent's 404 is
+      # not itself a cleanup failure.
+      - id: delete_agent_1
+        action: request
+        method: DELETE
+        path: /v1/agents/capped-bot-{scenario_token}@agents.e2a.dev?confirm=DELETE&permanent=true
+        auth_override: "Bearer {capped_api_key}"
+
+      - id: delete_agent_2
         action: request
         method: DELETE
         path: /v1/agents/capped-bot-2-{scenario_token}@agents.e2a.dev?confirm=DELETE&permanent=true
         auth_override: "Bearer {capped_api_key}"
-        expect:
-          status: 200
+
+      - id: delete_agent_3
+        action: request
+        method: DELETE
+        path: /v1/agents/capped-bot-3-{scenario_token}@agents.e2a.dev?confirm=DELETE&permanent=true
+        auth_override: "Bearer {capped_api_key}"
 
       - id: delete_domain
         action: request
         method: DELETE
         path: /v1/domains/capped-{scenario_token}.test.dev?confirm=DELETE
         auth_override: "Bearer {capped_api_key}"
-        expect:
-          status: 200


### PR DESCRIPTION
> **Supersedes #821**, which is now folded in here. AGENTS.md requires a changed `/v1` behavior to be pinned by a scenario proven in all three runners; keeping the fix and its proof in separate PRs left a window on `main` with no coverage, and meant this PR's own CI never ran the scenario that proves it.

## Summary

`POST /v1/domains` is idempotent for a domain the caller already owns — the cross-account guard is `user_id IS DISTINCT FROM $2`, so `ClaimOrCreateDomain` returns the existing row rather than creating one. But `handleRegisterDomain` ran `EnforceDomainCreate` before the claim unconditionally, so an account at `max_domains` got `402 limit_exceeded` for re-POSTing a domain it already held — an error naming a resource the request would never have consumed. An SDK retry, a re-run provisioning script, or the dashboard registering a domain already in its list all failed on a request that creates nothing.

The same PR adds the first contract-layer coverage of plan-limit enforcement, which is what lets the fix be pinned at all.

## The fix

The cap is evaluated only when the POST would actually create a row:

```go
alreadyOwned := false
if s.deps.LookupDomain != nil {
    if existing, lookupErr := s.deps.LookupDomain(ctx, normalized, user.ID); lookupErr == nil && existing != nil {
        alreadyOwned = true
    }
}
if !alreadyOwned && s.deps.EnforceDomainCreate != nil { /* unchanged */ }
```

"Already owned" comes from the same user-scoped `LookupDomain` that `GET /v1/domains/{domain}` uses (`WHERE domain = $1 AND user_id = $2`), which is what keeps it from becoming a bypass: another account's row is invisible to it, a parent/child claim is a genuinely new row no exact-match lookup finds, and every non-clean outcome — dep unwired, lookup failed, nil row — falls through to enforcing.

The check sits outside the claim transaction deliberately: that is the same non-transactional shape the cap already had.

## Contract coverage

`testutil.StartContractServer` set every cap to 100000 on purpose — *"contract scenarios exercise contract shape, not quota enforcement"* — so no limit path had contract-layer coverage in any language. (The e2e-prod harness does cover both caps, but it runs against production, not per-PR CI.)

A scenario step that lowers the caps would be the obvious approach and is a trap: caps are account-global, and the TS and Python setup loops silently ignore setup keys they don't recognize, so a cap lowered for one scenario and restored by a cleanup step some runner skipped would 402 every scenario after it. Instead the contract server seeds a **second account** with small, deliberately unequal caps and hands its key to the runners as `E2A_TEST_CAPPED_API_KEY`; scenarios reach it through `auth_override`, an existing primitive all three runners already resolve variables through. Nothing mutates, so nothing can leak. CI needs no workflow change — the env file is sourced with `set -a`.

`account_limits_enforced` pins both directions on two resources with different caps: refusal at the cap (with `resource`, `limit`, `current`, `plan_code`, `upgrade_url`) and success once a slot is freed — including `reregister_owned_domain_at_cap_is_allowed`, the step that pins this PR's fix.

## What a review pass changed

Five independent reviewers audited this. The behavior change held up — no bypass across 24 normalization probes (trailing dot, dot lookalikes, fullwidth, ZWSP, homoglyphs, `xn--`), fail-closed on every lookup error, and a measured zero delta to the pre-existing concurrency window. The tests did not:

- **Scoping was untestable, so it was untested.** The shared `LookupDomain` fake ignored `userID`, so passing `""` or another account's id left the whole package green. The fake now models ownership; both mutations fail.
- **The scenario leaked its first agent on any mid-run failure**, permanently parking the capped account at its cap and failing every later run at step one. Cleanup now covers every agent it can create. Verified by inducing a failure and re-running against the same server.
- **Two mutations were caught by nothing:** emptying `plan_code`/`upgrade_url` (both `omitempty` — a paywall with no way out), and every cap being 1, which made `limit` and `current` mutually substitutable.
- **The capped-account guard was satisfied by a comment** — all three runners matched a serialized dump, and the description mentions the placeholder in prose. They now inspect `auth_override` values.

Known limitation, stated rather than papered over: `current` is still not independently proven, because at refusal `current == limit` by definition of the `count >= cap` check. Only an over-cap account (a downgrade) distinguishes them — filed separately.

## Client surface checklist

- [x] Go handler + tests
- [x] Contract scenario proven in the Go, TypeScript **and** Python live runners
- [ ] ~~Migration~~ — none, no schema change
- [x] OpenAPI spec — no shape change; `make spec-check` confirms byte-identical (no new status codes or fields), nothing for the compat gate
- [ ] ~~TS / Python SDK, CLI, MCP~~ — no surface change. MCP already advertises `idempotentHint: true` for `register_domain`; this makes the server *more* consistent with that annotation
- [x] **Web dashboard** (not listed in the template, checked manually) — no change needed: no `402`/`limit_exceeded` branch anywhere in `web/src`. It surfaces errors generically, so an at-cap user re-registering an owned domain currently sees a raw quota error; this fixes that path

## Operational risk

Low, and it only ever loosens: a request that previously 402'd now succeeds, on a path where the server was already going to return the existing row. The skipped check guards a code path that creates nothing, so it cannot let an account hold more domains than its cap. Cost is one extra indexed lookup per `POST /v1/domains`.

Two pre-existing issues this did **not** change, both filed separately: `max_domains` is not actually enforced under concurrency (measured: cap 1, 12 concurrent registers → 12 rows, identical before and after this diff), and at-cap callers now reach the unconditional RSA-2048 keygen in `ClaimOrCreateDomain` that the 402 used to short-circuit.

## Test plan

- [x] Reclaim-at-cap fails pre-fix (`402 limits: domains cap reached (1/1)`), passes post-fix
- [x] Scoping mutations (`userID` → `""`, → another account) both fail the suite
- [x] `account_limits_enforced` green in **all three** live runners against a real contract server
- [x] Mid-scenario failure → re-run on the same server passes (no leak)
- [x] Mutation: emptying `plan_code`/`upgrade_url` now fails the contract suite
- [x] Mutation: every `auth_override` swapped to the primary account now fails all three shape tests
- [x] `tests/contract`, `internal/httpapi`, `internal/testutil`, TS SDK suite, Python contract file green; `gofmt`/`go vet` clean on every touched file; `make spec-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)