### PR TITLE
test(contract): cover plan-limit enforcement in all three runners

### DIFF
--- a/cmd/e2a-contract-server/main.go
+++ b/cmd/e2a-contract-server/main.go
@@ -29,7 +29,14 @@ func main() {
 		log.Fatalf("contract server health check failed: %v", err)
 	}
 
-	envContent := fmt.Sprintf("E2A_TEST_BASE_URL=%s\nE2A_TEST_API_KEY=%s\n", srv.BaseURL, srv.APIKey)
+	// E2A_TEST_CAPPED_API_KEY authenticates the secondary account seeded with
+	// testutil.CappedLimits. Scenarios that assert quota enforcement run as
+	// that account; CI sources this file with `set -a`, so the runners pick it
+	// up with no workflow change.
+	envContent := fmt.Sprintf(
+		"E2A_TEST_BASE_URL=%s\nE2A_TEST_API_KEY=%s\nE2A_TEST_CAPPED_API_KEY=%s\n",
+		srv.BaseURL, srv.APIKey, srv.CappedAPIKey,
+	)
 	if envFile != "" {
 		if err := os.WriteFile(envFile, []byte(envContent), 0o600); err != nil {
 			log.Fatalf("write env file: %v", err)

--- a/internal/testutil/contract_server.go
+++ b/internal/testutil/contract_server.go
@@ -25,10 +25,38 @@ import (
 	"github.com/tokencanopy/e2a/internal/ws"
 )
 
+// CappedLimits are the plan caps of the secondary account described on
+// ContractServer.CappedAPIKey. One slot per create-limited resource is the
+// smallest cap that can express BOTH directions of enforcement: a scenario can
+// consume the slot (success), be refused at the cap (402), free it, and
+// succeed again — proving the limit is a cap and not an unconditional refusal.
+var CappedLimits = limits.Limits{
+	PlanCode:         "contract_capped",
+	MaxAgents:        1,
+	MaxDomains:       1,
+	MaxMessagesMonth: 1,
+	MaxStorageBytes:  1 << 20,
+	UpgradeURL:       "https://e2a.dev/upgrade",
+}
+
 type ContractServer struct {
-	BaseURL    string
-	APIKey     string
-	UserID     string
+	BaseURL string
+	APIKey  string
+	UserID  string
+	// CappedAPIKey authenticates a SECOND account seeded with CappedLimits,
+	// so scenarios can exercise quota enforcement without touching the
+	// primary account's generous caps.
+	//
+	// A separate account rather than a "set the caps" scenario step: caps are
+	// account-global, and the TS and Python runners silently ignore setup keys
+	// they do not recognize, so a cap lowered for one scenario and restored by
+	// a cleanup step that some runner skipped would 402 every scenario after
+	// it. Nothing here is mutable, so nothing can leak. It also means the
+	// enforcer's limits cache needs no special handling: the row is written
+	// before the server accepts its first request and never changes, so there
+	// is no staleness window for a scenario to race.
+	CappedAPIKey string
+	CappedUserID string
 	DBPool     *pgxpool.Pool
 	Store      *identity.Store
 	WSHub      *ws.Hub
@@ -62,9 +90,12 @@ func StartContractServer(ctx context.Context, dbURL string) (*ContractServer, er
 	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
 	noopUsage := usage.NewNoopUsageTracker()
 
-	// Limits/usage/webhook components the /v1 Deps bind to. Caps are set
-	// generously so contract scenarios exercise contract shape, not quota
-	// enforcement (the 402 limit paths have dedicated httpapi unit tests).
+	// Limits/usage/webhook components the /v1 Deps bind to. These DEFAULTS are
+	// generous on purpose: they apply to the primary contract account, whose
+	// scenarios exercise contract shape and must never trip a quota. Quota
+	// enforcement is exercised by the separate capped account seeded at the
+	// bottom of this function (CappedAPIKey) — an account_limits row overrides
+	// these defaults for that user alone.
 	usageStore := usage.NewStore(pool)
 	enforcer := limits.NewEnforcer(limits.NewStore(pool), usageStore, limits.Defaults{
 		PlanCode: "contract_test", MaxAgents: 100000, MaxDomains: 100000,
@@ -186,10 +217,42 @@ func StartContractServer(ctx context.Context, dbURL string) (*ContractServer, er
 		return nil, err
 	}
 
+	// The capped account. Seeded here, before the first request is served, so
+	// its account_limits row is already in place the first time the enforcer
+	// resolves it — no cache invalidation, no warm-up, no race.
+	cappedUser, err := store.CreateOrGetUser(ctx, "capped@test.dev", "Contract Capped", "google-contract-capped")
+	if err != nil {
+		_ = smtpServer.Close()
+		_ = httpServer.Shutdown(context.Background())
+		_ = httpLn.Close()
+		wsHub.Close()
+		pool.Close()
+		return nil, err
+	}
+	if err := limits.NewStore(pool).Upsert(ctx, cappedUser.ID, CappedLimits); err != nil {
+		_ = smtpServer.Close()
+		_ = httpServer.Shutdown(context.Background())
+		_ = httpLn.Close()
+		wsHub.Close()
+		pool.Close()
+		return nil, err
+	}
+	cappedKey, err := store.CreateAPIKey(ctx, cappedUser.ID, "contract-capped-key", nil)
+	if err != nil {
+		_ = smtpServer.Close()
+		_ = httpServer.Shutdown(context.Background())
+		_ = httpLn.Close()
+		wsHub.Close()
+		pool.Close()
+		return nil, err
+	}
+
 	return &ContractServer{
-		BaseURL:    "http://" + httpLn.Addr().String(),
-		APIKey:     key.PlaintextKey,
-		UserID:     user.ID,
+		BaseURL:      "http://" + httpLn.Addr().String(),
+		APIKey:       key.PlaintextKey,
+		UserID:       user.ID,
+		CappedAPIKey: cappedKey.PlaintextKey,
+		CappedUserID: cappedUser.ID,
 		DBPool:     pool,
 		Store:      store,
 		WSHub:      wsHub,

--- a/sdks/python/tests/test_contract.py
+++ b/sdks/python/tests/test_contract.py
@@ -3,6 +3,10 @@
 Runs against a live test server. Requires env vars:
   E2A_TEST_BASE_URL  — test server URL (e.g. http://localhost:8080)
   E2A_TEST_API_KEY   — valid API key for the test user
+  E2A_TEST_CAPPED_API_KEY — optional; key for the contract server's secondary
+    account, seeded with tiny plan caps. Scenarios asserting quota enforcement
+    run as that account and skip without it (a deployed staging target has no
+    capped account to offer).
 
 The runner drives the server over raw HTTP (a thin scenario interpreter, not
 the ergonomic client):
@@ -42,6 +46,7 @@ from e2a.v1.generated.models import PageMessageLifecycleTransition
 
 BASE_URL = os.environ.get("E2A_TEST_BASE_URL", "")
 API_KEY = os.environ.get("E2A_TEST_API_KEY", "")
+CAPPED_API_KEY = os.environ.get("E2A_TEST_CAPPED_API_KEY", "")
 
 # tests/test_contract.py -> sdks/python/tests/ -> sdks/python/ -> sdks/ -> repo root
 SCENARIOS_PATH = Path(__file__).resolve().parents[3] / "tests" / "contract" / "scenarios.yaml"
@@ -130,6 +135,17 @@ def values_equal(json_val: Any, yaml_val: Any) -> bool:
 
 STORE_ACTIONS = {"inject_message", "verify_and_retry"}
 
+CAPPED_KEY_PLACEHOLDER = "{capped_api_key}"
+
+
+def scenario_needs_capped_account(sc: dict[str, Any]) -> bool:
+    """True when the scenario authenticates as the capped-plan account.
+
+    Those scenarios need a cap they can actually reach, which only the contract
+    server's seeded secondary account provides.
+    """
+    return CAPPED_KEY_PLACEHOLDER in json_mod.dumps(sc)
+
 
 def scenario_needs_store(sc: dict[str, Any]) -> bool:
     setup = sc.get("setup") or []
@@ -159,6 +175,10 @@ class Runner:
             "future_rfc3339": future.isoformat().replace("+00:00", "Z"),
             "scenario_token": uuid.uuid4().hex[:12],
         }
+        # Bound only when supplied: scenarios needing it skip otherwise, so an
+        # empty bearer token can never reach the wire as a confusing 401.
+        if CAPPED_API_KEY:
+            self.vars["capped_api_key"] = CAPPED_API_KEY
         self._http = httpx.Client(base_url=base_url, timeout=30)
 
     def close(self):
@@ -980,6 +1000,46 @@ def test_scheduled_send_scenario_is_self_cleaning_and_projection_complete():
     ]
 
 
+def test_limits_scenario_shape():
+    """Always-on guard for the quota scenario.
+
+    The live quota run skips without a capped key (a deployed target has no
+    capped account), so this shape test is what keeps that skip from decaying
+    into zero coverage. It fails if the scenario is deleted, stops using the
+    capped account, or loses either direction of enforcement.
+    """
+    scenario = _scenario_by_name("account_limits_enforced")
+    assert scenario_needs_capped_account(scenario)
+
+    steps = {step["id"]: step for step in scenario["steps"]}
+
+    # Refused AT the cap, with the machine-readable envelope an SDK needs to
+    # say WHICH quota stopped the caller.
+    refused = steps["second_domain_hits_the_cap"]["expect"]
+    assert refused["status"] == 402
+    assert refused["body_match"]["error.code"] == "limit_exceeded"
+    assert refused["body_match"]["error.details.resource"] == "domains"
+    assert refused["body_match"]["error.details.limit"] == 1
+    assert steps["second_agent_hits_the_cap"]["expect"]["body_match"][
+        "error.details.resource"
+    ] == "agents"
+
+    # ...and allowed when it should be. Without these, a server that 402'd
+    # unconditionally would satisfy every assertion above.
+    assert steps["reregister_owned_domain_at_cap_is_allowed"]["expect"]["status"] == 201
+    assert (
+        steps["agent_create_succeeds_again_after_freeing_a_slot"]["expect"]["status"]
+        == 201
+    )
+
+    # The capped account holds one slot per resource, so a leak puts the NEXT
+    # run at its cap on step one.
+    assert [step["id"] for step in scenario["cleanup"]] == [
+        "delete_agent_permanently",
+        "delete_domain",
+    ]
+
+
 @pytest.fixture(params=_scenario_ids() if SCENARIOS_PATH.exists() else [])
 def scenario(request):
     return _scenario_by_name(request.param)
@@ -989,6 +1049,11 @@ def scenario(request):
 def test_contract_scenario(scenario):
     if scenario_needs_store(scenario):
         pytest.skip(f"scenario {scenario['name']}: requires store access (inject_message/verify_domain)")
+    # No capped account on this target (e.g. a deployed server) → no reachable
+    # cap. The Go runner always has one, and test_limits_scenario_shape below
+    # runs everywhere, so this skip cannot silently become zero coverage.
+    if scenario_needs_capped_account(scenario) and not CAPPED_API_KEY:
+        pytest.skip(f"scenario {scenario['name']}: needs E2A_TEST_CAPPED_API_KEY")
 
     runner = Runner(BASE_URL, API_KEY, scenario)
     try:

--- a/sdks/typescript/test/v1/contract.test.ts
+++ b/sdks/typescript/test/v1/contract.test.ts
@@ -4,6 +4,10 @@
  * Runs against a live test server. Requires env vars:
  *   E2A_TEST_BASE_URL  — test server URL (e.g. http://localhost:8080)
  *   E2A_TEST_API_KEY   — valid API key for the test user
+ *   E2A_TEST_CAPPED_API_KEY — optional; key for the contract server's
+ *     secondary account, seeded with tiny plan caps. Scenarios that assert
+ *     quota enforcement run as that account and skip without it (a deployed
+ *     staging target has no capped account to offer).
  *
  * The runner drives the server over raw HTTP (a thin scenario interpreter,
  * not the ergonomic client) plus {@link WSListener} for WebSocket steps.
@@ -29,6 +33,15 @@ import type { PageMessageLifecycleTransition } from "../../src/v1/index.js";
 // When the isolated CF zone + SMTP port are configured, store-dependent scenarios
 // are SEEDED over the API (verified domains + real inbound) instead of skipped.
 const SEED = seedEnabled();
+
+// The contract server's capped-account key (see the header). Absent when the
+// runner is pointed at a deployed server, which has no such account.
+const CAPPED_API_KEY = process.env.E2A_TEST_CAPPED_API_KEY;
+
+/** True when the scenario authenticates as the capped account anywhere. */
+function scenarioNeedsCappedAccount(sc: Scenario): boolean {
+  return JSON.stringify(sc).includes("{capped_api_key}");
+}
 
 it("parses the generated message lifecycle page contract", () => {
   const page = ObjectSerializer.deserialize(
@@ -100,6 +113,45 @@ it("keeps the managed-unsubscribe scenario self-cleaning and lifecycle-observabl
   });
 
   expect(scenario!.steps.map((step) => step.id)).not.toContain("delete_agent_permanently");
+  expect(scenario!.cleanup?.map((step) => step.id)).toEqual([
+    "delete_agent_permanently",
+    "delete_domain",
+  ]);
+});
+
+// Always-on: the live quota run skips without a capped key (deployed targets
+// have no capped account), so this shape test is what keeps that skip from
+// decaying into zero coverage. It fails if the scenario is deleted, stops using
+// the capped account, or loses either direction of enforcement.
+it("keeps the account-limits scenario pinned to both directions of enforcement", () => {
+  const scenario = loadScenarios().find((c) => c.name === "account_limits_enforced");
+  expect(scenario).toBeDefined();
+  expect(scenarioNeedsCappedAccount(scenario!)).toBe(true);
+
+  const steps = new Map(scenario!.steps.map((step) => [step.id, step]));
+
+  // Refused AT the cap, with the machine-readable envelope an SDK needs to say
+  // WHICH quota stopped the caller.
+  expect(steps.get("second_domain_hits_the_cap")?.expect).toMatchObject({
+    status: 402,
+    body_match: {
+      "error.code": "limit_exceeded",
+      "error.details.resource": "domains",
+      "error.details.limit": 1,
+    },
+  });
+  expect(steps.get("second_agent_hits_the_cap")?.expect).toMatchObject({
+    status: 402,
+    body_match: { "error.details.resource": "agents" },
+  });
+
+  // ...and allowed when it should be. Without these, a server that 402'd
+  // unconditionally would satisfy every assertion above.
+  expect(steps.get("reregister_owned_domain_at_cap_is_allowed")?.expect?.status).toBe(201);
+  expect(steps.get("agent_create_succeeds_again_after_freeing_a_slot")?.expect?.status).toBe(201);
+
+  // The capped account holds one slot per resource, so a leak puts the NEXT
+  // run at its cap on step one.
   expect(scenario!.cleanup?.map((step) => step.id)).toEqual([
     "delete_agent_permanently",
     "delete_domain",
@@ -717,6 +769,9 @@ class Runner {
     future.setUTCMilliseconds(0);
     this.vars.future_rfc3339 = future.toISOString().replace(".000Z", "Z");
     this.vars.scenario_token = randomBytes(6).toString("hex");
+    // Only bind when present: scenarios needing it are skipped otherwise, so a
+    // silently-empty bearer token can never reach the wire as a confusing 401.
+    if (CAPPED_API_KEY) this.vars.capped_api_key = CAPPED_API_KEY;
     this.api = new RawApi(apiKey, baseUrl);
     this.seeder = SEED ? new Seeder(baseUrl, apiKey) : null;
   }
@@ -1115,7 +1170,15 @@ describe.skipIf(!baseUrl || !apiKey)("Contract scenarios", () => {
   for (const sc of scenarios) {
     // Store-dependent scenarios run when SEED supplies their preconditions over
     // the API; otherwise they skip. Account-global scenarios skip regardless.
-    const skip = ACCOUNT_GLOBAL.has(sc.name) || (scenarioNeedsStore(sc) && !SEED);
+    // Quota scenarios need the capped account; without its key there is no way
+    // to reach a cap on a live server, so they skip. The Go runner owns the
+    // contract server in-process and always has it, and the always-on shape
+    // test below fails if the scenario is ever deleted or defanged — so a skip
+    // here can never quietly become zero coverage.
+    const skip =
+      ACCOUNT_GLOBAL.has(sc.name) ||
+      (scenarioNeedsStore(sc) && !SEED) ||
+      (scenarioNeedsCappedAccount(sc) && !CAPPED_API_KEY);
 
     (skip ? it.skip : it)(
       sc.name,

--- a/tests/contract/contract_test.go
+++ b/tests/contract/contract_test.go
@@ -134,6 +134,9 @@ type testEnv struct {
 	wsHub   *ws.Hub
 	apiKey  string
 	userID  string
+	// cappedAPIKey authenticates the contract server's secondary account,
+	// seeded with testutil.CappedLimits, that quota scenarios run as.
+	cappedAPIKey string
 }
 
 func setupEnv(t *testing.T) *testEnv {
@@ -157,6 +160,8 @@ func setupEnv(t *testing.T) *testEnv {
 		wsHub:   cs.WSHub,
 		apiKey:  cs.APIKey,
 		userID:  cs.UserID,
+
+		cappedAPIKey: cs.CappedAPIKey,
 	}
 }
 
@@ -350,6 +355,7 @@ func TestRunnerInitializesDynamicScenarioVars(t *testing.T) {
 func (r *runner) resolve(s string) string {
 	s = strings.ReplaceAll(s, "{base_url}", r.env.baseURL)
 	s = strings.ReplaceAll(s, "{api_key}", r.env.apiKey)
+	s = strings.ReplaceAll(s, "{capped_api_key}", r.env.cappedAPIKey)
 	for k, v := range r.vars {
 		s = strings.ReplaceAll(s, "{"+k+"}", v)
 	}
@@ -917,16 +923,104 @@ func loadScenarios(t *testing.T) []scenario {
 	return sf.Scenarios
 }
 
+// requireCappedKey fails a scenario that asks for the capped account when the
+// harness cannot supply it. Deliberately a failure and not a skip: a quota
+// scenario that quietly stops running is indistinguishable from one that
+// passes, which is exactly how limit coverage would rot back to zero.
+func requireCappedKey(t *testing.T, env *testEnv, sc scenario) {
+	t.Helper()
+	if env.cappedAPIKey == "" && scenarioUsesCappedKey(t, sc) {
+		t.Fatalf("scenario %s uses %s but the contract server supplied no capped API key", sc.Name, cappedKeyPlaceholder)
+	}
+}
+
+// scenarioUsesCappedKey reports whether the scenario authenticates as the
+// capped-plan account anywhere.
+func scenarioUsesCappedKey(t *testing.T, sc scenario) bool {
+	t.Helper()
+	raw, err := yaml.Marshal(sc)
+	if err != nil {
+		t.Fatalf("marshal scenario %s: %v", sc.Name, err)
+	}
+	return strings.Contains(string(raw), cappedKeyPlaceholder)
+}
+
+const cappedKeyPlaceholder = "{capped_api_key}"
+
 func TestScenarios(t *testing.T) {
 	scenarios := loadScenarios(t)
 	for _, sc := range scenarios {
 		sc := sc
 		t.Run(sc.Name, func(t *testing.T) {
 			env := setupEnv(t)
+			requireCappedKey(t, env, sc)
 			r := newRunner(env, sc)
 			t.Cleanup(func() { r.cleanup(t) })
 			r.executeSetup(t)
 			r.executeSteps(t)
 		})
+	}
+}
+
+// TestLimitsScenarioShape is the Go half of the always-on guard the TS and
+// Python runners also carry. The live quota run can skip in those runners when
+// no capped key is supplied (a deployed target has no capped account); this
+// pins the scenario's shape everywhere, so a deletion or a defanged assertion
+// fails the build even where the live run does not execute.
+func TestLimitsScenarioShape(t *testing.T) {
+	var sc scenario
+	for _, candidate := range loadScenarios(t) {
+		if candidate.Name == "account_limits_enforced" {
+			sc = candidate
+			break
+		}
+	}
+	if sc.Name == "" {
+		t.Fatal("scenario account_limits_enforced not found — quota enforcement would have no live coverage in any runner")
+	}
+	if !scenarioUsesCappedKey(t, sc) {
+		t.Fatalf("scenario %s no longer authenticates as the capped account, so it cannot reach a cap", sc.Name)
+	}
+
+	steps := map[string]step{}
+	for _, s := range sc.Steps {
+		steps[s.ID] = s
+	}
+
+	// Refused AT the cap, carrying the fields an SDK needs to say WHICH quota
+	// stopped the caller.
+	refused, ok := steps["second_domain_hits_the_cap"]
+	if !ok || refused.Expect == nil || refused.Expect.Status != 402 {
+		t.Fatalf("second_domain_hits_the_cap must expect 402, got %+v", refused.Expect)
+	}
+	for path, want := range map[string]interface{}{
+		"error.code":             "limit_exceeded",
+		"error.details.resource": "domains",
+		"error.details.limit":    1,
+	} {
+		if got := refused.Expect.BodyMatch[path]; fmt.Sprint(got) != fmt.Sprint(want) {
+			t.Errorf("second_domain_hits_the_cap body_match[%q] = %v, want %v", path, got, want)
+		}
+	}
+	if got := steps["second_agent_hits_the_cap"].Expect.BodyMatch["error.details.resource"]; fmt.Sprint(got) != "agents" {
+		t.Errorf("second_agent_hits_the_cap resource = %v, want agents (a second resource proves one wired quota is not standing in for all four)", got)
+	}
+
+	// ...and allowed when it should be. Without these a server that 402'd
+	// unconditionally would satisfy every assertion above.
+	for _, id := range []string{"reregister_owned_domain_at_cap_is_allowed", "agent_create_succeeds_again_after_freeing_a_slot"} {
+		if s, ok := steps[id]; !ok || s.Expect == nil || s.Expect.Status != 201 {
+			t.Errorf("%s must expect 201, got %+v", id, s.Expect)
+		}
+	}
+
+	// The capped account holds one slot per resource, so anything left behind
+	// puts the NEXT run at its cap on the very first step.
+	var cleanupIDs []string
+	for _, c := range sc.Cleanup {
+		cleanupIDs = append(cleanupIDs, c.ID)
+	}
+	if len(cleanupIDs) != 2 || cleanupIDs[0] != "delete_agent_permanently" || cleanupIDs[1] != "delete_domain" {
+		t.Errorf("cleanup = %v, want [delete_agent_permanently delete_domain]", cleanupIDs)
 	}
 }

--- a/tests/contract/scenarios.yaml
+++ b/tests/contract/scenarios.yaml
@@ -2030,3 +2030,141 @@ scenarios:
           status: 404
           body_match:
             "error.code": contact_not_found
+
+  - name: account_limits_enforced
+    description: >
+      Plan caps are enforced on the create paths and surface as a 402
+      limit_exceeded envelope carrying the resource, the cap, and the current
+      usage — the fields an SDK needs to tell a caller WHICH quota stopped
+      them and by how much. Everything here runs as a SECOND, permanently
+      capped account (auth_override with {capped_api_key}) that the contract
+      server seeds at startup with max_domains 1 / max_agents 1. Nothing
+      mutates a cap, so this scenario cannot leak enforcement into the ones
+      that follow — which is the whole reason the caps are a separate account
+      instead of a limits-seeding step: both the TS and Python runners
+      silently ignore setup keys they do not recognize, so a "reset the caps"
+      cleanup that one runner skipped would 402 every later scenario.
+      Until this existed, no limit path in the product was covered by any
+      live-server test in any language (the contract server deliberately set
+      caps to 100000, per the comment in testutil.StartContractServer).
+    steps:
+      # The capped account starts empty, so its single domain slot is free.
+      - id: first_domain_fits_the_cap
+        action: request
+        method: POST
+        path: /v1/domains
+        auth_override: "Bearer {capped_api_key}"
+        body:
+          domain: capped-{scenario_token}.test.dev
+        expect:
+          status: 201
+          body_match:
+            domain: capped-{scenario_token}.test.dev
+
+      # The cap bites, and says so in a machine-readable way: an SDK surfacing
+      # only "402" leaves the caller guessing which of four quotas they hit.
+      - id: second_domain_hits_the_cap
+        action: request
+        method: POST
+        path: /v1/domains
+        auth_override: "Bearer {capped_api_key}"
+        body:
+          domain: capped-2-{scenario_token}.test.dev
+        expect:
+          status: 402
+          body_match:
+            "error.code": limit_exceeded
+            "error.details.resource": domains
+            "error.details.limit": 1
+            "error.details.current": 1
+
+      # The exemption (#811 / #819): a same-owner re-register creates nothing —
+      # the claim returns the existing row — so the CREATE cap must not apply
+      # to it. Pre-fix this 402'd, failing an SDK retry of a request the server
+      # had already satisfied. This step is the reason the account is capped at
+      # exactly 1: the account is provably AT its cap on the line above.
+      - id: reregister_owned_domain_at_cap_is_allowed
+        action: request
+        method: POST
+        path: /v1/domains
+        auth_override: "Bearer {capped_api_key}"
+        body:
+          domain: capped-{scenario_token}.test.dev
+        expect:
+          status: 201
+          body_match:
+            domain: capped-{scenario_token}.test.dev
+
+      # A DIFFERENT resource, so a passing suite cannot come from one quota
+      # being wired while the others are not. The shared domain needs no
+      # verification, so the agent cap is reachable over pure HTTP in every
+      # runner.
+      - id: first_agent_fits_the_cap
+        action: request
+        method: POST
+        path: /v1/agents
+        auth_override: "Bearer {capped_api_key}"
+        body:
+          email: capped-bot-{scenario_token}@agents.e2a.dev
+        expect:
+          status: 201
+          body_match:
+            email: capped-bot-{scenario_token}@agents.e2a.dev
+
+      - id: second_agent_hits_the_cap
+        action: request
+        method: POST
+        path: /v1/agents
+        auth_override: "Bearer {capped_api_key}"
+        body:
+          email: capped-bot-2-{scenario_token}@agents.e2a.dev
+        expect:
+          status: 402
+          body_match:
+            "error.code": limit_exceeded
+            "error.details.resource": agents
+            "error.details.limit": 1
+            "error.details.current": 1
+
+      # The cap is a cap, not a wall: freeing the slot makes the create work
+      # again. Without this, a server that 402'd unconditionally would pass
+      # every assertion above.
+      - id: agent_slot_frees_on_delete
+        action: request
+        method: DELETE
+        path: /v1/agents/capped-bot-{scenario_token}@agents.e2a.dev?confirm=DELETE&permanent=true
+        auth_override: "Bearer {capped_api_key}"
+        expect:
+          status: 200
+          body_match:
+            deleted: true
+
+      - id: agent_create_succeeds_again_after_freeing_a_slot
+        action: request
+        method: POST
+        path: /v1/agents
+        auth_override: "Bearer {capped_api_key}"
+        body:
+          email: capped-bot-2-{scenario_token}@agents.e2a.dev
+        expect:
+          status: 201
+
+    cleanup:
+      # Self-cleaning is load-bearing here, not tidiness: the capped account
+      # has exactly one slot per resource, so anything left behind puts the
+      # NEXT run at its cap on the very first step.
+      - id: delete_agent_permanently
+        action: request
+        method: DELETE
+        path: /v1/agents/capped-bot-2-{scenario_token}@agents.e2a.dev?confirm=DELETE&permanent=true
+        auth_override: "Bearer {capped_api_key}"
+        expect:
+          status: 200
+
+      - id: delete_domain
+        action: request
+        method: DELETE
+        path: /v1/domains/capped-{scenario_token}.test.dev?confirm=DELETE
+        auth_override: "Bearer {capped_api_key}"
+        expect:
+          status: 200


### PR DESCRIPTION
> **Stacked on #819** — based on `fix/domain-reclaim-limit` so the diff here is just this commit. GitHub will retarget it to `main` when #819 merges.

## Summary

No limit path in the product had live-server coverage in any language. `testutil.StartContractServer` set every cap to 100000 **deliberately** — its comment read *"contract scenarios exercise contract shape, not quota enforcement (the 402 limit paths have dedicated httpapi unit tests)"* — so the 402 envelope, the field an SDK reads to tell a caller **which** quota stopped them, was proven only by handler tests against fakes.

This adds that coverage to all three contract runners, and pins the re-register-at-cap exemption from #819 — the contract-level coverage that PR could not get on its own.

## Why a second account, not a "lower the caps" step

The obvious design is a setup primitive that lowers the caps for one scenario and restores them in cleanup. That is a trap here: caps are **account-global**, and both the TS and Python setup loops **silently ignore setup keys they do not recognize**. A cap lowered for one scenario and restored by a cleanup step some runner skipped would 402 every scenario after it — surfacing as a product bug, not a harness bug.

So the contract server seeds a **second account** (`CappedLimits`, one slot per create-limited resource) and hands its key to the runners as `E2A_TEST_CAPPED_API_KEY`. Scenarios reach it through `auth_override` — an existing primitive all three runners already support and already resolve variables through. Nothing mutates, so nothing can leak. The enforcer's 60s limits cache needs no special handling either: the row is written before the server serves its first request and never changes, so there is no staleness window to race.

CI needs **no workflow change** — the env file is already sourced with `set -a`.

## The scenario pins both directions, on two resources

`account_limits_enforced` asserts refusal **at** the cap (with `resource` / `limit` / `current`) *and* success once a slot is freed, across domains and agents. A server that 402'd unconditionally — or one that wired a single quota and left the others open — cannot pass it.

## Coverage cannot silently rot back to zero

This is the part worth reviewing closely, since a quota scenario that quietly stops running is indistinguishable from one that passes:

- **Go** owns the contract server in-process, so it can never legitimately lack the key → a missing capped key is a **hard failure**, never a skip. This is the per-PR gate that cannot be skipped.
- **TS / Python** skip only when pointed at a target with no capped account (a deployed staging server, which cannot provision one). Per-PR CI always supplies the key via the env file.
- **All three** carry an **always-on shape test** — no live server needed — that fails if the scenario is deleted, stops using the capped account, or loses either direction of enforcement.

## Test plan

- [x] **Go runner, live:** `✓ account_limits_enforced`
- [x] **TypeScript runner, live:** `✓ account_limits_enforced` (against a real `cmd/e2a-contract-server`)
- [x] **Python runner, live:** `PASSED [account_limits_enforced]` (same server)
- [x] Skip path with the key unset → `SKIPPED` cleanly, so the out-of-repo staging conformance job is unaffected
- [x] The exemption step **fails** without #819's fix (`402 limits: domains cap reached (1/1)`), proving it is a real pin and not incidental
- [x] Shape test teeth: defanging one assertion (`resource: domains` → `messages`) **fails** the build
- [x] `tests/contract`, `internal/testutil`, TS SDK suite (233 tests), Python contract file all green; `gofmt` / `go vet` clean

## Not covered

Only the two **create** caps (domains, agents). `max_messages_month` and `max_storage_bytes` are seeded on the capped account but unexercised — reaching them means sending mail, which the contract server accepts but deliberately does not deliver. Worth a follow-up rather than bolting onto this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)