### PR TITLE
fix(api): reject an approved self-send that would drop a held schedule

### DIFF
--- a/internal/agent/hitl_api.go
+++ b/internal/agent/hitl_api.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"github.com/tokencanopy/e2a/internal/identity"
@@ -137,6 +138,20 @@ func (a *API) ApprovePendingCore(ctx context.Context, userID, messageID, expecte
 	}
 	if uerr := prepareManagedUnsubscribe(ctx, a.unsubscribeIssuer, a.fromDomain, agent.UserID, agent, &mergedReq, true); uerr != nil {
 		return nil, uerr
+	}
+	// A held draft that carried a future send_at must not silently lose it to a
+	// reviewer edit (#815): self-delivery is an immediate in-process loopback with
+	// no scheduled arm, so approving a still-scheduled hold whose FINAL (edited)
+	// recipients target the agent's own address would deliver now and drop the
+	// schedule. Reject before dispatch — the hold stays pending_review and the
+	// reviewer re-targets an external recipient (or waits for the schedule to
+	// lapse, after which approval delivers immediately). Mirrors the accept-path
+	// rejection in DeliverOutbound; a lapsed schedule is already satisfied, so it
+	// falls through to the immediate loopback below.
+	if preview.ScheduledAt != nil && preview.ScheduledAt.After(time.Now()) && isSelfSend(mergedReq, agent.EmailAddress()) {
+		return nil, &OutboundError{Status: http.StatusBadRequest, Code: "invalid_request",
+			Msg: fmt.Sprintf("cannot approve: this held message is scheduled to send at %s and the edited recipients target the agent's own address, which is delivered as an immediate loopback — change the recipients to an external address to approve",
+				preview.ScheduledAt.UTC().Format(time.RFC3339))}
 	}
 	// Transition the hold to review_approved + delivery_status='accepted'
 	// and enqueue an outbound_send job; the SendWorker performs the SMTP submit +

--- a/internal/agent/schedule_hold_test.go
+++ b/internal/agent/schedule_hold_test.go
@@ -167,3 +167,75 @@ func TestApprovePendingCore_PastScheduleSendsImmediately(t *testing.T) {
 		t.Fatalf("enqueued ScheduledAt = %v, want the immediate arm (zero) for a lapsed schedule", enq.scheduledAt)
 	}
 }
