### PR TITLE
docs(readme): add missing e2a suppressions row to CLI table

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ domains/webhooks in the **web dashboard**.
 | `e2a keys create\|list\|delete` | Mint, list, and revoke API keys (requires an account-scoped key) |
 | `e2a protection get\|set` | Show or update an agent's HITL screening/review config |
 | `e2a contacts list\|get\|create\|update\|delete\|import\|outreach ...` | Manage account contacts and per-agent outreach state, with suppression visibility |
+| `e2a suppressions list\|add\|remove` | Inspect and manage recipient block lists (account-wide GA; agent-scoped is beta) |
 | `e2a send` / `e2a reply` | Send an email as the agent, or reply in-thread |
 | `e2a messages list\|get` | List or fetch messages for an agent |
 | `e2a listen --agent <email>` | Stream inbound email for an agent over WebSocket (real-time; `--json` for raw, `--forward <url>` to bridge to a local HTTP handler) |


### PR DESCRIPTION
## Summary

The root `README.md` CLI command reference table lists every CLI command except `e2a suppressions`, even though the command is implemented (`cli/src/commands/suppressions.ts`), fully documented in `cli/README.md`, and shipped per the `cli/CHANGELOG.md` 2.2.0 entry. This adds the missing row, matching the style and detail level of the neighboring rows.

Docs-only change — no API, migration, or client-surface impact, so the client surface checklist is omitted per the template note.

## Test plan

- [x] Visual diff of the CLI table in `README.md` against `cli/README.md`'s `e2a suppressions` section to confirm accuracy
- [x] Confirmed `cli/src/commands/suppressions.ts` exists and matches the described subcommands (`list`, `add`, `remove`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ES13GeMVtQk8NxG3fz6JYd)_