### PR TITLE
fix(web): surface contact metadata in the dashboard

### DIFF
--- a/web/src/app/(app)/contacts/_lib/csv.test.ts
+++ b/web/src/app/(app)/contacts/_lib/csv.test.ts
@@ -1,4 +1,4 @@
-import { mapCsvRows, parseCsv } from "./csv";
+import { getCsvMetadataColumns, mapCsvRows, parseCsv } from "./csv";
 
 describe("contacts CSV parsing", () => {
   it("handles BOM, quoted commas, escaped quotes, and newlines", () => {
@@ -18,6 +18,49 @@ describe("contacts CSV parsing", () => {
       address: "partner@fund.vc",
       display_name: "A. Partner",
       metadata: { Fund: "Example Capital" },
+    }]);
+  });
+
+  it("reports metadata columns with first-row samples", () => {
+    const table = parseCsv(
+      "email,name,company,role,notes\npartner@example.com,A. Partner,Example Capital,GP,met at demo day\n",
+    );
+
+    expect(getCsvMetadataColumns(table, "email", "name")).toEqual([
+      { name: "company", sampleValue: "Example Capital" },
+      { name: "role", sampleValue: "GP" },
+      { name: "notes", sampleValue: "met at demo day" },
+    ]);
+  });
+
+  it("updates metadata reporting when the selected name column changes", () => {
+    const table = parseCsv("email,name,company\npartner@example.com,A. Partner,Example Capital\n");
+
+    expect(getCsvMetadataColumns(table, "email", "name")).toEqual([
+      { name: "company", sampleValue: "Example Capital" },
+    ]);
+    expect(getCsvMetadataColumns(table, "email", "company")).toEqual([
+      { name: "name", sampleValue: "A. Partner" },
+    ]);
+    expect(mapCsvRows(table, "email", "company")).toEqual([{
+      address: "partner@example.com",
+      display_name: "Example Capital",
+      metadata: { name: "A. Partner" },
+    }]);
+  });
+
+  it("reports no metadata columns and skips empty headers", () => {
+    const onlyIdentity = parseCsv("email,name\npartner@example.com,A. Partner\n");
+    const withEmptyHeader = parseCsv("email,name, ,role\npartner@example.com,A. Partner,ignored,GP\n");
+
+    expect(getCsvMetadataColumns(onlyIdentity, "email", "name")).toEqual([]);
+    expect(getCsvMetadataColumns(withEmptyHeader, "email", "name")).toEqual([
+      { name: "role", sampleValue: "GP" },
+    ]);
+    expect(mapCsvRows(withEmptyHeader, "email", "name")).toEqual([{
+      address: "partner@example.com",
+      display_name: "A. Partner",
+      metadata: { role: "GP" },
     }]);
   });
 });

--- a/web/src/app/(app)/contacts/_lib/csv.test.ts
+++ b/web/src/app/(app)/contacts/_lib/csv.test.ts
@@ -63,4 +63,17 @@ describe("contacts CSV parsing", () => {
       metadata: { role: "GP" },
     }]);
   });
+
+  it("keeps mapping and reporting aligned when the selected email header is empty", () => {
+    const table = parseCsv(",alias,company\n1,A. Partner,Example Capital\n");
+
+    expect(getCsvMetadataColumns(table, "")).toEqual([
+      { name: "alias", sampleValue: "A. Partner" },
+      { name: "company", sampleValue: "Example Capital" },
+    ]);
+    expect(mapCsvRows(table, "")).toEqual([{
+      address: "1",
+      metadata: { alias: "A. Partner", company: "Example Capital" },
+    }]);
+  });
 });

--- a/web/src/app/(app)/contacts/_lib/csv.ts
+++ b/web/src/app/(app)/contacts/_lib/csv.ts
@@ -45,25 +45,50 @@ export type ImportPreviewRow = {
   metadata?: Record<string, string>;
 };
 
