### PR TITLE
chore: bump client versions for the v1.6.0 feature release

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2a/cli",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "CLI for e2a — email for AI agents",
   "bin": {
     "e2a": "./dist/bin/e2a.js"

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "e2a"
-version = "5.5.0"
+version = "5.6.0"
 description = "Python SDK for the e2a protocol — email-to-agent authentication"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2a/sdk",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "TypeScript SDK for e2a — email for AI agents",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Three-line version bump ahead of the v1.6.0 client publishes: `@e2a/sdk` 5.5.0→5.6.0, `e2a` (PyPI) 5.5.0→5.6.0, `@e2a/cli` 2.2.0→2.3.0 — minor bumps for the `reply_to` address-list support (#831) shipped in server v1.6.0. All three registries currently hold exactly 5.5.0/5.5.0/2.2.0 (verified), so tags without these bumps would be duplicate publishes.

After merge, tags push in strict order: `ts-sdk-v5.6.0` → (npm publish confirmed) → `python-v5.6.0` → `cli-v2.3.0` — CLI last because it depends on `@e2a/sdk` (`^5.0.0`, satisfied by 5.6.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)