### PR TITLE
docs: catch up CHANGELOGs and CLI README for repeatable --reply-to

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2.3.0
+
+Additive only — no flag, output-field, or exit-code meaning changes to any
+command that shipped in 2.2.0.
+
+**Changed:** `--reply-to <email>` on `e2a send` and `e2a reply` is now
+repeatable (max 5 addresses), so a caller can direct replies to several
+destinations (e.g. a shared triage inbox and an individual owner). A single
+`--reply-to` still sends the byte-identical scalar wire form as before;
+several become an address list, matching the server's widened `reply_to`
+field.
+
 ## 2.2.0
 
 Additive only — no flag, output-field, or exit-code meaning changes to any

--- a/cli/README.md
+++ b/cli/README.md
@@ -208,8 +208,9 @@ e2a reply msg_abc123 --body "On it." --agent bot@acme.com
 
 Common `send`/`reply` flags: `--body` / `--body-file`, `--html-file` (text
 fallback derived if no `--body`), `--attach` (repeatable; max 10 files, 10 MB
-each, 25 MB total), `--reply-to`, `--send-at` (RFC 3339 with an explicit UTC
-offset, at most 90 days ahead), `--idempotency-key`, `--agent`, `--json`
+each, 25 MB total), `--reply-to` (repeatable; max 5 addresses), `--send-at`
+(RFC 3339 with an explicit UTC offset, at most 90 days ahead),
+`--idempotency-key`, `--agent`, `--json`
 (print the full send result). `send`-only: `--to` (repeatable), `--subject`,
 `--conversation-id` (alias `--conversation`) — `reply` infers these from the
 message being replied to and rejects them as unknown flags.

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 5.6.0
+
+Additive only. Every 5.5.0 call site keeps working identically. Available on
+both ``AsyncE2AClient`` and the synchronous ``E2AClient``.
+
+### Changed
+- **``reply_to`` on ``client.messages.send`` / ``.reply`` / ``.forward`` now
+  accepts a list.** It keeps taking a single RFC 5322 address string
+  (unchanged, and still the byte-identical wire form), or a list of up to 5
+  addresses to direct replies to several destinations (e.g. a shared triage
+  inbox and an individual owner). Each address is validated server-side; a
+  violation is a typed 400.
+
 ## 5.5.0
 
 Additive only. Every 5.4.0 call site keeps working identically. The new

--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 5.6.0
+
+Additive only. Every 5.5.0 call site keeps compiling and behaving identically.
+
+### Changed
+- **`replyTo` on `client.messages.send` / `.reply` / `.forward` now accepts a
+  list.** It keeps taking a single RFC 5322 address string (unchanged, and
+  still the byte-identical wire form), or an array of up to 5 addresses to
+  direct replies to several destinations (e.g. a shared triage inbox and an
+  individual owner). Each address is validated server-side; a violation is a
+  typed 400.
+
 ## 5.5.0
 
 Additive only. Every 5.4.0 call site keeps compiling and behaving identically.


### PR DESCRIPTION
## Summary

The v1.6.0 client-version bump (fea8c7a, #841) bumped `cli/package.json`, `sdks/typescript/package.json`, and `sdks/python/pyproject.toml` (2.2.0→2.3.0, 5.5.0→5.6.0, 5.5.0→5.6.0) for the `reply_to` address-list feature (#831), but the bump commit only touched the manifests — no CHANGELOG entries were added, so all three CHANGELOGs stop one version short of the published package version. `cli/README.md`'s flag summary also still described `--reply-to` as a plain flag, unlike the repeatable note already given to `--attach` in the same sentence and unlike the CLI's own `--help` text (`cli/src/bin/e2a.ts:115`), which already says "Repeatable to direct replies to several addresses (max 5)".

This is a documentation-only fix — no behavior, code, or version changes.

## Changes

- `cli/CHANGELOG.md`: add a `2.3.0` entry describing the repeatable `--reply-to`
- `sdks/typescript/CHANGELOG.md`: add a `5.6.0` entry describing the widened `replyTo`
- `sdks/python/CHANGELOG.md`: add a `5.6.0` entry describing the widened `reply_to`
- `cli/README.md`: note `--reply-to` is repeatable (max 5 addresses), matching `--attach`'s style in the same sentence

## Test plan

- [x] Diffed each CHANGELOG addition against the actual `f48f005` (#831) feature diff and `cli/src/bin/e2a.ts` / `cli/src/commands/send.ts` behavior
- [x] Confirmed `cli/README.md`'s existing wording pattern for repeatable flags (`--attach`) and matched it

---
_Generated by [Claude Code](https://claude.ai/code/session_013bpCcNv4TCopbzLkUtVpKB)_