### PR TITLE
docs(mcp): fix misleading list_reviews demo prompt in examples README

### DIFF
--- a/mcp/examples/README.md
+++ b/mcp/examples/README.md
@@ -32,7 +32,10 @@ tool failures whose structured error reports `retryable: true`.
 - `what's in my inbox?` — exercises `list_messages` + `get_message`
 - `reply to the most recent message politely` — exercises `reply_to_message` (preserves threading headers)
 - `who am I?` — exercises `whoami`
-- `what's waiting for my approval?` — exercises `list_reviews` (works once you've enabled HITL on your agent)
+- `what's waiting for my approval?` — exercises `list_reviews`. This is an
+  account-owner review-queue tool, not agent self-approval, so it's only
+  visible to an **account-scoped** key — it won't register as a tool at all
+  under the agent-scoped key these examples otherwise use.
 
 ## Pointing at a self-hosted e2a
 


### PR DESCRIPTION
## Summary

`mcp/examples/README.md`'s "Things to try" section suggested `what's waiting for my approval?` "works once you've enabled HITL on your agent" — but `list_reviews` is in `ADMIN_TOOLS` (`mcp/src/tools/tiers.ts`), deliberately excluded from `RUNTIME_TOOLS` because review discovery/decisions are an account-owner action, never agent self-approval. An **agent-scoped** key never sees `list_reviews` registered as a tool at all, regardless of HITL config — and the LangChain, CrewAI, and OpenAI Agents SDK example READMEs this file describes all explicitly recommend an agent-scoped key. So the demo prompt as documented can't work.

This is a documentation-only fix — no behavior or code changes.

## Changes

- `mcp/examples/README.md`: reword the `list_reviews` bullet to note it requires an account-scoped key, not "enabled HITL"

## Test plan

- [x] Confirmed `list_reviews` placement in `ADMIN_TOOLS` vs `RUNTIME_TOOLS` in `mcp/src/tools/tiers.ts`
- [x] Confirmed the three Python example READMEs recommend an agent-scoped key
- [x] Cross-checked against `mcp/README.md`'s own scope-tier explanation, which already states this correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_013bpCcNv4TCopbzLkUtVpKB)_