### PR TITLE
feat(web): FAQPage schema on / and /docs, positioning in llms.txt

### DIFF
--- a/plugins/e2a/docs/llms.txt
+++ b/plugins/e2a/docs/llms.txt
@@ -21,9 +21,9 @@ own, with two-way send and receive.
   headers the agent has to parse and trust.
 - **An approval gate before anything is sent.** Opt-in, per agent: an outbound
   message is accepted but not dispatched (`status: pending_review`) until a
-  person approves it from the dashboard, the CLI, the API, or a magic link
-  mailed to them. A hold that expires without a decision can be set to reject
-  rather than send.
+  person approves it from the dashboard, the API, the MCP tools, or a magic
+  link mailed to them. A hold that expires without a decision can be set to
+  reject rather than send.
 - **Prompt-injection and phishing screening on inbound.** Opt-in content
   screening flags hidden HTML, Unicode-tag smuggling, and encoded instructions
   with dependency-free heuristics — and phishing when the optional LLM detector

--- a/plugins/e2a/docs/llms.txt
+++ b/plugins/e2a/docs/llms.txt
@@ -5,6 +5,36 @@
 > verification. Connect
 > over a hosted MCP server (OAuth, no API key), the REST API, or the SDKs.
 
+**The problem e2a solves.** An AI agent that has to reach people, or other
+agents, has no identity of its own on the one channel every organization
+already runs on. Pointing an agent at a human's mailbox borrows that person's
+identity, mixes the agent's mail in with theirs, and leaves the agent no way to
+tell a real sender from a spoofed one. e2a gives the mailbox to the agent: its
+own verified address, on the shared `agents.e2a.dev` domain or on a domain you
+own, with two-way send and receive.
+
+**What is distinctive about e2a:**
+
+- **Sender verification on every inbound message.** e2a evaluates SPF, every
+  DKIM signature, and DMARC — including alignment — before the agent sees a
+  message, and hands the result over as structured evidence rather than raw
+  headers the agent has to parse and trust.
+- **An approval gate before anything is sent.** Opt-in, per agent: an outbound
+  message is accepted but not dispatched (`status: pending_review`) until a
+  person approves it from the dashboard, the CLI, the API, or a magic link
+  mailed to them. A hold that expires without a decision can be set to reject
+  rather than send.
+- **Prompt-injection and phishing screening on inbound.** Opt-in content
+  screening flags hidden HTML, Unicode-tag smuggling, and encoded instructions
+  with dependency-free heuristics — and phishing when the optional LLM detector
+  is enabled — then routes each message to allow, review, or block.
+- **No public URL required.** WebSocket streaming, REST polling, and the MCP
+  tools all work from a laptop or from behind a firewall. Webhooks are an
+  option, not a prerequisite, and every webhook delivery is HMAC-signed.
+- **Apache-2.0 and self-hostable.** The whole stack is open source and runs
+  against your own Postgres and outbound relay, with every feature intact. The
+  hosted service at e2a.dev runs that same server image.
+
 ## Start here
 
 - [setup.md](https://e2a.dev/setup.md): What e2a is, how an agent connects (one MCP command), and what it can do. Read this first.
@@ -25,6 +55,17 @@
 - [Agent plugin + skills](https://github.com/tokencanopy/e2a/tree/main/plugins/e2a): The `e2a` plugin bundles the hosted MCP server config and agent guidance for Claude Code, Codex, and Cursor.
 - [MCP overview](https://e2a.dev/mcp): Per-client connection instructions (Claude Code, Codex, Cursor/Windsurf/Claude Desktop, VS Code + Copilot), what the agent can do once connected, and how an agent-owned inbox differs from a mailbox integration.
 - MCP endpoint: `https://api.e2a.dev/mcp` (Streamable HTTP, OAuth 2.1). Add with `claude mcp add --transport http --scope user e2a https://api.e2a.dev/mcp`, then run `/mcp` to authorize (`--scope user` installs it globally; drop it for current-directory only). Per-client config (Cursor, VS Code, Codex, …) is in [setup.md](https://e2a.dev/setup.md).
+
+## Pricing
+
+- [Pricing](https://e2a.dev/pricing): Hosted plans. The free tier needs no credit card and includes the shared `agents.e2a.dev` domain, a custom domain, sender verification, and real-time WebSocket delivery; paid Pro and Scale tiers raise the agent, custom-domain, monthly-message, and storage limits. Self-hosting the Apache-2.0 server costs nothing. Current amounts and limits live on the page rather than in this file, so read it before quoting a number.
+
+## Blog
+
+- [Blog](https://e2a.dev/blog): Tutorials and release notes. The posts below are complete, runnable integrations; the index carries the rest.
+- [Send real email from a Python AI agent in 20 lines](https://e2a.dev/blog/send-email-from-python-agent): Give a Python agent an address, send verified mail, receive replies over webhook or WebSocket, and thread the conversation.
+- [Give your OpenClaw agent an email address (with real-time WebSocket delivery)](https://e2a.dev/blog/email-for-openclaw-agents): Wiring a locally-running agent to a real inbox over WebSocket, with no public URL to host.
+- [Give your Google ADK agent an email inbox (with conversation memory)](https://e2a.dev/blog/email-agent-with-google-adk): HMAC-verified webhooks and multi-turn memory across email replies, binding `conversation_id` to an ADK `session_id`. Full runnable example.
 
 ## Source
 

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -21,9 +21,9 @@ own, with two-way send and receive.
   headers the agent has to parse and trust.
 - **An approval gate before anything is sent.** Opt-in, per agent: an outbound
   message is accepted but not dispatched (`status: pending_review`) until a
-  person approves it from the dashboard, the CLI, the API, or a magic link
-  mailed to them. A hold that expires without a decision can be set to reject
-  rather than send.
+  person approves it from the dashboard, the API, the MCP tools, or a magic
+  link mailed to them. A hold that expires without a decision can be set to
+  reject rather than send.
 - **Prompt-injection and phishing screening on inbound.** Opt-in content
   screening flags hidden HTML, Unicode-tag smuggling, and encoded instructions
   with dependency-free heuristics — and phishing when the optional LLM detector

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -5,6 +5,36 @@
 > verification. Connect
 > over a hosted MCP server (OAuth, no API key), the REST API, or the SDKs.
 
+**The problem e2a solves.** An AI agent that has to reach people, or other
+agents, has no identity of its own on the one channel every organization
+already runs on. Pointing an agent at a human's mailbox borrows that person's
+identity, mixes the agent's mail in with theirs, and leaves the agent no way to
+tell a real sender from a spoofed one. e2a gives the mailbox to the agent: its
+own verified address, on the shared `agents.e2a.dev` domain or on a domain you
+own, with two-way send and receive.
+
+**What is distinctive about e2a:**
+
+- **Sender verification on every inbound message.** e2a evaluates SPF, every
+  DKIM signature, and DMARC — including alignment — before the agent sees a
+  message, and hands the result over as structured evidence rather than raw
+  headers the agent has to parse and trust.
+- **An approval gate before anything is sent.** Opt-in, per agent: an outbound
+  message is accepted but not dispatched (`status: pending_review`) until a
+  person approves it from the dashboard, the CLI, the API, or a magic link
+  mailed to them. A hold that expires without a decision can be set to reject
+  rather than send.
+- **Prompt-injection and phishing screening on inbound.** Opt-in content
+  screening flags hidden HTML, Unicode-tag smuggling, and encoded instructions
+  with dependency-free heuristics — and phishing when the optional LLM detector
+  is enabled — then routes each message to allow, review, or block.
+- **No public URL required.** WebSocket streaming, REST polling, and the MCP
+  tools all work from a laptop or from behind a firewall. Webhooks are an
+  option, not a prerequisite, and every webhook delivery is HMAC-signed.
+- **Apache-2.0 and self-hostable.** The whole stack is open source and runs
+  against your own Postgres and outbound relay, with every feature intact. The
+  hosted service at e2a.dev runs that same server image.
+
 ## Start here
 
 - [setup.md](https://e2a.dev/setup.md): What e2a is, how an agent connects (one MCP command), and what it can do. Read this first.
@@ -25,6 +55,17 @@
 - [Agent plugin + skills](https://github.com/tokencanopy/e2a/tree/main/plugins/e2a): The `e2a` plugin bundles the hosted MCP server config and agent guidance for Claude Code, Codex, and Cursor.
 - [MCP overview](https://e2a.dev/mcp): Per-client connection instructions (Claude Code, Codex, Cursor/Windsurf/Claude Desktop, VS Code + Copilot), what the agent can do once connected, and how an agent-owned inbox differs from a mailbox integration.
 - MCP endpoint: `https://api.e2a.dev/mcp` (Streamable HTTP, OAuth 2.1). Add with `claude mcp add --transport http --scope user e2a https://api.e2a.dev/mcp`, then run `/mcp` to authorize (`--scope user` installs it globally; drop it for current-directory only). Per-client config (Cursor, VS Code, Codex, …) is in [setup.md](https://e2a.dev/setup.md).
+
+## Pricing
+
+- [Pricing](https://e2a.dev/pricing): Hosted plans. The free tier needs no credit card and includes the shared `agents.e2a.dev` domain, a custom domain, sender verification, and real-time WebSocket delivery; paid Pro and Scale tiers raise the agent, custom-domain, monthly-message, and storage limits. Self-hosting the Apache-2.0 server costs nothing. Current amounts and limits live on the page rather than in this file, so read it before quoting a number.
+
+## Blog
+
+- [Blog](https://e2a.dev/blog): Tutorials and release notes. The posts below are complete, runnable integrations; the index carries the rest.
+- [Send real email from a Python AI agent in 20 lines](https://e2a.dev/blog/send-email-from-python-agent): Give a Python agent an address, send verified mail, receive replies over webhook or WebSocket, and thread the conversation.
+- [Give your OpenClaw agent an email address (with real-time WebSocket delivery)](https://e2a.dev/blog/email-for-openclaw-agents): Wiring a locally-running agent to a real inbox over WebSocket, with no public URL to host.
+- [Give your Google ADK agent an email inbox (with conversation memory)](https://e2a.dev/blog/email-agent-with-google-adk): HMAC-verified webhooks and multi-turn memory across email replies, binding `conversation_id` to an ADK `session_id`. Full runnable example.
 
 ## Source
 

--- a/web/src/app/docs/layout.tsx
+++ b/web/src/app/docs/layout.tsx
@@ -2,8 +2,12 @@ import type { Metadata } from "next";
 import { SITE_URL } from "../../lib/site";
 
 const TITLE = "Docs — e2a email API for AI agents";
+// Describes what this page actually answers — connecting over MCP/REST/SDK,
+// the credential model, webhook vs WebSocket delivery, threading, idempotency
+// — rather than the whole product. A description that overshoots its page is
+// the one search engines rewrite.
 const DESC =
-  "Developer docs for e2a: authenticated email API for AI agents. SDKs, CLI, webhook payload reference, SPF/DKIM auth headers, conversation threading, agent-to-agent routing.";
+  "Developer docs for e2a, the authenticated email API for AI agents: connect over MCP, REST, or the TypeScript and Python SDKs; API keys and OAuth 2.1; webhook vs WebSocket delivery; conversation threading and idempotent sends.";
 
 export const metadata: Metadata = {
   title: { absolute: TITLE },

--- a/web/src/app/docs/page.test.tsx
+++ b/web/src/app/docs/page.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from "@testing-library/react";
+import DocsPage from "./page";
+
+jest.mock("next/link", () => {
+  return function MockLink({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) {
+    return (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    );
+  };
+});
+
+function ldNodes(container: HTMLElement): Record<string, unknown>[] {
+  return Array.from(
+    container.querySelectorAll('script[type="application/ld+json"]'),
+  ).map((s) => JSON.parse(s.innerHTML.replace(/\\u003c/g, "<")));
+}
+
+describe("Docs page", () => {
+  // This route used to be a JS redirect whose entire payload to a crawler was
+  // "Loading API docs...". The point of the page is now that it answers
+  // something without running any JavaScript.
+  it("renders statically, with no redirect", () => {
+    render(<DocsPage />);
+    expect(screen.queryByText(/Loading API docs/i)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 1, name: /e2a developer docs/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("routes onward to the full API reference", () => {
+    render(<DocsPage />);
+    // Nobody arriving here for the endpoint reference should be stranded.
+    const toReference = screen
+      .getAllByRole("link")
+      .filter((l) => l.getAttribute("href") === "/api-docs");
+    expect(toReference.length).toBeGreaterThan(0);
+  });
+
+  it("lists the machine-readable documents an agent should fetch", () => {
+    render(<DocsPage />);
+    for (const [name, href] of [
+      ["openapi.yaml", "https://e2a.dev/v1/openapi.yaml"],
+      ["setup.md", "https://e2a.dev/setup.md"],
+      ["auth.md", "https://e2a.dev/auth.md"],
+      ["sdk.md", "https://e2a.dev/sdk.md"],
+      ["llms.txt", "https://e2a.dev/llms.txt"],
+    ] as const) {
+      expect(screen.getByRole("link", { name })).toHaveAttribute("href", href);
+    }
+  });
+
+  it("emits a valid FAQPage whose answers match the visible ones", () => {
+    const { container } = render(<DocsPage />);
+    const faq = ldNodes(container).find((n) => n["@type"] === "FAQPage");
+    expect(faq).toBeDefined();
+
+    const questions = faq!.mainEntity as {
+      "@type": string;
+      name: string;
+      acceptedAnswer: { "@type": string; text: string };
+    }[];
+    expect(questions.length).toBeGreaterThanOrEqual(4);
+    for (const q of questions) {
+      expect(q["@type"]).toBe("Question");
+      expect(q.acceptedAnswer["@type"]).toBe("Answer");
+      // A quoted answer has to attribute on its own, with no page around it.
+      expect(q.acceptedAnswer.text).toMatch(/e2a/);
+      expect(screen.getByText(q.acceptedAnswer.text)).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: q.name })).toBeInTheDocument();
+    }
+  });
+
+  it("emits breadcrumbs rooted at the site home", () => {
+    const { container } = render(<DocsPage />);
+    const crumbs = ldNodes(container).find(
+      (n) => n["@type"] === "BreadcrumbList",
+    );
+    expect(crumbs).toBeDefined();
+    const items = crumbs!.itemListElement as { position: number; name: string }[];
+    expect(items.map((i) => i.position)).toEqual([1, 2]);
+    expect(items.map((i) => i.name)).toEqual(["e2a", "Docs"]);
+  });
+
+  // /mcp already owns the "how do I connect an MCP client" questions. Repeating
+  // them here would split the signal across two pages instead of ranking one.
+  it("does not duplicate the MCP page's questions", () => {
+    const { container } = render(<DocsPage />);
+    const faq = ldNodes(container).find((n) => n["@type"] === "FAQPage");
+    const names = (faq!.mainEntity as { name: string }[]).map((q) => q.name);
+    expect(names).not.toContain("How do I give my AI agent an email address?");
+    expect(names).not.toContain("Which MCP clients does e2a work with?");
+  });
+});

--- a/web/src/app/docs/page.tsx
+++ b/web/src/app/docs/page.tsx
@@ -1,18 +1,291 @@
-"use client";
+import Link from "next/link";
+import { JsonLd } from "../components/JsonLd";
+import { breadcrumbs, faqPage, type FaqEntry } from "../../lib/jsonld";
 
-import { useEffect } from "react";
+// Deliberately a server component with no "use client". This route used to be
+// a JavaScript redirect to /scalar.html, which meant the one thing it shipped
+// to a crawler was the string "Loading API docs..." — a sitemap entry at
+// priority 0.8 that could answer nothing. The full reference still lives at
+// /api-docs (and /scalar.html); this page is the index that links there and
+// answers the implementation questions people ask on the way in.
+
+// Implementation-shaped questions, grounded in setup.md / auth.md / sdk.md.
+// They deliberately do not repeat /mcp's questions, which cover connecting an
+// MCP client specifically; these cover choosing between the client surfaces
+// and the mechanics you hit once you have chosen.
+//
+// Each answer must survive being quoted with none of this page attached, so it
+// names e2a instead of saying "we" or "it", and claims only shipped behavior.
+const FAQ: FaqEntry[] = [
+  {
+    question: "How do I connect an AI agent to e2a — over MCP, REST, or an SDK?",
+    answer:
+      "e2a offers all three over one API, so the choice is about how your agent runs rather than what it can do. Point any Streamable HTTP MCP client at https://api.e2a.dev/mcp and the agent gets the inbox as tools with no API key to paste — the fastest path for coding agents and agent frameworks. If you are writing the integration yourself, install @e2a/sdk for TypeScript or e2a for Python to get typed clients with one-call webhook verification and a WebSocket listen() stream; if your language has no SDK, call the REST API at https://api.e2a.dev/v1 directly against the published OpenAPI 3.1 contract.",
+  },
+  {
+    question: "How does authentication work for the e2a API?",
+    answer:
+      "Every authenticated e2a request carries an Authorization: Bearer credential, and e2a accepts two kinds, told apart by prefix. Interactive MCP clients use OAuth 2.1 access tokens (ate2a_…), obtained by self-registering through RFC 7591 Dynamic Client Registration with PKCE, so no human ever pastes a secret. API keys are issued from the e2a dashboard or CLI in two scopes — an account key (e2a_acct_…) manages agents, domains, and keys, while an agent key (e2a_agt_…) is pinned to a single inbox — and are what you use for servers, scripts, and CI where no browser is available.",
+  },
+  {
+    question: "Should my agent receive email over a webhook or a WebSocket?",
+    answer:
+      "Use a webhook when the agent runs as a service that can host a public HTTPS endpoint: e2a POSTs a signed metadata trigger, and the SDK's constructEvent or construct_event helper verifies the per-webhook HMAC before you hydrate the full message. Use the WebSocket stream — client.listen(agentEmail) in either SDK, or e2a listen in the CLI — when the agent runs on a laptop or behind a firewall and cannot host a URL at all. Both carry the same email.received event, and REST polling and the MCP tools read the same mailbox, so different deployments of the same agent can use different channels.",
+  },
+  {
+    question: "How does e2a thread an email conversation?",
+    answer:
+      "Reply with e2a's reply operation and the original message_id — client.messages.reply(...) in the SDKs, reply_to_message over MCP — and e2a sets the standards-compliant reply headers that keep the exchange in one thread in Gmail and Outlook. conversation_id is a separate, caller-owned correlation field: bind it to your agent framework's session ID so the agent has memory across replies, but on its own it does not set those headers and it is never an authorization decision. Starting a fresh send instead of a reply opens a new thread in the recipient's mail client.",
+  },
+  {
+    question: "How do I keep a retried API call from sending the same email twice?",
+    answer:
+      "e2a's send, reply, and forward operations accept an Idempotency-Key header — use one UUIDv4 per logical message. Reuse the same key on transport retries such as timeouts and dropped connections and e2a replays the original response instead of sending again; reusing a key with a different body returns 422, and a genuinely new message needs a fresh key. Separately, a send that returns 202 with status pending_review has already been accepted and is being held for approval, so report the status and stop rather than retrying, which would queue a duplicate.",
+  },
+  {
+    question: "Is the e2a /v1 API stable enough to build on?",
+    answer:
+      "e2a's core /v1 REST API and its TypeScript and Python SDKs are generally available: v1.5.0 is the compatibility baseline, there are no breaking changes within /v1, and every later release is audited against that tag. A small, explicitly enumerated set of newer resources is still beta and may change — those are marked x-stability-level: beta in the OpenAPI document and (beta) in the docs, so GA and beta can be told apart mechanically rather than by reading prose. The contract at https://e2a.dev/v1/openapi.yaml is generated from the live handlers and drift-checked in CI, so it cannot fall out of step with the running service.",
+  },
+];
+
+// The documents an agent (or a person) should read next. Machine-readable
+// first: an LLM landing here should find llms.txt without scrolling.
+const REFERENCES: { label: string; href: string; desc: string }[] = [
+  {
+    label: "API reference",
+    href: "/api-docs",
+    desc: "Every /v1 endpoint, request and response body, enum, and error code, rendered from the live OpenAPI contract.",
+  },
+  {
+    label: "openapi.yaml",
+    href: "https://e2a.dev/v1/openapi.yaml",
+    desc: "The OpenAPI 3.1 document itself — generated from the handlers and authoritative for exact signatures.",
+  },
+  {
+    label: "setup.md",
+    href: "https://e2a.dev/setup.md",
+    desc: "Connect a client, pick or create an inbox, and confirm it is ready to send and receive.",
+  },
+  {
+    label: "auth.md",
+    href: "https://e2a.dev/auth.md",
+    desc: "The credential model in full: OAuth 2.1 with Dynamic Client Registration, API key scopes, errors, and revocation.",
+  },
+  {
+    label: "sdk.md",
+    href: "https://e2a.dev/sdk.md",
+    desc: "TypeScript and Python quick starts — send, receive over webhook or WebSocket, reply in-thread — plus raw REST.",
+  },
+  {
+    label: "templates.md",
+    href: "https://e2a.dev/templates.md",
+    desc: "Email templates (beta): reusable server-rendered bodies with {{variable}} interpolation and a starter catalog.",
+  },
+  {
+    label: "llms.txt",
+    href: "https://e2a.dev/llms.txt",
+    desc: "Machine-readable index of everything above. llms-full.txt inlines the whole corpus in one fetch.",
+  },
+];
 
 export default function DocsPage() {
-  useEffect(() => {
-    window.location.replace("/scalar.html");
-  }, []);
-
   return (
     <div
-      className="flex items-center justify-center h-screen text-[13px]"
-      style={{ background: "var(--bg)", color: "var(--fg-muted)" }}
+      className="min-h-screen"
+      style={{
+        background: "var(--bg)",
+        color: "var(--fg)",
+        fontFamily: "var(--f-ui)",
+      }}
     >
-      Loading API docs...
+      <JsonLd
+        data={[
+          faqPage(FAQ),
+          breadcrumbs([
+            { name: "e2a", path: "/" },
+            { name: "Docs", path: "/docs" },
+          ]),
+        ]}
+      />
+
+      <nav
+        className="sticky top-0 z-50"
+        style={{
+          background: "var(--bg)",
+          borderBottom: "1px solid var(--border)",
+        }}
+      >
+        <div className="max-w-[760px] mx-auto flex items-center justify-between px-6 md:px-8 py-3.5">
+          <Link
+            href="/"
+            className="font-mono font-bold text-[15px]"
+            style={{ color: "var(--fg)", letterSpacing: "-0.02em" }}
+          >
+            e2a
+          </Link>
+          <div className="flex items-center gap-4">
+            <Link href="/mcp" className="text-[13px]" style={{ color: "var(--fg-muted)" }}>
+              MCP
+            </Link>
+            <Link href="/blog" className="text-[13px]" style={{ color: "var(--fg-muted)" }}>
+              Blog
+            </Link>
+            <Link
+              href="/api-docs"
+              className="inline-flex items-center gap-1.5 px-3.5 py-1.5 text-[13px] font-medium"
+              style={{
+                background: "var(--fg)",
+                color: "var(--bg)",
+                borderRadius: "var(--r-md)",
+              }}
+            >
+              API reference <span className="font-mono">→</span>
+            </Link>
+          </div>
+        </div>
+      </nav>
+
+      <main className="max-w-[720px] mx-auto px-6 md:px-8 py-14 md:py-[56px] pb-20">
+        <p
+          className="font-mono text-[11px] mb-3"
+          style={{ color: "var(--fg-subtle)", letterSpacing: "0.08em" }}
+        >
+          DOCS
+        </p>
+        <h1
+          className="text-[34px] md:text-[40px] font-semibold leading-[1.12] mb-5"
+          style={{ letterSpacing: "-0.025em" }}
+        >
+          e2a developer docs
+        </h1>
+
+        {/* The lede is the extractable answer: what the docs cover and where
+            the exhaustive reference lives. */}
+        <p className="text-[17px] leading-[1.6]" style={{ color: "var(--fg-muted)" }}>
+          e2a is an authenticated email gateway for AI agents: it gives an agent
+          its own verified email address, evaluates SPF, DKIM, and DMARC on every
+          inbound message, and delivers that mail over MCP, a signed webhook, a
+          WebSocket stream, or REST. These pages cover how to connect, how to
+          authenticate, and how mail is threaded; the exhaustive endpoint
+          reference is the{" "}
+          <Link href="/api-docs" style={{ color: "var(--fg)", textDecoration: "underline" }}>
+            API reference
+          </Link>
+          .
+        </p>
+
+        <Section id="reference" title="Where the reference lives">
+          <p className="text-[15px] leading-[1.65]" style={{ color: "var(--fg-muted)" }}>
+            Each document below is a plain, fetchable file — the Markdown ones
+            are written to be read by an agent as easily as by a person.
+          </p>
+          <ul className="mt-4 space-y-3.5">
+            {REFERENCES.map((r) => (
+              <li key={r.href} className="text-[14.5px] leading-[1.6]">
+                <A href={r.href}>{r.label}</A>{" "}
+                <span style={{ color: "var(--fg-muted)" }}>— {r.desc}</span>
+              </li>
+            ))}
+          </ul>
+        </Section>
+
+        <Section id="faq" title="Frequently asked questions">
+          <div className="mt-1">
+            {FAQ.map((f) => (
+              <div
+                key={f.question}
+                className="py-4"
+                style={{ borderTop: "1px solid var(--border)" }}
+              >
+                <h3 className="text-[15px] font-semibold mb-1.5">{f.question}</h3>
+                <p
+                  className="text-[14.5px] leading-[1.6]"
+                  style={{ color: "var(--fg-muted)" }}
+                >
+                  {f.answer}
+                </p>
+              </div>
+            ))}
+          </div>
+        </Section>
+
+        <div
+          className="mt-12 p-6"
+          style={{
+            border: "1px solid var(--border)",
+            borderRadius: "var(--r-lg)",
+            background: "var(--bg-elev)",
+          }}
+        >
+          <h2 className="text-[17px] font-semibold mb-1.5">Give your agent an inbox</h2>
+          <p className="text-[14.5px] mb-4" style={{ color: "var(--fg-muted)" }}>
+            Free tier, no card. Create an inbox on the shared domain and send
+            your first message without any DNS setup.
+          </p>
+          <Link
+            href="/get-started"
+            className="inline-flex items-center gap-1.5 px-4 py-2 text-[14px] font-medium"
+            style={{
+              background: "var(--fg)",
+              color: "var(--bg)",
+              borderRadius: "var(--r-md)",
+            }}
+          >
+            Start building <span className="font-mono">→</span>
+          </Link>
+        </div>
+      </main>
+
+      <footer
+        className="max-w-[720px] mx-auto flex justify-between px-6 md:px-8 py-5"
+        style={{ borderTop: "1px solid var(--border)" }}
+      >
+        <span
+          className="font-mono font-bold text-[13px]"
+          style={{ color: "var(--fg)", letterSpacing: "-0.02em" }}
+        >
+          e2a
+        </span>
+        <span className="font-mono text-[12px]" style={{ color: "var(--fg-subtle)" }}>
+          Apache 2.0
+        </span>
+      </footer>
     </div>
+  );
+}
+
+function Section({
+  id,
+  title,
+  children,
+}: {
+  id: string;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section id={id} className="mt-12 scroll-mt-20">
+      <h2
+        className="text-[22px] font-semibold mb-3.5 leading-[1.25]"
+        style={{ letterSpacing: "-0.015em" }}
+      >
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+function A({ href, children }: { href: string; children: React.ReactNode }) {
+  const external = href.startsWith("http");
+  return (
+    <a
+      href={href}
+      style={{ color: "var(--fg)", textDecoration: "underline" }}
+      {...(external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+    >
+      {children}
+    </a>
   );
 }

--- a/web/src/app/page.test.tsx
+++ b/web/src/app/page.test.tsx
@@ -204,6 +204,69 @@ describe("Landing page", () => {
   });
 });
 
+// The landing page is the site's main answer surface. These assertions guard
+// the two properties that make it one: the FAQ answers are actually in the
+// HTML (not only in the markup), and the markup parses as a valid FAQPage.
+describe("FAQ and structured data", () => {
+  function ldNodes(container: HTMLElement): Record<string, unknown>[] {
+    return Array.from(
+      container.querySelectorAll('script[type="application/ld+json"]'),
+    ).map((s) => JSON.parse(s.innerHTML.replace(/\\u003c/g, "<")));
+  }
+
+  it("renders the FAQ answers as visible prose", () => {
+    render(<Home />);
+    expect(
+      screen.getByRole("heading", { name: /Questions people ask/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        name: "Can an AI agent have its own email address?",
+      }),
+    ).toBeInTheDocument();
+    // Google only honors FAQ markup whose answers are on the page, and an
+    // answer engine quotes the prose as readily as the JSON-LD.
+    expect(
+      screen.getByText(/The inbox belongs to the agent rather than to a human/),
+    ).toBeInTheDocument();
+  });
+
+  it("emits a valid FAQPage whose answers match the visible ones", () => {
+    const { container } = render(<Home />);
+    const faq = ldNodes(container).find((n) => n["@type"] === "FAQPage");
+    expect(faq).toBeDefined();
+
+    const questions = faq!.mainEntity as {
+      "@type": string;
+      name: string;
+      acceptedAnswer: { "@type": string; text: string };
+    }[];
+    expect(questions.length).toBeGreaterThanOrEqual(6);
+    for (const q of questions) {
+      expect(q["@type"]).toBe("Question");
+      expect(q.acceptedAnswer["@type"]).toBe("Answer");
+      // Self-contained means the answer names the product: a quoted fragment
+      // has to still attribute, with none of this page attached to it.
+      expect(q.acceptedAnswer.text).toMatch(/e2a/);
+      // Same strings in both copies, so a quote can't diverge from the page.
+      expect(screen.getByText(q.acceptedAnswer.text)).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", { name: q.name }),
+      ).toBeInTheDocument();
+    }
+  });
+
+  it("links the FAQ from the Product menu", () => {
+    render(<Home />);
+    const product = screen.getByText(/^Product/).closest("div")!;
+    fireEvent.mouseEnter(product);
+    expect(screen.getByRole("link", { name: "FAQ" })).toHaveAttribute(
+      "href",
+      "#faq",
+    );
+  });
+});
+
 describe("Navigation auth state", () => {
   it("shows Sign in link when not authenticated", () => {
     render(<Home />);

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -4,7 +4,9 @@ import Link from "next/link";
 import { useState } from "react";
 import { useAuth } from "./components/AuthProvider";
 import { Eyebrow } from "@e2a/ui";
+import { JsonLd } from "./components/JsonLd";
 import { TokenCanopyBadge } from "./components/loft/TokenCanopyBadge";
+import { faqPage, type FaqEntry } from "../lib/jsonld";
 import { SIGN_IN_URL } from "../lib/site";
 
 // Onboarding surfaces, in the order an agent-native user meets them: install
@@ -33,6 +35,7 @@ const PRODUCT_LINKS: NavItem[] = [
   { label: "Build agent systems", href: "#build" },
   { label: "Human-in-the-loop", href: "#hitl" },
   { label: "Use cases", href: "#use-cases" },
+  { label: "FAQ", href: "#faq" },
 ];
 
 const RESOURCE_LINKS: NavItem[] = [
@@ -94,6 +97,54 @@ const FOOTER_LINKS: { label: string; href: string; external?: boolean }[] = [
   { label: "Feedback", href: "/feedback" },
 ];
 
+// The landing page's answer surface. Every entry is rendered twice: as visible
+// prose below, and as FAQPage structured data — Google only honors FAQ markup
+// whose answers are on the page, and an answer engine that quotes one of these
+// will quote whichever copy it reached first, so they must be the same strings.
+//
+// Each answer is written to survive being lifted on its own, with none of the
+// surrounding page attached: it names e2a rather than saying "we" or "it", and
+// it states only what ships today. The questions are the ones people actually
+// type; deliberately distinct from /mcp's, which answer "how do I connect".
+const FAQ: FaqEntry[] = [
+  {
+    question: "Can an AI agent have its own email address?",
+    answer:
+      "Yes. e2a gives an AI agent its own real, authenticated email address — on the shared agents.e2a.dev domain, or on a domain you verify yourself — that it can send from, receive to, and reply in-thread on. The inbox belongs to the agent rather than to a human whose mailbox the agent reads, so recipients can tell agent mail apart from yours and revoking the agent never touches anyone's personal mail. The agent reaches that inbox over MCP tools, a signed webhook, a WebSocket stream, REST polling, or the TypeScript and Python SDKs.",
+  },
+  {
+    question: "How do you verify an email actually came from an AI agent?",
+    answer:
+      "e2a evaluates SPF, every DKIM signature, and DMARC on every inbound message, then hands the agent a normalized verdict — including whether DMARC passed with alignment — as structured evidence instead of raw headers the agent has to parse and trust. That proves the message really came from the domain it claims, so mail from an agent on a verified e2a domain is distinguishable from a spoof of it. e2a treats an aligned DMARC pass as authorization to use the From domain, not as proof of a particular person or mailbox.",
+  },
+  {
+    question:
+      "What is the difference between e2a and a transactional email API like Resend?",
+    answer:
+      "A transactional email API sends mail on behalf of an application; e2a gives an AI agent a two-way mailbox of its own. e2a accepts inbound mail over SMTP, verifies SPF/DKIM/DMARC, and delivers it to the agent over webhook, WebSocket, REST, or MCP, then sends the agent's replies back out in-thread through its HTTP API — with an optional approval hold and optional prompt-injection screening on the way through. The two are not mutually exclusive: e2a can use an upstream provider such as Amazon SES or Resend as the relay that carries its outbound mail to human recipients.",
+  },
+  {
+    question: "Is there an open-source email API for AI agents?",
+    answer:
+      "Yes — e2a is Apache-2.0, and the whole stack is public at github.com/tokencanopy/e2a: the Go server and SMTP relay, the TypeScript and Python SDKs, the CLI, the MCP server, and the dashboard. You can self-host it against your own Postgres and your own outbound SMTP relay, and every feature works the same way there. The hosted service at e2a.dev runs that same open-source server image, so choosing hosted is a deployment decision rather than a different product.",
+  },
+  {
+    question: "How do you stop an AI agent from sending an email without approval?",
+    answer:
+      "e2a has an opt-in human-in-the-loop approval gate you turn on per agent. With it on, an outbound send is accepted but not dispatched — the API returns 202 with status pending_review — and the message leaves only once a person approves it from the dashboard, the CLI, the MCP tools, the API, or a magic link mailed to the reviewer's own inbox. A recipient allowlist can narrow the gate so only unfamiliar recipients are held, and a hold that expires without a decision can be configured to reject rather than send.",
+  },
+  {
+    question: "How do you protect an agent inbox from prompt injection over email?",
+    answer:
+      "e2a can screen inbound mail before the agent ever sees it. Its opt-in content screening flags prompt-injection payloads — hidden HTML, Unicode-tag smuggling, encoded instructions — with dependency-free heuristics, and, with the optional LLM detector enabled, phishing as well; each message is then routed to allow, review, or block. Messages routed to review land in the same queue as held outbound mail, so a person decides before the agent acts on them. e2a also attaches SPF, DKIM, and DMARC results to every inbound message, so an agent can weigh how far to trust a sender instead of trusting the From header.",
+  },
+  {
+    question: "How does an AI agent receive email if it runs locally, with no public URL?",
+    answer:
+      "e2a delivers inbound mail over a WebSocket stream and plain REST polling as well as webhooks, so an agent running on a laptop, in a notebook, or behind a firewall never needs a public HTTPS endpoint. The e2a CLI's listen command bridges that stream to a local HTTP handler, and the hosted MCP server exposes the same inbox as tools for agents that run no server at all. When you do host a webhook, e2a signs every delivery with a per-webhook HMAC secret that the SDKs verify in one call.",
+  },
+];
+
 export default function Home() {
   const { user, loading: checkingAuth } = useAuth();
   const [activeTab, setActiveTab] = useState<Tab>("claude");
@@ -108,6 +159,12 @@ export default function Home() {
         fontFamily: "var(--f-ui)",
       }}
     >
+      {/* Organization / WebSite / SoftwareApplication come from the root
+          layout; the FAQ is page-specific, so it is emitted here rather than
+          site-wide. Static export prerenders this client component, so the
+          markup lands in the HTML crawlers get without running our JS. */}
+      <JsonLd data={faqPage(FAQ)} />
+
       {/* Nav */}
       <nav
         className="sticky top-0 z-50 backdrop-blur-md backdrop-saturate-150"
@@ -812,12 +869,66 @@ export default function Home() {
         </div>
       </section>
 
-      {/* CTA — continues the alternation: 04 Use cases is light, so the
-          closing section takes the elevated background. */}
+      {/* FAQ — continues the alternation: 04 Use cases is light, so this one
+          takes the elevated background. Question-shaped H2/H3 with the answer
+          immediately below is the shape both featured snippets and LLM
+          extraction key off, and it mirrors the same content emitted as
+          FAQPage structured data at the top of this page. */}
+      <section
+        id="faq"
+        className="px-6 md:px-8 py-12 md:py-16 scroll-mt-20"
+        style={{
+          background: "var(--bg-elev)",
+          borderTop: "1px solid var(--border)",
+        }}
+      >
+        <div className="max-w-[760px] mx-auto">
+          <div className="mb-8">
+            <Eyebrow>05 · FAQ</Eyebrow>
+            <h2
+              className="mt-3"
+              style={{
+                fontFamily: "var(--f-editorial)",
+                fontWeight: 400,
+                fontSize: "clamp(28px, 4vw, 38px)",
+                letterSpacing: "-0.01em",
+                color: "var(--fg)",
+              }}
+            >
+              Questions people ask.
+            </h2>
+          </div>
+          <div>
+            {FAQ.map((f) => (
+              <div
+                key={f.question}
+                className="py-5"
+                style={{ borderTop: "1px solid var(--border)" }}
+              >
+                <h3
+                  className="text-[15px] font-semibold mb-2"
+                  style={{ color: "var(--fg)" }}
+                >
+                  {f.question}
+                </h3>
+                <p
+                  className="text-[14px] leading-[1.65]"
+                  style={{ color: "var(--fg-muted)" }}
+                >
+                  {f.answer}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* CTA — continues the alternation: 05 FAQ is elevated, so the closing
+          section drops back to the page background. */}
       <section
         className="px-6 md:px-8 py-14 md:py-[72px] text-center"
         style={{
-          background: "var(--bg-elev)",
+          background: "var(--bg)",
           borderTop: "1px solid var(--border)",
         }}
       >

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -131,7 +131,7 @@ const FAQ: FaqEntry[] = [
   {
     question: "How do you stop an AI agent from sending an email without approval?",
     answer:
-      "e2a has an opt-in human-in-the-loop approval gate you turn on per agent. With it on, an outbound send is accepted but not dispatched — the API returns 202 with status pending_review — and the message leaves only once a person approves it from the dashboard, the CLI, the MCP tools, the API, or a magic link mailed to the reviewer's own inbox. A recipient allowlist can narrow the gate so only unfamiliar recipients are held, and a hold that expires without a decision can be configured to reject rather than send.",
+      "e2a has an opt-in human-in-the-loop approval gate you turn on per agent. With it on, an outbound send is accepted but not dispatched — the API returns 202 with status pending_review — and the message leaves only once a person approves it from the dashboard, the MCP tools, the API, or a magic link mailed to the reviewer's own inbox. A recipient allowlist can narrow the gate so only unfamiliar recipients are held, and a hold that expires without a decision can be configured to reject rather than send.",
   },
   {
     question: "How do you protect an agent inbox from prompt injection over email?",

--- a/web/src/lib/jsonld.test.ts
+++ b/web/src/lib/jsonld.test.ts
@@ -1,5 +1,6 @@
 import {
   ORGANIZATION_ID,
+  SOFTWARE_ID,
   blogPosting,
   breadcrumbs,
   faqPage,
@@ -17,6 +18,28 @@ describe("structured data", () => {
     expect(website().publisher).toEqual({ "@id": ORGANIZATION_ID });
     expect(softwareApplication("desc").publisher).toEqual({
       "@id": ORGANIZATION_ID,
+    });
+  });
+
+  it("gives the product a stable @id the pricing page can attach Offers to", () => {
+    // The pricing page ships from a different repo and hangs its paid-tier
+    // Offer nodes off this @id. Drop it and that reference dangles, leaving
+    // two competing SoftwareApplication nodes for one product.
+    expect(softwareApplication("desc")["@id"]).toBe(SOFTWARE_ID);
+    expect(SOFTWARE_ID).toMatch(/#software$/);
+    // Resolved from SITE_URL, never a hardcoded host — a self-host overrides it.
+    expect(SOFTWARE_ID.startsWith(String(softwareApplication("desc").url))).toBe(
+      true,
+    );
+  });
+
+  it("keeps dollar amounts off the software node", () => {
+    // Only the free tier is stated here; paid amounts live on the pricing
+    // page so structured data cannot drift away from billing.
+    expect(softwareApplication("desc").offers).toEqual({
+      "@type": "Offer",
+      price: "0",
+      priceCurrency: "USD",
     });
   });
 

--- a/web/src/lib/jsonld.ts
+++ b/web/src/lib/jsonld.ts
@@ -62,10 +62,20 @@ export function website(): JsonLdNode {
   };
 }
 
+/**
+ * The product node's stable @id, for the same reason ORGANIZATION_ID exists:
+ * the pricing page is served from the hosted deployment's own repo, and it
+ * attaches its paid-tier Offer nodes to this @id. Without one, that reference
+ * dangles and the two pages describe two competing SoftwareApplications
+ * instead of one.
+ */
+export const SOFTWARE_ID = `${SITE_URL}/#software`;
+
 export function softwareApplication(description: string): JsonLdNode {
   return {
     "@context": "https://schema.org",
     "@type": "SoftwareApplication",
+    "@id": SOFTWARE_ID,
     name: SITE_NAME,
     description,
     url: SITE_URL,
@@ -73,9 +83,12 @@ export function softwareApplication(description: string): JsonLdNode {
     operatingSystem: "Any",
     publisher: { "@id": ORGANIZATION_ID },
     // The free tier is real and requires no card, so a zero-price Offer is
-    // accurate. Paid tiers are described on /pricing, which carries its own
-    // Offer nodes rather than restating dollar amounts here where they would
-    // drift out of sync with billing.
+    // accurate here. Dollar amounts are deliberately NOT restated in this
+    // file: paid tiers belong to the pricing page, which is not part of this
+    // app (see PRICING_PATH in ./site) and describes them against SOFTWARE_ID.
+    // Duplicating them here is how structured data drifts out of sync with
+    // billing — and a deployment that overrides SITE_URL may price differently
+    // or not sell at all.
     offers: {
       "@type": "Offer",
       price: "0",


### PR DESCRIPTION
## Summary

Adds FAQPage JSON-LD structured data to the marketing home page and the docs page, plus product-positioning copy in `llms.txt` (both copies kept byte-identical; `sync-agent-docs.mjs --check` passes). Markup and prose are generated from the same `FAQ` arrays, so they cannot drift, and the tests cross-check every JSON-LD answer against the visibly rendered text (the Google requirement).

The biggest win is `/docs`: today it's a client-side `window.location.replace("/scalar.html")` whose entire payload to a crawler is "Loading API docs..." — yet it sits in the sitemap at priority 0.8. This replaces it with a server-rendered index page (reference links, 6 implementation FAQs, FAQPage + BreadcrumbList JSON-LD). Also adds `SOFTWARE_ID`/`@id` to the `softwareApplication()` node so the hosted pricing page can attach Offers to a stable product id.

**Rebase note:** branch already contains #807 and merges cleanly over current main (disjoint file sets — zero conflicts).

## Operational risk

Static-export web content only; no API or data impact. `/pricing` links in llms.txt resolve on the hosted deployment only (same pattern as the existing `PRICING_PATH`).

## Test plan

- [x] `web` Jest: page.test.tsx, docs/page.test.tsx, jsonld.test.ts — 36/36 pass
- [x] `scripts/sync-agent-docs.mjs --check` clean
- [ ] After merge: validate the rendered FAQPage schema with a structured-data linter

🤖 Generated with [Kimi Code](https://www.kimi.com/code)