### PR TITLE
docs(cli): document the --filter flag on messages list

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -241,7 +241,8 @@ e2a messages lifecycle msg_abc123 --agent bot@acme.com --json   # beta
 ```
 
 `list` flags: `--direction` (`inbound`/`outbound`/`all`), `--since` (inclusive
-ISO timestamp), `--conversation` (alias `--conversation-id`), `--read-status`
+ISO timestamp), `--filter <expr>` (beta boolean filter expression, see
+`docs/api.md`), `--conversation` (alias `--conversation-id`), `--read-status`
 (`unread`/`read`/`all`, default `all`), `--limit`, `--agent`, `--json` (NDJSON
 instead of TSV). `get` flags: `--text` (print parsed body text only),
 `--agent`, `--json` (print the full message as JSON). `lifecycle` (beta) shows


### PR DESCRIPTION
## Summary

`e2a messages list` has a real, wired `--filter <expr>` flag (beta boolean
filter expression — declared in `cli/src/commands/messages.ts`, listed in
`--help` and the flag whitelist in `cli/src/bin/e2a.ts`), but `cli/README.md`'s
`list` flag reference never mentioned it. Added it alongside the other `list`
flags, pointing to `docs/api.md` for the filter-language details.

Docs-only change; no behavior changes.

## Test plan

- [x] Verified `--filter` is implemented end-to-end (`cli/src/commands/messages.ts:9,30,65`, `cli/src/bin/e2a.ts:127,682,689`) and documented in `docs/api.md`, but absent from `cli/README.md` before this change.
- [x] Diffed before/after to confirm only the flag list line changed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fb9NUuAUe4iFxZadCuqWoq)_