-export function mapCsvRows(
-  table: string[][],
-  emailColumn: string,
-  nameColumn?: string,
-): ImportPreviewRow[] {
+export type CsvMetadataColumn = {
+  name: string;
+  sampleValue: string;
+};
+
+function resolveColumns(table: string[][], emailColumn: string, nameColumn?: string) {
   if (table.length < 2) throw new Error("CSV must include a header and at least one row");
   const headers = table[0].map((header) => header.trim());
   const emailIndex = headers.indexOf(emailColumn);
   if (emailIndex < 0) throw new Error(`No “${emailColumn}” column found`);
   const nameIndex = nameColumn ? headers.indexOf(nameColumn) : -1;
   if (nameColumn && nameIndex < 0) throw new Error(`No “${nameColumn}” column found`);
+  const metadataIndexes = headers
+    .map((header, index) => ({ header, index }))
+    .filter(({ header, index }) => header && index !== emailIndex && index !== nameIndex);
+  return { emailIndex, nameIndex, metadataIndexes };
+}
+
+export function getCsvMetadataColumns(
+  table: string[][],
+  emailColumn: string,
+  nameColumn?: string,
+): CsvMetadataColumn[] {
+  const { metadataIndexes } = resolveColumns(table, emailColumn, nameColumn);
+  const sampleRow = table[1];
+  const columns: Record<string, CsvMetadataColumn> = {};
+  metadataIndexes.forEach(({ header, index }) => {
+    columns[header] = { name: header, sampleValue: sampleRow[index] ?? "" };
+  });
+  return Object.values(columns);
+}
+
+export function mapCsvRows(
+  table: string[][],
+  emailColumn: string,
+  nameColumn?: string,
+): ImportPreviewRow[] {
+  const { emailIndex, nameIndex, metadataIndexes } = resolveColumns(table, emailColumn, nameColumn);
   const rows = table.slice(1).map((values) => {
     const row: ImportPreviewRow = { address: (values[emailIndex] ?? "").trim() };
     if (nameIndex >= 0) row.display_name = values[nameIndex] ?? "";
     const metadata: Record<string, string> = {};
-    headers.forEach((header, index) => {
-      if (header && index !== emailIndex && index !== nameIndex) {
-        metadata[header] = values[index] ?? "";
-      }
+    metadataIndexes.forEach(({ header, index }) => {
+      metadata[header] = values[index] ?? "";
     });
     if (Object.keys(metadata).length > 0) row.metadata = metadata;
     return row;

--- a/web/src/app/(app)/contacts/page.test.tsx
+++ b/web/src/app/(app)/contacts/page.test.tsx
@@ -309,11 +309,17 @@ it("shows metadata read-only in the editor and omits it from PATCH", async () =>
   render(<ContactsPage />);
 
   await userEvent.click(await screen.findByRole("button", { name: "Edit partner@example.com" }));
-  expect(await screen.findByText(
+  const editHeading = await screen.findByRole("heading", { name: "Edit partner@example.com" });
+  const editPanel = editHeading.closest("section");
+  expect(editPanel).not.toBeNull();
+  expect(within(editPanel as HTMLElement).getByText(
     "Metadata is read-only here. Manage it through CSV import or the API.",
   )).toBeInTheDocument();
-  expect(screen.getAllByText("Example Capital").length).toBeGreaterThan(0);
-  expect(screen.getAllByText("42").length).toBeGreaterThan(0);
+  const editorMetadataHeading = within(editPanel as HTMLElement).getByText("Metadata");
+  const editorMetadata = editorMetadataHeading.closest("div");
+  expect(editorMetadata).not.toBeNull();
+  expect(within(editorMetadata as HTMLElement).getAllByText("Example Capital").length).toBeGreaterThan(0);
+  expect(within(editorMetadata as HTMLElement).getAllByText("42").length).toBeGreaterThan(0);
 
   const input = screen.getByRole("textbox", { name: "Display name" });
   await userEvent.clear(input);
@@ -404,4 +410,109 @@ it("states when a CSV has no metadata columns", async () => {
   await userEvent.upload(screen.getByLabelText("CSV file"), file);
 
   expect(await screen.findByText("No columns will be stored as metadata.")).toBeInTheDocument();
+});
+
+it("disarms a staged import when a replacement CSV cannot be mapped", async () => {
+  fetchMock.mockResolvedValue({
+    ok: true,
+    json: async () => ({ items: [], next_cursor: null }),
+  });
+  render(<ContactsPage />);
+
+  await screen.findAllByText("No contacts yet. Create one or import a CSV.");
+  await userEvent.click(screen.getByRole("button", { name: "Import CSV" }));
+  const importHeading = screen.getByRole("heading", { name: "Import CSV" });
+  const importPanel = importHeading.closest("section");
+  expect(importPanel).not.toBeNull();
+  const fileInput = within(importPanel as HTMLElement).getByLabelText("CSV file");
+
+  const validCsv = "email,name,company\np@x.com,A. Partner,Example Capital";
+  const validFile = new File([validCsv], "a.csv", { type: "text/csv" });
+  Object.defineProperty(validFile, "text", { value: async () => validCsv });
+  await userEvent.upload(fileInput, validFile);
+  expect(await within(importPanel as HTMLElement).findByText(/a\.csv: 1 row ready/)).toBeInTheDocument();
+  expect(within(importPanel as HTMLElement).getByRole("button", { name: "Import 1 contact" })).toBeEnabled();
+
+  const invalidCsv = "email,name\n";
+  const invalidFile = new File([invalidCsv], "b.csv", { type: "text/csv" });
+  Object.defineProperty(invalidFile, "text", { value: async () => invalidCsv });
+  await userEvent.upload(fileInput, invalidFile);
+
+  expect(await within(importPanel as HTMLElement).findByRole("alert")).toHaveTextContent(
+    "CSV must include a header and at least one row",
+  );
+  expect(within(importPanel as HTMLElement).queryByText(/a\.csv: 1 row ready/)).not.toBeInTheDocument();
+  expect(within(importPanel as HTMLElement).queryByText(/b\.csv:/)).not.toBeInTheDocument();
+  expect(within(importPanel as HTMLElement).queryByRole("region", {
+    name: "CSV metadata mapping",
+  })).not.toBeInTheDocument();
+  expect(within(importPanel as HTMLElement).getByRole("button", { name: "Import contacts" })).toBeDisabled();
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+});
+
+it("previews and posts metadata when the selected email header is empty", async () => {
+  fetchMock
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ items: [], next_cursor: null }) })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        batch_id: "cimp_empty_header",
+        created: 1,
+        updated: 0,
+        skipped: 0,
+        failed: 0,
+        results: [{ index: 0, address: "1", status: "created" }],
+      }),
+    })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ items: [], next_cursor: null }) });
+  render(<ContactsPage />);
+
+  await screen.findAllByText("No contacts yet. Create one or import a CSV.");
+  await userEvent.click(screen.getByRole("button", { name: "Import CSV" }));
+  const csv = ",alias,company\n1,A. Partner,Example Capital";
+  const file = new File([csv], "blank-email-header.csv", { type: "text/csv" });
+  Object.defineProperty(file, "text", { value: async () => csv });
+  await userEvent.upload(screen.getByLabelText("CSV file"), file);
+
+  const mapping = await screen.findByRole("region", { name: "CSV metadata mapping" });
+  expect(within(mapping).getByText("alias")).toBeInTheDocument();
+  expect(within(mapping).getByText("A. Partner")).toBeInTheDocument();
+  expect(within(mapping).getByText("company")).toBeInTheDocument();
+  expect(within(mapping).getByText("Example Capital")).toBeInTheDocument();
+  expect(within(mapping).queryByText("No columns will be stored as metadata.")).not.toBeInTheDocument();
+
+  await userEvent.click(screen.getByRole("button", { name: "Import 1 contact" }));
+  await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+  const [, importRequest] = fetchMock.mock.calls[1] as [string, RequestInit];
+  expect(JSON.parse(importRequest.body as string)).toEqual({
+    contacts: [{
+      address: "1",
+      metadata: { alias: "A. Partner", company: "Example Capital" },
+    }],
+    on_conflict: "merge",
+  });
+});
+
+it("does not emit duplicate-key warnings for headers that collide after trimming", async () => {
+  const consoleError = jest.spyOn(console, "error").mockImplementation(() => undefined);
+  try {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ items: [], next_cursor: null }),
+    });
+    render(<ContactsPage />);
+
+    await screen.findAllByText("No contacts yet. Create one or import a CSV.");
+    await userEvent.click(screen.getByRole("button", { name: "Import CSV" }));
+    const csv = "email,tag, tag\np@x.com,first,second";
+    const file = new File([csv], "duplicate-trimmed-headers.csv", { type: "text/csv" });
+    Object.defineProperty(file, "text", { value: async () => csv });
+    await userEvent.upload(screen.getByLabelText("CSV file"), file);
+    await screen.findByRole("region", { name: "CSV metadata mapping" });
+
+    const messages = consoleError.mock.calls.flat().join(" ");
+    expect(messages).not.toMatch(/same key|Encountered two children with the same key/i);
+  } finally {
+    consoleError.mockRestore();
+  }
 });

