### PR TITLE
fix(web): identify inbound thread messages by their own From header

### DIFF
--- a/web/src/app/components/messages/ThreadBubble.test.tsx
+++ b/web/src/app/components/messages/ThreadBubble.test.tsx
@@ -55,8 +55,6 @@ function msg(id: string): MessageSummary {
     created_at: new Date().toISOString(),
   };
 }
-const CP = { email: "james@x.com", name: "James" };
-
 function inbound(wire: Record<string, unknown>) {
   mockGet.mockResolvedValue(wire as never);
 }
@@ -102,7 +100,7 @@ describe("ThreadBubble canonical lifecycle", () => {
       status: "sent",
     };
 
-    render(<ThreadBubble message={m} counterparty={CP} agentEmail="support@acme.dev" />);
+    render(<ThreadBubble message={m} agentEmail="support@acme.dev" />);
 
     const toggle = screen.getByRole("button", { name: /show lifecycle/i });
     expect(toggle).not.toHaveTextContent(/beta/i);
@@ -121,7 +119,7 @@ describe("ThreadBubble canonical lifecycle", () => {
 describe("ThreadBubble body precedence", () => {
   it("renders parsed.html in the sandboxed iframe when present", async () => {
     inbound({ parsed: { text: "flat text", html: "<p>rich <b>html</b></p>" }, raw_message: "" });
-    render(<ThreadBubble message={msg("msg_html")} counterparty={CP} agentEmail="support@acme.dev" />);
+    render(<ThreadBubble message={msg("msg_html")} agentEmail="support@acme.dev" />);
     await waitFor(() => {
       const frame = screen.getByTitle("Email body") as HTMLIFrameElement;
       expect(frame.getAttribute("srcdoc")).toContain("rich <b>html</b>");
@@ -132,11 +130,31 @@ describe("ThreadBubble body precedence", () => {
 
   it("falls back to parsed.text (no iframe) when there is no HTML part", async () => {
     inbound({ parsed: { text: "just the plain body" }, raw_message: "" });
-    render(<ThreadBubble message={msg("msg_text")} counterparty={CP} agentEmail="support@acme.dev" />);
+    render(<ThreadBubble message={msg("msg_text")} agentEmail="support@acme.dev" />);
     await waitFor(() => {
       expect(screen.getByText("just the plain body")).toBeInTheDocument();
     });
     expect(screen.queryByTitle("Email body")).not.toBeInTheDocument();
+  });
+});
+
+describe("ThreadBubble inbound sender identity", () => {
+  // In a multi-party thread (e.g. the agent is Cc'd on mail between two other
+  // parties), a message's From can differ from the thread's derived
+  // counterparty. The bubble must identify each inbound message by its own
+  // From — labeling it with the thread counterparty misattributes the mail.
+  it("renders the message's own From, not the thread counterparty", async () => {
+    inbound({ parsed: { text: "body" }, raw_message: "" });
+    const m = { ...msg("msg_multiparty_sender"), from: "casey@sender.example" };
+
+    render(<ThreadBubble message={m} agentEmail="support@acme.dev" />);
+
+    await screen.findByText("body");
+    // Header: name derived from the From address, plus the address itself.
+    expect(screen.getByText("Casey")).toBeInTheDocument();
+    expect(screen.getByText("casey@sender.example")).toBeInTheDocument();
+    // Avatar initials come from the sender too.
+    expect(screen.getByText("CA")).toBeInTheDocument();
   });
 });
 
@@ -145,7 +163,7 @@ describe("ThreadBubble inbound authentication summary", () => {
     inbound({ parsed: { text: "body" }, raw_message: "" });
     const m = { ...msg("msg_dmarc_pass"), verified_domain: "example.com" };
 
-    render(<ThreadBubble message={m} counterparty={CP} agentEmail="support@acme.dev" />);
+    render(<ThreadBubble message={m} agentEmail="support@acme.dev" />);
 
     expect(screen.getByText("DMARC verified · example.com")).toBeInTheDocument();
   });
@@ -154,7 +172,7 @@ describe("ThreadBubble inbound authentication summary", () => {
     inbound({ parsed: { text: "body" }, raw_message: "" });
     const m = { ...msg("msg_dmarc_not_verified"), verified_domain: null };
 
-    render(<ThreadBubble message={m} counterparty={CP} agentEmail="support@acme.dev" />);
+    render(<ThreadBubble message={m} agentEmail="support@acme.dev" />);
 
     expect(screen.getByText("DMARC not verified")).toBeInTheDocument();
   });
@@ -167,7 +185,7 @@ describe("ThreadBubble marks-read cache refresh", () => {
   it("invalidates the thread list + unread badge after reading an unread inbound message", async () => {
     inbound({ parsed: { text: "body" }, raw_message: "" });
     const m = { ...msg("msg_unread_inbound"), read_status: "unread" };
-    render(<ThreadBubble message={m} counterparty={CP} agentEmail="support@acme.dev" />);
+    render(<ThreadBubble message={m} agentEmail="support@acme.dev" />);
     await waitFor(() => {
       expect(mockInvalidateMessages).toHaveBeenCalledWith("support@acme.dev");
       expect(mockInvalidateUnread).toHaveBeenCalledWith("support@acme.dev");
@@ -177,7 +195,7 @@ describe("ThreadBubble marks-read cache refresh", () => {
   it("does not invalidate when the inbound message was already read", async () => {
     inbound({ parsed: { text: "body" }, raw_message: "" });
     const m = { ...msg("msg_read_inbound"), read_status: "read" };
-    render(<ThreadBubble message={m} counterparty={CP} agentEmail="support@acme.dev" />);
+    render(<ThreadBubble message={m} agentEmail="support@acme.dev" />);
     // Wait for the body fetch to resolve so onSuccess has had its chance.
     await waitFor(() => expect(screen.getByText("body")).toBeInTheDocument());
     expect(mockInvalidateMessages).not.toHaveBeenCalled();
@@ -187,7 +205,7 @@ describe("ThreadBubble marks-read cache refresh", () => {
   it("does not invalidate for outbound messages", async () => {
     outbound("sent body");
     const m: MessageSummary = { ...msg("msg_outbound"), direction: "outbound", read_status: "" };
-    render(<ThreadBubble message={m} counterparty={CP} agentEmail="support@acme.dev" />);
+    render(<ThreadBubble message={m} agentEmail="support@acme.dev" />);
     await waitFor(() => expect(screen.getByText("sent body")).toBeInTheDocument());
     expect(mockInvalidateMessages).not.toHaveBeenCalled();
     expect(mockInvalidateUnread).not.toHaveBeenCalled();
@@ -216,7 +234,7 @@ describe("ThreadBubble outbound delivery status", () => {
       status,
     };
 
-    render(<ThreadBubble message={m} counterparty={CP} agentEmail="support@acme.dev" />);
+    render(<ThreadBubble message={m} agentEmail="support@acme.dev" />);
 
     expect(await screen.findByText(label)).toHaveClass("shrink-0", "whitespace-nowrap");
   });
@@ -237,7 +255,7 @@ describe("ThreadBubble outbound delivery status", () => {
       review_status,
     };
 
-    render(<ThreadBubble message={m} counterparty={CP} agentEmail="support@acme.dev" />);
+    render(<ThreadBubble message={m} agentEmail="support@acme.dev" />);
 
     expect(await screen.findByText(label)).toHaveClass("shrink-0", "whitespace-nowrap");
   });
@@ -246,7 +264,7 @@ describe("ThreadBubble outbound delivery status", () => {
     inbound({ parsed: { text: "inbound body" }, raw_message: "" });
     const m = { ...msg("msg_status_inbound"), status: "failed" };
 
-    render(<ThreadBubble message={m} counterparty={CP} agentEmail="support@acme.dev" />);
+    render(<ThreadBubble message={m} agentEmail="support@acme.dev" />);
 
     await screen.findByText("inbound body");
     expect(screen.queryByText("Failed")).not.toBeInTheDocument();

--- a/web/src/app/components/messages/ThreadBubble.tsx
+++ b/web/src/app/components/messages/ThreadBubble.tsx
@@ -27,7 +27,7 @@ import {
   messageDetailKey,
 } from "../../../lib/swrKeys";
 import type { AttachmentMeta, MessageSummary } from "../types";
-import type { Counterparty } from "./threading";
+import { nameFromEmail } from "./threading";
 
 // Absolute, human time for the message header (e.g. "Jun 21, 8:07 PM").
 // title carries the full locale string for hover.
@@ -70,11 +70,9 @@ function MetaRow({ label, value }: { label: string; value: string }) {
 
 export function ThreadBubble({
   message,
-  counterparty,
   agentEmail,
 }: {
   message: MessageSummary;
-  counterparty: Counterparty;
   agentEmail: string;
 }) {
   const isInbound = message.direction === "inbound";
@@ -164,8 +162,11 @@ export function ThreadBubble({
   // surface as download chips beneath it.
   const chipAttachments = downloadableAttachments(attachments, htmlBody);
 
-  const senderName = isInbound ? counterparty.name : "Inbox";
-  const senderEmail = isInbound ? counterparty.email : agentEmail;
+  // Identify inbound mail by the message's own From, never the thread-level
+  // counterparty: in a multi-party thread (agent Cc'd on mail between other
+  // parties) the counterparty can be a different participant entirely.
+  const senderName = isInbound ? nameFromEmail(message.from) : "Inbox";
+  const senderEmail = isInbound ? message.from : agentEmail;
   const toList = (message.to ?? []).join(", ");
 
   return (
@@ -175,10 +176,10 @@ export function ThreadBubble({
       className="flex"
       style={{ gap: 12, marginBottom: 20, alignItems: "flex-start" }}
     >
-      {/* Avatar — counterparty face for inbound, e2a tile for outbound. */}
+      {/* Avatar — sender face for inbound, e2a tile for outbound. */}
       <div style={{ flexShrink: 0, paddingTop: 2 }}>
         {isInbound ? (
-          <CounterpartyAvatar email={counterparty.email} name={counterparty.name} size={32} />
+          <CounterpartyAvatar email={senderEmail} name={senderName} size={32} />
         ) : (
           <span
             aria-hidden

--- a/web/src/app/components/messages/ThreadDetail.tsx
+++ b/web/src/app/components/messages/ThreadDetail.tsx
@@ -177,12 +177,7 @@ export function ThreadDetail({
         style={{ padding: "24px 28px 28px" }}
       >
         {thread.messages.map((m) => (
-          <ThreadBubble
-            key={m.id}
-            message={m}
-            counterparty={thread.counterparty}
-            agentEmail={agentEmail}
-          />
+          <ThreadBubble key={m.id} message={m} agentEmail={agentEmail} />
         ))}
 
         {pendingDraft && (

--- a/web/src/app/components/messages/threading.ts
+++ b/web/src/app/components/messages/threading.ts
@@ -71,7 +71,7 @@ function counterpartyEmail(m: MessageSummary): string {
   return m.to?.[0] ?? m.recipient;
 }
 
-function nameFromEmail(email: string): string {
+export function nameFromEmail(email: string): string {
   const local = email.split("@")[0] || email;
   const parts = local.split(/[._-]+/).filter(Boolean);
   if (parts.length === 0) return email;


### PR DESCRIPTION
## Problem

In the dashboard thread view, every inbound message in a thread rendered with the **thread-level counterparty's** name, email, and avatar instead of the message's own sender. The counterparty is derived once per thread from the latest message's "other side" (`threading.ts`), so in a 1:1 thread the mislabeling is invisible — but in a multi-party thread (e.g. the agent Cc'd on mail between two other participants) messages get attributed to the wrong person entirely: a message from `sender-a@example.com` renders with `participant-b@example.com`'s name and avatar, while the per-message DMARC badge and the expanded `From:` row contradict it.

## Fix

- `ThreadBubble` now derives inbound sender identity (header name, address, avatar) from the message's own `from` field, via the exported `nameFromEmail`.
- The now-dead `counterparty` prop is removed from `ThreadBubble`; the thread-level counterparty remains where a single "who this thread is with" label is intended (thread list row, thread header in `ThreadDetail`).

## Test plan

Written test-first: `ThreadBubble.test.tsx` gains an inbound-sender-identity test rendering a message whose `From` differs from the thread counterparty, pinning header name, address, and avatar initials to the message's own sender (red on the old code — it read the counterparty at exactly that spot — green after the fix).

- `npx jest src/app/components/messages/` — 125/125 pass
- `eslint` clean on the four touched files; the pre-existing `tsc --noEmit` errors on main are untouched (none in these files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)