### PR TITLE
fix(web): render blog posts in the reader's theme

### DIFF
--- a/web/src/app/blog/email-agent-with-google-adk/page.mdx
+++ b/web/src/app/blog/email-agent-with-google-adk/page.mdx
@@ -23,7 +23,7 @@ export const metadata = {
 
 <PostSchema post={post} />
 
-<div style={{ fontSize: 11, color: "#A89A8A", fontFamily: "'IBM Plex Mono', monospace", marginBottom: 6 }}>
+<div style={{ fontSize: 11, color: "var(--fg-subtle)", fontFamily: "var(--f-mono)", marginBottom: 6 }}>
   {new Date(post.date + "T00:00:00Z").toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric", timeZone: "UTC" })} · {post.readingMinutes} min read
 </div>
 

--- a/web/src/app/blog/email-for-openclaw-agents/page.mdx
+++ b/web/src/app/blog/email-for-openclaw-agents/page.mdx
@@ -23,7 +23,7 @@ export const metadata = {
 
 <PostSchema post={post} />
 
-<div style={{ fontSize: 11, color: "#A89A8A", fontFamily: "'IBM Plex Mono', monospace", marginBottom: 6 }}>
+<div style={{ fontSize: 11, color: "var(--fg-subtle)", fontFamily: "var(--f-mono)", marginBottom: 6 }}>
   {new Date(post.date + "T00:00:00Z").toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric", timeZone: "UTC" })} · {post.readingMinutes} min read
 </div>
 

--- a/web/src/app/blog/human-in-the-loop-for-agent-email/page.mdx
+++ b/web/src/app/blog/human-in-the-loop-for-agent-email/page.mdx
@@ -23,7 +23,7 @@ export const metadata = {
 
 <PostSchema post={post} />
 
-<div style={{ fontSize: 11, color: "#A89A8A", fontFamily: "'IBM Plex Mono', monospace", marginBottom: 6 }}>
+<div style={{ fontSize: 11, color: "var(--fg-subtle)", fontFamily: "var(--f-mono)", marginBottom: 6 }}>
   {new Date(post.date + "T00:00:00Z").toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric", timeZone: "UTC" })} · {post.readingMinutes} min read
 </div>
 

--- a/web/src/app/blog/send-email-from-python-agent/page.mdx
+++ b/web/src/app/blog/send-email-from-python-agent/page.mdx
@@ -23,7 +23,7 @@ export const metadata = {
 
 <PostSchema post={post} />
 
-<div style={{ fontSize: 11, color: "#A89A8A", fontFamily: "'IBM Plex Mono', monospace", marginBottom: 6 }}>
+<div style={{ fontSize: 11, color: "var(--fg-subtle)", fontFamily: "var(--f-mono)", marginBottom: 6 }}>
   {new Date(post.date + "T00:00:00Z").toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric", timeZone: "UTC" })} · {post.readingMinutes} min read
 </div>
 

--- a/web/src/mdx-components.tsx
+++ b/web/src/mdx-components.tsx
@@ -2,6 +2,12 @@ import type { MDXComponents } from "mdx/types";
 
 // Map MDX elements to styled HTML for the blog.
 // Keep this list minimal — post-specific overrides can be passed in per-page.
+//
+// Colors MUST come from Loft tokens (`var(--…)`), never literal hex. These are
+// inline styles, so a `@media (prefers-color-scheme)` rule cannot reach them;
+// the tokens are what makes the article body follow the `.dark` class that
+// ThemeProvider puts on <html>. Hardcoded light-theme hex here is what made
+// blog posts render near-invisible (h1 at 1.09:1) for dark-mode visitors.
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {
     h1: ({ children }) => (
@@ -11,7 +17,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
           fontSize: "clamp(32px, 3.5vw, 44px)",
           lineHeight: 1.15,
           fontWeight: 400,
-          color: "#1C1A17",
+          color: "var(--fg)",
           margin: "0 0 18px",
           letterSpacing: "-0.01em",
         }}
@@ -25,7 +31,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
           fontFamily: "var(--f-editorial)",
           fontSize: 26,
           fontWeight: 400,
-          color: "#1C1A17",
+          color: "var(--fg)",
           margin: "36px 0 12px",
           letterSpacing: "-0.005em",
         }}
@@ -34,30 +40,34 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
       </h2>
     ),
     h3: ({ children }) => (
-      <h3 style={{ fontSize: 18, fontWeight: 600, color: "#1C1A17", margin: "28px 0 10px" }}>
+      <h3 style={{ fontSize: 18, fontWeight: 600, color: "var(--fg)", margin: "28px 0 10px" }}>
         {children}
       </h3>
     ),
     p: ({ children }) => (
-      <p style={{ fontSize: 16, lineHeight: 1.7, color: "#3A342D", margin: "0 0 16px" }}>
+      <p style={{ fontSize: 16, lineHeight: 1.7, color: "var(--fg)", margin: "0 0 16px" }}>
         {children}
       </p>
     ),
     a: ({ href, children }) => (
       <a
         href={href}
-        style={{ color: "#8B5E3C", textDecoration: "underline", textUnderlineOffset: "3px" }}
+        style={{
+          color: "var(--accent-strong)",
+          textDecoration: "underline",
+          textUnderlineOffset: "3px",
+        }}
       >
         {children}
       </a>
     ),
     ul: ({ children }) => (
-      <ul style={{ fontSize: 16, lineHeight: 1.7, color: "#3A342D", margin: "0 0 16px", paddingLeft: 22 }}>
+      <ul style={{ fontSize: 16, lineHeight: 1.7, color: "var(--fg)", margin: "0 0 16px", paddingLeft: 22 }}>
         {children}
       </ul>
     ),
     ol: ({ children }) => (
-      <ol style={{ fontSize: 16, lineHeight: 1.7, color: "#3A342D", margin: "0 0 16px", paddingLeft: 22 }}>
+      <ol style={{ fontSize: 16, lineHeight: 1.7, color: "var(--fg)", margin: "0 0 16px", paddingLeft: 22 }}>
         {children}
       </ol>
     ),
@@ -70,11 +80,11 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
             style={{
               fontFamily: "var(--f-mono)",
               fontSize: "0.92em",
-              background: "#F0EAE0",
+              background: "var(--bg-elev)",
               padding: "1px 6px",
               borderRadius: 4,
-              border: "0.5px solid #E8E0D4",
-              color: "#1C1A17",
+              border: "0.5px solid var(--border)",
+              color: "var(--fg)",
             }}
           >
             {children}
@@ -83,11 +93,15 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
       }
       return <code {...props}>{children}</code>;
     },
+    // Code blocks stay on the ink surface in both themes — dark-on-cream in
+    // light mode, sunken below --bg in dark mode. --ink-border keeps the edge
+    // from haloing on cream while still separating the block in dark mode.
     pre: ({ children }) => (
       <pre
         style={{
-          background: "#1C1A17",
-          color: "#E8E0D4",
+          background: "var(--ink)",
+          color: "var(--ink-fg)",
+          border: "1px solid var(--ink-border)",
           padding: "20px 24px",
           borderRadius: 10,
           fontFamily: "var(--f-mono)",
@@ -103,17 +117,19 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     blockquote: ({ children }) => (
       <blockquote
         style={{
-          borderLeft: "3px solid #D4C9BC",
+          borderLeft: "3px solid var(--border-strong)",
           paddingLeft: 18,
           margin: "20px 0",
-          color: "#7A6F63",
+          color: "var(--fg-muted)",
           fontStyle: "italic",
         }}
       >
         {children}
       </blockquote>
     ),
-    hr: () => <hr style={{ border: "none", borderTop: "0.5px solid #E8E0D4", margin: "36px 0" }} />,
+    hr: () => (
+      <hr style={{ border: "none", borderTop: "0.5px solid var(--border)", margin: "36px 0" }} />
+    ),
     ...components,
   };
 }


### PR DESCRIPTION
## Summary

Blog posts were readable only in light mode. The page frame around a post —
the nav, the footer, and the post index — followed the reader's theme, but the
article itself did not: it kept light-theme colors no matter what. A visitor
whose browser or operating system defaults to dark got a dark page with
near-black text on it. Measured on the published site, headings sat at roughly
1.1:1 against the page background and body copy at 1.5:1, which is effectively
invisible; the pale background behind inline code fragments made them the only
legible part of the article. All four posts were affected, not just the one this
was reported on.

The article now takes its colors from the same shared theme values the rest of
the site already uses, so headings, body copy, lists, links, quotes, rules and
code all follow whichever theme is active. Headings and body copy now measure
about 15:1 against the background in dark mode and 17:1 in light, links 10:1 and
6:1, quotes 7:1 and 5:1. Light mode is otherwise unchanged, apart from body copy
sitting a little darker than it did before.

One smaller fix rides along: the date line above each post title was asking for
a font the site never loads and silently falling back to whatever the reader's
system offered. It now uses the site's own monospace face.

This PR is the fix only. It changes no behavior and adds nothing new — see the
follow-ups below for what it deliberately leaves out.

<!-- Client surface checklist deleted: this PR touches only the marketing blog.
     No API, migration, spec, SDK, CLI or MCP surface changes. -->

## Operational risk

Low. Presentation only — no user data, no side effects, no auth, billing,
notifications or external integrations touched, and nothing behind a flag to
roll back. Rollback is a plain revert.

Two things a reviewer should weigh rather than assume:

- Body copy in light mode is now slightly darker than the shade it replaced.
  There is no shared value for the in-between tone the posts used, so this takes
  the standard body color rather than introducing a new one. If the softer
  reading is preferred, that is a deliberate addition and belongs in its own
  change.
- The date line above each title now follows the same treatment as the date on
  the post index, which keeps the two pages consistent. It is still a low
  contrast line — about 2.9:1 in light and 3.3:1 in dark — so it does not meet
  AA. That is not new; it reads slightly better in light mode than before and
  slightly worse in dark. Raising it means changing the index at the same time,
  which is why it is not here.

## Test plan

- [x] Reproduced the original problem on the published post with the browser
      defaulting to dark, and recorded the contrast of every text element in the
      article before the change.
- [x] Re-measured the same elements locally after the change, in both themes.
      Everything in the article body clears AA, and headings, body copy and code
      clear AAA. The date line above the title is the one exception, noted above.
- [x] Confirmed the light theme still matches its previous appearance, value by
      value, with body copy the one intended difference.
- [x] Checked all four posts, since they share the same presentation, and the
      post index, which was already correct and is unchanged.
- [x] Dashboard test suite, lint and type check all clean. The four type errors
      that remain are in unrelated test files and predate this branch.

After merge: open any post with the operating system set to dark and confirm the
article reads normally.

## Follow-ups, not in this PR

- **A theme control on the blog.** Right now the browser or operating system
  preference is the only thing deciding how a post reads, and the site's only
  theme control lives in the dashboard sidebar, which blog readers never see —
  they arrive from search with no session. So a rendering problem in one theme
  has no workaround for exactly the people most likely to hit it, and this PR
  does not change that. Recommended as the next change: put the same three-way
  control the dashboard already uses into the blog nav, so a reader can follow
  the system preference or pin either theme. Prepared as its own PR, stacked on
  this one, on `feat/blog-theme-switcher`.
- Nothing stops the next contributor from reintroducing fixed colors in a post
  and quietly breaking one theme again. A small guard in the test suite would
  catch it; the contributor checklist does not currently mention this surface at
  all.
- Dark-mode readers still see a brief flash of the light theme on first paint,
  because the theme is applied after the page loads rather than before it paints.
  That predates this change and affects the whole site, not only the blog.
- The docs pages were not audited for the same class of problem.