--- a/web/src/app/(app)/contacts/page.test.tsx
+++ b/web/src/app/(app)/contacts/page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import ContactsPage from "./page";
 
@@ -216,4 +216,192 @@ it("shows a reversible import receipt and refreshes the contact list", async () 
   const [url, request] = fetchMock.mock.calls[3] as [string, RequestInit];
   expect(url).toBe("/v1/contacts/imports/cimp_test?confirm=DELETE");
   expect(request.method).toBe("DELETE");
+});
+
+it("renders contact metadata safely and discloses fields beyond the inline cap", async () => {
+  fetchMock.mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      items: [{
+        address: "partner@example.com",
+        display_name: "A. Partner",
+        metadata: {
+          company: "Example Capital",
+          role: "GP",
+          notes: "met at demo day",
+          score: 42,
+          last_contact: null,
+          profile: { tier: "gold" },
+        },
+        source: "import",
+        created_at: "2026-07-27T00:00:00Z",
+        updated_at: "2026-07-27T00:00:00Z",
+      }],
+      next_cursor: null,
+    }),
+  });
+  render(<ContactsPage />);
+
+  expect((await screen.findAllByText("Metadata")).length).toBe(2);
+  expect(screen.getAllByText("company").length).toBeGreaterThan(0);
+  expect(screen.getAllByText("Example Capital").length).toBeGreaterThan(0);
+  expect(screen.getAllByText("role").length).toBeGreaterThan(0);
+  expect(screen.getAllByText("GP").length).toBeGreaterThan(0);
+  expect(screen.getAllByText("notes").length).toBeGreaterThan(0);
+  expect(screen.getAllByText("met at demo day").length).toBeGreaterThan(0);
+
+  const summaries = screen.getAllByText("View all 6 metadata fields (3 more)");
+  expect(summaries).toHaveLength(2);
+  await userEvent.click(summaries[0]);
+  const disclosure = summaries[0].closest("details");
+  expect(disclosure).not.toBeNull();
+  expect(within(disclosure as HTMLElement).getByText("score")).toBeInTheDocument();
+  expect(within(disclosure as HTMLElement).getByText("42")).toBeInTheDocument();
+  expect(within(disclosure as HTMLElement).getByText("last_contact")).toBeInTheDocument();
+  expect(within(disclosure as HTMLElement).getByText("null")).toBeInTheDocument();
+  expect(within(disclosure as HTMLElement).getByText('{"tier":"gold"}')).toBeInTheDocument();
+  expect(screen.queryByText("[object Object]")).not.toBeInTheDocument();
+});
+
+it("does not render a metadata affordance for empty metadata", async () => {
+  fetchMock.mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      items: [{
+        address: "partner@example.com",
+        display_name: "A. Partner",
+        metadata: {},
+        source: "manual",
+        created_at: "2026-07-27T00:00:00Z",
+        updated_at: "2026-07-27T00:00:00Z",
+      }],
+      next_cursor: null,
+    }),
+  });
+  render(<ContactsPage />);
+
+  await screen.findAllByText("A. Partner");
+  expect(screen.queryByText("Metadata")).not.toBeInTheDocument();
+  expect(screen.queryByText(/View (?:all|full) metadata/)).not.toBeInTheDocument();
+});
+
+it("shows metadata read-only in the editor and omits it from PATCH", async () => {
+  const contact = {
+    address: "partner@example.com",
+    display_name: "A. Partner",
+    metadata: { company: "Example Capital", score: 42 },
+    source: "import",
+    created_at: "2026-07-27T00:00:00Z",
+    updated_at: "2026-07-27T00:00:00Z",
+  };
+  fetchMock
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ items: [contact], next_cursor: null }) })
+    .mockResolvedValueOnce({
+      ok: true,
+      headers: new Headers({ ETag: '"contact-v1"' }),
+      json: async () => contact,
+    })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ ...contact, display_name: "Renamed" }) })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ items: [{ ...contact, display_name: "Renamed" }], next_cursor: null }),
+    });
+  render(<ContactsPage />);
+
+  await userEvent.click(await screen.findByRole("button", { name: "Edit partner@example.com" }));
+  expect(await screen.findByText(
+    "Metadata is read-only here. Manage it through CSV import or the API.",
+  )).toBeInTheDocument();
+  expect(screen.getAllByText("Example Capital").length).toBeGreaterThan(0);
+  expect(screen.getAllByText("42").length).toBeGreaterThan(0);
+
+  const input = screen.getByRole("textbox", { name: "Display name" });
+  await userEvent.clear(input);
+  await userEvent.type(input, "Renamed");
+  await userEvent.click(screen.getByRole("button", { name: "Save contact" }));
+
+  await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(4));
+  const [, patchRequest] = fetchMock.mock.calls[2] as [string, RequestInit];
+  const body = JSON.parse(patchRequest.body as string) as Record<string, unknown>;
+  expect(body).toEqual({ display_name: "Renamed" });
+  expect(body).not.toHaveProperty("metadata");
+});
+
+it("previews CSV metadata mapping and preserves the import request shape", async () => {
+  fetchMock
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ items: [], next_cursor: null }) })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        batch_id: "cimp_preview",
+        created: 1,
+        updated: 0,
+        skipped: 0,
+        failed: 0,
+        results: [{ index: 0, address: "partner@example.com", status: "created" }],
+      }),
+    })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ items: [], next_cursor: null }) });
+  render(<ContactsPage />);
+
+  await screen.findAllByText("No contacts yet. Create one or import a CSV.");
+  await userEvent.click(screen.getByRole("button", { name: "Import CSV" }));
+  const csv = [
+    "email,name,company,role,notes",
+    "partner@example.com,A. Partner,Example Capital,GP,met at demo day",
+  ].join("\n");
+  const file = new File([csv], "contacts.csv", { type: "text/csv" });
+  Object.defineProperty(file, "text", { value: async () => csv });
+  await userEvent.upload(screen.getByLabelText("CSV file"), file);
+
+  const mapping = await screen.findByRole("region", { name: "CSV metadata mapping" });
+  expect(within(mapping).getByText("company")).toBeInTheDocument();
+  expect(within(mapping).getByText("Example Capital")).toBeInTheDocument();
+  expect(within(mapping).getByText("role")).toBeInTheDocument();
+  expect(within(mapping).getByText("GP")).toBeInTheDocument();
+  expect(within(mapping).getByText("notes")).toBeInTheDocument();
+  expect(within(mapping).getByText("met at demo day")).toBeInTheDocument();
+
+  await userEvent.selectOptions(screen.getByRole("combobox", { name: "Name column" }), "company");
+  expect(within(mapping).getByText("name")).toBeInTheDocument();
+  expect(within(mapping).getByText("A. Partner")).toBeInTheDocument();
+  expect(within(mapping).queryByText("company")).not.toBeInTheDocument();
+  await userEvent.selectOptions(screen.getByRole("combobox", { name: "Name column" }), "name");
+
+  await userEvent.click(screen.getByRole("button", { name: "Import 1 contact" }));
+  await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+  const [url, importRequest] = fetchMock.mock.calls[1] as [string, RequestInit];
+  expect(url).toBe("/v1/contacts/import");
+  expect(JSON.parse(importRequest.body as string)).toEqual({
+    contacts: [{
+      address: "partner@example.com",
+      display_name: "A. Partner",
+      metadata: {
+        company: "Example Capital",
+        role: "GP",
+        notes: "met at demo day",
+      },
+    }],
+    on_conflict: "merge",
+  });
+});
+
+it("states when a CSV has no metadata columns", async () => {
+  fetchMock.mockResolvedValue({
+    ok: true,
+    json: async () => ({ items: [], next_cursor: null }),
+  });
+  render(<ContactsPage />);
+
+  await screen.findAllByText("No contacts yet. Create one or import a CSV.");
+  await userEvent.click(screen.getByRole("button", { name: "Import CSV" }));
+  const file = new File(["email,name\npartner@example.com,A. Partner"], "contacts.csv", {
+    type: "text/csv",
+  });
+  Object.defineProperty(file, "text", {
+    value: async () => "email,name\npartner@example.com,A. Partner",
+  });
+  await userEvent.upload(screen.getByLabelText("CSV file"), file);
+
+  expect(await screen.findByText("No columns will be stored as metadata.")).toBeInTheDocument();
 });

