### PR TITLE
docs: link the e2a-runbooks examples from "What you can build"

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Receive inbound over **webhook · WebSocket · REST · MCP**. Send through an **
 
 **`/v1` is now generally available** — shipped in [**v1.5.0**](https://github.com/tokencanopy/e2a/releases/tag/v1.5.0).
 
-[Hosted (e2a.dev)](https://e2a.dev) · [Quickstart](#quickstart) · [Concepts](#concepts) · [API](#api) · [SDKs](#sdks) · [MCP](#mcp-server) · [Deploy](#deployment) · [FAQ](#faq)
+[Hosted (e2a.dev)](https://e2a.dev) · [Quickstart](#quickstart) · [Examples](#working-examples) · [Concepts](#concepts) · [API](#api) · [SDKs](#sdks) · [MCP](#mcp-server) · [Deploy](#deployment) · [FAQ](#faq)
 
 <a href="https://www.producthunt.com/products/e2a-open-source-email-api-for-agents?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-e2a-open-source-email-api-for-agents" target="_blank" rel="noopener noreferrer"><img alt="e2a – open-source email API for agents - Give your AI agents a real, authenticated email address. | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1145559&theme=light&t=1778615217650"></a>
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,21 @@ You can either use the hosted instance or self-host.
 - **Email-triggered workflows** — turn inbound mail into structured events: order confirmations, forms, support tickets, notifications, and receipts rendered server-side from templates, with `conversation_id` correlated back to your app's state.
 - **Autopilot with human oversight** — an agent drafts outbound mail (newsletters, outreach, reports) and holds each send for one-click approval via magic-link email or the review queue, with automatic expiry policy if no one reviews in time.
 
+### Working examples
+
+**[e2a-runbooks](https://github.com/tokencanopy/e2a-runbooks)** builds several of the above as small, complete, runnable projects — one per agent framework, each demonstrating a different use case and a different part of this API:
+
+| Example | Framework | What it shows |
+| --- | --- | --- |
+| Support agent | [Mastra](https://mastra.ai) | Threading, memory, and the outbound approval gate |
+| Receptionist | [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/) | `forward` to a desk allowlist, `update_labels` |
+| AI SRE | [Claude Agent SDK](https://code.claude.com/docs/en/agent-sdk) | Authentication as a gate; a no-tools agent that can't touch prod |
+| Contract review | [LangChain](https://docs.langchain.com) | Attachments — including the `data`-vs-`download_url` split |
+| Escalation desk | [CrewAI](https://docs.crewai.com) | Several agent identities; cross-identity `conversation_id` |
+| Scheduling secretary | [Pydantic AI](https://ai.pydantic.dev) | Multi-turn state rebuilt from `conversations`, no database |
+
+They are examples to copy from rather than services to deploy — each says what it simplifies. For the smallest possible signed-webhook reference instead, see the [in-repo minimal examples](examples/agent-framework-webhooks/README.md).
+
 ## How it works
 
 ```


### PR DESCRIPTION
## What

Adds a **Working examples** subsection under `## What you can build`, listing the six [e2a-runbooks](https://github.com/tokencanopy/e2a-runbooks) projects with the framework each uses and the part of this API it exercises.

## Why

The README describes what you can build but has no pointer to anything that builds it. The only examples referenced are the minimal signed-webhook snippets, mentioned deep inside `### Inbound authentication` — so a reader scanning for "show me a working agent" finds nothing.

The two are kept distinguishable rather than competing: the runbooks are complete per-framework projects, the in-repo examples remain the pointer for the smallest possible signed-webhook reference.

## Notes

- README-only, 15 lines added, no other files touched.
- All external links verified to return 200; the relative link to `examples/agent-framework-webhooks/README.md` resolves.
- Framed as examples to copy from rather than services to deploy — each runbook documents what it simplifies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)