+
+// TestApprovePendingCore_EditedSelfSendFutureScheduleRejects: approving a held
+// message that still carries a future send_at while EDITING the recipients to the
+// agent's own address is rejected up front — self-delivery is an immediate
+// loopback with no scheduled arm, so the approve would silently drop the schedule
+// (#815). The hold stays pending_review, so a corrected approve (without the
+// self-addressed edit) succeeds and re-arms the schedule.
+func TestApprovePendingCore_EditedSelfSendFutureScheduleRejects(t *testing.T) {
+	api, store, _, enq := setupAsyncAPI(t)
+	ctx := context.Background()
+	user, ag := selfAgent(t, store, "editselfsched")
+	ag = reviewGatedAgent(t, store, ctx, user, ag)
+	at := time.Now().Add(30 * time.Minute).UTC().Truncate(time.Second)
+
+	res, oerr := api.DeliverOutbound(ctx, user, ag, outbound.SendRequest{
+		To: []string{"alice@external.test"}, Subject: "held + scheduled", Body: "b",
+		ScheduledAt: &at,
+	}, "send", "", nil, nil)
+	if oerr != nil {
+		t.Fatalf("DeliverOutbound: %+v", oerr)
+	}
+
+	self := []string{ag.EmailAddress()}
+	_, oerr = api.ApprovePendingCore(ctx, user.ID, res.PendingMessageID, ag.Email, agent.ApproveOverrides{To: &self}, nil)
+	if oerr == nil || oerr.Status != 400 || oerr.Code != "invalid_request" {
+		t.Fatalf("edited self-send on a still-scheduled hold: want 400 invalid_request, got %+v", oerr)
+	}
+
+	// The hold is untouched — a corrected approve (original recipients, no edit)
+	// succeeds and re-arms the schedule.
+	sent, oerr := api.ApprovePendingCore(ctx, user.ID, res.PendingMessageID, ag.Email, agent.ApproveOverrides{}, nil)
+	if oerr != nil {
+		t.Fatalf("corrected approve: status=%d code=%s msg=%s", oerr.Status, oerr.Code, oerr.Msg)
+	}
+	if sent.ScheduledAt == nil || !sent.ScheduledAt.Equal(at) {
+		t.Fatalf("corrected approve ScheduledAt = %v, want %v (re-armed)", sent.ScheduledAt, at)
+	}
+	if !enq.scheduledAt.Equal(at) {
+		t.Fatalf("corrected approve enqueued ScheduledAt = %v, want %v", enq.scheduledAt, at)
+	}
+}
+
+// TestApprovePendingCore_EditedSelfSendLapsedScheduleDeliversNow: once the
+// schedule has lapsed while the message sat in review, "not before" is satisfied —
+// so a reviewer edit that re-targets the agent's own address is allowed and the
+// approval delivers via the immediate loopback (no schedule to drop).
+func TestApprovePendingCore_EditedSelfSendLapsedScheduleDeliversNow(t *testing.T) {
+	api, store, _, _ := setupAsyncAPI(t)
+	ctx := context.Background()
+	user, ag := selfAgent(t, store, "editselfschedlapsed")
+
+	msg, err := store.CreatePendingOutboundMessage(ctx, ag.ID,
+		[]string{"alice@external.test"}, nil, nil, "lapsed then re-targeted", "b", "", nil, "send", "", "", "", 3600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	past := time.Now().Add(-10 * time.Minute).UTC().Truncate(time.Second)
+	if err := store.WithTx(ctx, func(tx pgx.Tx) error {
+		return store.StampScheduledAtTx(ctx, tx, msg.ID, past)
+	}); err != nil {
+		t.Fatalf("StampScheduledAtTx: %v", err)
+	}
+
+	self := []string{ag.EmailAddress()}
+	sent, oerr := api.ApprovePendingCore(ctx, user.ID, msg.ID, ag.Email, agent.ApproveOverrides{To: &self}, nil)
+	if oerr != nil {
+		t.Fatalf("approve of lapsed schedule with self-edit: status=%d code=%s msg=%s", oerr.Status, oerr.Code, oerr.Msg)
+	}
+	if sent.Method != "loopback" {
+		t.Fatalf("Method = %q, want loopback (immediate self-delivery for a lapsed schedule)", sent.Method)
+	}
+}

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -3096,6 +3096,7 @@ func (s *Store) GetOutboundMessageForUser(ctx context.Context, messageID, userID
 		method, msgType    *string
 		approvalExpires    *time.Time
 		reviewedAt         *time.Time
+		scheduledAt        *time.Time
 		rejectionReason    *string
 		reviewedByID       *string
 		reviewedByName     *string
@@ -3106,7 +3107,7 @@ func (s *Store) GetOutboundMessageForUser(ctx context.Context, messageID, userID
 		        m.method, m.message_type,
 		        m.conversation_id, m.created_at, m.expires_at,
 		        m.to_recipients, m.cc, m.bcc, m.reply_to,
-		        m.status, m.approval_expires_at, m.reviewed_at,
+		        m.status, m.approval_expires_at, m.reviewed_at, m.scheduled_at,
 		        m.rejection_reason, m.edited,
 		        m.body_text, m.body_html, m.attachments_json, m.managed_unsubscribe,
 		        m.reviewed_by_user_id, r.name,
@@ -3123,7 +3124,7 @@ func (s *Store) GetOutboundMessageForUser(ctx context.Context, messageID, userID
 		&method, &msgType,
 		&m.ConversationID, &m.CreatedAt, &m.ExpiresAt,
 		&m.ToRecipients, &m.CC, &m.BCC, &m.ReplyTo,
-		&m.Status, &approvalExpires, &reviewedAt,
+		&m.Status, &approvalExpires, &reviewedAt, &scheduledAt,
 		&rejectionReason, &m.Edited,
 		&bodyText, &bodyHTML, &attachments, &m.ManagedUnsubscribe,
 		&reviewedByID, &reviewedByName,
@@ -3143,6 +3144,9 @@ func (s *Store) GetOutboundMessageForUser(ctx context.Context, messageID, userID
 	}
 	if reviewedAt != nil {
 		m.ReviewedAt = reviewedAt
+	}
+	if scheduledAt != nil {
+		m.ScheduledAt = scheduledAt
 	}
 	if rejectionReason != nil {
 		m.RejectionReason = *rejectionReason


### PR DESCRIPTION
## What

Closes the second residual case from #815/#833 review: a reviewer who approves a **scheduled** hold while editing its recipients to the agent's own address used to **silently drop the schedule** — the approval fell through to `approveSelfSend`, whose loopback is immediate and has no scheduled arm.

Now `ApprovePendingCore` rejects that combination up front with `400 invalid_request` (the same contract the accept path already enforces) when the draft's `scheduled_at` is still in the future. The hold stays `pending_review`, so a corrected approve (external recipient, no self-addressed edit) succeeds and re-arms the schedule. A schedule that has already **lapsed** is already satisfied — "not before" holds — so that approval still delivers via loopback.

## Why

The accept path rejects `send_at` + self-delivery outright (DeliverOutbound), so a scheduled hold can never *start* as a self-send. The only door left was a reviewer edit, which is exactly why the guard sits on the **merged** (post-edit) recipients.

## Implementation

- `internal/identity/store.go`: `GetOutboundMessageForUser` now selects `scheduled_at`, so the approve path can see the draft's preserved schedule.
- `internal/agent/hitl_api.go`: guard in `ApprovePendingCore` — future `scheduled_at` + `isSelfSend`(merged request) → 400 `invalid_request`, before any dispatch side effect (hold intact, idempotency key released like the suppression check).
- `internal/agent/schedule_hold_test.go`: two tests — rejected-while-future (with a corrected-approve success path proving the hold survives) and delivered-via-loopback-when-lapsed.

## Notes

The magic-link approve path is safe by construction (no reviewer edits; stored recipients cannot be a self-send with a future schedule since accept rejects it), so the guard is placed only where the edit is possible.

Stacked on #833 (`feat/schedule-survives-hold`); retargets to `main` automatically once #833 merges. All affected Go tests pass (`agent`, `identity`, `hitlworker`, `httpapi`); `go build ./...` clean.