--- a/web/src/app/(app)/contacts/page.test.tsx
+++ b/web/src/app/(app)/contacts/page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import ContactsPage from "./page";
 
@@ -515,4 +515,76 @@ it("does not emit duplicate-key warnings for headers that collide after trimming
   } finally {
     consoleError.mockRestore();
   }
+});
+
+it("keeps the latest CSV when an earlier file read resolves last", async () => {
+  fetchMock
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ items: [], next_cursor: null }) })
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        batch_id: "cimp_latest_file",
+        created: 1,
+        updated: 0,
+        skipped: 0,
+        failed: 0,
+        results: [{ index: 0, address: "second@example.com", status: "created" }],
+      }),
+    })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ items: [], next_cursor: null }) });
+  render(<ContactsPage />);
+
+  await screen.findAllByText("No contacts yet. Create one or import a CSV.");
+  await userEvent.click(screen.getByRole("button", { name: "Import CSV" }));
+  const importHeading = screen.getByRole("heading", { name: "Import CSV" });
+  const importPanel = importHeading.closest("section");
+  expect(importPanel).not.toBeNull();
+  const fileInput = within(importPanel as HTMLElement).getByLabelText("CSV file");
+
+  let resolveFirstText!: (value: string) => void;
+  let resolveSecondText!: (value: string) => void;
+  const firstText = new Promise<string>((resolve) => { resolveFirstText = resolve; });
+  const secondText = new Promise<string>((resolve) => { resolveSecondText = resolve; });
+  const firstCsv = "email,name,company\nfirst@example.com,First,First Capital";
+  const secondCsv = "email,name,role\nsecond@example.com,Second,GP";
+  const firstFile = new File([firstCsv], "first.csv", { type: "text/csv" });
+  const secondFile = new File([secondCsv], "second.csv", { type: "text/csv" });
+  Object.defineProperty(firstFile, "text", { value: () => firstText });
+  Object.defineProperty(secondFile, "text", { value: () => secondText });
+
+  await userEvent.upload(fileInput, firstFile);
+  await userEvent.upload(fileInput, secondFile);
+  await act(async () => {
+    resolveSecondText(secondCsv);
+    await secondText;
+  });
+  expect(within(importPanel as HTMLElement).getByText(/second\.csv: 1 row ready/)).toBeInTheDocument();
+
+  await act(async () => {
+    resolveFirstText(firstCsv);
+    await firstText;
+  });
+  expect(within(importPanel as HTMLElement).getByText(/second\.csv: 1 row ready/)).toBeInTheDocument();
+  expect(within(importPanel as HTMLElement).queryByText(/first\.csv:/)).not.toBeInTheDocument();
+  const mapping = within(importPanel as HTMLElement).getByRole("region", {
+    name: "CSV metadata mapping",
+  });
+  expect(within(mapping).getByText("role")).toBeInTheDocument();
+  expect(within(mapping).getByText("GP")).toBeInTheDocument();
+  expect(within(mapping).queryByText("company")).not.toBeInTheDocument();
+  expect(within(mapping).queryByText("First Capital")).not.toBeInTheDocument();
+
+  await userEvent.click(within(importPanel as HTMLElement).getByRole("button", {
+    name: "Import 1 contact",
+  }));
+  await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+  const [, importRequest] = fetchMock.mock.calls[1] as [string, RequestInit];
+  expect(JSON.parse(importRequest.body as string)).toEqual({
+    contacts: [{
+      address: "second@example.com",
+      display_name: "Second",
+      metadata: { role: "GP" },
+    }],
+    on_conflict: "merge",
+  });
 });

