### PR TITLE
test(e2e-prod): stop leaking production fixtures on abnormal teardown

### DIFF
--- a/tests/e2e-prod/harness/cleanup.test.ts
+++ b/tests/e2e-prod/harness/cleanup.test.ts
@@ -11,9 +11,10 @@ import {
   track,
   untrack,
   getTracked,
-  disarmSafetyNet,
-  setSafetyNetDeps,
-  runSafetyNet,
+  armLeakReporter,
+  disarmLeakReporter,
+  setReporterDeps,
+  reportLeaks,
 } from "./cleanup.ts";
 
 /** A scripted response: an HTTP status, a thrown value, or a status + headers. */
@@ -63,17 +64,16 @@ function drainTracked(): void {
 beforeEach(() => {
   // The registry is module-level state shared across tests in this file.
   drainTracked();
-  // track() arms the real process-level net, whose default client is built
-  // from the ambient E2A_API_KEY. A Ctrl-C mid-run would otherwise fire real
-  // DELETEs at production for these synthetic ids. Disarm it; the tests that
-  // exercise the net re-enter it deliberately through injected deps.
-  disarmSafetyNet();
-  setSafetyNetDeps();
+  // track() arms the process-level leak reporter, whose signal handlers call
+  // process.exit(). Disarm between tests so a real Ctrl-C during the run can't
+  // fire it; the reporter tests re-arm deliberately through injected seams.
+  disarmLeakReporter();
+  setReporterDeps();
 });
 
 after(() => {
-  disarmSafetyNet();
-  setSafetyNetDeps();
+  disarmLeakReporter();
+  setReporterDeps();
 });
 
 test("cleanup deletes every tracked fixture and empties the registry", async () => {
@@ -302,105 +302,85 @@ test("cleanup on an empty registry is a no-op", async () => {
   assert.equal(calls.length, 0);
 });
 
-// --- abnormal-exit safety net --------------------------------------------
+// --- abnormal-exit leak reporter -----------------------------------------
 //
-// These drive runSafetyNet() directly with injected client/exit/stderr seams,
-// so nothing kills this process and no request leaves it. They deliberately do
-// NOT install signal handlers.
+// The reporter is intentionally synchronous and delete-free (see cleanup.ts
+// for why an async delete-on-crash net is a trap under node:test's per-suite
+// process isolation). These tests capture its stderr through an injected seam,
+// so nothing is written to a real fd and the process is never killed.
 
-/** Captures the net's exit code and stderr, and hands it a scripted client. */
-function netHarness(script: (path: string, attempt: number) => Outcome) {
-  const { client, calls } = fakeClient(script);
-  const exits: number[] = [];
+function captureReporter() {
   const lines: string[] = [];
-  setSafetyNetDeps({
-    resolveClient: () => Promise.resolve(client),
-    exit: (code) => exits.push(code),
-    write: (line) => lines.push(line),
-  });
-  return { calls, exits, out: () => lines.join("") };
+  const exits: number[] = [];
+  setReporterDeps({ write: (l) => lines.push(l), exit: (c) => exits.push(c) });
+  return { out: () => lines.join(""), exits };
 }
 
-test("safety net deletes tracked fixtures and exits non-zero", async () => {
-  track("agent", "doomed@x.dev");
-  track("domain", "doomed.x.dev");
-  const net = netHarness(() => 204);
-
-  await runSafetyNet("SIGINT", 130);
-
-  assert.equal(net.calls.length, 2, "both fixtures must be deleted before exit");
-  assert.equal(getTracked().length, 0);
-  assert.deepEqual(net.exits, [130], "the signal's exit code must be preserved");
-  assert.match(net.out(), /teardown net fired \(SIGINT\)/);
-  assert.match(net.out(), /2 deleted, 0 LEAKED/);
+test("armLeakReporter is idempotent — one listener per signal", () => {
+  disarmLeakReporter();
+  armLeakReporter();
+  armLeakReporter();
+  armLeakReporter();
+  assert.equal(process.listenerCount("SIGINT"), 1);
+  assert.equal(process.listenerCount("SIGTERM"), 1);
+  assert.equal(process.listenerCount("exit"), 1);
+  disarmLeakReporter();
+  assert.equal(process.listenerCount("SIGINT"), 0);
+  assert.equal(process.listenerCount("exit"), 0);
 });
 
-test("safety net names every fixture it could not delete", async () => {
-  track("agent", "stuck@x.dev");
-  const net = netHarness(() => 500);
-
-  await runSafetyNet("uncaughtException: boom", 1);
-
-  assert.deepEqual(net.exits, [1], "a crash must still exit non-zero");
-  assert.match(net.out(), /uncaughtException: boom/, "the crash cause must survive");
-  assert.match(net.out(), /LEAKED agent stuck@x\.dev: HTTP 500/);
-});
-
-test("safety net exits non-zero even with nothing tracked", async () => {
-  const net = netHarness(() => 204);
-  await runSafetyNet("SIGTERM", 143);
-  assert.equal(net.calls.length, 0);
-  assert.deepEqual(net.exits, [143]);
-});
-
-test("safety net survives a client that cannot even be constructed", async () => {
+test("reportLeaks names every still-tracked fixture, once", () => {
   track("agent", "orphan@x.dev");
-  const exits: number[] = [];
-  const lines: string[] = [];
-  setSafetyNetDeps({
-    // loadEnv() throws when E2A_API_KEY is unset — the net must still report.
-    resolveClient: () => Promise.reject(new Error("No API key found")),
-    exit: (code) => exits.push(code),
-    write: (line) => lines.push(line),
-  });
+  track("domain", "orphan.x.dev");
+  const cap = captureReporter();
 
-  await runSafetyNet("SIGINT", 130);
+  reportLeaks("exit");
+  reportLeaks("exit"); // idempotent: a signal's exit re-runs the exit handler
 
-  assert.deepEqual(exits, [130]);
-  assert.match(lines.join(""), /teardown net failed: No API key found/);
-  assert.match(lines.join(""), /LEAKED agent orphan@x\.dev/);
+  assert.match(cap.out(), /2 fixture\(s\) still tracked at exit/);
+  assert.match(cap.out(), /LEAKED agent orphan@x\.dev — delete manually/);
+  assert.match(cap.out(), /LEAKED domain orphan\.x\.dev — delete manually/);
+  // Printed exactly once despite two calls.
+  assert.equal(cap.out().match(/still tracked at exit/g)?.length, 1);
 });
 
-test("a second signal during a sweep reports the remainder instead of hanging", async () => {
-  // Regression guard for `process.once`: the first signal consumed the handler,
-  // so an impatient second Ctrl-C hit Node's default terminate and killed the
-  // sweep mid-flight — losing both the deletes and the leak report.
-  track("agent", "slow@x.dev");
-  const exits: number[] = [];
-  const lines: string[] = [];
-  let release!: () => void;
-  const gate = new Promise<void>((r) => (release = r));
-  setSafetyNetDeps({
-    resolveClient: async () => {
-      await gate;
-      return fakeClient(() => 204).client;
-    },
-    exit: (code) => exits.push(code),
-    write: (line) => lines.push(line),
-  });
+test("reportLeaks is silent when teardown emptied the registry", () => {
+  track("agent", "cleaned@x.dev");
+  untrack("agent", "cleaned@x.dev");
+  const cap = captureReporter();
 
-  const first = runSafetyNet("SIGINT", 130);
-  // Second signal lands while the first sweep is still awaiting its client.
-  await runSafetyNet("SIGINT", 130);
+  reportLeaks("exit");
 
-  assert.deepEqual(exits, [130], "the second signal must exit immediately");
-  assert.match(lines.join(""), /teardown net interrupted \(SIGINT\)/);
-  assert.match(lines.join(""), /LEAKED agent slow@x\.dev/);
-  // And it must not have started a competing sweep.
-  assert.equal(lines.join("").match(/teardown net fired/g)?.length, 1);
+  assert.equal(cap.out(), "", "a clean run must print nothing on exit");
+});
 
-  release();
-  await first;
+test("the SIGINT handler translates the signal into a non-zero exit", () => {
+  disarmLeakReporter();
+  const cap = captureReporter();
+  armLeakReporter();
+
+  // Fire the actual registered handler, not an internal — proves the signal is
+  // wired to exit (which is what runs the exit-time reportLeaks).
+  process.emit("SIGINT");
+  process.emit("SIGTERM");
+
+  assert.deepEqual(cap.exits, [130, 143]);
+  disarmLeakReporter();
+});
+
+test("disarm removes only our handlers, not a foreign one", () => {
+  disarmLeakReporter();
+  const foreign = () => {};
+  process.on("SIGINT", foreign);
+  armLeakReporter();
+  assert.equal(process.listenerCount("SIGINT"), 2);
+
+  disarmLeakReporter();
+
+  // The foreign listener (a stand-in for node:test's own) must survive.
+  assert.equal(process.listenerCount("SIGINT"), 1);
+  assert.deepEqual(process.listeners("SIGINT"), [foreign]);
+  process.off("SIGINT", foreign);
 });
 
 test("a second cleanup pass retries what the first one failed", async () => {

--- a/tests/e2e-prod/harness/cleanup.test.ts
+++ b/tests/e2e-prod/harness/cleanup.test.ts
@@ -3,13 +3,24 @@
 // in for ApiClient and no network request is made. Deliberately NOT under
 // `suites/` — `npm test` globs `suites/*.test.ts` and runs against live prod.
 // Run these with `npm run test:harness`.
-import { test, beforeEach } from "node:test";
+import { test, beforeEach, after } from "node:test";
 import assert from "node:assert/strict";
 import type { ApiClient, RawResponse } from "./client.ts";
-import { cleanup, track, untrack, getTracked } from "./cleanup.ts";
+import {
+  cleanup,
+  track,
+  untrack,
+  getTracked,
+  disarmSafetyNet,
+  setSafetyNetDeps,
+  runSafetyNet,
+} from "./cleanup.ts";
+
+/** A scripted response: an HTTP status, a thrown value, or a status + headers. */
+type Outcome = number | Error | unknown | { status: number; headers: Record<string, string> };
 
 /** A DELETE recorder whose per-path responses are scripted by the test. */
-function fakeClient(script: (path: string, attempt: number) => number | Error): {
+function fakeClient(script: (path: string, attempt: number) => Outcome): {
   client: ApiClient;
   calls: string[];
 } {
@@ -21,11 +32,19 @@ function fakeClient(script: (path: string, attempt: number) => number | Error): 
       const n = (attempts.get(path) ?? 0) + 1;
       attempts.set(path, n);
       const outcome = script(path, n);
-      if (outcome instanceof Error) return Promise.reject(outcome);
+      const shaped =
+        typeof outcome === "number"
+          ? { status: outcome, headers: {} as Record<string, string> }
+          : outcome && typeof outcome === "object" && "status" in outcome
+            ? (outcome as { status: number; headers: Record<string, string> })
+            : null;
+      // Anything that isn't a status shape is a rejection — including non-Error
+      // values, which is the point of the isolation test below.
+      if (shaped === null) return Promise.reject(outcome);
       return Promise.resolve({
-        status: outcome,
-        ok: outcome < 400,
-        headers: {},
+        status: shaped.status,
+        ok: shaped.status < 400,
+        headers: shaped.headers,
         body: null,
         raw: "",
         latencyMs: 0,
@@ -44,6 +63,17 @@ function drainTracked(): void {
 beforeEach(() => {
   // The registry is module-level state shared across tests in this file.
   drainTracked();
+  // track() arms the real process-level net, whose default client is built
+  // from the ambient E2A_API_KEY. A Ctrl-C mid-run would otherwise fire real
+  // DELETEs at production for these synthetic ids. Disarm it; the tests that
+  // exercise the net re-enter it deliberately through injected deps.
+  disarmSafetyNet();
+  setSafetyNetDeps();
+});
+
+after(() => {
+  disarmSafetyNet();
+  setSafetyNetDeps();
 });
 
 test("cleanup deletes every tracked fixture and empties the registry", async () => {
@@ -169,18 +199,100 @@ test("404 and 403 count as success (already gone / anti-enumeration)", async () 
   assert.equal(getTracked().length, 0);
 });
 
-test("tracking the same identity twice is idempotent under teardown", async () => {
-  // Over-tracking is the safe direction: suites now track a requested identity
-  // before the create, which can duplicate an id already tracked elsewhere.
+test("tracking the same identity twice registers it once", async () => {
+  // Over-tracking is the safe direction — suites now track a requested identity
+  // before the create, which can duplicate an id tracked elsewhere — but a
+  // duplicate registry entry makes one 5xx report a LEAK for a fixture whose
+  // twin deleted fine. track() dedupes so the report stays truthful.
   track("agent", "dupe@x.dev");
   track("agent", "dupe@x.dev");
-  const { client, calls } = fakeClient((_p, attempt) => (attempt === 1 ? 204 : 404));
+  assert.equal(getTracked().length, 1, "duplicate track must not double-register");
+  const { client, calls } = fakeClient(() => 204);
 
   const r = await cleanup(client, { sleep: noSleep });
 
-  assert.equal(r.succeeded, 2);
+  assert.equal(r.attempted, 1);
+  assert.equal(r.succeeded, 1);
+  assert.equal(calls.length, 1, "one fixture, one DELETE");
+  assert.equal(getTracked().length, 0);
+});
+
+test("kind is part of identity — same id under two kinds stays two fixtures", async () => {
+  track("agent", "x.dev");
+  track("domain", "x.dev");
+  assert.equal(getTracked().length, 2);
+  const { client, calls } = fakeClient(() => 204);
+
+  await cleanup(client, { sleep: noSleep });
+
   assert.equal(calls.length, 2);
-  assert.equal(getTracked().length, 0, "both registry entries must be cleared");
+  assert.ok(calls.some((c) => c.startsWith("/v1/agents/")));
+  assert.ok(calls.some((c) => c.startsWith("/v1/domains/")));
+});
+
+test("a rejection carrying a non-Error does not abandon the remaining fixtures", async () => {
+  // Regression guard: `(e as Error).message` on a null rejection throws a
+  // TypeError out of the catch, out of cleanup()'s loop, and skips every
+  // fixture queued behind it — silently converting a per-fixture failure into
+  // an all-or-nothing one. `first` is deleted LAST (reverse order), so it is
+  // the one that goes missing when isolation breaks.
+  track("agent", "first@x.dev");
+  track("agent", "nonerror@x.dev");
+  track("agent", "last@x.dev");
+  const { client } = fakeClient((path) => (path.includes("nonerror") ? null : 204));
+
+  const r = await cleanup(client, { attempts: 1, sleep: noSleep });
+
+  assert.equal(r.succeeded, 2, "both healthy fixtures must still be deleted");
+  assert.equal(r.failed.length, 1);
+  assert.equal(r.failed[0]!.id, "nonerror@x.dev");
+  assert.deepEqual(
+    getTracked().map((t) => t.id),
+    ["nonerror@x.dev"],
+  );
+});
+
+test("a 429 Retry-After longer than the backoff floor is honored, and capped", async () => {
+  // internal/ratelimit rounds Retry-After up to a whole second of the remaining
+  // sliding window. Retrying on a sub-second backoff is guaranteed to 429 again
+  // and just adds load to an account that is already throttled.
+  track("agent", "throttled@x.dev");
+  const slept: number[] = [];
+  const { client } = fakeClient((_p, attempt) =>
+    attempt === 1
+      ? { status: 429, headers: { "retry-after": "4" } }
+      : { status: 429, headers: { "retry-after": "600" } },
+  );
+
+  const r = await cleanup(client, {
+    attempts: 3,
+    backoffMs: 1_000,
+    sleep: (ms) => {
+      slept.push(ms);
+      return Promise.resolve();
+    },
+  });
+
+  // 4s beats the 1s floor; 600s is clamped so teardown cannot hang for 10 min.
+  assert.deepEqual(slept, [4_000, 15_000]);
+  assert.equal(r.failed.length, 1);
+});
+
+test("a Retry-After shorter than the backoff floor does not shorten the wait", async () => {
+  track("agent", "throttled@x.dev");
+  const slept: number[] = [];
+  const { client } = fakeClient(() => ({ status: 429, headers: { "retry-after": "0" } }));
+
+  await cleanup(client, {
+    attempts: 2,
+    backoffMs: 1_000,
+    sleep: (ms) => {
+      slept.push(ms);
+      return Promise.resolve();
+    },
+  });
+
+  assert.deepEqual(slept, [1_000]);
 });
 
 test("cleanup on an empty registry is a no-op", async () => {
@@ -188,6 +300,107 @@ test("cleanup on an empty registry is a no-op", async () => {
   const r = await cleanup(client, { sleep: noSleep });
   assert.deepEqual(r, { attempted: 0, succeeded: 0, failed: [] });
   assert.equal(calls.length, 0);
+});
+
+// --- abnormal-exit safety net --------------------------------------------
+//
+// These drive runSafetyNet() directly with injected client/exit/stderr seams,
+// so nothing kills this process and no request leaves it. They deliberately do
+// NOT install signal handlers.
+
+/** Captures the net's exit code and stderr, and hands it a scripted client. */
+function netHarness(script: (path: string, attempt: number) => Outcome) {
+  const { client, calls } = fakeClient(script);
+  const exits: number[] = [];
+  const lines: string[] = [];
+  setSafetyNetDeps({
+    resolveClient: () => Promise.resolve(client),
+    exit: (code) => exits.push(code),
+    write: (line) => lines.push(line),
+  });
+  return { calls, exits, out: () => lines.join("") };
+}
+
+test("safety net deletes tracked fixtures and exits non-zero", async () => {
+  track("agent", "doomed@x.dev");
+  track("domain", "doomed.x.dev");
+  const net = netHarness(() => 204);
+
+  await runSafetyNet("SIGINT", 130);
+
+  assert.equal(net.calls.length, 2, "both fixtures must be deleted before exit");
+  assert.equal(getTracked().length, 0);
+  assert.deepEqual(net.exits, [130], "the signal's exit code must be preserved");
+  assert.match(net.out(), /teardown net fired \(SIGINT\)/);
+  assert.match(net.out(), /2 deleted, 0 LEAKED/);
+});
+
+test("safety net names every fixture it could not delete", async () => {
+  track("agent", "stuck@x.dev");
+  const net = netHarness(() => 500);
+
+  await runSafetyNet("uncaughtException: boom", 1);
+
+  assert.deepEqual(net.exits, [1], "a crash must still exit non-zero");
+  assert.match(net.out(), /uncaughtException: boom/, "the crash cause must survive");
+  assert.match(net.out(), /LEAKED agent stuck@x\.dev: HTTP 500/);
+});
+
+test("safety net exits non-zero even with nothing tracked", async () => {
+  const net = netHarness(() => 204);
+  await runSafetyNet("SIGTERM", 143);
+  assert.equal(net.calls.length, 0);
+  assert.deepEqual(net.exits, [143]);
+});
+
+test("safety net survives a client that cannot even be constructed", async () => {
+  track("agent", "orphan@x.dev");
+  const exits: number[] = [];
+  const lines: string[] = [];
+  setSafetyNetDeps({
+    // loadEnv() throws when E2A_API_KEY is unset — the net must still report.
+    resolveClient: () => Promise.reject(new Error("No API key found")),
+    exit: (code) => exits.push(code),
+    write: (line) => lines.push(line),
+  });
+
+  await runSafetyNet("SIGINT", 130);
+
+  assert.deepEqual(exits, [130]);
+  assert.match(lines.join(""), /teardown net failed: No API key found/);
+  assert.match(lines.join(""), /LEAKED agent orphan@x\.dev/);
+});
+
+test("a second signal during a sweep reports the remainder instead of hanging", async () => {
+  // Regression guard for `process.once`: the first signal consumed the handler,
+  // so an impatient second Ctrl-C hit Node's default terminate and killed the
+  // sweep mid-flight — losing both the deletes and the leak report.
+  track("agent", "slow@x.dev");
+  const exits: number[] = [];
+  const lines: string[] = [];
+  let release!: () => void;
+  const gate = new Promise<void>((r) => (release = r));
+  setSafetyNetDeps({
+    resolveClient: async () => {
+      await gate;
+      return fakeClient(() => 204).client;
+    },
+    exit: (code) => exits.push(code),
+    write: (line) => lines.push(line),
+  });
+
+  const first = runSafetyNet("SIGINT", 130);
+  // Second signal lands while the first sweep is still awaiting its client.
+  await runSafetyNet("SIGINT", 130);
+
+  assert.deepEqual(exits, [130], "the second signal must exit immediately");
+  assert.match(lines.join(""), /teardown net interrupted \(SIGINT\)/);
+  assert.match(lines.join(""), /LEAKED agent slow@x\.dev/);
+  // And it must not have started a competing sweep.
+  assert.equal(lines.join("").match(/teardown net fired/g)?.length, 1);
+
+  release();
+  await first;
 });
 
 test("a second cleanup pass retries what the first one failed", async () => {

--- a/tests/e2e-prod/harness/cleanup.test.ts
+++ b/tests/e2e-prod/harness/cleanup.test.ts
@@ -2,7 +2,7 @@
 // only thing cleanup() calls on its client is `delete(path)`, so a fake stands
 // in for ApiClient and no network request is made. Deliberately NOT under
 // `suites/` — `npm test` globs `suites/*.test.ts` and runs against live prod.
-// Run these with `npm run test:harness`.
+// Run these with `npm run test:unit` (CI's harness-tests job runs the same glob).
 import { test, beforeEach, after } from "node:test";
 import assert from "node:assert/strict";
 import type { ApiClient, RawResponse } from "./client.ts";
@@ -323,9 +323,11 @@ test("armLeakReporter is idempotent — one listener per signal", () => {
   armLeakReporter();
   assert.equal(process.listenerCount("SIGINT"), 1);
   assert.equal(process.listenerCount("SIGTERM"), 1);
+  assert.equal(process.listenerCount("SIGHUP"), 1);
   assert.equal(process.listenerCount("exit"), 1);
   disarmLeakReporter();
   assert.equal(process.listenerCount("SIGINT"), 0);
+  assert.equal(process.listenerCount("SIGHUP"), 0);
   assert.equal(process.listenerCount("exit"), 0);
 });
 
@@ -363,8 +365,9 @@ test("the SIGINT handler translates the signal into a non-zero exit", () => {
   // wired to exit (which is what runs the exit-time reportLeaks).
   process.emit("SIGINT");
   process.emit("SIGTERM");
+  process.emit("SIGHUP");
 
-  assert.deepEqual(cap.exits, [130, 143]);
+  assert.deepEqual(cap.exits, [130, 143, 129]);
   disarmLeakReporter();
 });
 

--- a/tests/e2e-prod/harness/cleanup.test.ts
+++ b/tests/e2e-prod/harness/cleanup.test.ts
@@ -1,0 +1,204 @@
+// Unit tests for the teardown registry. These NEVER touch production: the
+// only thing cleanup() calls on its client is `delete(path)`, so a fake stands
+// in for ApiClient and no network request is made. Deliberately NOT under
+// `suites/` — `npm test` globs `suites/*.test.ts` and runs against live prod.
+// Run these with `npm run test:harness`.
+import { test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import type { ApiClient, RawResponse } from "./client.ts";
+import { cleanup, track, untrack, getTracked } from "./cleanup.ts";
+
+/** A DELETE recorder whose per-path responses are scripted by the test. */
+function fakeClient(script: (path: string, attempt: number) => number | Error): {
+  client: ApiClient;
+  calls: string[];
+} {
+  const calls: string[] = [];
+  const attempts = new Map<string, number>();
+  const client = {
+    delete(path: string): Promise<RawResponse> {
+      calls.push(path);
+      const n = (attempts.get(path) ?? 0) + 1;
+      attempts.set(path, n);
+      const outcome = script(path, n);
+      if (outcome instanceof Error) return Promise.reject(outcome);
+      return Promise.resolve({
+        status: outcome,
+        ok: outcome < 400,
+        headers: {},
+        body: null,
+        raw: "",
+        latencyMs: 0,
+      });
+    },
+  } as unknown as ApiClient;
+  return { client, calls };
+}
+
+const noSleep = () => Promise.resolve();
+
+function drainTracked(): void {
+  for (const t of [...getTracked()]) untrack(t.kind, t.id);
+}
+
+beforeEach(() => {
+  // The registry is module-level state shared across tests in this file.
+  drainTracked();
+});
+
+test("cleanup deletes every tracked fixture and empties the registry", async () => {
+  track("agent", "a@x.dev");
+  track("agent", "b@x.dev");
+  track("domain", "d.x.dev");
+  const { client, calls } = fakeClient(() => 204);
+
+  const r = await cleanup(client, { sleep: noSleep });
+
+  assert.equal(r.attempted, 3);
+  assert.equal(r.succeeded, 3);
+  assert.deepEqual(r.failed, []);
+  assert.equal(getTracked().length, 0);
+  assert.equal(calls.length, 3);
+  // Reverse order (newest fixture first) is the existing teardown contract.
+  assert.match(calls[0]!, /d\.x\.dev/);
+  assert.match(calls[0]!, /confirm=DELETE/);
+});
+
+test("a permanently failing fixture does not block the remaining ones", async () => {
+  track("agent", "first@x.dev");
+  track("agent", "doomed@x.dev");
+  track("agent", "last@x.dev");
+  // 400 is non-retryable, so this is one attempt and a hard give-up.
+  const { client } = fakeClient((path) => (path.includes("doomed") ? 400 : 204));
+
+  const r = await cleanup(client, { sleep: noSleep });
+
+  assert.equal(r.attempted, 3);
+  assert.equal(r.succeeded, 2, "the other two fixtures must still be deleted");
+  assert.equal(r.failed.length, 1);
+  assert.equal(r.failed[0]!.id, "doomed@x.dev");
+  // Only the failure stays tracked, so the safety net can report it as leaked.
+  assert.deepEqual(
+    getTracked().map((t) => t.id),
+    ["doomed@x.dev"],
+  );
+});
+
+test("a thrown request does not block the remaining fixtures", async () => {
+  track("agent", "first@x.dev");
+  track("agent", "boom@x.dev");
+  track("agent", "last@x.dev");
+  const { client } = fakeClient((path) =>
+    path.includes("boom") ? new Error("socket hang up") : 204,
+  );
+
+  const r = await cleanup(client, { attempts: 2, sleep: noSleep });
+
+  assert.equal(r.succeeded, 2);
+  assert.equal(r.failed.length, 1);
+  assert.match(r.failed[0]!.reason, /socket hang up/);
+});
+
+test("a transient 429 is retried and the fixture is still deleted", async () => {
+  track("agent", "ratelimited@x.dev");
+  // This is the production failure mode: cleanup runs at the tail of a suite,
+  // when the run's rate-limit budget is most depleted. Pre-fix, this single
+  // 429 abandoned a real agent permanently.
+  const { client, calls } = fakeClient((_path, attempt) => (attempt === 1 ? 429 : 204));
+
+  const r = await cleanup(client, { sleep: noSleep });
+
+  assert.equal(r.succeeded, 1);
+  assert.deepEqual(r.failed, []);
+  assert.equal(calls.length, 2, "should have retried exactly once");
+  assert.equal(getTracked().length, 0);
+});
+
+test("5xx is retried; a non-retryable status is not", async () => {
+  track("agent", "flaky@x.dev");
+  const flaky = fakeClient((_p, attempt) => (attempt < 3 ? 503 : 200));
+  const r1 = await cleanup(flaky.client, { attempts: 3, sleep: noSleep });
+  assert.equal(r1.succeeded, 1);
+  assert.equal(flaky.calls.length, 3);
+
+  drainTracked();
+  track("agent", "hard@x.dev");
+  const hard = fakeClient(() => 422);
+  const r2 = await cleanup(hard.client, { attempts: 3, sleep: noSleep });
+  assert.equal(r2.failed.length, 1);
+  assert.equal(hard.calls.length, 1, "422 must not consume the retry budget");
+});
+
+test("retries are bounded and the give-up reason names the last status", async () => {
+  track("agent", "downforever@x.dev");
+  const { client, calls } = fakeClient(() => 500);
+
+  const r = await cleanup(client, { attempts: 3, sleep: noSleep });
+
+  assert.equal(calls.length, 3);
+  assert.equal(r.succeeded, 0);
+  assert.match(r.failed[0]!.reason, /HTTP 500/);
+});
+
+test("backoff grows per attempt", async () => {
+  track("agent", "slow@x.dev");
+  const slept: number[] = [];
+  const { client } = fakeClient(() => 429);
+
+  await cleanup(client, {
+    attempts: 3,
+    backoffMs: 100,
+    sleep: (ms) => {
+      slept.push(ms);
+      return Promise.resolve();
+    },
+  });
+
+  // Two waits for three attempts — none after the final one.
+  assert.deepEqual(slept, [100, 200]);
+});
+
+test("404 and 403 count as success (already gone / anti-enumeration)", async () => {
+  track("agent", "gone@x.dev");
+  track("agent", "notours@x.dev");
+  const { client } = fakeClient((path) => (path.includes("gone") ? 404 : 403));
+
+  const r = await cleanup(client, { sleep: noSleep });
+
+  assert.equal(r.succeeded, 2);
+  assert.equal(getTracked().length, 0);
+});
+
+test("tracking the same identity twice is idempotent under teardown", async () => {
+  // Over-tracking is the safe direction: suites now track a requested identity
+  // before the create, which can duplicate an id already tracked elsewhere.
+  track("agent", "dupe@x.dev");
+  track("agent", "dupe@x.dev");
+  const { client, calls } = fakeClient((_p, attempt) => (attempt === 1 ? 204 : 404));
+
+  const r = await cleanup(client, { sleep: noSleep });
+
+  assert.equal(r.succeeded, 2);
+  assert.equal(calls.length, 2);
+  assert.equal(getTracked().length, 0, "both registry entries must be cleared");
+});
+
+test("cleanup on an empty registry is a no-op", async () => {
+  const { client, calls } = fakeClient(() => 204);
+  const r = await cleanup(client, { sleep: noSleep });
+  assert.deepEqual(r, { attempted: 0, succeeded: 0, failed: [] });
+  assert.equal(calls.length, 0);
+});
+
+test("a second cleanup pass retries what the first one failed", async () => {
+  track("agent", "recoverable@x.dev");
+  const down = fakeClient(() => 500);
+  const r1 = await cleanup(down.client, { attempts: 1, sleep: noSleep });
+  assert.equal(r1.failed.length, 1);
+  assert.equal(getTracked().length, 1, "a failed fixture stays tracked");
+
+  const up = fakeClient(() => 204);
+  const r2 = await cleanup(up.client, { attempts: 1, sleep: noSleep });
+  assert.equal(r2.succeeded, 1);
+  assert.equal(getTracked().length, 0);
+});

--- a/tests/e2e-prod/harness/cleanup.ts
+++ b/tests/e2e-prod/harness/cleanup.ts
@@ -8,6 +8,7 @@ interface Tracked {
 }
 
 export interface CleanupResult {
+  /** Distinct fixtures in this pass's snapshot. track() dedupes, so 1 per fixture. */
   attempted: number;
   succeeded: number;
   failed: Array<{ kind: Kind; id: string; reason: string }>;
@@ -22,7 +23,12 @@ export interface CleanupOpts {
    * fixtures for reasons that would clear on a second try.
    */
   attempts?: number;
-  /** Base delay between retries; grows linearly per attempt. */
+  /**
+   * Floor for the delay between retries; grows linearly per attempt. A server
+   * `Retry-After` wins when it is larger, because internal/ratelimit guarantees
+   * a whole-second, sliding-window-aware value — retrying before it elapses is
+   * guaranteed to 429 again and just adds load to an already-throttled account.
+   */
   backoffMs?: number;
   /** Injectable so unit tests don't burn real wall-clock time. */
   sleep?: (ms: number) => Promise<void>;
@@ -36,16 +42,25 @@ const tracked: Tracked[] = [];
 const TERMINAL_OK = new Set([200, 204, 404, 403]);
 
 const DEFAULT_ATTEMPTS = 3;
-const DEFAULT_BACKOFF_MS = 500;
+// internal/ratelimit rounds Retry-After up to a whole second, so a sub-second
+// floor cannot outlast even the shortest 429 window.
+const DEFAULT_BACKOFF_MS = 1_000;
+// Teardown must not hang on a long sliding window (a per-minute limit can
+// report Retry-After: 60). Wait at most this long, then take the next attempt.
+const MAX_BACKOFF_MS = 15_000;
 
 export function track(kind: Kind, id: string): void {
-  tracked.push({ kind, id });
   // Every teardown path in this harness is an `after()` hook, and `after()`
   // does not run when the process dies abnormally — Ctrl-C on a long prod
   // sweep, an unhandled rejection, an uncaught throw outside a test. Anything
   // tracked at that moment leaks a REAL production resource, so arm a
   // process-level net the first time a suite tracks anything.
   armSafetyNet();
+  // Dedupe: suites now track a requested identity before the create, which can
+  // name an id some other call site already tracked. Without this, one 5xx on
+  // a duplicated id gets reported as LEAKED even though its twin deleted fine.
+  if (tracked.some((t) => t.kind === kind && t.id === id)) return;
+  tracked.push({ kind, id });
 }
 
 export function untrack(kind: Kind, id: string): void {
@@ -89,22 +104,42 @@ async function deleteWithRetry(
   let reason = "no attempt made";
   for (let attempt = 1; attempt <= attempts; attempt++) {
     let retryable: boolean;
+    let waitMs = backoffMs * attempt;
     try {
       const res = await client.delete(path);
       if (TERMINAL_OK.has(res.status)) return null;
       reason = `HTTP ${res.status}: ${res.raw.slice(0, 200)}`;
       retryable = isRetryableStatus(res.status);
+      waitMs = Math.max(waitMs, retryAfterMs(res.headers));
     } catch (e) {
       // A thrown request is a transport failure (DNS, socket reset, abort).
       // The DELETE may well have reached the server, but we cannot know — and
       // this DELETE is idempotent, so retrying is always safe.
-      reason = (e as Error).message;
+      // errMessage(), not `(e as Error).message`: a rejection carrying a
+      // non-object (null, a string) would otherwise throw a TypeError out of
+      // this catch, out of cleanup()'s loop, and abandon every fixture after
+      // this one — the exact all-or-nothing failure this function exists to
+      // prevent.
+      reason = errMessage(e);
       retryable = true;
     }
     if (!retryable || attempt === attempts) break;
-    await sleep(backoffMs * attempt);
+    await sleep(Math.min(waitMs, MAX_BACKOFF_MS));
   }
   return reason;
+}
+
+function errMessage(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  return String(e);
+}
+
+function retryAfterMs(headers: Record<string, string>): number {
+  const raw = headers["retry-after"];
+  if (!raw) return 0;
+  const secs = Number(raw);
+  // Delta-seconds only; the HTTP-date form is legal but this API never emits it.
+  return Number.isFinite(secs) && secs > 0 ? secs * 1000 : 0;
 }
 
 // 429 is the realistic one — cleanup competes with the suite's own traffic
@@ -130,6 +165,31 @@ export function getTracked(): readonly Tracked[] {
 
 // --- abnormal-exit safety net --------------------------------------------
 
+/** Seams so the net is testable without actually killing the test process. */
+export interface SafetyNetDeps {
+  resolveClient: () => Promise<ApiClient>;
+  exit: (code: number) => void;
+  write: (line: string) => void;
+}
+
+// The net's own sweep must not crawl: defaultClient inherits E2E_RPS (default
+// 1 req/s), which on a large registry means a minute-plus of silence after
+// Ctrl-C — long enough that an operator presses it again. Its DELETEs are the
+// last requests the process makes, so a higher rate costs nothing downstream.
+const NET_RPS = 5;
+
+const defaultDeps: SafetyNetDeps = {
+  resolveClient: async () => {
+    // Imported lazily so this module stays free of env-loading side effects at
+    // import time (loadEnv() throws when the API key is unset).
+    const { ApiClient } = await import("./client.ts");
+    return new ApiClient(undefined, NET_RPS);
+  },
+  exit: (code) => process.exit(code),
+  write: (line) => process.stderr.write(line),
+};
+
+let deps: SafetyNetDeps = defaultDeps;
 let safetyNetArmed = false;
 let safetyNetRunning = false;
 
@@ -139,43 +199,68 @@ let safetyNetRunning = false;
  * called automatically from track().
  *
  * The handlers always re-establish a non-zero exit, so a suite that crashed
- * still reports failure — the net changes what gets deleted, never whether
- * the run is considered green.
+ * still reports failure. Note the deliberate trade: handling uncaughtException
+ * means node:test loses its "which test generated this" attribution, so the
+ * cause (with stack) is written to stderr first. Deleting a real production
+ * agent is worth more than one diagnostic line.
  */
 export function armSafetyNet(): void {
   if (safetyNetArmed) return;
   safetyNetArmed = true;
-  process.once("SIGINT", () => void runSafetyNet("SIGINT", 130));
-  process.once("SIGTERM", () => void runSafetyNet("SIGTERM", 143));
-  process.once("uncaughtException", (e) => void runSafetyNet(`uncaughtException: ${e?.stack ?? e}`, 1));
-  process.once("unhandledRejection", (e) => void runSafetyNet(`unhandledRejection: ${String(e)}`, 1));
+  // `on`, not `once`: a second SIGINT must still be caught. With `once` the
+  // handler is consumed by the first signal and an impatient second Ctrl-C
+  // hits Node's default terminate, killing the sweep mid-flight and taking
+  // the leak report with it — strictly worse than not sweeping at all.
+  process.on("SIGINT", () => void runSafetyNet("SIGINT", 130));
+  process.on("SIGTERM", () => void runSafetyNet("SIGTERM", 143));
+  process.on("uncaughtException", (e) => void runSafetyNet(`uncaughtException: ${e?.stack ?? e}`, 1));
+  process.on("unhandledRejection", (e) => void runSafetyNet(`unhandledRejection: ${String(e)}`, 1));
 }
 
-async function runSafetyNet(cause: string, exitCode: number): Promise<void> {
-  if (safetyNetRunning) return;
+/** Test-only: drop the handlers so a unit test cannot fire a real sweep. */
+export function disarmSafetyNet(): void {
+  process.removeAllListeners("SIGINT");
+  process.removeAllListeners("SIGTERM");
+  process.removeAllListeners("uncaughtException");
+  process.removeAllListeners("unhandledRejection");
+  safetyNetArmed = false;
+  safetyNetRunning = false;
+}
+
+/** Test-only: swap the net's client/exit/stderr seams. Pass nothing to restore. */
+export function setSafetyNetDeps(d?: Partial<SafetyNetDeps>): void {
+  deps = d ? { ...defaultDeps, ...d } : defaultDeps;
+}
+
+export async function runSafetyNet(cause: string, exitCode: number): Promise<void> {
+  if (safetyNetRunning) {
+    // Second signal while the first sweep is in flight. Don't start a second
+    // concurrent pass (it would double the request pressure on an already
+    // throttled account) — report what is still outstanding and go now, since
+    // the operator has asked twice.
+    deps.write(`[e2e-prod] teardown net interrupted (${cause}) — ${tracked.length} fixture(s) NOT deleted\n`);
+    for (const t of tracked) deps.write(`[e2e-prod]   LEAKED ${t.kind} ${t.id}\n`);
+    deps.exit(exitCode);
+    return;
+  }
   safetyNetRunning = true;
   // Print the cause first — handling uncaughtException suppresses Node's own
   // crash report, and a silently-swallowed crash is worse than a leaked fixture.
-  process.stderr.write(`\n[e2e-prod] teardown net fired (${cause})\n`);
+  deps.write(`\n[e2e-prod] teardown net fired (${cause})\n`);
   if (tracked.length > 0) {
-    process.stderr.write(`[e2e-prod] deleting ${tracked.length} tracked fixture(s) before exit\n`);
+    deps.write(`[e2e-prod] deleting ${tracked.length} tracked fixture(s) before exit — Ctrl-C again to abandon them\n`);
     try {
-      // Imported lazily so this module stays free of env-loading side effects
-      // at import time (loadEnv() throws when the API key is unset).
-      const { defaultClient } = await import("./client.ts");
       // One attempt each: the process is already dying and may be on a signal
       // deadline, so a full retry budget risks being killed mid-sweep.
-      const r = await cleanup(defaultClient, { attempts: 1 });
-      process.stderr.write(`[e2e-prod] teardown net: ${r.succeeded} deleted, ${r.failed.length} LEAKED\n`);
+      const r = await cleanup(await deps.resolveClient(), { attempts: 1 });
+      deps.write(`[e2e-prod] teardown net: ${r.succeeded} deleted, ${r.failed.length} LEAKED\n`);
       for (const f of r.failed) {
-        process.stderr.write(`[e2e-prod]   LEAKED ${f.kind} ${f.id}: ${f.reason}\n`);
+        deps.write(`[e2e-prod]   LEAKED ${f.kind} ${f.id}: ${f.reason}\n`);
       }
     } catch (e) {
-      process.stderr.write(`[e2e-prod] teardown net failed: ${(e as Error).message}\n`);
-      for (const t of tracked) {
-        process.stderr.write(`[e2e-prod]   LEAKED ${t.kind} ${t.id}\n`);
-      }
+      deps.write(`[e2e-prod] teardown net failed: ${errMessage(e)}\n`);
+      for (const t of tracked) deps.write(`[e2e-prod]   LEAKED ${t.kind} ${t.id}\n`);
     }
   }
-  process.exit(exitCode);
+  deps.exit(exitCode);
 }

--- a/tests/e2e-prod/harness/cleanup.ts
+++ b/tests/e2e-prod/harness/cleanup.ts
@@ -7,10 +7,45 @@ interface Tracked {
   id: string;
 }
 
+export interface CleanupResult {
+  attempted: number;
+  succeeded: number;
+  failed: Array<{ kind: Kind; id: string; reason: string }>;
+}
+
+export interface CleanupOpts {
+  force?: boolean;
+  /**
+   * Total DELETE attempts per fixture before giving up. Cleanup runs at the
+   * tail of a suite, when the run's rate-limit budget is most depleted and a
+   * 429 is most likely, so a single-shot pass abandons real production
+   * fixtures for reasons that would clear on a second try.
+   */
+  attempts?: number;
+  /** Base delay between retries; grows linearly per attempt. */
+  backoffMs?: number;
+  /** Injectable so unit tests don't burn real wall-clock time. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
 const tracked: Tracked[] = [];
+
+// A DELETE landing on one of these is terminal-good: the fixture is gone, or
+// was never ours to begin with (403 == "not owned"/already deleted under
+// anti-enumeration semantics). Stop retrying and untrack.
+const TERMINAL_OK = new Set([200, 204, 404, 403]);
+
+const DEFAULT_ATTEMPTS = 3;
+const DEFAULT_BACKOFF_MS = 500;
 
 export function track(kind: Kind, id: string): void {
   tracked.push({ kind, id });
+  // Every teardown path in this harness is an `after()` hook, and `after()`
+  // does not run when the process dies abnormally — Ctrl-C on a long prod
+  // sweep, an unhandled rejection, an uncaught throw outside a test. Anything
+  // tracked at that moment leaks a REAL production resource, so arm a
+  // process-level net the first time a suite tracks anything.
+  armSafetyNet();
 }
 
 export function untrack(kind: Kind, id: string): void {
@@ -18,29 +53,64 @@ export function untrack(kind: Kind, id: string): void {
   if (i >= 0) tracked.splice(i, 1);
 }
 
-export async function cleanup(client: ApiClient, opts: { force?: boolean } = {}): Promise<{
-  attempted: number;
-  succeeded: number;
-  failed: Array<{ kind: Kind; id: string; reason: string }>;
-}> {
-  const failed: Array<{ kind: Kind; id: string; reason: string }> = [];
+export async function cleanup(client: ApiClient, opts: CleanupOpts = {}): Promise<CleanupResult> {
+  const attempts = Math.max(1, opts.attempts ?? DEFAULT_ATTEMPTS);
+  const backoffMs = opts.backoffMs ?? DEFAULT_BACKOFF_MS;
+  const sleep = opts.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+
+  const failed: CleanupResult["failed"] = [];
   let succeeded = 0;
-  for (const t of [...tracked].reverse()) {
-    try {
-      const path = pathFor(t);
-      const res = await client.delete(path);
-      if (res.status === 204 || res.status === 200 || res.status === 404 || res.status === 403) {
-        // 403 == "not owned"/already deleted under anti-enumeration semantics
-        succeeded++;
-        untrack(t.kind, t.id);
-      } else {
-        failed.push({ ...t, reason: `HTTP ${res.status}: ${res.raw.slice(0, 200)}` });
-      }
-    } catch (e) {
-      failed.push({ ...t, reason: (e as Error).message });
+  // Snapshot up front: the loop mutates `tracked` via untrack().
+  const batch = [...tracked].reverse();
+  for (const t of batch) {
+    // Each fixture is fully isolated — its own try/catch AND its own retry
+    // budget — so neither a hard failure nor an exhausted retry on one fixture
+    // can stop the remaining ones from being deleted.
+    const reason = await deleteWithRetry(client, t, attempts, backoffMs, sleep);
+    if (reason === null) {
+      succeeded++;
+      untrack(t.kind, t.id);
+    } else {
+      failed.push({ ...t, reason });
     }
   }
-  return { attempted: tracked.length + succeeded, succeeded, failed };
+  return { attempted: batch.length, succeeded, failed };
+}
+
+/** Returns null once the fixture is gone, or a human-readable reason on give-up. */
+async function deleteWithRetry(
+  client: ApiClient,
+  t: Tracked,
+  attempts: number,
+  backoffMs: number,
+  sleep: (ms: number) => Promise<void>,
+): Promise<string | null> {
+  const path = pathFor(t);
+  let reason = "no attempt made";
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    let retryable: boolean;
+    try {
+      const res = await client.delete(path);
+      if (TERMINAL_OK.has(res.status)) return null;
+      reason = `HTTP ${res.status}: ${res.raw.slice(0, 200)}`;
+      retryable = isRetryableStatus(res.status);
+    } catch (e) {
+      // A thrown request is a transport failure (DNS, socket reset, abort).
+      // The DELETE may well have reached the server, but we cannot know — and
+      // this DELETE is idempotent, so retrying is always safe.
+      reason = (e as Error).message;
+      retryable = true;
+    }
+    if (!retryable || attempt === attempts) break;
+    await sleep(backoffMs * attempt);
+  }
+  return reason;
+}
+
+// 429 is the realistic one — cleanup competes with the suite's own traffic
+// against the agent rate limit. 408 and 5xx are transient by definition.
+function isRetryableStatus(status: number): boolean {
+  return status === 429 || status === 408 || status >= 500;
 }
 
 function pathFor(t: Tracked): string {
@@ -56,4 +126,56 @@ function pathFor(t: Tracked): string {
 
 export function getTracked(): readonly Tracked[] {
   return tracked;
+}
+
+// --- abnormal-exit safety net --------------------------------------------
+
+let safetyNetArmed = false;
+let safetyNetRunning = false;
+
+/**
+ * Arm process-level handlers that run a best-effort cleanup pass when the
+ * process is about to die without reaching its `after()` hooks. Idempotent;
+ * called automatically from track().
+ *
+ * The handlers always re-establish a non-zero exit, so a suite that crashed
+ * still reports failure — the net changes what gets deleted, never whether
+ * the run is considered green.
+ */
+export function armSafetyNet(): void {
+  if (safetyNetArmed) return;
+  safetyNetArmed = true;
+  process.once("SIGINT", () => void runSafetyNet("SIGINT", 130));
+  process.once("SIGTERM", () => void runSafetyNet("SIGTERM", 143));
+  process.once("uncaughtException", (e) => void runSafetyNet(`uncaughtException: ${e?.stack ?? e}`, 1));
+  process.once("unhandledRejection", (e) => void runSafetyNet(`unhandledRejection: ${String(e)}`, 1));
+}
+
+async function runSafetyNet(cause: string, exitCode: number): Promise<void> {
+  if (safetyNetRunning) return;
+  safetyNetRunning = true;
+  // Print the cause first — handling uncaughtException suppresses Node's own
+  // crash report, and a silently-swallowed crash is worse than a leaked fixture.
+  process.stderr.write(`\n[e2e-prod] teardown net fired (${cause})\n`);
+  if (tracked.length > 0) {
+    process.stderr.write(`[e2e-prod] deleting ${tracked.length} tracked fixture(s) before exit\n`);
+    try {
+      // Imported lazily so this module stays free of env-loading side effects
+      // at import time (loadEnv() throws when the API key is unset).
+      const { defaultClient } = await import("./client.ts");
+      // One attempt each: the process is already dying and may be on a signal
+      // deadline, so a full retry budget risks being killed mid-sweep.
+      const r = await cleanup(defaultClient, { attempts: 1 });
+      process.stderr.write(`[e2e-prod] teardown net: ${r.succeeded} deleted, ${r.failed.length} LEAKED\n`);
+      for (const f of r.failed) {
+        process.stderr.write(`[e2e-prod]   LEAKED ${f.kind} ${f.id}: ${f.reason}\n`);
+      }
+    } catch (e) {
+      process.stderr.write(`[e2e-prod] teardown net failed: ${(e as Error).message}\n`);
+      for (const t of tracked) {
+        process.stderr.write(`[e2e-prod]   LEAKED ${t.kind} ${t.id}\n`);
+      }
+    }
+  }
+  process.exit(exitCode);
 }

--- a/tests/e2e-prod/harness/cleanup.ts
+++ b/tests/e2e-prod/harness/cleanup.ts
@@ -1,3 +1,4 @@
+import { writeSync } from "node:fs";
 import type { ApiClient } from "./client.ts";
 
 type Kind = "agent" | "domain";
@@ -15,7 +16,6 @@ export interface CleanupResult {
 }
 
 export interface CleanupOpts {
-  force?: boolean;
   /**
    * Total DELETE attempts per fixture before giving up. Cleanup runs at the
    * tail of a suite, when the run's rate-limit budget is most depleted and a
@@ -190,7 +190,17 @@ export interface ReporterDeps {
 }
 
 const defaultReporterDeps: ReporterDeps = {
-  write: (line) => process.stderr.write(line),
+  // writeSync(2), not process.stderr.write: an async write during the 'exit'
+  // event can be truncated, and on Ctrl-C the runner may already have torn
+  // down the pipe — an EPIPE thrown here escapes the 'exit' listener as an
+  // uncaught exception, masks the exit code, and buries the leak report.
+  write: (line) => {
+    try {
+      writeSync(2, line);
+    } catch {
+      // stderr is gone; the exit path must never throw.
+    }
+  },
   exit: (code) => process.exit(code),
 };
 
@@ -201,9 +211,12 @@ let reported = false;
 // A signal fires no `process.on("exit")`, so translate the common ones into an
 // explicit exit — which DOES run the exit handler, and thus the reporter. Kept
 // as named references so disarm can remove exactly these, never the runner's.
+// SIGHUP matters for runs over SSH: a terminal close default-terminates
+// without an 'exit' event, so without a handler no report would print.
 const onExit = () => reportLeaks("exit");
 const onSigint = () => reporterDeps.exit(130);
 const onSigterm = () => reporterDeps.exit(143);
+const onSighup = () => reporterDeps.exit(129);
 
 /** Idempotent; called automatically from track(). */
 export function armLeakReporter(): void {
@@ -212,6 +225,7 @@ export function armLeakReporter(): void {
   process.on("exit", onExit);
   process.on("SIGINT", onSigint);
   process.on("SIGTERM", onSigterm);
+  process.on("SIGHUP", onSighup);
 }
 
 /**
@@ -224,6 +238,7 @@ export function disarmLeakReporter(): void {
   process.off("exit", onExit);
   process.off("SIGINT", onSigint);
   process.off("SIGTERM", onSigterm);
+  process.off("SIGHUP", onSighup);
   reporterArmed = false;
   reported = false;
 }
@@ -243,7 +258,8 @@ export function reportLeaks(cause: string): void {
   if (reported || tracked.length === 0) return;
   reported = true;
   reporterDeps.write(
-    `\n[e2e-prod] ${tracked.length} fixture(s) still tracked at ${cause} — teardown did not run to completion:\n`,
+    `\n[e2e-prod] ${tracked.length} fixture(s) still tracked at ${cause} — teardown did not run to completion:\n` +
+      `[e2e-prod] (a tracked identity whose create never succeeded may appear here; its manual delete will 404, harmlessly)\n`,
   );
   for (const t of tracked) {
     reporterDeps.write(`[e2e-prod]   LEAKED ${t.kind} ${t.id} — delete manually\n`);

--- a/tests/e2e-prod/harness/cleanup.ts
+++ b/tests/e2e-prod/harness/cleanup.ts
@@ -50,12 +50,9 @@ const DEFAULT_BACKOFF_MS = 1_000;
 const MAX_BACKOFF_MS = 15_000;
 
 export function track(kind: Kind, id: string): void {
-  // Every teardown path in this harness is an `after()` hook, and `after()`
-  // does not run when the process dies abnormally — Ctrl-C on a long prod
-  // sweep, an unhandled rejection, an uncaught throw outside a test. Anything
-  // tracked at that moment leaks a REAL production resource, so arm a
-  // process-level net the first time a suite tracks anything.
-  armSafetyNet();
+  // Arm the leak reporter the first time a suite tracks anything, so a fixture
+  // that outlives teardown announces itself (see the reporter section below).
+  armLeakReporter();
   // Dedupe: suites now track a requested identity before the create, which can
   // name an id some other call site already tracked. Without this, one 5xx on
   // a duplicated id gets reported as LEAKED even though its twin deleted fine.
@@ -163,104 +160,92 @@ export function getTracked(): readonly Tracked[] {
   return tracked;
 }
 
-// --- abnormal-exit safety net --------------------------------------------
+// --- abnormal-exit leak reporter -----------------------------------------
+//
+// The reliable teardown path is the per-suite `after()` hook calling cleanup()
+// (with the retry/isolation above). `after()` does NOT run when the process
+// dies without finishing normally: a module-level throw, an unhandled
+// rejection, or a Ctrl-C. Anything still tracked at that point is a REAL
+// leaked production resource.
+//
+// This reporter deliberately does NOT try to DELETE on the way out. An earlier
+// version did, and it was a trap: `npm test` runs each suite in its own child
+// process (Node's `--test-isolation=process` default), so a terminal Ctrl-C
+// signals the whole process group — the node:test RUNNER parent has no signal
+// handler, exits in milliseconds, and tears the child down long before an
+// async, rate-limited DELETE sweep could finish. A net that deletes 1 of N
+// fixtures while claiming to be a safety net is worse than an honest reporter.
+// Deleting on crash needs a supervisor ABOVE the child (a wrapper that traps
+// the signal and reaps), which is out of scope for this module.
+//
+// So instead we surface the leak synchronously: print every still-tracked id
+// on the way out, in a form a human can act on. That directly serves the
+// manual-deletion follow-up leaked fixtures require, and it cannot hang, cannot
+// double-delete, and cannot stomp the runner's own handlers.
 
-/** Seams so the net is testable without actually killing the test process. */
-export interface SafetyNetDeps {
-  resolveClient: () => Promise<ApiClient>;
-  exit: (code: number) => void;
+/** Test seams: swap stderr and exit so a unit test never writes to a real fd. */
+export interface ReporterDeps {
   write: (line: string) => void;
+  exit: (code: number) => void;
 }
 
-// The net's own sweep must not crawl: defaultClient inherits E2E_RPS (default
-// 1 req/s), which on a large registry means a minute-plus of silence after
-// Ctrl-C — long enough that an operator presses it again. Its DELETEs are the
-// last requests the process makes, so a higher rate costs nothing downstream.
-const NET_RPS = 5;
-
-const defaultDeps: SafetyNetDeps = {
-  resolveClient: async () => {
-    // Imported lazily so this module stays free of env-loading side effects at
-    // import time (loadEnv() throws when the API key is unset).
-    const { ApiClient } = await import("./client.ts");
-    return new ApiClient(undefined, NET_RPS);
-  },
-  exit: (code) => process.exit(code),
+const defaultReporterDeps: ReporterDeps = {
   write: (line) => process.stderr.write(line),
+  exit: (code) => process.exit(code),
 };
 
-let deps: SafetyNetDeps = defaultDeps;
-let safetyNetArmed = false;
-let safetyNetRunning = false;
+let reporterDeps: ReporterDeps = defaultReporterDeps;
+let reporterArmed = false;
+let reported = false;
+
+// A signal fires no `process.on("exit")`, so translate the common ones into an
+// explicit exit — which DOES run the exit handler, and thus the reporter. Kept
+// as named references so disarm can remove exactly these, never the runner's.
+const onExit = () => reportLeaks("exit");
+const onSigint = () => reporterDeps.exit(130);
+const onSigterm = () => reporterDeps.exit(143);
+
+/** Idempotent; called automatically from track(). */
+export function armLeakReporter(): void {
+  if (reporterArmed) return;
+  reporterArmed = true;
+  process.on("exit", onExit);
+  process.on("SIGINT", onSigint);
+  process.on("SIGTERM", onSigterm);
+}
 
 /**
- * Arm process-level handlers that run a best-effort cleanup pass when the
- * process is about to die without reaching its `after()` hooks. Idempotent;
- * called automatically from track().
- *
- * The handlers always re-establish a non-zero exit, so a suite that crashed
- * still reports failure. Note the deliberate trade: handling uncaughtException
- * means node:test loses its "which test generated this" attribution, so the
- * cause (with stack) is written to stderr first. Deleting a real production
- * agent is worth more than one diagnostic line.
+ * Test-only: remove exactly the handlers armLeakReporter added. Uses `off`
+ * with retained references, NOT removeAllListeners — the latter would also
+ * tear out node:test's own uncaughtException/rejection handlers and silently
+ * break test attribution.
  */
-export function armSafetyNet(): void {
-  if (safetyNetArmed) return;
-  safetyNetArmed = true;
-  // `on`, not `once`: a second SIGINT must still be caught. With `once` the
-  // handler is consumed by the first signal and an impatient second Ctrl-C
-  // hits Node's default terminate, killing the sweep mid-flight and taking
-  // the leak report with it — strictly worse than not sweeping at all.
-  process.on("SIGINT", () => void runSafetyNet("SIGINT", 130));
-  process.on("SIGTERM", () => void runSafetyNet("SIGTERM", 143));
-  process.on("uncaughtException", (e) => void runSafetyNet(`uncaughtException: ${e?.stack ?? e}`, 1));
-  process.on("unhandledRejection", (e) => void runSafetyNet(`unhandledRejection: ${String(e)}`, 1));
+export function disarmLeakReporter(): void {
+  process.off("exit", onExit);
+  process.off("SIGINT", onSigint);
+  process.off("SIGTERM", onSigterm);
+  reporterArmed = false;
+  reported = false;
 }
 
-/** Test-only: drop the handlers so a unit test cannot fire a real sweep. */
-export function disarmSafetyNet(): void {
-  process.removeAllListeners("SIGINT");
-  process.removeAllListeners("SIGTERM");
-  process.removeAllListeners("uncaughtException");
-  process.removeAllListeners("unhandledRejection");
-  safetyNetArmed = false;
-  safetyNetRunning = false;
+/** Test-only: swap the write/exit seams. Pass nothing to restore the defaults. */
+export function setReporterDeps(d?: Partial<ReporterDeps>): void {
+  reporterDeps = d ? { ...defaultReporterDeps, ...d } : defaultReporterDeps;
 }
 
-/** Test-only: swap the net's client/exit/stderr seams. Pass nothing to restore. */
-export function setSafetyNetDeps(d?: Partial<SafetyNetDeps>): void {
-  deps = d ? { ...defaultDeps, ...d } : defaultDeps;
-}
-
-export async function runSafetyNet(cause: string, exitCode: number): Promise<void> {
-  if (safetyNetRunning) {
-    // Second signal while the first sweep is in flight. Don't start a second
-    // concurrent pass (it would double the request pressure on an already
-    // throttled account) — report what is still outstanding and go now, since
-    // the operator has asked twice.
-    deps.write(`[e2e-prod] teardown net interrupted (${cause}) — ${tracked.length} fixture(s) NOT deleted\n`);
-    for (const t of tracked) deps.write(`[e2e-prod]   LEAKED ${t.kind} ${t.id}\n`);
-    deps.exit(exitCode);
-    return;
+/**
+ * Synchronously print every still-tracked fixture. Runs at process exit (and
+ * is idempotent via `reported`, since a signal handler's explicit exit re-runs
+ * the exit handler). No-op when the registry is empty — a suite whose `after()`
+ * cleaned up prints nothing.
+ */
+export function reportLeaks(cause: string): void {
+  if (reported || tracked.length === 0) return;
+  reported = true;
+  reporterDeps.write(
+    `\n[e2e-prod] ${tracked.length} fixture(s) still tracked at ${cause} — teardown did not run to completion:\n`,
+  );
+  for (const t of tracked) {
+    reporterDeps.write(`[e2e-prod]   LEAKED ${t.kind} ${t.id} — delete manually\n`);
   }
-  safetyNetRunning = true;
-  // Print the cause first — handling uncaughtException suppresses Node's own
-  // crash report, and a silently-swallowed crash is worse than a leaked fixture.
-  deps.write(`\n[e2e-prod] teardown net fired (${cause})\n`);
-  if (tracked.length > 0) {
-    deps.write(`[e2e-prod] deleting ${tracked.length} tracked fixture(s) before exit — Ctrl-C again to abandon them\n`);
-    try {
-      // One attempt each: the process is already dying and may be on a signal
-      // deadline, so a full retry budget risks being killed mid-sweep.
-      const r = await cleanup(await deps.resolveClient(), { attempts: 1 });
-      deps.write(`[e2e-prod] teardown net: ${r.succeeded} deleted, ${r.failed.length} LEAKED\n`);
-      for (const f of r.failed) {
-        deps.write(`[e2e-prod]   LEAKED ${f.kind} ${f.id}: ${f.reason}\n`);
-      }
-    } catch (e) {
-      deps.write(`[e2e-prod] teardown net failed: ${errMessage(e)}\n`);
-      for (const t of tracked) deps.write(`[e2e-prod]   LEAKED ${t.kind} ${t.id}\n`);
-    }
-  }
-  deps.exit(exitCode);
 }

--- a/tests/e2e-prod/suites/03-concurrency.test.ts
+++ b/tests/e2e-prod/suites/03-concurrency.test.ts
@@ -165,13 +165,16 @@ test("concurrency: parallel DELETE of the same agent is idempotent under content
   // because the previous assert (>=1 success) accepted all 4 returning
   // 2xx and only emitted info(). If you want to lock in first-writer-wins
   // specifically, tighten the assertion to ok.length === 1.
-  const slug = uniqueSlug("del");
+  const email = `${uniqueSlug("del")}@${client.env.sharedDomain}`;
+  // Track even though the test is expected to consume it: if all four parallel
+  // DELETEs below get rate-limited, the agent survives, and an untracked
+  // survivor is exactly the leak this suite was caught producing. Teardown
+  // treats the already-deleted case as a 404, i.e. success.
+  track("agent", email);
   const c = await client.post<{ email: string }>("/v1/agents", {
-    body: { email: `${slug}@${client.env.sharedDomain}`, name: "del" },
+    body: { email, name: "del" },
   });
   assert.equal(c.status, 201);
-  const email = c.body!.email;
-  // Don't track — this test consumes it.
 
   const results = await Promise.all(
     Array.from({ length: 4 }, () => burst.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE`)),

--- a/tests/e2e-prod/suites/06-reliability.test.ts
+++ b/tests/e2e-prod/suites/06-reliability.test.ts
@@ -12,15 +12,17 @@ let sharedAgentEmail = "";
 
 before(async () => {
   // Single agent shared across reliability tests to avoid hitting the agent-creation rate limit.
-  const slug = uniqueSlug("rel");
+  sharedAgentEmail = `${uniqueSlug("rel")}@${client.env.sharedDomain}`;
+  // Track before the create, not after: a create that succeeds server-side but
+  // whose response is lost (or malformed) would otherwise be invisible to
+  // teardown, and a throw here skips the rest of this hook entirely.
+  track("agent", sharedAgentEmail);
   const c = await client.post<{ email: string }>("/v1/agents", {
-    body: { email: `${slug}@${client.env.sharedDomain}`, name: "rel-shared" },
+    body: { email: sharedAgentEmail, name: "rel-shared" },
   });
   if (c.status !== 201) {
     throw new Error(`shared-agent setup failed: ${c.status} ${c.raw.slice(0, 200)}`);
   }
-  sharedAgentEmail = c.body!.email;
-  track("agent", sharedAgentEmail);
 });
 
 after(async () => {

--- a/tests/e2e-prod/suites/06-reliability.test.ts
+++ b/tests/e2e-prod/suites/06-reliability.test.ts
@@ -23,6 +23,9 @@ before(async () => {
   if (c.status !== 201) {
     throw new Error(`shared-agent setup failed: ${c.status} ${c.raw.slice(0, 200)}`);
   }
+  if (c.body?.email !== sharedAgentEmail) {
+    throw new Error(`server echoed a different address: requested ${sharedAgentEmail}, got ${c.body?.email}`);
+  }
 });
 
 after(async () => {


### PR DESCRIPTION
## Summary

The production smoke-test harness could leak test fixtures (agents, domains created in the PRODUCTION environment) when a run died abnormally — the teardown net deleted asynchronously and could be lost with the process. This PR makes per-fixture cleanup retry-aware and isolation-safe, and turns the abnormal-exit path into a synchronous leak **reporter** (no deletes on the way out — the runner-kills-child race makes that a trap; rationale in the code comments).

- `tests/e2e-prod/harness/cleanup.ts` — per-fixture retry with 429/`Retry-After`-aware bounded backoff, non-Error rejection isolation, dedupe-by-identity tracking, and the exit/signal leak reporter (SIGINT/SIGTERM/SIGHUP → 130/143/129; EPIPE-safe synchronous write)
- `tests/e2e-prod/harness/cleanup.test.ts` — 397-line unit suite, fully offline (faked client, injected sleep). **CI coverage already exists**: the `harness-tests` job in test.yml runs `node --test tests/e2e-prod/harness/*.test.ts`, which picks this file up automatically
- `06-reliability` + one spot in `03-concurrency` — track-before-create so a mid-loop throw or lost response can't strand a fixture (teardown treats 404/403 as success, so over-tracking is free)

**Rebase note:** while this branch was parked, main independently landed track-before-create in most of `03-concurrency` and the `test:unit` harness script — those hunks were dropped on rebase as superseded; what remains here is the delta main lacks. Rolling track-before-create out to the remaining ~11 suites (`01-basic`, `02-authz`, `04-quota`, `05-security`, …) is deliberately **not** in this PR — follow-up.

## Operational risk

Test-harness only; no production code paths. Every DELETE is scoped to an explicitly tracked id with `?confirm=DELETE`; the abnormal-exit path deletes nothing. Rollback = revert.

## Test plan

- [x] `node --test harness/*.test.ts` — 38/38 pass
- [x] `tsc --noEmit` clean for tests/e2e-prod
- [ ] After merge: kill a prod-smoke run mid-flight (Ctrl-C) and confirm the leak report prints with actionable ids

🤖 Generated with [Kimi Code](https://www.kimi.com/code)