### PR TITLE
docs: fix docs/ file list and Python SDK surface count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,8 @@ with Go 1.26. Node: engines `>=18`, CI runs on 22. Python: `requires-python
 - `tests/contract/` — Go contract tests driven by `scenarios.yaml`;
   `tests/e2e-prod/` — production smoke-test harness (TypeScript).
 - `docs/` — `api.md`, `deployment.md`, `events.md`, `templates.md`,
-  `data-handling.md`, `api-compatibility-gate.md`, `design/`, `runbooks/`.
+  `observability.md`, `data-handling.md`, `api-compatibility-gate.md`,
+  `design/`, `runbooks/`.
 - `scripts/` — CI guardrails (OpenAPI compat check, plugin validator,
   SDK version-sync check, repo text-integrity check).
 - `examples/adk-cloud-webhook/`, `examples/agent-framework-webhooks/` —

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,10 +243,13 @@ alone don't catch schema drift.
 
 ## Making changes that touch the API
 
-e2a maintains parity across **eight client surfaces** for every API
+e2a maintains parity across **seven client surfaces** for every API
 change: the Go handler, OpenAPI spec, TypeScript SDK (raw + high-level),
-Python SDK sync (raw + high-level), Python SDK async (raw + high-level),
-CLI, MCP server, and the web dashboard. Each surface has its own tests.
+Python SDK (raw + hand-written `AsyncE2AClient`), CLI, MCP server, and the
+web dashboard. Each surface has its own tests. The Python sync client
+(`sync_client.py`) is a background-thread facade over `AsyncE2AClient` that
+mirrors its resources dynamically via `__getattr__`, so it needs no separate
+parity work — only `AsyncE2AClient` is hand-edited.
 
 The `/v1` OpenAPI document at `api/openapi.yaml` is emitted directly
 from the live Huma handlers, and generated SDK code lives in


### PR DESCRIPTION
## Summary

Two small, unrelated documentation gaps in the top-level agent/contributor docs:

1. **AGENTS.md** — the repository-layout `docs/` file list omitted `docs/observability.md` (a current, substantial metrics/SLO doc cross-linked from `docs/deployment.md` and `docs/design/prober-selftest.md`). The list reads as exhaustive (no "e.g." qualifier), so a reader following it wouldn't know to look there.
2. **CONTRIBUTING.md** — described parity across "**eight client surfaces**", including "Python SDK sync (raw + high-level)" and "Python SDK async (raw + high-level)" as two separately-maintained surfaces. There is no hand-written or generated raw sync layer: `sdks/python/src/e2a/v1/sync_client.py` is a background-thread facade over `AsyncE2AClient` that mirrors its resources dynamically via `__getattr__` — its own docstring states this is deliberate "so the sync surface cannot drift" from the async one. The PR template's Python SDK checklist item likewise only references `AsyncE2AClient`. Corrected the count to seven and reworded to describe the sync client as a mirror, not a surface needing separate parity work.

This is a documentation-only fix — no behavior or code changes.

## Changes

- `AGENTS.md`: add `observability.md` to the `docs/` file list
- `CONTRIBUTING.md`: correct "eight client surfaces" → "seven", and describe the Python sync client as an auto-mirrored facade rather than a separate raw surface

## Test plan

- [x] Confirmed `docs/observability.md` exists and is referenced elsewhere in the docs tree
- [x] Read `sync_client.py`'s docstring and the PR template's Python SDK checklist item to confirm the sync client needs no separate hand-edits

---
_Generated by [Claude Code](https://claude.ai/code/session_013bpCcNv4TCopbzLkUtVpKB)_