--- a/web/src/app/(app)/contacts/page.tsx
+++ b/web/src/app/(app)/contacts/page.tsx
@@ -6,7 +6,12 @@ import { Button } from "../../components/loft/Button";
 import { Chip } from "../../components/loft/Chip";
 import { PageShell } from "../../components/loft/PageShell";
 import { useAgents } from "../../components/hooks/useAgents";
-import { mapCsvRows, parseCsv, type ImportPreviewRow } from "./_lib/csv";
+import {
+  getCsvMetadataColumns,
+  mapCsvRows,
+  parseCsv,
+  type ImportPreviewRow,
+} from "./_lib/csv";
 import { ViewTabs } from "./_lib/ViewTabs";
 
 type Contact = {
@@ -51,6 +56,63 @@ const fieldStyle = {
   borderColor: "var(--border)",
   color: "var(--fg)",
 };
+
+const metadataInlineLimit = 3;
+const metadataInlineValueLimit = 80;
+
+function formatMetadataValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === null) return "null";
+  if (["number", "boolean", "bigint", "undefined"].includes(typeof value)) {
+    return String(value);
+  }
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return "Unable to display value";
+  }
+}
+
+function truncateMetadataValue(value: string): string {
+  if (value.length <= metadataInlineValueLimit) return value;
+  return `${value.slice(0, metadataInlineValueLimit - 1)}…`;
+}
+
+function MetadataFields({ metadata }: { metadata: Record<string, unknown> }) {
+  const entries = Object.entries(metadata);
+  if (entries.length === 0) return null;
+  const previewEntries = entries.slice(0, metadataInlineLimit);
+
+  return (
+    <div className="mt-3 max-w-[420px] text-[11px]" style={{ color: "var(--fg-muted)" }}>
+      <p className="font-semibold" style={{ color: "var(--fg)" }}>Metadata</p>
+      <dl className="mt-1 space-y-1">
+        {previewEntries.map(([key, value]) => (
+          <div key={key} className="grid grid-cols-[minmax(0,1fr)_minmax(0,2fr)] gap-2">
+            <dt className="break-words font-medium">{key}</dt>
+            <dd className="break-all">{truncateMetadataValue(formatMetadataValue(value))}</dd>
+          </div>
+        ))}
+      </dl>
+      <details className="mt-2">
+        <summary className="cursor-pointer font-medium" style={{ color: "var(--accent-strong)" }}>
+          {entries.length > metadataInlineLimit
+            ? `View all ${entries.length} metadata fields (${entries.length - metadataInlineLimit} more)`
+            : `View full metadata (${entries.length} field${entries.length === 1 ? "" : "s"})`}
+        </summary>
+        <dl className="mt-2 max-h-64 space-y-2 overflow-auto rounded-[var(--r-md)] border p-3"
+          style={{ borderColor: "var(--border)", background: "var(--bg)" }}>
+          {entries.map(([key, value]) => (
+            <div key={key}>
+              <dt className="break-words font-medium" style={{ color: "var(--fg)" }}>{key}</dt>
+              <dd className="mt-0.5 whitespace-pre-wrap break-all">{formatMetadataValue(value)}</dd>
+            </div>
+          ))}
+        </dl>
+      </details>
+    </div>
+  );
+}
 
 async function responseError(response: Response): Promise<string> {
   try {
@@ -267,6 +329,7 @@ export default function ContactsPage() {
                 <p className="mt-3 text-[11px]" style={{ color: "var(--fg-muted)" }}>
                   Added {new Date(contact.created_at).toLocaleDateString()}
                 </p>
+                <MetadataFields metadata={contact.metadata} />
                 <div className="mt-3 grid grid-cols-2 gap-2">
                   <Button variant="ghost" aria-label={`Edit contact ${contact.address}`}
                     onClick={() => setEditing(contact)}>Edit</Button>
@@ -303,6 +366,7 @@ export default function ContactsPage() {
                         {contact.display_name || contact.address}
                       </div>
                       {contact.display_name && <div className="mt-0.5 font-mono text-[11px]" style={{ color: "var(--fg-muted)" }}>{contact.address}</div>}
+                      <MetadataFields metadata={contact.metadata} />
                     </td>
                     <td className="px-4 py-3"><Chip>{contact.source}</Chip></td>
                     <td className="px-4 py-3" style={{ color: "var(--fg-muted)" }}>
@@ -395,6 +459,7 @@ function EditContactPanel({
   onSaved: () => Promise<void>;
 }) {
   const [name, setName] = useState(contact.display_name);
+  const [metadata, setMetadata] = useState(contact.metadata);
   const [etag, setETag] = useState("");
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -403,6 +468,7 @@ function EditContactPanel({
   useEffect(() => {
     const controller = new AbortController();
     setName(contact.display_name);
+    setMetadata(contact.metadata);
     setETag("");
     setLoading(true);
     setError("");
@@ -419,6 +485,7 @@ function EditContactPanel({
         }
         const current: Contact = await response.json();
         setName(current.display_name);
+        setMetadata(current.metadata ?? {});
         setETag(freshETag);
       } catch (err) {
         if (!controller.signal.aborted) {
@@ -429,7 +496,7 @@ function EditContactPanel({
       }
     })();
     return () => controller.abort();
-  }, [contact.address, contact.display_name]);
+  }, [contact.address, contact.display_name, contact.metadata]);
 
   const save = async (event: React.FormEvent) => {
     event.preventDefault();
@@ -482,6 +549,14 @@ function EditContactPanel({
           </Button>
         </div>
       </form>
+      {Object.keys(metadata).length > 0 && (
+        <div className="mt-4 border-t pt-4" style={{ borderColor: "var(--border)" }}>
+          <p className="text-[12px]" style={{ color: "var(--fg-muted)" }}>
+            Metadata is read-only here. Manage it through CSV import or the API.
+          </p>
+          <MetadataFields metadata={metadata} />
+        </div>
+      )}
       {error && <p role="alert" className="mt-3 text-[12px]" style={{ color: "var(--danger-strong)" }}>{error}</p>}
     </Panel>
   );
@@ -501,7 +576,15 @@ function ImportPanel({ agents, onImported }: {
   const [error, setError] = useState("");
   const [saving, setSaving] = useState(false);
   const [idempotencyKey, setIdempotencyKey] = useState(() => crypto.randomUUID());
-  const headers = table[0] ?? [];
+  const headers = (table[0] ?? []).map((header) => header.trim());
+  const metadataColumns = useMemo(() => {
+    if (!emailColumn || table.length < 2) return [];
+    try {
+      return getCsvMetadataColumns(table, emailColumn, nameColumn || undefined);
+    } catch {
+      return [];
+    }
+  }, [emailColumn, nameColumn, table]);
   const invalidateKey = () => setIdempotencyKey(crypto.randomUUID());
 
   const preview = (nextEmail = emailColumn, nextName = nameColumn) => {
@@ -532,9 +615,10 @@ function ImportPanel({ agents, onImported }: {
                 const parsed = parseCsv(await file.text());
                 setTable(parsed);
                 setFileName(file.name);
-                const normalized = parsed[0]?.map((header) => header.toLowerCase()) ?? [];
-                const email = parsed[0]?.[normalized.findIndex((header) => ["email", "address"].includes(header))] ?? parsed[0]?.[0] ?? "";
-                const name = parsed[0]?.[normalized.findIndex((header) => ["name", "display name", "full name"].includes(header))] ?? "";
+                const trimmedHeaders = parsed[0]?.map((header) => header.trim()) ?? [];
+                const normalized = trimmedHeaders.map((header) => header.toLowerCase());
+                const email = trimmedHeaders[normalized.findIndex((header) => ["email", "address"].includes(header))] ?? trimmedHeaders[0] ?? "";
+                const name = trimmedHeaders[normalized.findIndex((header) => ["name", "display name", "full name"].includes(header))] ?? "";
                 setEmailColumn(email);
                 setNameColumn(name);
                 setRows(mapCsvRows(parsed, email, name || undefined));
@@ -574,6 +658,34 @@ function ImportPanel({ agents, onImported }: {
       {fileName && <p className="mt-3 text-[12px]" style={{ color: "var(--fg-muted)" }}>
         {fileName}: {rows.length} row{rows.length === 1 ? "" : "s"} ready. Preview: {rows.slice(0, 3).map((row) => row.address || "(blank)").join(", ")}
       </p>}
+      {fileName && (
+        <section aria-label="CSV metadata mapping" className="mt-3 rounded-[var(--r-lg)] border p-3"
+          style={{ borderColor: "var(--border)", background: "var(--bg)" }}>
+          <h3 className="text-[12px] font-semibold" style={{ color: "var(--fg)" }}>Metadata mapping</h3>
+          {metadataColumns.length === 0 ? (
+            <p className="mt-1 text-[12px]" style={{ color: "var(--fg-muted)" }}>
+              No columns will be stored as metadata.
+            </p>
+          ) : (
+            <>
+              <p className="mt-1 text-[12px]" style={{ color: "var(--fg-muted)" }}>
+                These columns will be stored as metadata. Sample values are from the first row.
+              </p>
+              <dl className="mt-2 grid gap-2 sm:grid-cols-2">
+                {metadataColumns.map((column) => (
+                  <div key={column.name} className="min-w-0 rounded-[var(--r-md)] border px-3 py-2"
+                    style={{ borderColor: "var(--border)", background: "var(--bg-panel)" }}>
+                    <dt className="break-words text-[11px] font-semibold" style={{ color: "var(--fg)" }}>{column.name}</dt>
+                    <dd className="mt-0.5 truncate text-[12px]" style={{ color: "var(--fg-muted)" }}>
+                      {column.sampleValue || "(empty)"}
+                    </dd>
+                  </div>
+                ))}
+              </dl>
+            </>
+          )}
+        </section>
+      )}
       {error && <p role="alert" className="mt-3 text-[12px]" style={{ color: "var(--danger-strong)" }}>{error}</p>}
       <div className="mt-4"><Button disabled={saving || rows.length === 0} onClick={async () => {
         setSaving(true);

--- a/web/src/app/(app)/contacts/page.tsx
+++ b/web/src/app/(app)/contacts/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AgentPromptCard } from "../../components/AgentPromptCard";
 import { Button } from "../../components/loft/Button";
 import { Chip } from "../../components/loft/Chip";
@@ -576,9 +576,10 @@ function ImportPanel({ agents, onImported }: {
   const [error, setError] = useState("");
   const [saving, setSaving] = useState(false);
   const [idempotencyKey, setIdempotencyKey] = useState(() => crypto.randomUUID());
+  const fileReadSequence = useRef(0);
   const headers = (table[0] ?? []).map((header) => header.trim());
   const metadataColumns = useMemo(() => {
-    if (!emailColumn || table.length < 2) return [];
+    if (table.length < 2) return [];
     try {
       return getCsvMetadataColumns(table, emailColumn, nameColumn || undefined);
     } catch {
@@ -588,7 +589,6 @@ function ImportPanel({ agents, onImported }: {
   const invalidateKey = () => setIdempotencyKey(crypto.randomUUID());
 
   const preview = (nextEmail = emailColumn, nextName = nameColumn) => {
-    if (!nextEmail) return;
     try {
       setRows(mapCsvRows(table, nextEmail, nextName || undefined));
       setError("");
@@ -610,20 +610,30 @@ function ImportPanel({ agents, onImported }: {
             onChange={async (event) => {
               const file = event.target.files?.[0];
               if (!file) return;
+              const readSequence = ++fileReadSequence.current;
               invalidateKey();
+              setTable([]);
+              setFileName("");
+              setEmailColumn("");
+              setNameColumn("");
+              setRows([]);
+              setError("");
               try {
                 const parsed = parseCsv(await file.text());
-                setTable(parsed);
-                setFileName(file.name);
                 const trimmedHeaders = parsed[0]?.map((header) => header.trim()) ?? [];
                 const normalized = trimmedHeaders.map((header) => header.toLowerCase());
                 const email = trimmedHeaders[normalized.findIndex((header) => ["email", "address"].includes(header))] ?? trimmedHeaders[0] ?? "";
                 const name = trimmedHeaders[normalized.findIndex((header) => ["name", "display name", "full name"].includes(header))] ?? "";
+                const mappedRows = mapCsvRows(parsed, email, name || undefined);
+                if (readSequence !== fileReadSequence.current) return;
+                setTable(parsed);
+                setFileName(file.name);
                 setEmailColumn(email);
                 setNameColumn(name);
-                setRows(mapCsvRows(parsed, email, name || undefined));
+                setRows(mappedRows);
                 setError("");
               } catch (err) {
+                if (readSequence !== fileReadSequence.current) return;
                 setError(err instanceof Error ? err.message : "Could not read CSV");
               }
             }} />
@@ -632,14 +642,14 @@ function ImportPanel({ agents, onImported }: {
           <label className="text-[12px]" style={{ color: "var(--fg-muted)" }}>Email column
             <select className={`${fieldClass} mt-1`} style={fieldStyle} value={emailColumn}
               onChange={(event) => { invalidateKey(); setEmailColumn(event.target.value); preview(event.target.value, nameColumn); }}>
-              {headers.map((header) => <option key={header}>{header}</option>)}
+              {headers.map((header, index) => <option key={`${index}:${header}`} value={header}>{header}</option>)}
             </select>
           </label>
           <label className="text-[12px]" style={{ color: "var(--fg-muted)" }}>Name column
             <select className={`${fieldClass} mt-1`} style={fieldStyle} value={nameColumn}
               onChange={(event) => { invalidateKey(); setNameColumn(event.target.value); preview(emailColumn, event.target.value); }}>
               <option value="">None</option>
-              {headers.map((header) => <option key={header}>{header}</option>)}
+              {headers.map((header, index) => <option key={`${index}:${header}`} value={header}>{header}</option>)}
             </select>
           </label>
         </div>


### PR DESCRIPTION
## Summary

The contacts dashboard stored `metadata` and gave the user no way to read it back, and the CSV
importer filled it silently. Uploading `email,name,company,role,notes` and picking the email and
name columns accepted the other three, stored them, reported success, and made them permanently
unreachable from the surface that ingested them. This renders metadata everywhere the dashboard
reads a contact, and states the CSV column mapping before the user commits to the import.

Fixes #814. Web-only — the `/v1` contract already carries `metadata` on list, get, create and
PATCH, so no API, SDK, CLI or MCP change was needed.

**What changed**

- Metadata renders on the mobile card list, the desktop table, and read-only in the edit form.
  Inline display is capped at 3 fields and 80 characters per value; the full set sits behind a
  disclosure that reports how many more fields exist. Empty metadata renders no affordance, so
  the page stays as uncluttered as it is today for contacts that have none.
- Non-string values are formatted deliberately — `null` as `null`, numbers and booleans via
  `String`, objects and arrays as JSON, circular structures as a placeholder — instead of
  leaking `[object Object]`. The API documents metadata as flat but does not enforce scalar
  values, so this is reachable input.
- The CSV import preview names the columns that will become metadata and shows their first-row
  sample values, and says plainly when no columns will be stored as metadata rather than
  rendering an empty widget.
- `getCsvMetadataColumns` was added alongside `mapCsvRows` and shares its column resolution, so
  what the preview reports and what the import posts cannot drift — including for duplicate
  headers, blank headers, and headers differing only by whitespace.

**Metadata is read-only in the dashboard**, per the issue's "read-only is a defensible answer;
invisible is not". The edit form displays it and says so; PATCH still sends `display_name` only,
which the server treats as leaving metadata unchanged. There is a test asserting the PATCH body
has no `metadata` key, because a wholesale replace here would destroy what an import wrote.

Three pre-existing bugs surfaced while wiring this up and are fixed:

- The import panel's column auto-detection didn't trim headers, so a header like `" email "`
  set `emailColumn` to a string `mapCsvRows` could never resolve (`No " email " column found`).
- The column `<select>`s had no explicit `value`, so `HTMLOptionElement.value` fell back to
  whitespace-collapsed text — a header with an internal double space dispatched a value that
  `headers.indexOf` couldn't find.
- `preview()` bailed on a falsy email column, so re-selecting a blank header left `rows` mapped
  under the previously selected column.

## Client surface checklist

Not applicable — this is a web-dashboard-only change. The `/v1` contract already carries
`metadata` on read and write (`ContactView.Metadata`, `CreateContactRequest.Metadata`,
`UpdateContactRequest.Metadata`), and no handler, spec, SDK, CLI or MCP surface is touched. The
diff is four files, all under `web/src/app/(app)/contacts/`.

Worth noting the issue's closing point: the web dashboard isn't on this checklist, which is the
likely reason this drifted while the other surfaces kept parity. That's a separate follow-up.

## Operational risk

Low. Client-side rendering only; no new network calls, no new writes, no schema or auth change.

- No write path was added for metadata, so this cannot corrupt or erase stored metadata. PATCH
  continues to omit the field.
- The import request body is byte-identical to before — the `contacts` array is still exactly
  what `mapCsvRows` returns, asserted in a test.
- Rendering is bounded: metadata can legitimately carry the server's published maximum of 50
  keys with 4 KB values, so inline display is capped and the disclosure body is
  `max-h-64 overflow-auto`. A pathological contact degrades the row's height, not the page.
- Rollback is a revert; nothing persists.

## Test plan

Ran from `web/`. Baseline before this branch was `lint` exit 0, `jest` exit 0 with
89 suites / 731 tests, `build` exit 0.

- [x] `npm run lint` — exit 0
- [x] `npm test` — exit 0, 89 suites / **744** tests (+13)
- [x] `npm run build` — exit 0
- [x] Non-empty metadata is reachable in the list, and every key/value renders
- [x] `metadata: {}` renders no metadata heading or disclosure
- [x] Metadata beyond the inline cap is fully reachable and the UI signals more exists
- [x] Number, `null` and nested-object values render without `[object Object]`
- [x] Editor shows metadata read-only with wording saying it isn't editable there — scoped to
      the edit panel, and verified to fail when the editor's renderer is removed
- [x] The edit form's PATCH body is exactly `{display_name}` with no `metadata` key
- [x] Import preview names the metadata columns with first-row samples, and follows a change of
      the selected name column
- [x] A CSV with only email and name columns reports that nothing becomes metadata
- [x] The posted `contacts` array is unchanged by this work
- [x] A replacement CSV that fails to map disarms the previous file's staged rows, so the
      preview can never describe a different file than the one Import posts
- [x] Two uploads whose `text()` promises resolve out of order leave the second file previewed
      and imported

After merge: worth eyeballing a real contact with a wide import (many columns, long values) on
both breakpoints — the caps are judgement calls, not contract.
