### PR TITLE
feat(outbound): operator-configured outbound footer, gated per account

### DIFF
--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -242,6 +242,11 @@ func main() {
 	// configuration set so SES publishes delivery/bounce/complaint events.
 	// Empty = off (no header, no events).
 	sender.SetSESConfigurationSet(cfg.DeliveryFeedback.SESConfigurationSet)
+	// Outbound branding/disclosure footer (`outbound_footer:` config block):
+	// the CONTENT lives on the sender; the per-send DECISION is stamped on
+	// each request by the agent layer (SetOutboundFooterEnabled below +
+	// account_limits.outbound_footer_enabled). Empty content = inert.
+	sender.SetOutboundFooter(cfg.OutboundFooter.Text, cfg.OutboundFooter.HTML)
 
 	// Sender-identity manager (decision 4 / Slice 4). Only wired when SES is
 	// configured: domain verify enqueues a BYODKIM provision job + reconciler;
@@ -627,10 +632,16 @@ func main() {
 			MaxDomains:       cfg.Limits.MaxDomains,
 			MaxMessagesMonth: cfg.Limits.MaxMessagesMonth,
 			MaxStorageBytes:  cfg.Limits.MaxStorageBytes,
+			// Row-less fallback for the outbound-footer entitlement — the
+			// `outbound_footer:` block's default_enabled, not `limits:`.
+			OutboundFooterEnabled: cfg.OutboundFooter.DefaultEnabled,
 		},
 		time.Duration(cfg.Limits.CacheTTLSeconds)*time.Second,
 	)
 	api.SetEnforcer(enforcer)
+	// Master switch for the outbound footer; the enforcer above carries the
+	// per-account entitlement + row-less default the decision reads.
+	api.SetOutboundFooterEnabled(cfg.OutboundFooter.Enabled)
 	// Fire-time monthly-cap gate for scheduled sends: enforce the cap in the
 	// month a scheduled send actually fires (accept-time enforcement can't know a
 	// future fire month). Over-cap → refuse terminally; a transient lookup error

--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -642,6 +642,11 @@ func main() {
 	// Master switch for the outbound footer; the enforcer above carries the
 	// per-account entitlement + row-less default the decision reads.
 	api.SetOutboundFooterEnabled(cfg.OutboundFooter.Enabled)
+	// The TTL sweep composes held mail at auto-approve time, so it needs the
+	// same per-account footer decision the human-approve funnel resolves —
+	// otherwise an expires-to-approve hold ships unfootered while the identical
+	// human-approved hold does not.
+	hitlWorker.SetOutboundFooterResolver(api.OutboundFooterForAccount)
 	// Fire-time monthly-cap gate for scheduled sends: enforce the cap in the
 	// month a scheduled send actually fires (accept-time enforcement can't know a
 	// future fire month). Over-cap → refuse terminally; a transient lookup error

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -233,6 +233,27 @@ metrics:
   listen_addr: "127.0.0.1:9091"
   build: "unknown"               # release/image tag; attached to every sample
 
+# — Outbound footer ———————————————————————————————————————————————————————————
+# Optional footer appended to all SMTP-egress outbound mail at composition
+# time (inside the DKIM-signed body, above the managed-unsubscribe line, and
+# counted against the composed-size ceiling). Fully inert when enabled: false
+# (the default). Not applied to self-send loopback delivery or to non-standard
+# account classes (internal/system/demo). Useful for hosted branding or
+# self-host AI-disclosure notices.
+#
+# Per-account gating reads account_limits.outbound_footer_enabled: an account
+# WITH a row gets the footer only when that column is true (written by
+# whatever provisions the row); default_enabled covers accounts with NO row.
+# text is appended to the plain-text part after a blank line + "--" separator;
+# html is an operator-trusted fragment appended verbatim to the HTML part when
+# the message has one. Both empty = no-op. Override the master switch with
+# E2A_OUTBOUND_FOOTER_ENABLED.
+# outbound_footer:
+#   enabled: false          # master switch
+#   default_enabled: false  # applies to accounts with NO account_limits row
+#   text: ""                # plain-text footer
+#   html: ""                # HTML fragment appended to the HTML part
+
 
 
 # — Content screening (piguard) ——————————————————————————————————————————————

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -244,7 +244,8 @@ metrics:
 # Per-account gating reads account_limits.outbound_footer_enabled: an account
 # WITH a row gets the footer only when that column is true (written by
 # whatever provisions the row); default_enabled covers accounts with NO row.
-# text is appended to the plain-text part after a blank line + "--" separator;
+# text is appended to the plain-text part after a blank line + the RFC 3676
+# signature separator ("-- " with a trailing space, so clients trim it on reply);
 # html is an operator-trusted fragment appended verbatim to the HTML part when
 # the message has one. Both empty = no-op. Override the master switch with
 # E2A_OUTBOUND_FOOTER_ENABLED.

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -493,6 +493,15 @@ func (a *API) resolveOutboundFooter(ctx context.Context, user *identity.User) bo
 	return lim.OutboundFooterEnabled
 }
 
