### PR TITLE
fix(mcp): let delete_agent purge permanently, matching REST

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -165,7 +165,7 @@ before it is declared stable**.
 | `reply_to_message` | Reply to a message — one the agent received (replies to its sender) or one it sent (continues the thread to the original recipients). Preserves In-Reply-To / References for thread continuity and accepts the same optional `send_at` as `send_message`. |
 | `forward_message` | Forward a message into a new thread, carrying its existing attachments by default. Accepts the same optional `send_at` as `send_message`. |
 | `list_messages` | List mail; pass `deleted:true` to list trash. Filter by `read_status` (unread / read / all) and sender with reserved-word-safe `from_`; cursor-paginated (`cursor` + `limit` in, `next_cursor` out). |
-| `delete_message` | Move a message to the trash (restorable for ~30 days). Requires `confirm: true`. Permanent deletion is deliberately not exposed over MCP — use the REST API/SDK. |
+| `delete_message` | Move a message to the trash (restorable for ~30 days). Requires `confirm: true`. Per-message permanent deletion is deliberately not exposed over MCP — use the REST API/SDK. (Purging a whole inbox is available to account scope via `delete_agent`'s `permanent: true`.) |
 | `restore_message` | Restore a soft-deleted message and resume its retention clock. |
 | `get_message` | Fetch full body, headers, and attachment metadata for one message. |
 | `get_attachment` | Get one attachment's metadata + a short-lived `download_url` (fetch the bytes out of band); `inline: true` returns base64 `data` for small files (≤256 KB). |

--- a/mcp/src/client.ts
+++ b/mcp/src/client.ts
@@ -164,9 +164,9 @@ export class McpClient {
     return this.sdk.agents.replaceProtection(this.resolveAddress(explicitAddress), config);
   }
 
-  async deleteAgent(explicitAddress?: string): Promise<DeleteAgentResult> {
+  async deleteAgent(explicitAddress?: string, permanent?: boolean): Promise<DeleteAgentResult> {
     const address = this.resolveAddress(explicitAddress);
-    return this.sdk.agents.delete(address);
+    return this.sdk.agents.delete(address, { permanent });
   }
 
   restoreAgent(explicitAddress?: string): Promise<AgentView> {

--- a/mcp/src/tools/agents.ts
+++ b/mcp/src/tools/agents.ts
@@ -251,7 +251,7 @@ export function registerAgentTools(server: McpServer, client: McpClient): void {
       title: "Delete an agent inbox (DESTRUCTIVE)",
       annotations: { destructiveHint: true, idempotentHint: true },
       description:
-        "Move the agent inbox to trash for about 30 days by default. The agent stops receiving mail and disappears from normal lists, but its messages and configuration are retained so it can be restored before automatic purge. Pass `permanent: true` to skip the trash and delete irreversibly right away instead (accepts live and trashed agents); this is what `delete_domain` requires before a domain can be re-registered once every agent on it is gone for good. Requires `confirm: true` — set it explicitly to acknowledge the destructive action.",
+        "Move the agent inbox to trash for about 30 days by default. The agent stops receiving mail and disappears from normal lists, but its messages and configuration are retained so it can be restored before automatic purge. Pass `permanent: true` to skip the trash and delete the inbox and every message in it irreversibly right away instead (accepts live and trashed agents); `delete_domain` succeeds only when the domain has no agents, so permanently delete every live or trashed agent on it first. Requires `confirm: true` — set it explicitly to acknowledge the destructive action.",
       inputSchema: strictInputSchema({
         email: z
           .string()
@@ -269,7 +269,7 @@ export function registerAgentTools(server: McpServer, client: McpClient): void {
           .boolean()
           .optional()
           .describe(
-            "Skip the trash and delete irreversibly right away, for a live or already-trashed agent. Defaults to false (moves to trash, restorable for about 30 days).",
+            "Skip the trash and delete irreversibly right away, for a live or already-trashed agent. Purges every message in the inbox with no restore path. Defaults to false (moves to trash, restorable for about 30 days).",
           ),
       }),
     },

--- a/mcp/src/tools/agents.ts
+++ b/mcp/src/tools/agents.ts
@@ -251,7 +251,7 @@ export function registerAgentTools(server: McpServer, client: McpClient): void {
       title: "Delete an agent inbox (DESTRUCTIVE)",
       annotations: { destructiveHint: true, idempotentHint: true },
       description:
-        "Move the agent inbox to trash for about 30 days. The agent stops receiving mail and disappears from normal lists, but its messages and configuration are retained so it can be restored before automatic purge. Requires `confirm: true` — set it explicitly to acknowledge the destructive action.",
+        "Move the agent inbox to trash for about 30 days by default. The agent stops receiving mail and disappears from normal lists, but its messages and configuration are retained so it can be restored before automatic purge. Pass `permanent: true` to skip the trash and delete irreversibly right away instead (accepts live and trashed agents); this is what `delete_domain` requires before a domain can be re-registered once every agent on it is gone for good. Requires `confirm: true` — set it explicitly to acknowledge the destructive action.",
       inputSchema: strictInputSchema({
         email: z
           .string()
@@ -265,6 +265,12 @@ export function registerAgentTools(server: McpServer, client: McpClient): void {
           .describe(
             "Must be set to true to proceed. Guard against an LLM hallucinating a delete from ambiguous context.",
           ),
+        permanent: z
+          .boolean()
+          .optional()
+          .describe(
+            "Skip the trash and delete irreversibly right away, for a live or already-trashed agent. Defaults to false (moves to trash, restorable for about 30 days).",
+          ),
       }),
     },
     async (args) =>
@@ -276,7 +282,7 @@ export function registerAgentTools(server: McpServer, client: McpClient): void {
         }
         // Return the server's deletion receipt verbatim:
         // {deleted:true, email, messages_deleted}.
-        return client.deleteAgent(args.email);
+        return client.deleteAgent(args.email, args.permanent);
       }),
   );
 }

--- a/mcp/src/tools/tiers.ts
+++ b/mcp/src/tools/tiers.ts
@@ -30,9 +30,11 @@ export const RUNTIME_TOOLS: ReadonlySet<string> = new Set([
   "get_attachment_data",
   // Soft delete + restore are both per-agent inbox hygiene: the REST handler
   // pins an agent-scoped credential to its own bound agent (resolveOwnedAgent).
-  // The PERMANENT purge is account-only server-side, and the MCP tool doesn't
+  // The PERMANENT purge is account-only server-side, and delete_message doesn't
   // expose it at all — so no agent-scoped session can destroy evidence
-  // irreversibly, which is why this stays runtime while delete_agent is admin.
+  // irreversibly, which is why this stays runtime. delete_agent does expose a
+  // purge (`permanent: true`), which is exactly why it is admin: reaching it at
+  // all requires account scope.
   "delete_message",
   "restore_message",
   "update_message_labels",

--- a/mcp/tests/client.test.ts
+++ b/mcp/tests/client.test.ts
@@ -85,6 +85,7 @@ describe("McpClient trash/restore delegation", () => {
         agents: {
           list: vi.fn(() => ({ page: agentsPage })),
           restore: vi.fn(async (email: string) => ({ email })),
+          delete: vi.fn(async (email: string) => ({ deleted: true, email, messages_deleted: 0 })),
         },
         messages: {
           list: vi.fn(() => ({ page: messagesPage })),
@@ -109,6 +110,24 @@ describe("McpClient trash/restore delegation", () => {
     const c = new McpClient(sdk as never, "", "account");
     await c.restoreAgent("trashed@test.dev");
     expect(sdk.agents.restore).toHaveBeenCalledWith("trashed@test.dev");
+  });
+
+  it("deleteAgent forwards permanent to the SDK, not just to the tool layer", async () => {
+    const { sdk } = mockTrashSdk();
+    const c = new McpClient(sdk as never, "", "account");
+    await c.deleteAgent("doomed@test.dev", true);
+    // The tool-layer test in tools.test.ts stubs McpClient, so this is the only
+    // coverage that the flag survives the client → SDK hop. Dropping the second
+    // argument here would silently downgrade every purge to a trash move, and
+    // the receipt shape is identical, so the caller could not tell.
+    expect(sdk.agents.delete).toHaveBeenCalledWith("doomed@test.dev", { permanent: true });
+  });
+
+  it("deleteAgent defaults to the recoverable trash move", async () => {
+    const { sdk } = mockTrashSdk();
+    const c = new McpClient(sdk as never, "", "account");
+    await c.deleteAgent("doomed@test.dev");
+    expect(sdk.agents.delete).toHaveBeenCalledWith("doomed@test.dev", { permanent: undefined });
   });
 
   it("listMessages forwards deleted and explicitAddress without leaking it to the SDK filter", async () => {

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -1824,7 +1824,7 @@ describe("e2a MCP server", () => {
       name: "delete_agent",
       arguments: { email: "bot@example.com", confirm: true },
     });
-    expect(stub.deleteAgent).toHaveBeenCalledWith("bot@example.com");
+    expect(stub.deleteAgent).toHaveBeenCalledWith("bot@example.com", undefined);
     const content = res.content as Array<{ type: string; text: string }>;
     expect(JSON.parse(content[0]!.text)).toEqual({
       deleted: true,
@@ -1838,7 +1838,15 @@ describe("e2a MCP server", () => {
       name: "delete_agent",
       arguments: { confirm: true },
     });
-    expect(stub.deleteAgent).toHaveBeenCalledWith(undefined);
+    expect(stub.deleteAgent).toHaveBeenCalledWith(undefined, undefined);
+  });
+
+  it("delete_agent forwards permanent:true to skip the trash", async () => {
+    await client.callTool({
+      name: "delete_agent",
+      arguments: { email: "bot@example.com", confirm: true, permanent: true },
+    });
+    expect(stub.deleteAgent).toHaveBeenCalledWith("bot@example.com", true);
   });
 
   it("list_agents forwards deleted:true for the trash", async () => {

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -1849,6 +1849,16 @@ describe("e2a MCP server", () => {
     expect(stub.deleteAgent).toHaveBeenCalledWith("bot@example.com", true);
   });
 
+  it("delete_agent still requires confirm:true when permanent:true is set", async () => {
+    // `permanent` must never be a way around the confirm gate.
+    const res = await client.callTool({
+      name: "delete_agent",
+      arguments: { email: "bot@example.com", permanent: true },
+    });
+    expect(res.isError).toBe(true);
+    expect(stub.deleteAgent).not.toHaveBeenCalled();
+  });
+
   it("list_agents forwards deleted:true for the trash", async () => {
     await client.callTool({ name: "list_agents", arguments: { deleted: true } });
     expect(stub.listAgents).toHaveBeenCalledWith({ deleted: true });


### PR DESCRIPTION
REST's `DELETE /v1/agents/{email}` accepts `permanent=true` to skip the 30-day
trash and delete an agent right away (`AgentsApi.ts:143`, `client.ts:323`), but
the MCP `delete_agent` tool always called `client.deleteAgent(email)` with no
way to set it. `delete_domain`'s own description says a domain can only be
re-registered once every agent on it, live or trashed, is gone for good
(`domains.go:601,609`), so an MCP-only caller had no path to that state: the
only remedy was the REST/SDK layer directly.

Added an optional `permanent` boolean to `delete_agent`'s schema and threaded
it through `McpClient.deleteAgent` to the SDK's existing `agents.delete(email,
{ permanent })`. `delete_agent` is already account-scope only
(`mcp/src/tools/tiers.ts` `ADMIN_TOOLS`), the same boundary the REST handler
enforces server-side for `permanent=true` (`trash_endpoints_test.go` asserts
403 for an agent-scoped key), so this does not hand the capability to a
runtime agent credential. `delete_message` deliberately withholds `permanent`
for that reason (`client.ts:428`); `delete_agent` sits on the other side of
that boundary already, which is why the same argument does not apply here.

**Verification**
- `delete_agent forwards permanent:true to skip the trash` and the two
  existing forwarding tests (updated for the new second argument) fail on the
  pre-fix source and pass after it, run both ways in a clean container.
- Full `mcp` workspace suite (303 tests) and `test:types` pass; `tsc --build`
  and `check-mcp-tool-compat` (additive-only) both clean.
- Did not check: no live-server contract run against this endpoint, since the
  REST/SDK side of `permanent` already ships and is covered by
  `trash_endpoints_test.go`; this PR only extends what MCP exposes.

Fixes #633
