### PR TITLE
docs(api): document the sending_ramp field on domain responses

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -594,6 +594,16 @@ DKIM probe was skipped because no per-domain keypair is stored yet; `mismatch`
 means a DKIM record is published but its key doesn't match the issued one —
 usually a truncated TXT.)
 
+Every domain response also carries **`sending_ramp`** — the platform-managed
+recipient-volume ramp state for newly verified custom sender domains:
+`status` (open set; known values `inactive | ramping | complete | exempt`),
+`daily_recipient_limit` (zero means no cap applies), `recipients_used_today`,
+`active_days` / `ramp_days`, and `resets_at` / `estimated_completion_at`. You
+can read this state but cannot change the schedule, exempt yourself, or reset
+progression through the API — see
+[`docs/runbooks/sending-ramp.md`](runbooks/sending-ramp.md) for the
+operator-side mechanics.
+
 ### Agents (`/v1/agents`)
 
 An agent is an addressable inbox. Its email must be on a verified domain you own,

--- a/docs/runbooks/sending-ramp.md
+++ b/docs/runbooks/sending-ramp.md
@@ -1,8 +1,10 @@
 # Sending ramp operations
 
 The sending ramp is an operator-managed safeguard for newly verified custom
-sender domains. End users can read its state through the domain API but cannot
-change the schedule, exempt themselves, or reset progression.
+sender domains. End users can read its state through the domain API (the
+`sending_ramp` field — see
+[`docs/api.md` → Domains](../api.md#domains-v1domains)) but cannot change the
+schedule, exempt themselves, or reset progression.
 
 ## Progression and timeout
 


### PR DESCRIPTION
## Summary

Every `DomainView` response (list, fetch, register) carries a required `sending_ramp` object (`SendingRampView` in `api/openapi.yaml`, GA surface — no `x-stability-level` marker), but `docs/api.md`'s Domains section never mentioned it. `docs/runbooks/sending-ramp.md` already says "End users can read its state through the domain API," so this was a genuine gap between the two docs rather than a deliberate omission.

This is a documentation-only fix — no behavior, schema, or code changes.

## Changes

- `docs/api.md`: document the `sending_ramp` field (`status`, `daily_recipient_limit`, `recipients_used_today`, `active_days`/`ramp_days`, `resets_at`/`estimated_completion_at`) in the Domains section, linking to the runbook
- `docs/runbooks/sending-ramp.md`: cross-link back to the new `api.md` section

## Test plan

- [x] Confirmed `sending_ramp` / `SendingRampView` in `api/openapi.yaml` (required field on `DomainView`, no beta marker)
- [x] Confirmed the anchor slug against this repo's existing `api.md#...` anchor links (`#messages-v1agentsemailmessages`, `#webhooks-v1webhooks`)

---
_Generated by [Claude Code](https://claude.ai/code/session_013bpCcNv4TCopbzLkUtVpKB)_