+// OutboundFooterForAccount is the exported form of resolveOutboundFooterByUserID
+// for out-of-package composers that finalize held mail — today the hitlworker
+// TTL sweep, whose auto-approve composes at expiry time and therefore needs
+// the same per-account decision the human approve funnel resolves. Fail-closed
+// like the internal resolver.
+func (a *API) OutboundFooterForAccount(ctx context.Context, userID string) bool {
+	return a.resolveOutboundFooterByUserID(ctx, userID)
+}
+
 // resolveOutboundFooterByUserID is resolveOutboundFooter for call sites that
 // hold only the owning account's user id (the HITL approval funnel, where the
 // held row composes at approval time). Loads the user for its account_class;

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -197,27 +197,28 @@ type API struct {
 	// it when the deployment serves the API on a different host than the web
 	// app (e.g. api.e2a.dev vs e2a.dev). The OAuth authorization_endpoint
 	// and login/consent pages stay on publicURL (the browser-facing web app).
-	apiURL              string
-	production          bool
-	sendLimit           *ratelimit.Limiter
-	regLimit            *ratelimit.Limiter
-	pollLimit           *ratelimit.Limiter
-	feedbackLimit       *ratelimit.Limiter
-	dcrLimit            *ratelimit.Limiter    // OAuth Dynamic Client Registration — anonymous endpoint, per-IP
-	downloadLimit       *ratelimit.Limiter    // attachment byte-download — capability-token route (no bearer), per-IP
-	unsubscribeLimit    *ratelimit.Limiter    // managed unsubscribe — separate capability-token budget, per-IP
-	approvalSigner      *approvaltoken.Signer // optional; if nil, magic-link endpoints return 404
-	notifyEnq           NotifyEnqueuer        // optional; if nil, holdForApproval persists the hold but sends no notification
-	oauthProvider       fosite.OAuth2Provider // optional; if nil, /oauth2/* endpoints return 404
-	oauthStorage        *oauth.Storage        // optional; consent handler needs Pool() for cross-package tx
-	signer              *agentauth.Signer     // optional; nil ⇒ JWKS serves an empty set (agent-auth disabled)
-	idempotency         *idempotency.Store    // optional; when nil, Idempotency-Key header is ignored
-	enforcer            limits.Enforcer       // optional; when nil, all limit checks are skipped (effectively unlimited)
-	usageStore          *usage.Store          // optional; needed by handleGetMyLimits to surface current counts
-	internalAPISecret   string                // optional; when empty, /api/internal/* endpoints return 503
-	provisioningEnabled bool                  // false by default; keeps /api/internal/users/provision disabled even if a secret is present
-	provisioningSecret  string                // required with provisioningEnabled; signs /api/internal/users/provision
-	billingHookURL      string                // optional; when set, handleDeleteUserData POSTs an HMAC-signed user-deleted notice here (sidecar's /api/internal/billing/cancel)
+	apiURL                string
+	production            bool
+	sendLimit             *ratelimit.Limiter
+	regLimit              *ratelimit.Limiter
+	pollLimit             *ratelimit.Limiter
+	feedbackLimit         *ratelimit.Limiter
+	dcrLimit              *ratelimit.Limiter    // OAuth Dynamic Client Registration — anonymous endpoint, per-IP
+	downloadLimit         *ratelimit.Limiter    // attachment byte-download — capability-token route (no bearer), per-IP
+	unsubscribeLimit      *ratelimit.Limiter    // managed unsubscribe — separate capability-token budget, per-IP
+	approvalSigner        *approvaltoken.Signer // optional; if nil, magic-link endpoints return 404
+	notifyEnq             NotifyEnqueuer        // optional; if nil, holdForApproval persists the hold but sends no notification
+	oauthProvider         fosite.OAuth2Provider // optional; if nil, /oauth2/* endpoints return 404
+	oauthStorage          *oauth.Storage        // optional; consent handler needs Pool() for cross-package tx
+	signer                *agentauth.Signer     // optional; nil ⇒ JWKS serves an empty set (agent-auth disabled)
+	idempotency           *idempotency.Store    // optional; when nil, Idempotency-Key header is ignored
+	enforcer              limits.Enforcer       // optional; when nil, all limit checks are skipped (effectively unlimited)
+	outboundFooterEnabled bool                  // config outbound_footer.enabled — master switch for the send-time outbound footer
+	usageStore            *usage.Store          // optional; needed by handleGetMyLimits to surface current counts
+	internalAPISecret     string                // optional; when empty, /api/internal/* endpoints return 503
+	provisioningEnabled   bool                  // false by default; keeps /api/internal/users/provision disabled even if a secret is present
+	provisioningSecret    string                // required with provisioningEnabled; signs /api/internal/users/provision
+	billingHookURL        string                // optional; when set, handleDeleteUserData POSTs an HMAC-signed user-deleted notice here (sidecar's /api/internal/billing/cancel)
 	// subscriberStore powers the slice-2 webhooks-as-a-resource
 	// /webhooks/{id}/test and /webhooks/{id}/deliveries endpoints.
 	// Optional — when nil, those endpoints return 404 (the rest of
@@ -455,6 +456,58 @@ func (a *API) SetIdempotencyStore(s *idempotency.Store) { a.idempotency = s }
 // unlimited capacity. The cmd/e2a runtime always sets it; tests that
 // don't care about limits omit it and continue to work as before.
 func (a *API) SetEnforcer(e limits.Enforcer) { a.enforcer = e }
+
+// SetOutboundFooterEnabled wires the outbound_footer.enabled master switch.
+// False (the default) keeps the outbound-footer resolution entirely off —
+// no limits read, no footer, zero behavior change.
+func (a *API) SetOutboundFooterEnabled(enabled bool) { a.outboundFooterEnabled = enabled }
+
+// resolveOutboundFooter decides whether an external outbound send carries the
+// operator-configured outbound footer:
+//
+//	append := cfg.Enabled
+//	       && (row present ? row.OutboundFooterEnabled : cfg.DefaultEnabled)
+//	       && user.AccountClass == standard
+//
+// The row-present/row-absent ternary is exactly what the enforcer's Get
+// already resolves (limits.Defaults.OutboundFooterEnabled is wired from
+// outbound_footer.default_enabled), so the decision rides the existing limits
+// cache + invalidate flow untouched. Fail-closed: any limits read error means
+// NO footer — a missing footer is a lost impression, while a wrongly-added
+// footer on entitled-off mail is a customer-facing bug. Non-standard account
+// classes (internal/system/demo — probers, monitors, conformance accounts)
+// never get the footer, so body-asserting gates stay green. Strict equality
+// also means an EMPTY AccountClass (principals not resolved via API key) gets
+// no footer — the same fail-closed direction, deliberately.
+func (a *API) resolveOutboundFooter(ctx context.Context, user *identity.User) bool {
+	if !a.outboundFooterEnabled || a.enforcer == nil {
+		return false
+	}
+	if user == nil || usage.AccountClass(user.AccountClass) != usage.ClassStandard {
+		return false
+	}
+	lim, err := a.enforcer.Get(ctx, user.ID)
+	if err != nil {
+		return false
+	}
+	return lim.OutboundFooterEnabled
+}
+
+// resolveOutboundFooterByUserID is resolveOutboundFooter for call sites that
+// hold only the owning account's user id (the HITL approval funnel, where the
+// held row composes at approval time). Loads the user for its account_class;
+// fail-closed on any lookup error. The master-switch short-circuit keeps the
+// common self-host case (feature off) free of the extra user read.
+func (a *API) resolveOutboundFooterByUserID(ctx context.Context, userID string) bool {
+	if !a.outboundFooterEnabled || a.enforcer == nil {
+		return false
+	}
+	u, err := a.store.GetUserByID(ctx, userID)
+	if err != nil {
+		return false
+	}
+	return a.resolveOutboundFooter(ctx, u)
+}
 
 // SendLimitAllow exposes the per-agent outbound rate limiter so the v1 httpapi
 // layer shares the *same* token bucket as the legacy handlers (a caller hitting
@@ -1379,6 +1432,12 @@ func (a *API) DeliverOutbound(ctx context.Context, user *identity.User, agent *i
 		log.Printf("[api] outbound queue unavailable: agent=%s to_count=%d to_domains=%v", agent.Domain, len(req.To), logredact.AddressDomains(req.To))
 		return nil, &OutboundError{Status: http.StatusInternalServerError, Code: "internal_error", Msg: "outbound delivery queue unavailable"}
 	}
+	// Outbound branding/disclosure footer: resolved here — strictly after the
+	// self-send branch (loopback delivery never runs Sender.compose, so
+	// self-sends never carry it) and after the hold branch (held mail
+	// re-resolves at approval time, when it actually composes) — then frozen
+	// into the composed bytes below with the rest of the message.
+	req.AppendOutboundFooter = a.resolveOutboundFooter(ctx, user)
 	comp, cerr := a.sender.ComposeForAccept(agent, req)
 	if cerr != nil {
 		if sizeErr := composedSizeOutboundError(cerr); sizeErr != nil {

--- a/internal/agent/hitl_api.go
+++ b/internal/agent/hitl_api.go
@@ -217,6 +217,13 @@ func (a *API) approveOutboundAsyncComposed(ctx context.Context, agent *identity.
 	if isPlatformTest {
 		comp, err = a.sender.ComposePlatformForAccept(sendReq)
 	} else {
+		// Held mail composes here, at approval time, so the outbound-footer
+		// decision is resolved here too (same freeze-with-the-bytes semantics
+		// as DeliverOutbound's accept path). The flag is not persisted on the
+		// held row; the owning account's entitlement at approval time decides.
+		// Keyed to the agent's owner, not the reviewing userID param, though
+		// the ownership check upstream makes them the same account.
+		sendReq.AppendOutboundFooter = a.resolveOutboundFooterByUserID(ctx, agent.UserID)
 		comp, err = a.sender.ComposeForAccept(agent, sendReq)
 	}
 	if err != nil {

--- a/internal/agent/outbound_footer_internal_test.go
+++ b/internal/agent/outbound_footer_internal_test.go
@@ -1,0 +1,86 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/tokencanopy/e2a/internal/identity"
+	"github.com/tokencanopy/e2a/internal/limits"
+)
+
+// fakeFooterEnforcer is a minimal limits.Enforcer whose Get returns a fixed
+// resolved Limits (the enforcer is what already folds row-vs-default; that
+// resolution is pinned in internal/limits tests).
+type fakeFooterEnforcer struct {
+	lim   limits.Limits
+	err   error
+	calls int
+}
+
+func (f *fakeFooterEnforcer) Get(ctx context.Context, userID string) (limits.Limits, error) {
+	f.calls++
+	return f.lim, f.err
+}
+func (f *fakeFooterEnforcer) CheckAgentCreate(context.Context, string) error  { return nil }
+func (f *fakeFooterEnforcer) CheckDomainCreate(context.Context, string) error { return nil }
+func (f *fakeFooterEnforcer) CheckMessageSend(context.Context, string) error  { return nil }
+func (f *fakeFooterEnforcer) Invalidate(string)                               {}
+
+// TestResolveOutboundFooterMatrix pins the gating decision:
+//
+//	append := cfg.Enabled && resolvedEntitlement && class == standard
+//
+// with fail-closed behavior on every uncertain input (limits error, nil
+// user, empty class, missing enforcer).
+func TestResolveOutboundFooterMatrix(t *testing.T) {
+	stdUser := &identity.User{ID: "u1", AccountClass: "standard"}
+	entitled := &fakeFooterEnforcer{lim: limits.Limits{OutboundFooterEnabled: true}}
+	unentitled := &fakeFooterEnforcer{lim: limits.Limits{OutboundFooterEnabled: false}}
+
+	cases := []struct {
+		name     string
+		enabled  bool
+		enforcer limits.Enforcer
+		user     *identity.User
+		want     bool
+	}{
+		{"config_off_even_when_entitled", false, entitled, stdUser, false},
+		{"entitled_standard", true, entitled, stdUser, true},
+		{"unentitled_row", true, unentitled, stdUser, false},
+		{"limits_error_fails_closed", true, &fakeFooterEnforcer{err: errors.New("db down")}, stdUser, false},
+		{"nil_enforcer", true, nil, stdUser, false},
+		{"nil_user", true, entitled, nil, false},
+		{"class_internal", true, entitled, &identity.User{ID: "u2", AccountClass: "internal"}, false},
+		{"class_system", true, entitled, &identity.User{ID: "u3", AccountClass: "system"}, false},
+		{"class_demo", true, entitled, &identity.User{ID: "u4", AccountClass: "demo"}, false},
+		{"class_empty_fails_closed", true, entitled, &identity.User{ID: "u5"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &API{}
+			a.SetOutboundFooterEnabled(tc.enabled)
+			if tc.enforcer != nil {
+				a.SetEnforcer(tc.enforcer)
+			}
+			if got := a.resolveOutboundFooter(context.Background(), tc.user); got != tc.want {
+				t.Errorf("resolveOutboundFooter = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveOutboundFooterMasterSwitchSkipsLimitsRead: with the feature off,
+// the decision must not cost a limits read (the common self-host case).
+func TestResolveOutboundFooterMasterSwitchSkipsLimitsRead(t *testing.T) {
+	enf := &fakeFooterEnforcer{lim: limits.Limits{OutboundFooterEnabled: true}}
+	a := &API{}
+	a.SetEnforcer(enf)
+	a.SetOutboundFooterEnabled(false)
+	if a.resolveOutboundFooter(context.Background(), &identity.User{ID: "u1", AccountClass: "standard"}) {
+		t.Fatal("master switch off must resolve false")
+	}
+	if enf.calls != 0 {
+		t.Errorf("limits reads with feature off = %d, want 0", enf.calls)
+	}
+}

--- a/internal/agent/outbound_footer_test.go
+++ b/internal/agent/outbound_footer_test.go
@@ -125,6 +125,65 @@ func TestDeliverOutboundFooterGatingMatrix(t *testing.T) {
 	}
 }
 
+// TestApprovePendingFooterResolvedAtApprovalTime: held mail composes at
+// approval time, so the footer decision is resolved by the approve funnel
+// (dashboard ApprovePendingCore → approveOutboundAsyncComposed, shared with
+// the magic-link path) via the owning account's DB user — not by any flag on
+// the held row. The held draft itself must stay footer-free.
+func TestApprovePendingFooterResolvedAtApprovalTime(t *testing.T) {
+	api, store, pool := setupFooterAPI(t)
+	ctx := context.Background()
+	user, ag := selfAgent(t, store, "footerapprove")
+	user.AccountClass = "standard"
+	// Force a review hold for the external send.
+	ag.OutboundPolicy = identity.OutboundPolicyAllowlist
+	ag.OutboundPolicyAction = "review"
+	ag.OutboundScan = identity.ScanOff
+
+	res, oerr := api.DeliverOutbound(ctx, user, ag, outbound.SendRequest{
+		To: []string{"user@example.net"}, Subject: "held then footered", Body: "body text",
+	}, "send", "", nil, nil)
+	if oerr != nil || res == nil || !res.Held {
+		t.Fatalf("result=%+v error=%+v, want held", res, oerr)
+	}
+	var heldBody string
+	if err := pool.QueryRow(ctx, `SELECT COALESCE(body_text,'') FROM messages WHERE id=$1`, res.PendingMessageID).Scan(&heldBody); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(heldBody, footerMarker) {
+		t.Fatalf("held draft must not carry the footer (it composes at approval):\n%s", heldBody)
+	}
+
+	// Dashboard approve: the funnel resolves the footer from the DB user
+	// (account_class defaults to 'standard') + the row-less entitlement default.
+	sent, aerr := api.ApprovePendingCore(ctx, user.ID, res.PendingMessageID, "", agent.ApproveOverrides{}, nil)
+	if aerr != nil {
+		t.Fatalf("ApprovePendingCore: status=%d code=%s msg=%s", aerr.Status, aerr.Code, aerr.Msg)
+	}
+	if raw := acceptedRaw(t, store, sent.ID); !strings.Contains(raw, footerMarker) {
+		t.Fatalf("approved held mail missing the footer:\n%s", raw)
+	}
+
+	// Same funnel, non-standard owner: flip the DB class and approve a second
+	// hold — no footer.
+	if err := store.SetAccountClass(ctx, user.ID, "internal"); err != nil {
+		t.Fatal(err)
+	}
+	res2, oerr := api.DeliverOutbound(ctx, user, ag, outbound.SendRequest{
+		To: []string{"user@example.net"}, Subject: "held internal class", Body: "body text",
+	}, "send", "", nil, nil)
+	if oerr != nil || !res2.Held {
+		t.Fatalf("result=%+v error=%+v, want held", res2, oerr)
+	}
+	sent2, aerr := api.ApprovePendingCore(ctx, user.ID, res2.PendingMessageID, "", agent.ApproveOverrides{}, nil)
+	if aerr != nil {
+		t.Fatalf("ApprovePendingCore (internal): %+v", aerr)
+	}
+	if raw := acceptedRaw(t, store, sent2.ID); strings.Contains(raw, footerMarker) {
+		t.Fatalf("internal-class owner's approved mail carries the footer:\n%s", raw)
+	}
+}
+
 // TestDeliverOutboundFooterSelfSendNeverFootered: self-send loopback bypasses
 // Sender.compose entirely, so an entitled account's note-to-self carries no
 // footer — in either stored copy.

--- a/internal/agent/outbound_footer_test.go
+++ b/internal/agent/outbound_footer_test.go
@@ -1,0 +1,158 @@
+package agent_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/tokencanopy/e2a/internal/agent"
+	"github.com/tokencanopy/e2a/internal/config"
+	"github.com/tokencanopy/e2a/internal/identity"
+	"github.com/tokencanopy/e2a/internal/limits"
+	"github.com/tokencanopy/e2a/internal/outbound"
+	"github.com/tokencanopy/e2a/internal/testutil"
+	"github.com/tokencanopy/e2a/internal/usage"
+	"github.com/tokencanopy/e2a/internal/webhookpub"
+)
+
+const footerMarker = "Created with Example - https://example.com/footer"
+
+// setupFooterAPI mirrors setupAsyncAPI but keeps the sender handle so the
+// footer content can be configured, and wires a REAL enforcer (cacheTTL 0)
+// whose Defaults carry default_enabled=true — the hosted posture where
+// row-less accounts are entitled.
+func setupFooterAPI(t *testing.T) (*agent.API, *identity.Store, *pgxpool.Pool) {
+	t.Helper()
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	smtpRelay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{})
+	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
+	sender.SetSendingStatusLookup(store)
+	sender.SetOutboundFooter(footerMarker, `<p>Created with <a href="https://example.com/footer">Example</a></p>`)
+	api := agent.NewAPI(store, sender, smtpRelay, nil, usage.NewNoopUsageTracker(),
+		"e2a.dev", "test.e2a.dev", "agents.e2a.dev", "", false)
+	api.SetOutbox(webhookpub.NewOutbox(pool, webhookpub.StaticFlag(true)))
+	enq := &fakeOutboundEnqueuer{jobID: 997}
+	api.SetOutboundEnqueuer(enq)
+	store.SetOutboundJobCanceller(enq)
+	api.SetEnforcer(limits.NewEnforcer(limits.NewStore(pool), usage.NewStore(pool), limits.Defaults{
+		PlanCode: "default", MaxAgents: 100, MaxDomains: 10,
+		MaxMessagesMonth: 1_000_000, MaxStorageBytes: 1 << 40,
+		OutboundFooterEnabled: true, // outbound_footer.default_enabled
+	}, 0))
+	api.SetOutboundFooterEnabled(true)
+	return api, store, pool
+}
+
+func acceptedRaw(t *testing.T, store *identity.Store, messageID string) string {
+	t.Helper()
+	var raw []byte
+	if err := store.WithTx(context.Background(), func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(), `SELECT raw_message FROM messages WHERE id=$1`, messageID).Scan(&raw)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return string(raw)
+}
+
+func deliverExternal(t *testing.T, api *agent.API, user *identity.User, ag *identity.AgentIdentity, subject string) *agent.OutboundResult {
+	t.Helper()
+	res, oerr := api.DeliverOutbound(context.Background(), user, ag, outbound.SendRequest{
+		To: []string{"user@example.net"}, Subject: subject, Body: "body text",
+	}, "send", "", nil, nil)
+	if oerr != nil {
+		t.Fatalf("DeliverOutbound: status=%d code=%s msg=%s", oerr.Status, oerr.Code, oerr.Msg)
+	}
+	return res
+}
+
+// TestDeliverOutboundFooterGatingMatrix drives the real accept path against a
+// real DB + enforcer through the states the hosted deployment will see:
+// row-less standard account (default_enabled applies), explicit row false /
+// true (row wins), config master switch off, and a non-standard account class.
+func TestDeliverOutboundFooterGatingMatrix(t *testing.T) {
+	api, store, pool := setupFooterAPI(t)
+	ctx := context.Background()
+	user, ag := selfAgent(t, store, "footergate")
+	// AccountClass is loaded at auth in production (API-key path); the test
+	// fixture user carries none, so stamp the standard class explicitly.
+	user.AccountClass = "standard"
+
+	// 1. No account_limits row → default_enabled (true) applies.
+	res := deliverExternal(t, api, user, ag, "footer rowless")
+	if raw := acceptedRaw(t, store, res.MessageID); !strings.Contains(raw, footerMarker) {
+		t.Fatalf("row-less standard account: footer missing:\n%s", raw)
+	}
+
+	// 2. Row present with outbound_footer_enabled=false (the paid-plan shape,
+	// and the column default) → row wins over the true default.
+	if err := limits.NewStore(pool).Upsert(ctx, user.ID, limits.Limits{
+		PlanCode: "pro", MaxAgents: 100, MaxDomains: 10,
+		MaxMessagesMonth: 1_000_000, MaxStorageBytes: 1 << 40,
+	}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	res = deliverExternal(t, api, user, ag, "footer row off")
+	if raw := acceptedRaw(t, store, res.MessageID); strings.Contains(raw, footerMarker) {
+		t.Fatalf("row-off account still got the footer:\n%s", raw)
+	}
+
+	// 3. Provisioner flips the row on (the Free-plan shape) → footer returns.
+	if _, err := pool.Exec(ctx, `UPDATE account_limits SET outbound_footer_enabled = TRUE WHERE user_id = $1`, user.ID); err != nil {
+		t.Fatalf("UPDATE: %v", err)
+	}
+	res = deliverExternal(t, api, user, ag, "footer row on")
+	if raw := acceptedRaw(t, store, res.MessageID); !strings.Contains(raw, footerMarker) {
+		t.Fatalf("row-on account missing the footer:\n%s", raw)
+	}
+
+	// 4. Non-standard account class never gets the footer, even entitled.
+	internalUser := *user
+	internalUser.AccountClass = "internal"
+	res = deliverExternal(t, api, &internalUser, ag, "footer internal class")
+	if raw := acceptedRaw(t, store, res.MessageID); strings.Contains(raw, footerMarker) {
+		t.Fatalf("internal-class account got the footer:\n%s", raw)
+	}
+
+	// 5. Config master switch off → no footer regardless of entitlement.
+	api.SetOutboundFooterEnabled(false)
+	res = deliverExternal(t, api, user, ag, "footer config off")
+	if raw := acceptedRaw(t, store, res.MessageID); strings.Contains(raw, footerMarker) {
+		t.Fatalf("config-off deployment appended the footer:\n%s", raw)
+	}
+}
+
+// TestDeliverOutboundFooterSelfSendNeverFootered: self-send loopback bypasses
+// Sender.compose entirely, so an entitled account's note-to-self carries no
+// footer — in either stored copy.
+func TestDeliverOutboundFooterSelfSendNeverFootered(t *testing.T) {
+	api, store, pool := setupFooterAPI(t)
+	ctx := context.Background()
+	user, ag := selfAgent(t, store, "footerself")
+	user.AccountClass = "standard"
+
+	res, oerr := api.DeliverOutbound(ctx, user, ag, outbound.SendRequest{
+		To: []string{ag.EmailAddress()}, Subject: "footer self send", Body: "note to self",
+	}, "send", "", nil, nil)
+	if oerr != nil {
+		t.Fatalf("DeliverOutbound: %v", oerr)
+	}
+	if res.Method != "loopback" {
+		t.Fatalf("method=%q want loopback", res.Method)
+	}
+	var footered int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM messages WHERE agent_id=$1
+		   AND (convert_from(COALESCE(raw_message, ''::bytea), 'UTF8') LIKE '%'||$2||'%'
+		     OR COALESCE(body_text, '') LIKE '%'||$2||'%')`,
+		ag.ID, footerMarker,
+	).Scan(&footered); err != nil {
+		t.Fatal(err)
+	}
+	if footered != 0 {
+		t.Errorf("%d self-send message rows carry the footer, want 0", footered)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -135,8 +135,10 @@ type OutboundFooterConfig struct {
 	Enabled bool `yaml:"enabled"`
 	// DefaultEnabled applies to accounts with NO account_limits row.
 	DefaultEnabled bool `yaml:"default_enabled"`
-	// Text is the plain-text footer, appended after a blank line + "--"
-	// separator. Empty = no text-part append.
+	// Text is the plain-text footer, appended after a blank line + the
+	// RFC 3676 signature separator ("-- " on its own line, trailing space
+	// included, so mail clients trim it when quoting a reply). Empty = no
+	// text-part append.
 	Text string `yaml:"text"`
 	// HTML is the HTML fragment appended to the HTML part when the message
 	// has one. Empty = no HTML-part append.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,7 @@ type Config struct {
 	RateLimits       RateLimitsConfig       `yaml:"rate_limits"`
 	Trash            TrashConfig            `yaml:"trash"`
 	Metrics          MetricsConfig          `yaml:"metrics"`
+	OutboundFooter   OutboundFooterConfig   `yaml:"outbound_footer"`
 	Env              string                 `yaml:"env"` // "development" or "production"
 	// SharedDomain enables slug-based agent registration. When set
 	// (e.g. "agents.example.com"), users can register agents with just a
@@ -114,6 +115,32 @@ type MetricsConfig struct {
 	// Build is the bounded release/image identifier attached to every sample.
 	// Override with E2A_METRICS_BUILD. Empty is exposed as "unknown".
 	Build string `yaml:"build"`
+}
+
+// OutboundFooterConfig controls an optional operator-configured footer
+// appended to all SMTP-egress outbound mail at composition time (before the
+// composed-size check, the MIME build, and DKIM signing, and above the managed
+// unsubscribe line). Fully inert when Enabled is false (the default) — zero
+// behavior change for existing deployments. Never applied to self-send
+// loopback delivery or to non-standard account classes (internal/system/demo).
+//
+// Per-account gating rides account_limits.outbound_footer_enabled: a present
+// row decides for itself; DefaultEnabled covers accounts with NO row. Text and
+// HTML are operator-trusted content (config, not user input) — the HTML
+// fragment is appended verbatim to the HTML part, so the operator owns its
+// escaping. Both empty with Enabled true = a no-op, not an error.
+type OutboundFooterConfig struct {
+	// Enabled is the master switch for the feature.
+	// Override with E2A_OUTBOUND_FOOTER_ENABLED.
+	Enabled bool `yaml:"enabled"`
+	// DefaultEnabled applies to accounts with NO account_limits row.
+	DefaultEnabled bool `yaml:"default_enabled"`
+	// Text is the plain-text footer, appended after a blank line + "--"
+	// separator. Empty = no text-part append.
+	Text string `yaml:"text"`
+	// HTML is the HTML fragment appended to the HTML part when the message
+	// has one. Empty = no HTML-part append.
+	HTML string `yaml:"html"`
 }
 
 type DatabaseConfig struct {
@@ -458,6 +485,11 @@ func Load(path string) (*Config, error) {
 	}
 	if v := os.Getenv("E2A_METRICS_BUILD"); v != "" {
 		cfg.Metrics.Build = v
+	}
+	if v := os.Getenv("E2A_OUTBOUND_FOOTER_ENABLED"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.OutboundFooter.Enabled = b
+		}
 	}
 	// An explicit empty listen_addr would otherwise bind ":80" (Go's
 	// default) — silently public and usually fatal. Empty means default.

--- a/internal/hitlworker/outbound_footer_test.go
+++ b/internal/hitlworker/outbound_footer_test.go
@@ -1,0 +1,135 @@
+package hitlworker_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/tokencanopy/e2a/internal/agent"
+	"github.com/tokencanopy/e2a/internal/config"
+	"github.com/tokencanopy/e2a/internal/hitlworker"
+	"github.com/tokencanopy/e2a/internal/identity"
+	"github.com/tokencanopy/e2a/internal/limits"
+	"github.com/tokencanopy/e2a/internal/outbound"
+	"github.com/tokencanopy/e2a/internal/testutil"
+	"github.com/tokencanopy/e2a/internal/usage"
+	"github.com/tokencanopy/e2a/internal/webhookpub"
+)
+
+const footerMarker = "Created with Example - https://example.com/footer"
+
+// TestWorkerAutoApproveAsync_AppendsOutboundFooter pins the TTL sweep's footer
+// resolution end to end THROUGH THE PRODUCTION WIRING: the worker's resolver
+// is agent.API.OutboundFooterForAccount (exactly what main wires), backed by a
+// real enforcer whose row-less default entitles the account. An
+// expires-to-approve hold must ship with the same footer a human approval
+// would have added — and a non-standard owner must not.
+func TestWorkerAutoApproveAsync_AppendsOutboundFooter(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	smtpRelay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{})
+	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
+	sender.SetOutboundFooter(footerMarker, `<p>Created with <a href="https://example.com/footer">Example</a></p>`)
+
+	api := agent.NewAPI(store, sender, smtpRelay, nil, usage.NewNoopUsageTracker(),
+		"e2a.dev", "test.e2a.dev", "agents.e2a.dev", "", false)
+	api.SetEnforcer(limits.NewEnforcer(limits.NewStore(pool), usage.NewStore(pool), limits.Defaults{
+		PlanCode: "default", MaxAgents: 100, MaxDomains: 10,
+		MaxMessagesMonth: 1_000_000, MaxStorageBytes: 1 << 40,
+		OutboundFooterEnabled: true, // outbound_footer.default_enabled
+	}, 0))
+	api.SetOutboundFooterEnabled(true)
+
+	w := hitlworker.New(store, sender, usage.NewUsageTracker(usage.NewStore(pool)), "test.e2a.dev")
+	w.SetOutbox(webhookpub.NewOutbox(pool, webhookpub.StaticFlag(true)))
+	w.SetOutboundEnqueuer(&fakeEnq{})
+	w.SetOutboundFooterResolver(api.OutboundFooterForAccount)
+
+	ctx := context.Background()
+	ag := prepareAgent(t, store, "approve-footer", identity.HITLExpirationApprove)
+
+	msg, err := store.CreatePendingOutboundMessage(ctx, ag.ID,
+		[]string{"alice@external.test"}, nil, nil,
+		"Held footered", "body", "<p>html</p>", nil, "send", "", "", "", 60)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backdateExpiry(t, pool, msg.ID)
+
+	w.RunOnce(ctx)
+
+	var status, raw string
+	if err := pool.QueryRow(ctx,
+		`SELECT status, convert_from(COALESCE(raw_message, ''::bytea), 'UTF8') FROM messages WHERE id=$1`, msg.ID,
+	).Scan(&status, &raw); err != nil {
+		t.Fatal(err)
+	}
+	if status != identity.MessageStatusReviewExpiredApproved {
+		t.Fatalf("status = %q, want %q", status, identity.MessageStatusReviewExpiredApproved)
+	}
+	if !strings.Contains(raw, footerMarker) {
+		t.Fatalf("TTL auto-approved mail missing the footer:\n%s", raw)
+	}
+
+	// Non-standard owner: same sweep, no footer.
+	if err := store.SetAccountClass(ctx, ag.UserID, "internal"); err != nil {
+		t.Fatal(err)
+	}
+	msg2, err := store.CreatePendingOutboundMessage(ctx, ag.ID,
+		[]string{"alice@external.test"}, nil, nil,
+		"Held internal owner", "body", "<p>html</p>", nil, "send", "", "", "", 60)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backdateExpiry(t, pool, msg2.ID)
+
+	w.RunOnce(ctx)
+
+	var raw2 string
+	if err := pool.QueryRow(ctx,
+		`SELECT convert_from(COALESCE(raw_message, ''::bytea), 'UTF8') FROM messages WHERE id=$1`, msg2.ID,
+	).Scan(&raw2); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(raw2, footerMarker) {
+		t.Fatalf("internal-class owner's auto-approved mail carries the footer:\n%s", raw2)
+	}
+}
+
+// TestWorkerAutoApproveAsync_NilFooterResolverNeverFooters pins the fail-closed
+// default: a worker without a resolver (self-host, feature off) appends nothing
+// even when the sender has footer content configured.
+func TestWorkerAutoApproveAsync_NilFooterResolverNeverFooters(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	smtpRelay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{})
+	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
+	sender.SetOutboundFooter(footerMarker, "")
+
+	w := hitlworker.New(store, sender, usage.NewUsageTracker(usage.NewStore(pool)), "test.e2a.dev")
+	w.SetOutbox(webhookpub.NewOutbox(pool, webhookpub.StaticFlag(true)))
+	w.SetOutboundEnqueuer(&fakeEnq{})
+	// No SetOutboundFooterResolver.
+
+	ctx := context.Background()
+	ag := prepareAgent(t, store, "approve-nofooter", identity.HITLExpirationApprove)
+	msg, err := store.CreatePendingOutboundMessage(ctx, ag.ID,
+		[]string{"alice@external.test"}, nil, nil,
+		"Held unfootered", "body", "", nil, "send", "", "", "", 60)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backdateExpiry(t, pool, msg.ID)
+
+	w.RunOnce(ctx)
+
+	var raw string
+	if err := pool.QueryRow(ctx,
+		`SELECT convert_from(COALESCE(raw_message, ''::bytea), 'UTF8') FROM messages WHERE id=$1`, msg.ID,
+	).Scan(&raw); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(raw, footerMarker) {
+		t.Fatalf("nil resolver must never footer:\n%s", raw)
+	}
+}

--- a/internal/hitlworker/worker.go
+++ b/internal/hitlworker/worker.go
@@ -76,6 +76,14 @@ type Worker struct {
 	outboundEnq       OutboundEnqueuer
 	unsubscribeIssuer ManagedUnsubscribeIssuer
 	wsHub             WebSocketHub
+	// footerResolver decides whether a TTL-auto-approved external send carries
+	// the operator-configured outbound footer (SendRequest.AppendOutboundFooter).
+	// Held rows do not persist the flag — every approval funnel resolves it at
+	// compose time — so the sweep needs the same per-account decision the human
+	// approve paths use (main wires agent.API.OutboundFooterForAccount).
+	// Optional and fail-closed: nil (self-host default, feature off) means the
+	// sweep never appends a footer.
+	footerResolver func(ctx context.Context, userID string) bool
 	// inboundScreen runs the agent's inbound protection over the loopback
 	// inbound leg of a TTL-auto-approved self-send — the same engine
 	// construction (heuristics + optional Gemini) the relay uses for SMTP
@@ -100,6 +108,12 @@ func (w *Worker) SetOutboundEnqueuer(e OutboundEnqueuer) { w.outboundEnq = e }
 
 func (w *Worker) SetManagedUnsubscribeIssuer(i ManagedUnsubscribeIssuer) { w.unsubscribeIssuer = i }
 func (w *Worker) SetWebSocketHub(h WebSocketHub)                         { w.wsHub = h }
+
+// SetOutboundFooterResolver wires the per-account outbound-footer decision for
+// TTL auto-approved sends. See the footerResolver field for semantics.
+func (w *Worker) SetOutboundFooterResolver(r func(ctx context.Context, userID string) bool) {
+	w.footerResolver = r
+}
 
 // New constructs a Worker. fromDomain is the deployment's outbound
 // from-domain (cfg.OutboundSMTP.FromDomain) — used by the self-send
@@ -320,6 +334,15 @@ func (w *Worker) autoApproveAsync(ctx context.Context, agent *identity.AgentIden
 	if isPlatformTest {
 		comp, err = w.sender.ComposePlatformForAccept(req)
 	} else {
+		// Outbound footer: TTL auto-approval composes here, so the footer
+		// decision is resolved here — the same approval-time semantics as the
+		// human approve funnel (internal/agent approveOutboundAsyncComposed).
+		// Without this, an expires-to-approve hold would ship unfootered while
+		// the identical hold approved by a human a minute earlier would not.
+		// Fail-closed: nil resolver (feature off / self-host) = no footer.
+		if w.footerResolver != nil {
+			req.AppendOutboundFooter = w.footerResolver(ctx, agent.UserID)
+		}
 		comp, err = w.sender.ComposeForAccept(agent, req)
 	}
 	if err != nil {

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -5296,10 +5296,10 @@ func (s *Store) CreateUserSession(ctx context.Context, userID string) (string, e
 func (s *Store) GetUserSession(ctx context.Context, token string) (*User, error) {
 	u := &User{}
 	err := s.pool.QueryRow(ctx,
-		`SELECT u.id, u.email, u.name, u.google_subject, u.created_at
+		`SELECT u.id, u.email, u.name, u.google_subject, u.created_at, u.account_class
 		 FROM user_sessions s JOIN users u ON s.user_id = u.id
 		 WHERE s.token = $1 AND s.expires_at > now()`, token,
-	).Scan(&u.ID, &u.Email, &u.Name, &u.GoogleSubject, &u.CreatedAt)
+	).Scan(&u.ID, &u.Email, &u.Name, &u.GoogleSubject, &u.CreatedAt, &u.AccountClass)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -5251,8 +5251,8 @@ func (s *Store) ProvisionUser(ctx context.Context, externalRef, email, name stri
 func (s *Store) GetUserByID(ctx context.Context, id string) (*User, error) {
 	u := &User{}
 	err := s.pool.QueryRow(ctx,
-		`SELECT id, email, name, google_subject, created_at FROM users WHERE id = $1`, id,
-	).Scan(&u.ID, &u.Email, &u.Name, &u.GoogleSubject, &u.CreatedAt)
+		`SELECT id, email, name, google_subject, created_at, account_class FROM users WHERE id = $1`, id,
+	).Scan(&u.ID, &u.Email, &u.Name, &u.GoogleSubject, &u.CreatedAt, &u.AccountClass)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/limits/enforcer.go
+++ b/internal/limits/enforcer.go
@@ -120,11 +120,12 @@ func (e *DBEnforcer) Get(ctx context.Context, userID string) (Limits, error) {
 		resolved = row
 	} else {
 		resolved = Limits{
-			PlanCode:         e.defaults.PlanCode,
-			MaxAgents:        e.defaults.MaxAgents,
-			MaxDomains:       e.defaults.MaxDomains,
-			MaxMessagesMonth: e.defaults.MaxMessagesMonth,
-			MaxStorageBytes:  e.defaults.MaxStorageBytes,
+			PlanCode:              e.defaults.PlanCode,
+			MaxAgents:             e.defaults.MaxAgents,
+			MaxDomains:            e.defaults.MaxDomains,
+			MaxMessagesMonth:      e.defaults.MaxMessagesMonth,
+			MaxStorageBytes:       e.defaults.MaxStorageBytes,
+			OutboundFooterEnabled: e.defaults.OutboundFooterEnabled,
 		}
 	}
 	e.cachePut(userID, resolved, gen)

--- a/internal/limits/integration_test.go
+++ b/internal/limits/integration_test.go
@@ -156,6 +156,44 @@ func TestUpsert_PreservesColumnsOutsideSetList_RealDB(t *testing.T) {
 	}
 }
 
+// TestStoreGet_OutboundFooterColumn_RealDB pins the migration-095 column read:
+// a fresh row carries the column default FALSE; an external provisioner
+// flipping it to TRUE is visible through Store.Get. (Upsert deliberately does
+// NOT include the column in its SET list — the preserve-on-conflict test above
+// covers that class of column.)
+func TestStoreGet_OutboundFooterColumn_RealDB(t *testing.T) {
+	pool, _, _, _, userID := setupLimitsUser(t, "footercol")
+	ctx := context.Background()
+	limitsStore := limits.NewStore(pool)
+
+	if err := limitsStore.Upsert(ctx, userID, limits.Limits{
+		PlanCode: "free", MaxAgents: 1, MaxDomains: 1,
+		MaxMessagesMonth: 100, MaxStorageBytes: 1 << 20,
+	}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	got, found, err := limitsStore.Get(ctx, userID)
+	if err != nil || !found {
+		t.Fatalf("Get: err=%v found=%v", err, found)
+	}
+	if got.OutboundFooterEnabled {
+		t.Error("fresh row OutboundFooterEnabled = true, want column default false")
+	}
+
+	if _, err := pool.Exec(ctx,
+		`UPDATE account_limits SET outbound_footer_enabled = TRUE WHERE user_id = $1`, userID,
+	); err != nil {
+		t.Fatalf("UPDATE: %v", err)
+	}
+	got, found, err = limitsStore.Get(ctx, userID)
+	if err != nil || !found {
+		t.Fatalf("Get (after flip): err=%v found=%v", err, found)
+	}
+	if !got.OutboundFooterEnabled {
+		t.Error("OutboundFooterEnabled = false after provisioner flip, want true")
+	}
+}
+
 func TestEnforcer_BlocksAtAgentCap_RealDB(t *testing.T) {
 	pool, idStore, usageStore, _, userID := setupLimitsUser(t, "agentcap")
 	ctx := context.Background()

--- a/internal/limits/limits.go
+++ b/internal/limits/limits.go
@@ -27,6 +27,14 @@ type Limits struct {
 	MaxMessagesMonth int    `json:"max_messages_month"`
 	MaxStorageBytes  int64  `json:"max_storage_bytes"`
 	UpgradeURL       string `json:"upgrade_url"`
+	// OutboundFooterEnabled is a feature entitlement, not a cap: whether
+	// outbound mail from this account carries the operator-configured
+	// footer (config `outbound_footer:` block; the feature's master switch
+	// lives there, not here). Like PlanCode, the semantics of who gets the
+	// footer are owned by whatever provisions the row. Excluded from JSON
+	// so the public limits payloads (GET /v1/account, the 402 envelope)
+	// are unchanged.
+	OutboundFooterEnabled bool `json:"-"`
 }
 
 // Defaults is the operator-configured fallback applied when a user has
@@ -38,6 +46,9 @@ type Defaults struct {
 	MaxDomains       int
 	MaxMessagesMonth int
 	MaxStorageBytes  int64
+	// OutboundFooterEnabled is the row-less fallback for the outbound
+	// footer entitlement, wired from `outbound_footer.default_enabled`.
+	OutboundFooterEnabled bool
 }
 
 // Enforcer is the interface that handlers call. Implementations must be

--- a/internal/limits/limits_test.go
+++ b/internal/limits/limits_test.go
@@ -139,6 +139,47 @@ func TestEnforcer_GetReturnsRowWhenPresent(t *testing.T) {
 	}
 }
 
+// TestEnforcer_OutboundFooterRowVsDefault pins the outbound-footer
+// entitlement's resolution contract: a present row decides for itself
+// (its value wins in BOTH directions), a missing row falls back to
+// Defaults.OutboundFooterEnabled (wired from outbound_footer.default_enabled).
+func TestEnforcer_OutboundFooterRowVsDefault(t *testing.T) {
+	defaults := defaultsForTest()
+	defaults.OutboundFooterEnabled = true
+
+	cases := []struct {
+		name  string
+		store *fakeStore
+		want  bool
+	}{
+		{"no_row_uses_default", &fakeStore{found: false}, true},
+		{"row_false_overrides_true_default", &fakeStore{found: true, row: Limits{PlanCode: "pro", MaxAgents: 1, MaxDomains: 1, MaxMessagesMonth: 1, MaxStorageBytes: 1, OutboundFooterEnabled: false}}, false},
+		{"row_true_wins", &fakeStore{found: true, row: Limits{PlanCode: "free", MaxAgents: 1, MaxDomains: 1, MaxMessagesMonth: 1, MaxStorageBytes: 1, OutboundFooterEnabled: true}}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := newEnforcerWithReader(tc.store, &fakeCounter{}, defaults, 0)
+			got, err := e.Get(context.Background(), "user1")
+			if err != nil {
+				t.Fatalf("Get: %v", err)
+			}
+			if got.OutboundFooterEnabled != tc.want {
+				t.Errorf("OutboundFooterEnabled = %v, want %v", got.OutboundFooterEnabled, tc.want)
+			}
+		})
+	}
+
+	// Default false + no row stays false (self-host inert default).
+	e := newEnforcerWithReader(&fakeStore{found: false}, &fakeCounter{}, defaultsForTest(), 0)
+	got, err := e.Get(context.Background(), "user1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.OutboundFooterEnabled {
+		t.Error("zero-value default must resolve to false for row-less users")
+	}
+}
+
 func TestEnforcer_GetPropagatesStoreError(t *testing.T) {
 	sentinel := errors.New("db down")
 	store := &fakeStore{err: sentinel}

--- a/internal/limits/store.go
+++ b/internal/limits/store.go
@@ -27,9 +27,9 @@ func NewStore(pool *pgxpool.Pool) *Store {
 func (s *Store) Get(ctx context.Context, userID string) (Limits, bool, error) {
 	l := Limits{}
 	err := s.pool.QueryRow(ctx,
-		`SELECT plan_code, max_agents, max_domains, max_messages_month, max_storage_bytes, upgrade_url
+		`SELECT plan_code, max_agents, max_domains, max_messages_month, max_storage_bytes, upgrade_url, outbound_footer_enabled
 		   FROM account_limits WHERE user_id = $1`, userID,
-	).Scan(&l.PlanCode, &l.MaxAgents, &l.MaxDomains, &l.MaxMessagesMonth, &l.MaxStorageBytes, &l.UpgradeURL)
+	).Scan(&l.PlanCode, &l.MaxAgents, &l.MaxDomains, &l.MaxMessagesMonth, &l.MaxStorageBytes, &l.UpgradeURL, &l.OutboundFooterEnabled)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return Limits{}, false, nil

--- a/internal/outbound/outbound_footer_test.go
+++ b/internal/outbound/outbound_footer_test.go
@@ -170,6 +170,11 @@ func TestComposeOutboundFooterTextOnlySendSkipsHTMLFragment(t *testing.T) {
 	if strings.Contains(raw, "<a href") {
 		t.Fatalf("text-only send must not gain an HTML part:\n%s", raw)
 	}
+	// RFC 3676 signature separator: dash-dash-SPACE-newline, so mail clients
+	// trim the footer when quoting a reply. The trailing space is the point.
+	if !strings.Contains(raw, "-- \nCreated with") && !strings.Contains(raw, "-- \r\nCreated with") {
+		t.Fatalf("footer must follow the RFC 3676 %q separator:\n%q", "-- \\n", raw)
+	}
 }
 
 // TestComposeOutboundFooterRejectsPostFooterComposedSize: the composed-size
@@ -249,7 +254,9 @@ func TestComposeOutboundFooterIsDKIMSigned(t *testing.T) {
 }
 
 // TestComposeOutboundFooterForAcceptMatchesSyncComposeBytes: the async/sync
-// stored-bytes invariant holds with the footer applied.
+// stored-bytes invariant holds with the footer applied — ComposeForAccept
+// returns byte-identical Sent-folder bytes to the sync compose path (the same
+// contract TestComposeForAccept_MatchesSyncComposeBytes pins footer-free).
 func TestComposeOutboundFooterForAcceptMatchesSyncComposeBytes(t *testing.T) {
 	s := footerSender()
 	req := SendRequest{To: []string{"user@example.net"}, Subject: "hi", Body: "plain body", AppendOutboundFooter: true}
@@ -261,7 +268,10 @@ func TestComposeOutboundFooterForAcceptMatchesSyncComposeBytes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !bytes.Contains(c.sentBody, []byte("Created with")) || !bytes.Contains(cr.Raw, []byte("Created with")) {
-		t.Fatal("both paths must carry the footer")
+	if !bytes.Equal(cr.Raw, c.sentBody) {
+		t.Errorf("ComposeForAccept.Raw (%d B) != compose().sentBody (%d B) — async/sync stored-bytes drift with the footer on", len(cr.Raw), len(c.sentBody))
+	}
+	if !bytes.Contains(cr.Raw, []byte("Created with")) {
+		t.Fatal("compared bytes do not carry the footer — the equality above would be vacuous")
 	}
 }

--- a/internal/outbound/outbound_footer_test.go
+++ b/internal/outbound/outbound_footer_test.go
@@ -1,0 +1,267 @@
+package outbound
+
+import (
+	"bytes"
+	"context"
+	"net/mail"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/tokencanopy/e2a/internal/dkim"
+	"github.com/tokencanopy/e2a/internal/identity"
+)
+
+// The footer content deliberately avoids '=' (quoted-printable escapes it)
+// so raw-substring assertions stay robust against body encoding.
+const (
+	testFooterText = "Created with Example, email for AI agents - https://example.com/footer"
+	testFooterHTML = `<p>Created with <a href="https://example.com/footer">Example</a></p>`
+)
+
+func footerSender() *Sender {
+	s := NewSender(nil, "send.example.com")
+	s.SetOutboundFooter(testFooterText, testFooterHTML)
+	return s
+}
+
+func footerAgent() *identity.AgentIdentity {
+	return &identity.AgentIdentity{ID: "bot@example.com", Email: "bot@example.com", Domain: "example.com"}
+}
+
+// TestComposeOutboundFooterAppendsToBothParts: the flag appends the text
+// footer to the text part and the HTML fragment to the HTML part; without the
+// flag the composed bytes are footer-free.
+func TestComposeOutboundFooterAppendsToBothParts(t *testing.T) {
+	s := footerSender()
+	req := SendRequest{To: []string{"user@example.net"}, Subject: "hi", Body: "plain body", HTMLBody: "<p>html body</p>"}
+
+	req.AppendOutboundFooter = true
+	on, err := s.ComposeForAccept(footerAgent(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Count(string(on.Raw), "Created with"); got != 2 {
+		t.Fatalf("footer occurrences = %d, want 2 (text + html part):\n%s", got, on.Raw)
+	}
+	if !strings.Contains(string(on.Raw), `href="https://example.com/footer"`) {
+		t.Fatalf("HTML fragment missing from HTML part:\n%s", on.Raw)
+	}
+
+	req.AppendOutboundFooter = false
+	off, err := s.ComposeForAccept(footerAgent(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(off.Raw), "Created with") {
+		t.Fatalf("flag off must not append the footer:\n%s", off.Raw)
+	}
+}
+
+// TestComposeOutboundFooterEmptyContentIsNoOp: enabled flag with no configured
+// content must compose byte-identically to the flag-off message — never error.
+func TestComposeOutboundFooterEmptyContentIsNoOp(t *testing.T) {
+	s := NewSender(nil, "send.example.com") // no SetOutboundFooter
+	req := SendRequest{To: []string{"user@example.net"}, Subject: "hi", Body: "plain body", HTMLBody: "<p>html body</p>"}
+
+	req.AppendOutboundFooter = true
+	on, err := s.ComposeForAccept(footerAgent(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.AppendOutboundFooter = false
+	off, err := s.ComposeForAccept(footerAgent(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Strip the per-compose Date/Message-ID variance by comparing bodies only.
+	onBody := string(on.Raw[strings.Index(string(on.Raw), "\r\n\r\n"):])
+	offBody := string(off.Raw[strings.Index(string(off.Raw), "\r\n\r\n"):])
+	// Multipart boundaries are random per compose; compare after removing them.
+	if stripBoundaries(onBody) != stripBoundaries(offBody) {
+		t.Fatalf("empty footer content must be a byte-level no-op:\non=%q\noff=%q", onBody, offBody)
+	}
+}
+
+var boundaryRe = regexp.MustCompile(`[A-Za-z0-9+/=_-]{16,}`)
+
+func stripBoundaries(s string) string { return boundaryRe.ReplaceAllString(s, "") }
+
+// TestComposeOutboundFooterOrderingAboveUnsubscribe: when both footers apply,
+// the branding footer sits ABOVE the managed-unsubscribe line in both parts —
+// the unsubscribe line keeps its compliance position as the last body content.
+func TestComposeOutboundFooterOrderingAboveUnsubscribe(t *testing.T) {
+	s := footerSender()
+	got, err := s.ComposeForAccept(footerAgent(), SendRequest{
+		To: []string{"user@example.net"}, Subject: "hi", Body: "plain body", HTMLBody: "<p>html body</p>",
+		Unsubscribe:          &UnsubscribeOptions{Mode: "managed", URL: "https://api.example.com/u/u1_token"},
+		AppendOutboundFooter: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw := string(got.Raw)
+	const unsub = "Unsubscribe from emails sent by"
+	if strings.Count(raw, "Created with") != 2 || strings.Count(raw, unsub) != 2 {
+		t.Fatalf("expected both footers in both parts:\n%s", raw)
+	}
+	// Text part: first occurrences; HTML part: last occurrences.
+	if strings.Index(raw, "Created with") > strings.Index(raw, unsub) {
+		t.Errorf("text part: branding footer must precede the unsubscribe line:\n%s", raw)
+	}
+	if strings.LastIndex(raw, "Created with") > strings.LastIndex(raw, unsub) {
+		t.Errorf("html part: branding footer must precede the unsubscribe line:\n%s", raw)
+	}
+}
+
+// TestComposeOutboundFooterWithAttachments: the attachments MIME shape gets the
+// footer in both alternative parts too.
+func TestComposeOutboundFooterWithAttachments(t *testing.T) {
+	s := footerSender()
+	got, err := s.ComposeForAccept(footerAgent(), SendRequest{
+		To: []string{"user@example.net"}, Subject: "hi", Body: "plain body", HTMLBody: "<p>html body</p>",
+		Attachments:          []Attachment{{Filename: "note.txt", ContentType: "text/plain", Data: "aGk="}},
+		AppendOutboundFooter: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw := string(got.Raw)
+	if strings.Count(raw, "Created with") != 2 {
+		t.Fatalf("footer occurrences = %d, want 2 in the attachment shape:\n%s", strings.Count(raw, "Created with"), raw)
+	}
+	if !strings.Contains(raw, `filename="note.txt"`) {
+		t.Fatalf("attachment lost:\n%s", raw)
+	}
+}
+
+// TestComposeOutboundFooterHTMLOnlySend: an HTML-only send (empty text body)
+// still gets the text footer in its (otherwise empty) text part, plus the HTML
+// fragment — disclosure stays visible to text-part readers.
+func TestComposeOutboundFooterHTMLOnlySend(t *testing.T) {
+	s := footerSender()
+	got, err := s.ComposeForAccept(footerAgent(), SendRequest{
+		To: []string{"user@example.net"}, Subject: "hi", HTMLBody: "<p>html only</p>",
+		AppendOutboundFooter: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(string(got.Raw), "Created with") != 2 {
+		t.Fatalf("HTML-only send must carry the footer in both parts:\n%s", got.Raw)
+	}
+}
+
+// TestComposeOutboundFooterTextOnlySendSkipsHTMLFragment: a text-only send
+// must not grow an HTML part just to carry the HTML fragment.
+func TestComposeOutboundFooterTextOnlySendSkipsHTMLFragment(t *testing.T) {
+	s := footerSender()
+	got, err := s.ComposeForAccept(footerAgent(), SendRequest{
+		To: []string{"user@example.net"}, Subject: "hi", Body: "plain body",
+		AppendOutboundFooter: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw := string(got.Raw)
+	if strings.Count(raw, "Created with") != 1 {
+		t.Fatalf("text-only send footer occurrences = %d, want 1:\n%s", strings.Count(raw, "Created with"), raw)
+	}
+	if strings.Contains(raw, "<a href") {
+		t.Fatalf("text-only send must not gain an HTML part:\n%s", raw)
+	}
+}
+
+// TestComposeOutboundFooterRejectsPostFooterComposedSize: the composed-size
+// ceiling is checked AFTER the footer append (same contract as the
+// managed-unsubscribe footer) — a message that only fits without the footer
+// is rejected.
+func TestComposeOutboundFooterRejectsPostFooterComposedSize(t *testing.T) {
+	s := footerSender()
+	subject := "s"
+	req := SendRequest{
+		To: []string{"user@example.net"}, Subject: subject,
+		Body:                 strings.Repeat("x", MaxComposedMessageBytes-len(subject)),
+		AppendOutboundFooter: true,
+	}
+	if before := ComposedSize(req.Subject, req.Body, req.HTMLBody, req.Attachments); before != MaxComposedMessageBytes {
+		t.Fatalf("pre-footer size=%d, want %d", before, MaxComposedMessageBytes)
+	}
+	if _, err := s.ComposeForAccept(footerAgent(), req); !IsComposedSizeError(err) {
+		t.Fatalf("error=%T %v, want composed-size error", err, err)
+	}
+	// Same message without the flag stays accepted — the rejection above is
+	// attributable to the footer bytes alone.
+	req.AppendOutboundFooter = false
+	if _, err := s.ComposeForAccept(footerAgent(), req); err != nil {
+		t.Fatalf("flag-off message at cap rejected: %v", err)
+	}
+}
+
+// TestComposeOutboundFooterIsDKIMSigned: the footer is appended before DKIM
+// signing, so the signed body hash (bh=) covers it — proven by the hash
+// changing when the footer is toggled on an otherwise identical message.
+func TestComposeOutboundFooterIsDKIMSigned(t *testing.T) {
+	keypair, err := dkim.GenerateKeypair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	lookup := &fakeDKIMLookup{get: func(_ context.Context, _ string) (string, []byte, error) {
+		return keypair.Selector, keypair.PrivateKeyDER, nil
+	}}
+	s := NewSenderWithDKIM(nil, "example.com", lookup)
+	s.SetOutboundFooter(testFooterText, testFooterHTML)
+	req := SendRequest{To: []string{"user@example.net"}, Subject: "hi", Body: "plain body"}
+
+	bodyHash := func(t *testing.T, raw []byte) string {
+		t.Helper()
+		m, err := mail.ReadMessage(bytes.NewReader(raw))
+		if err != nil {
+			t.Fatal(err)
+		}
+		sig := m.Header.Get("DKIM-Signature")
+		if sig == "" {
+			t.Fatalf("message is not DKIM-signed:\n%s", raw)
+		}
+		match := regexp.MustCompile(`bh=([^;]+)`).FindStringSubmatch(sig)
+		if match == nil {
+			t.Fatalf("DKIM-Signature missing bh=: %q", sig)
+		}
+		return match[1]
+	}
+
+	req.AppendOutboundFooter = true
+	on, err := s.ComposeForAccept(footerAgent(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(on.Raw), "Created with") {
+		t.Fatalf("signed message lost the footer:\n%s", on.Raw)
+	}
+	req.AppendOutboundFooter = false
+	off, err := s.ComposeForAccept(footerAgent(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bodyHash(t, on.Raw) == bodyHash(t, off.Raw) {
+		t.Error("DKIM bh= identical with and without the footer — the signature does not cover the footer bytes")
+	}
+}
+
+// TestComposeOutboundFooterForAcceptMatchesSyncComposeBytes: the async/sync
+// stored-bytes invariant holds with the footer applied.
+func TestComposeOutboundFooterForAcceptMatchesSyncComposeBytes(t *testing.T) {
+	s := footerSender()
+	req := SendRequest{To: []string{"user@example.net"}, Subject: "hi", Body: "plain body", AppendOutboundFooter: true}
+	c, err := s.compose(footerAgent(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cr, err := s.ComposeForAccept(footerAgent(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(c.sentBody, []byte("Created with")) || !bytes.Contains(cr.Raw, []byte("Created with")) {
+		t.Fatal("both paths must carry the footer")
+	}
+}

--- a/internal/outbound/sender.go
+++ b/internal/outbound/sender.go
@@ -27,9 +27,13 @@ import (
 // part. Both fragments are operator-trusted config, not user input — the
 // HTML is appended verbatim, so the operator owns its escaping. Empty
 // text+html = no-op.
+//
+// The text separator is the RFC 3676 signature delimiter "-- \n"
+// (dash-dash-SPACE-newline) — the convention mail clients recognize to trim
+// signatures when quoting a reply. The trailing space is load-bearing.
 func appendOutboundFooter(textBody, htmlBody, text, htmlFragment string) (string, string) {
 	if text != "" {
-		textBody += "\n\n--\n" + text
+		textBody += "\n\n-- \n" + text
 	}
 	if htmlBody != "" && htmlFragment != "" {
 		htmlBody += htmlFragment

--- a/internal/outbound/sender.go
+++ b/internal/outbound/sender.go
@@ -16,6 +16,27 @@ import (
 	"github.com/tokencanopy/e2a/internal/mailfrom"
 )
 
+// appendOutboundFooter appends the operator-configured branding/disclosure
+// footer (config `outbound_footer:` block) to both body parts. Called BEFORE
+// appendUnsubscribeFooter so the unsubscribe line keeps its compliance
+// position as the last body content, and before the composed-size check and
+// the MIME build / DKIM signing — the footer is inside the signed,
+// size-capped bytes. The text footer is appended even when the text body is
+// empty (HTML-only sends), keeping the disclosure visible to text-part
+// readers; the HTML fragment is appended only when the message has an HTML
+// part. Both fragments are operator-trusted config, not user input — the
+// HTML is appended verbatim, so the operator owns its escaping. Empty
+// text+html = no-op.
+func appendOutboundFooter(textBody, htmlBody, text, htmlFragment string) (string, string) {
+	if text != "" {
+		textBody += "\n\n--\n" + text
+	}
+	if htmlBody != "" && htmlFragment != "" {
+		htmlBody += htmlFragment
+	}
+	return textBody, htmlBody
+}
+
 func appendUnsubscribeFooter(textBody, htmlBody, agentAddress, link string) (string, string) {
 	textBody += "\n\nUnsubscribe from emails sent by " + agentAddress + ": " + link
 	if htmlBody != "" {
@@ -79,6 +100,13 @@ type SendRequest struct {
 	ConversationID   string              `json:"conversation_id,omitempty"`
 	Attachments      []Attachment        `json:"attachments,omitempty"`
 	Unsubscribe      *UnsubscribeOptions `json:"unsubscribe,omitempty"`
+	// AppendOutboundFooter, when true, makes compose append the
+	// operator-configured outbound footer (Sender.SetOutboundFooter) to the
+	// message body, above any managed-unsubscribe line. Resolved server-side
+	// by the agent layer (per-account entitlement + account class + config
+	// master switch) — never caller-supplied, never part of the wire API
+	// contract.
+	AppendOutboundFooter bool `json:"-"`
 	// ScheduledAt, when non-nil, defers this send to a future instant: the
 	// message is accepted + queued immediately (delivery_status='accepted'), but
 	// its River outbound_send job is held until this time. Nil means send now.
@@ -160,6 +188,21 @@ type Sender struct {
 	// SES publishes delivery/bounce/complaint events (decision 9 / Slice 4b).
 	// Empty (the default) = no header, no events — dev/self-host without SES.
 	sesConfigSet string
+	// footerText / footerHTML are the operator-configured outbound-footer
+	// fragments (config outbound_footer.text / .html), appended by compose
+	// only when the request carries AppendOutboundFooter. Both empty (the
+	// default) makes the append a no-op.
+	footerText string
+	footerHTML string
+}
+
+// SetOutboundFooter configures the operator-defined footer content appended
+// when a SendRequest carries AppendOutboundFooter. Optional-setter pattern
+// (cf. SetSendingStatusLookup) so existing call sites and tests are
+// unaffected; empty text+html leaves the append a no-op.
+func (s *Sender) SetOutboundFooter(text, html string) {
+	s.footerText = text
+	s.footerHTML = html
 }
 
 // SetSESConfigurationSet enables SES event publishing for outbound mail by
@@ -366,6 +409,13 @@ func (s *Sender) compose(agent *identity.AgentIdentity, req SendRequest) (*compo
 	to, cc, bcc, envelope, err := NormalizeRecipients(agent, s.fromDomain, req)
 	if err != nil {
 		return nil, err
+	}
+	// Operator-configured outbound footer — appended strictly before the
+	// unsubscribe footer (compliance: the unsubscribe line stays last) and
+	// therefore before the composed-size check and the MIME build / DKIM
+	// signing below.
+	if req.AppendOutboundFooter {
+		req.Body, req.HTMLBody = appendOutboundFooter(req.Body, req.HTMLBody, s.footerText, s.footerHTML)
 	}
 	if req.Unsubscribe != nil {
 		if req.Unsubscribe.Mode != "managed" || req.Unsubscribe.URL == "" {

--- a/migrations/095_account_limits_outbound_footer.sql
+++ b/migrations/095_account_limits_outbound_footer.sql
@@ -1,0 +1,21 @@
+-- 095_account_limits_outbound_footer.sql
+--
+-- Per-account entitlement for the operator-configured outbound footer
+-- (config `outbound_footer:` block): when the deployment enables the
+-- feature, an account WITH a row gets the footer appended to its
+-- SMTP-egress outbound mail only when this column is true; accounts with
+-- NO row fall back to `outbound_footer.default_enabled` in config —
+-- exactly the existing account_limits row-vs-defaults contract (016).
+--
+-- Like plan_code, the semantics of who gets the footer are opaque to the
+-- OSS server: whatever provisions the row (the hosted billing sidecar,
+-- admin tooling, manual SQL) writes this column; the OSS server only
+-- reads it at send time. Default FALSE keeps self-host deployments and
+-- every existing row byte-for-byte unchanged.
+--
+-- ALTER TABLE ... ADD COLUMN ... DEFAULT FALSE is metadata-only on
+-- Postgres 11+ (constant default). Safe on the small account_limits
+-- table regardless. Idempotent via IF NOT EXISTS.
+
+ALTER TABLE account_limits
+    ADD COLUMN IF NOT EXISTS outbound_footer_enabled BOOLEAN NOT NULL DEFAULT FALSE;


### PR DESCRIPTION
## What / why

OSS half of the outbound branding footer feature (hosted: Free-tier mail carries a small "Created with e2a" footer; paid plans don't — the removal doubles as the upgrade nudge). The OSS mechanism is deliberately general and **fully inert by default**: an operator-configured footer (`outbound_footer:` config block) appended to SMTP-egress outbound mail, gated per account through the existing limits machinery. Self-hosters can use it for e.g. AI-disclosure footers; a deployment that doesn't set the block sees zero behavior change.

The hosted gating (plan catalog `BrandingFooter`, sidecar limits writer, `config.prod.yaml` / `config.staging.yaml` copy, pricing-page note) lands separately in e2a-ops.

## Mechanism

- **Config** (`internal/config`): new optional `outbound_footer:` block — `enabled` (master switch, `E2A_OUTBOUND_FOOTER_ENABLED` override per the `E2A_METRICS_ENABLED` precedent), `default_enabled` (row-less fallback), `text`, `html`. Commented block added to `config.example.yaml`.
- **Schema**: migration `095_account_limits_outbound_footer.sql` — `outbound_footer_enabled BOOLEAN NOT NULL DEFAULT FALSE` on `account_limits`, written by external provisioners exactly like `plan_code` (016/024 typed-column pattern).
- **Limits read path**: `limits.Limits.OutboundFooterEnabled` (JSON-excluded — the public `GET /v1/account` and 402 payloads are unchanged) + `Defaults.OutboundFooterEnabled` wired from `default_enabled`. `Store.Get` already returns a found-bool, so the enforcer's existing row-vs-defaults resolution gives "row present → row value, row absent → config default" with the cache + invalidate flow untouched.
- **Gating** (`internal/agent`): `resolveOutboundFooter` = `cfg.enabled && resolvedEntitlement && account_class == standard`, fail-closed on any limits/user read error (a missing footer is a lost impression; a wrongly-added footer on paid mail is a customer-facing bug). Resolved at every compose site (see "Compose sites" below), stamped on the request as a wire-invisible `SendRequest.AppendOutboundFooter`; non-standard classes (internal/system/demo — probers, monitors, conformance) never get it, so body-asserting gates stay green.
- **Append point** (`internal/outbound`): `appendOutboundFooter` runs in `compose` **before** `appendUnsubscribeFooter` (the unsubscribe line keeps its compliance position as last body content), therefore before the composed-size check and the MIME build / DKIM signing. Text part gets the footer after a blank line + the **RFC 3676 signature separator** `"-- \n"` (dash-dash-SPACE-newline — the convention clients recognize to trim signatures on reply; the trailing space is load-bearing and test-asserted). Applied always, incl. empty-body HTML-only sends; the HTML fragment is appended only when the message has an HTML part. Empty content with the feature on is a no-op, never an error. Content reaches the Sender via `SetOutboundFooter` (optional-setter pattern).

## Compose sites (all three covered)

Held mail composes at approval time and the flag is not persisted on the held row, so every composer resolves the decision itself:

1. **Accept path** — `DeliverOutbound`, strictly after the self-send branch (loopback never runs `Sender.compose`).
2. **Human approval funnel** — `approveOutboundAsyncComposed` (shared by dashboard `ApprovePendingCore` and the magic-link path), via the owning account's DB user.
3. **TTL auto-approve** — the `hitlworker` sweep (`hitl_expiration_action='approve'`) takes an injected fail-closed resolver (`SetOutboundFooterResolver`); main wires `agent.API.OutboundFooterForAccount`, the same decision the human funnel uses. *This third site was missed in the first revision (flagged by both reviewers) — an expires-to-approve hold would have shipped unfootered while the identical human-approved hold was footered.*

## YAML decode strictness (rollout-ordering question)

**The config decode is LENIENT.** `internal/config.Load` uses `gopkg.in/yaml.v3`'s plain `yaml.Unmarshal` — no `Decoder.KnownFields(true)` — so unknown top-level keys are silently ignored. An `outbound_footer:` block reaching a server that predates this change is harmless (ignored), i.e. the hosted rollout is not hard-blocked on ordering. The design's release-before-config ordering still applies for the feature to actually work.

## ⚠️ Declared behavior change: rate-limit exemption scope

`GetUserByID` and `GetUserSession` now load `account_class` (previously only the API-key auth path did). Besides the footer gating, this field feeds the poll/agent-create rate-limiter exemptions (`internal/httpapi/ratelimit.go`) through `principalFromOAuthToken`, the agent-JWT path, and session principals. **Net effect: internal- and system-class accounts authenticated via OAuth/MCP tokens, agent JWTs, or dashboard session cookies become exempt from those limiters, where previously the empty class fail-closed to standard (limited).** Demo-class stays limited everywhere. This is a deliberate alignment with the API-key path — the class is a server-side operator-set attribute and the exemption policy (`usage.RateLimited`) was always written to key off it; the empty-class behavior was an artifact of the loaders not fetching the column.

## Notes / deviations from the design doc

1. **All three compose sites resolve the footer** (design §4.1 names only `DeliverOutbound`, but its "decision frozen at accept/approval time" clause requires resolution wherever composition happens): the human-approve funnel and the hitlworker TTL sweep were added — see "Compose sites". The first revision covered only sites 1–2; review caught site 3.
2. **`GetUserByID` / `GetUserSession` now load `account_class`** — required for sites 2–3 and for session-authed sends to gate identically to API-key sends. See the declared behavior change above.
3. `Limits.OutboundFooterEnabled` is `json:"-"` — the design doesn't specify serialization, and excluding it keeps the public account/limits payloads and the OpenAPI surface byte-identical (dashboard visibility is an explicit non-goal for v1).
4. Migration uses `ADD COLUMN IF NOT EXISTS` (house idempotency style per 024) rather than the design's bare `ADD COLUMN`.
5. An **empty** `AccountClass` (unusual principals that still lack the field) gets no footer — strict `== standard`, same fail-closed direction, documented at the resolver.
6. Text separator is RFC 3676 `"-- \n"` (the design sketch wrote `"--\n"`); the trailing space is what makes clients trim the footer on reply.

Known scope note: scheduled sends (`send_at`) freeze the footer decision at accept with the rest of the bytes — a plan change while a message waits does not alter it (consistent with existing compose semantics; escalated separately as a product question).

## Tests

Full `go test ./...`: **53 packages ok, 0 failures** (DB-backed tests ran against the local test Postgres — not skipped). The six touched packages report **928 top-level test passes, 0 fail, 0 skip**. `go build ./...` and `go vet ./...` clean (vet diff vs `main` baseline: no new findings).

Coverage:
- `internal/outbound/outbound_footer_test.go` — footer on/off in both MIME shapes (multipart/alternative + attachments), HTML-only send (text footer still present), text-only send (no HTML part grown, RFC 3676 `"-- \n"` separator asserted), branding footer strictly **above** the unsubscribe footer in both parts, composed-size ceiling counts the footer (and the same message passes without it), DKIM `bh=` changes when the footer toggles (signature covers the footer bytes), and byte-identical async/sync compose output with the footer on. Existing `TestComposeForAccept_MatchesSyncComposeBytes` and the managed-unsubscribe suite still pass.
- `internal/limits` — enforcer row-vs-default resolution matrix (row false overrides a true default, and vice versa); DB-backed migration-095 column read (fresh row defaults FALSE, provisioner flip visible via `Store.Get`).
- `internal/agent` — unit gating matrix (config off / entitled / unentitled / limits error / nil user / internal / system / demo / empty class), master-switch-off costs zero limits reads, DB-backed `DeliverOutbound` matrix against a real enforcer (row-less default, row off, row flipped on, internal class, config off) asserting the accepted `raw_message`, self-send never footered, and **hold → dashboard approve → footer present in persisted `raw_message`** (held draft stays footer-free; internal-class owner negative).
- `internal/hitlworker` — **TTL auto-approve through the production resolver wiring** (`agent.API.OutboundFooterForAccount` + real enforcer): expires-to-approve mail carries the footer, internal-class owner does not, and a nil resolver (self-host default) never footers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
