### PR TITLE
docs(readme): add open-source AI email service tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
   <img src="assets/e2a-wordmark-light.svg" width="320" alt="e2a">
 </picture>
 
+### The first open-source email service built for AI agents.
+
 ### Give your AI agents a real, authenticated email address.
 
 Receive inbound over **webhook · WebSocket · REST · MCP**. Send through an **HTTP API**. Every sender — human or agent — **identity-verified**.


### PR DESCRIPTION
## What

Adds a tagline above the existing one in the README header:

> ### The first open-source email service built for AI agents.

## Why

Call out the open-source positioning of e2a up front.

## Testing

Docs-only change; no code affected.