### PR TITLE
docs(plugins): fix stale job-gateway capability names in autopilot SKILL.md

### DIFF
--- a/plugins/e2a/skills/autopilot/SKILL.md
+++ b/plugins/e2a/skills/autopilot/SKILL.md
@@ -95,9 +95,9 @@ The supervisor owns the agent-scoped e2a key. A task runtime never receives an
 e2a key, MCP credential, forward token, or arbitrary mailbox access. Each job gets
 a new local socket and capability exposing only:
 
-- `get_current_message`
-- `get_current_thread`
-- `submit_reply`
+- `current-message` (read)
+- `current-thread` (read)
+- `reply` (submit)
 - `escalate`
 - `complete`
 


### PR DESCRIPTION
## Summary

The Autopilot skill's "Enforced architecture" section listed the job
gateway's exposed capabilities as `get_current_message`, `get_current_thread`,
and `submit_reply` — names that don't exist anywhere in the implementation.
The actual job-tool commands and gateway HTTP routes
(`plugins/e2a/skills/autopilot/job-tool.mjs`, `gateway.mjs`) are
`current-message`, `current-thread`, and `reply` (`escalate` and `complete`
were already correct). Updated the doc to match the real command/route names.

Docs-only change; no behavior changes.

## Test plan

- [x] Verified `job-tool.mjs` and `gateway.mjs` use `current-message` / `current-thread` / `reply` / `escalate` / `complete`, and that `get_current_message` / `get_current_thread` / `submit_reply` appear nowhere outside `SKILL.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fb9NUuAUe4iFxZadCuqWoq)_