### PR TITLE
feat(notify): give operational email a real reply path, drop the noreply senders

### DIFF
--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -600,7 +600,7 @@ func main() {
 		// unreachable in practice — kept as a defensive guard against future drift.
 		log.Printf("[hitl] notifier disabled: notification job pipeline not registered")
 	} else {
-		notifier := hitlnotify.New(store, smtpRelay, approvalSigner, cfg.OutboundSMTP.FromDomain, cfg.Notifications.FromAddress, cfg.Notifications.ReplyTo, cfg.HTTP.PublicURL)
+		notifier := hitlnotify.New(store, smtpRelay, approvalSigner, cfg.OutboundSMTP.FromDomain, cfg.Notifications.FromAddress, cfg.Notifications.ReplyTo, cfg.HTTP.PublicURL).WithDKIM(store)
 		// Late-bind the concrete Deliverer onto the registered NotifyWorker (which
 		// has been running since jobsClient.Start; jobs enqueued before this bind
 		// simply retry) and give the hold path its accept-tx enqueuer. The HTTP

--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -600,7 +600,7 @@ func main() {
 		// unreachable in practice — kept as a defensive guard against future drift.
 		log.Printf("[hitl] notifier disabled: notification job pipeline not registered")
 	} else {
-		notifier := hitlnotify.New(store, smtpRelay, approvalSigner, cfg.OutboundSMTP.FromDomain, cfg.HTTP.PublicURL)
+		notifier := hitlnotify.New(store, smtpRelay, approvalSigner, cfg.OutboundSMTP.FromDomain, cfg.Notifications.FromAddress, cfg.Notifications.ReplyTo, cfg.HTTP.PublicURL)
 		// Late-bind the concrete Deliverer onto the registered NotifyWorker (which
 		// has been running since jobsClient.Start; jobs enqueued before this bind
 		// simply retry) and give the hold path its accept-tx enqueuer. The HTTP

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -116,25 +116,28 @@ outbound_smtp:
   # explicitly only for non-standard endpoints.
   # message_id_domain: "us-east-2.amazonses.com"
 
-# Platform notification emails (webhook health alerts: an early warning
-# when a webhook's deliveries start failing, and a notice when e2a
-# auto-disables one).
+# Platform notification emails: HITL approval requests, plus webhook health
+# alerts (an early warning when a webhook's deliveries start failing, and a
+# notice when e2a auto-disables one). Both senders read the settings below.
 notifications:
-  # Sender address for those emails. Optional — when empty they send from
-  # a fixed no-reply local part on outbound_smtp.from_domain, so
-  # self-hosted deployments need no configuration here. If set, it must
-  # be an address your upstream is authorized to send as. If e2a holds a
-  # DKIM key for the address's domain (a domain registered with this
-  # server), each notification is DKIM-signed in-process for that domain;
-  # with no stored key it is sent unsigned.
+  # Sender address for those emails. Optional — when empty, each kind sends
+  # from its own fixed local part on outbound_smtp.from_domain (approvals@
+  # and webhooks@, kept distinct so a time-boxed approval stays filterable
+  # apart from routine webhook mail), so self-hosted deployments need no
+  # configuration here. SETTING THIS COLLAPSES BOTH INTO ONE IDENTITY.
+  # If set, it must be an address your upstream is authorized to send as.
+  # If e2a holds a DKIM key for the address's domain (a domain registered
+  # with this server), each notification is DKIM-signed in-process for that
+  # domain; with no stored key it is sent unsigned.
   # from_address: "support@send.your-company.example"
   #
   # Optional Reply-To for those emails. Set it when the sending domain is
   # relay-only (no mailbox behind from_address) so replies land in a real
   # support inbox — the same From-on-the-relay-domain + Reply-To pattern
-  # shared-domain agent sends use. Leave unset when from_address is
-  # itself a real mailbox: no Reply-To header is emitted and replies
-  # follow From.
+  # shared-domain agent sends use. Leave unset when from_address is itself
+  # a real mailbox — replies then follow the sender address either way
+  # (webhook mail emits no Reply-To; approval mail emits one pointing at
+  # its own sender, preserving its long-standing behaviour).
   # reply_to: "support@your-company.example"
 
 # Outbound delivery is always asynchronous and at-least-once. The send API

--- a/docs/design/2026-08-08-webhook-health-notifications.md
+++ b/docs/design/2026-08-08-webhook-health-notifications.md
@@ -97,7 +97,7 @@ This design copies that structure rather than inventing one. Concretely reusable
 - `jobs.QueueNotify` already exists (`internal/jobs/queues.go:28`) with a small pool,
   deliberately isolated so notification backlog can't starve customer outbound delivery.
 - `store.GetUserByID(ctx, agent.UserID)` → `owner.Email` for addressing.
-- A fixed no-reply local part so clients thread the mail (HITL uses `hitl-noreply`).
+- A fixed local part so clients thread the mail (HITL uses `approvals`; this package uses `webhooks` — deliberately distinct so the two kinds stay separately filterable).
 
 ### The sweep is not currently transactional
 
@@ -529,7 +529,7 @@ decisions, so the doc describes what actually shipped:
   from_address` and the new `notifications.reply_to`
   (`E2A_NOTIFICATIONS_FROM_ADDRESS` / `E2A_NOTIFICATIONS_REPLY_TO`, each
   validated as a bare address). Unset from_address falls back to
-  `webhooks-noreply@<outbound_smtp.from_domain>`; unset reply_to emits NO
+  `webhooks@<outbound_smtp.from_domain>`; unset reply_to emits NO
   Reply-To header (replies follow From — the sane self-host default,
   since a self-hoster's from_address is typically a real mailbox and has
   no `agents.e2a.dev`). The notifier is gated on

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -232,13 +232,17 @@ type OutboundSMTPConfig struct {
 }
 
 // NotificationsConfig carries settings for the platform's operational
-// notification emails (currently the webhook health warning/disabled
-// alerts).
+// notification emails: HITL approval requests (internal/hitlnotify) and the
+// webhook health warning/disabled alerts (internal/webhooknotify). Both
+// senders read these settings.
 type NotificationsConfig struct {
 	// FromAddress is the sender address for operational notification
-	// emails. Optional. When empty, notifications fall back to a fixed
-	// no-reply local part on outbound_smtp.from_domain (the hitlnotify
-	// pattern), so self-hosted deployments work with zero configuration.
+	// emails. Optional. When empty, each sender falls back to its OWN
+	// fixed local part on outbound_smtp.from_domain (approvals@ and
+	// webhooks@ respectively, kept distinct so a time-boxed approval stays
+	// filterable apart from routine webhook mail), so self-hosted
+	// deployments work with zero configuration. Setting this collapses
+	// both senders into a single identity.
 	// The value MUST be an address the deployment's sending identity is
 	// allowed to send as. Deliberately configuration, never a constant: a
 	// hardcoded operator address would make every self-host try to send
@@ -250,9 +254,12 @@ type NotificationsConfig struct {
 	// with no mailbox behind it, so replies land in a real support inbox
 	// on another domain — the same From-on-the-relay-domain +
 	// Reply-To-at-the-real-inbox pattern the product's shared-domain
-	// sends already use. Optional: empty emits NO Reply-To header
-	// (replies follow From), the sane default when from_address is
-	// itself a real mailbox. Override with E2A_NOTIFICATIONS_REPLY_TO.
+	// sends already use. Optional: empty means replies follow the sender
+	// address — webhook mail emits no Reply-To, while approval mail emits
+	// one pointing at its own sender (its long-standing behaviour, kept so
+	// unconfigured deployments are byte-identical to before). The sane
+	// default when from_address is itself a real mailbox. Override with
+	// E2A_NOTIFICATIONS_REPLY_TO.
 	ReplyTo string `yaml:"reply_to"`
 }
 

--- a/internal/hitlnotify/e2e_test.go
+++ b/internal/hitlnotify/e2e_test.go
@@ -34,7 +34,7 @@ func TestEndToEnd_AcceptTxThroughRiverToSMTP(t *testing.T) {
 		Host: smtpAddr.Host, Port: smtpAddr.Port, FromDomain: "notify.test",
 	})
 	signer := approvaltoken.NewSigner("hitl-notify-e2e-secret")
-	notifier := hitlnotify.New(store, relay, signer, "notify.test", "https://app.example.test")
+	notifier := hitlnotify.New(store, relay, signer, "notify.test", "", "", "https://app.example.test")
 
 	// Seed a verified HITL agent + owner.
 	user, err := store.CreateOrGetUser(ctx, "owner-e2e@reviewer.test", "Owner", "google-notify-e2e")

--- a/internal/hitlnotify/notifier.go
+++ b/internal/hitlnotify/notifier.go
@@ -28,10 +28,18 @@ import (
 	"github.com/tokencanopy/e2a/internal/outbound"
 )
 
-// notifyLocalPart is the fixed local-part of the notification sender
-// address. Reusing a single from-address lets mail clients group all HITL
-// notifications into a single conversation / filter.
-const notifyLocalPart = "hitl-noreply"
+// notifyLocalPart is the default local-part of the notification sender
+// address, used when notifications.from_address is unset. Reusing a single
+// from-address lets mail clients group all HITL notifications into a single
+// conversation / filter — deliberately a DIFFERENT default from
+// webhooknotify's, so an approval (time-boxed: miss it and the hold expires)
+// stays filterable apart from routine webhook-health mail.
+//
+// Not "hitl-noreply": once notifications.reply_to points at a real inbox, a
+// From that says noreply tells the reader the opposite of what we want, and
+// the From is the most visible address in a mail client. "hitl" was also
+// internal jargon on a customer-facing address.
+const notifyLocalPart = "approvals"
 
 // tokenGraceAfterTTL extends the magic-link token's exp slightly past the
 // message's approval_expires_at so a click received just before TTL is
@@ -42,24 +50,49 @@ const tokenGraceAfterTTL = 10 * time.Minute
 // call NotifyPendingApproval from the HITL gate right after the pending
 // row is written. Errors are logged, never returned upstream.
 type Notifier struct {
-	store      *identity.Store
-	relay      *outbound.SMTPRelay
-	signer     *approvaltoken.Signer
+	store  *identity.Store
+	relay  *outbound.SMTPRelay
+	signer *approvaltoken.Signer
+	// fromAddress is the resolved sender: notifications.from_address when
+	// set, else notifyLocalPart on fromDomain.
+	fromAddress string
+	// fromDomain is the domain used for Message-ID generation. It tracks
+	// fromAddress's domain when that is configured, so a Message-ID never
+	// claims a domain the From does not use.
 	fromDomain string
-	publicURL  string
+	// replyTo is notifications.reply_to. Empty preserves the historical
+	// behaviour of pointing Reply-To back at the sender address.
+	replyTo   string
+	publicURL string
 }
 
 // New returns a Notifier that sends mail through relay using the given
-// public URL to build magic-link URLs. fromDomain is the platform
-// relay's from-domain — e.g. "send.example.com" — which is combined with
-// the fixed local-part to produce the From address.
-func New(store *identity.Store, relay *outbound.SMTPRelay, signer *approvaltoken.Signer, fromDomain, publicURL string) *Notifier {
+// public URL to build magic-link URLs. fromDomain is the platform relay's
+// from-domain — e.g. "send.example.com" — combined with notifyLocalPart to
+// produce the From address when fromAddress is empty.
+//
+// fromAddress and replyTo are notifications.from_address / .reply_to. Setting
+// fromAddress to the same value here and in webhooknotify is what
+// consolidates both senders into one identity; leaving it unset keeps them
+// distinct and separately filterable. Resolution mirrors webhooknotify.New so
+// the two packages cannot drift.
+func New(store *identity.Store, relay *outbound.SMTPRelay, signer *approvaltoken.Signer, fromDomain, fromAddress, replyTo, publicURL string) *Notifier {
+	addr := strings.TrimSpace(fromAddress)
+	if addr == "" {
+		addr = fmt.Sprintf("%s@%s", notifyLocalPart, fromDomain)
+	}
+	msgIDDomain := fromDomain
+	if i := strings.LastIndex(addr, "@"); i >= 0 && i+1 < len(addr) {
+		msgIDDomain = addr[i+1:]
+	}
 	return &Notifier{
-		store:      store,
-		relay:      relay,
-		signer:     signer,
-		fromDomain: fromDomain,
-		publicURL:  strings.TrimRight(publicURL, "/"),
+		store:       store,
+		relay:       relay,
+		signer:      signer,
+		fromAddress: addr,
+		fromDomain:  msgIDDomain,
+		replyTo:     strings.TrimSpace(replyTo),
+		publicURL:   strings.TrimRight(publicURL, "/"),
 	}
 }
 
@@ -113,8 +146,19 @@ func (n *Notifier) NotifyPendingApproval(ctx context.Context, msg *identity.Mess
 	text := renderText(msg, agent, approveURL, rejectURL, dashboardURL)
 	htmlBody := renderHTML(msg, agent, approveURL, rejectURL, dashboardURL)
 
-	fromAddr := fmt.Sprintf("%s@%s", notifyLocalPart, n.fromDomain)
+	fromAddr := n.fromAddress
 	fromHeader := fmt.Sprintf("e2a <%s>", fromAddr)
+
+	// Reply-To: the configured inbox when there is one, else the sender
+	// address as before. The historical value pointed replies back at the
+	// platform rather than the agent, which was the right instinct — but the
+	// platform relay domain has no mailbox, so a reviewer who hit Reply was
+	// talking to the bounce endpoint. That matters most here: an approval is
+	// time-boxed, and a reviewer who cannot sign in has only the magic links.
+	replyTo := n.replyTo
+	if replyTo == "" {
+		replyTo = fromAddr
+	}
 
 	message, err := outbound.ComposeMultipartMessage(
 		fromHeader, []string{owner.Email}, nil,
@@ -122,7 +166,7 @@ func (n *Notifier) NotifyPendingApproval(ctx context.Context, msg *identity.Mess
 		"",           // no reply-to-message-id (fresh notification)
 		nil,          // no references chain (fresh notification)
 		n.fromDomain, // from_domain (Message-ID generation)
-		fromAddr,     // reply_to — point replies back at the platform, not the agent
+		replyTo,      // reply_to — a real inbox when configured, never the agent
 		"",           // no conversation_id
 	)
 	if err != nil {

--- a/internal/hitlnotify/notifier.go
+++ b/internal/hitlnotify/notifier.go
@@ -64,6 +64,9 @@ type Notifier struct {
 	// behaviour of pointing Reply-To back at the sender address.
 	replyTo   string
 	publicURL string
+	// dkim, when wired via WithDKIM, signs for the From-header domain.
+	// nil (the zero-config self-host path) sends unsigned.
+	dkim outbound.DKIMKeyLookup
 }
 
 // New returns a Notifier that sends mail through relay using the given
@@ -74,8 +77,9 @@ type Notifier struct {
 // fromAddress and replyTo are notifications.from_address / .reply_to. Setting
 // fromAddress to the same value here and in webhooknotify is what
 // consolidates both senders into one identity; leaving it unset keeps them
-// distinct and separately filterable. Resolution mirrors webhooknotify.New so
-// the two packages cannot drift.
+// distinct and separately filterable. Resolution deliberately mirrors
+// webhooknotify.New line for line; it is a copy rather than a shared helper,
+// so changing one means changing the other.
 func New(store *identity.Store, relay *outbound.SMTPRelay, signer *approvaltoken.Signer, fromDomain, fromAddress, replyTo, publicURL string) *Notifier {
 	addr := strings.TrimSpace(fromAddress)
 	if addr == "" {
@@ -94,6 +98,15 @@ func New(store *identity.Store, relay *outbound.SMTPRelay, signer *approvaltoken
 		replyTo:     strings.TrimSpace(replyTo),
 		publicURL:   strings.TrimRight(publicURL, "/"),
 	}
+}
+
+// WithDKIM wires per-domain DKIM signing, mirroring webhooknotify. The relay
+// itself never signs and an upstream provider only signs identities it
+// manages, so a custom notifications.from_address domain is signed here or
+// not at all. nil-safe and fail-open via outbound.SignWithDKIM.
+func (n *Notifier) WithDKIM(lookup outbound.DKIMKeyLookup) *Notifier {
+	n.dkim = lookup
+	return n
 }
 
 // NotifyPendingApproval composes and sends the notification email for a held
@@ -194,6 +207,22 @@ func (n *Notifier) NotifyPendingApproval(ctx context.Context, msg *identity.Mess
 	// assigned id (no dedup, but no injection either).
 	if !strings.ContainsAny(msgIDHeader, "\r\n") {
 		message = append([]byte("Message-ID: "+msgIDHeader+"\r\n"), message...)
+	}
+
+	// DKIM-sign for the From-header domain AFTER the Message-ID prepend, so the
+	// signature covers the final header set.
+	//
+	// Required for parity with webhooknotify once from_address is configurable:
+	// the SMTP relay never signs, and an upstream provider only signs identities
+	// IT manages, so a custom from_address domain (BYODKIM — e2a holds the key)
+	// is signed here or not at all. Without this, an operator who set
+	// notifications.from_address would get signed webhook-health mail and
+	// UNSIGNED approval mail — leaving the most time-sensitive email the
+	// platform sends on a single SPF leg, and so quarantined the moment anyone
+	// forwards it. Fail-open via outbound.SignWithDKIM: no lookup, no stored key
+	// for the domain, or a signing failure all send unsigned, exactly as before.
+	if signed, ok := outbound.SignWithDKIM(n.dkim, message, n.fromDomain); ok {
+		message = signed
 	}
 
 	// SendOnce, not Send: this runs inside a River job, so River (not the relay's

--- a/internal/hitlnotify/notifier_test.go
+++ b/internal/hitlnotify/notifier_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/tokencanopy/e2a/internal/approvaltoken"
 	"github.com/tokencanopy/e2a/internal/config"
+	"github.com/tokencanopy/e2a/internal/dkim"
 	"github.com/tokencanopy/e2a/internal/hitlnotify"
 	"github.com/tokencanopy/e2a/internal/identity"
 	"github.com/tokencanopy/e2a/internal/outbound"
@@ -387,5 +388,87 @@ func TestNotifierHonoursConfiguredFromAddress(t *testing.T) {
 	}
 	if strings.Contains(data, "Message-ID: <") && !strings.Contains(data, "@mail.test>") {
 		t.Errorf("Message-ID domain should follow the configured From, got:\n%s", firstHeaders(data))
+	}
+}
+
+// fakeDKIMLookup is a DKIMKeyLookup test double.
+type fakeDKIMLookup struct {
+	get func(ctx context.Context, domain string) (string, []byte, error)
+}
+
+func (f *fakeDKIMLookup) GetDKIMKeyInternal(ctx context.Context, domain string) (string, []byte, error) {
+	return f.get(ctx, domain)
+}
+
+// Parity with webhooknotify. The relay never DKIM-signs on e2a's behalf for a
+// custom notifications.from_address domain (BYODKIM: e2a holds the key), so
+// the notifier must sign in-process. Without this, an operator who configured
+// from_address would get signed webhook-health mail and UNSIGNED approval
+// mail — leaving the most time-sensitive email the platform sends on an SPF
+// leg alone, and so quarantined the moment anyone forwards it.
+func TestNotifierSignsWithDKIMForConfiguredFromDomain(t *testing.T) {
+	keypair, err := dkim.GenerateKeypair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	lookup := &fakeDKIMLookup{get: func(_ context.Context, domain string) (string, []byte, error) {
+		if domain != "corp.example" {
+			t.Fatalf("DKIM lookup domain = %q, want the From-header domain corp.example", domain)
+		}
+		return keypair.Selector, keypair.PrivateKeyDER, nil
+	}}
+
+	smtpAddr, smtpDone := testutil.FakeSMTPServer(t)
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	relay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{
+		Host: smtpAddr.Host, Port: smtpAddr.Port, FromDomain: notifyFromDomain,
+	})
+	signer := approvaltoken.NewSigner(notifySecret)
+	n := hitlnotify.New(store, relay, signer, notifyFromDomain, "approvals@corp.example", "", publicURL).WithDKIM(lookup)
+
+	agent, msg := setupPendingMessage(t, store, "dkim")
+	if err := n.NotifyPendingApproval(context.Background(), msg, agent); err != nil {
+		t.Fatalf("NotifyPendingApproval: %v", err)
+	}
+	msgs := smtpDone()
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 SMTP message, got %d", len(msgs))
+	}
+	data := string(msgs[0].Data)
+
+	if !strings.Contains(data, "DKIM-Signature:") {
+		t.Fatalf("approval mail sent UNSIGNED from a custom from_address domain:\n%s", firstHeaders(data))
+	}
+	if !strings.Contains(data, "d=corp.example") {
+		t.Errorf("DKIM-Signature must be for the From-header domain (d=corp.example):\n%s", firstHeaders(data))
+	}
+}
+
+// The zero-config self-host path: no key, or no lookup wired at all, must
+// send unsigned rather than fail.
+func TestNotifierSendsUnsignedWithoutDKIMKey(t *testing.T) {
+	lookup := &fakeDKIMLookup{get: func(_ context.Context, _ string) (string, []byte, error) {
+		return "", nil, nil // no key stored
+	}}
+	smtpAddr, smtpDone := testutil.FakeSMTPServer(t)
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	relay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{
+		Host: smtpAddr.Host, Port: smtpAddr.Port, FromDomain: notifyFromDomain,
+	})
+	signer := approvaltoken.NewSigner(notifySecret)
+	n := hitlnotify.New(store, relay, signer, notifyFromDomain, "", "", publicURL).WithDKIM(lookup)
+
+	agent, msg := setupPendingMessage(t, store, "nodkim")
+	if err := n.NotifyPendingApproval(context.Background(), msg, agent); err != nil {
+		t.Fatalf("must succeed unsigned: %v", err)
+	}
+	msgs := smtpDone()
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 SMTP message, got %d", len(msgs))
+	}
+	if strings.Contains(string(msgs[0].Data), "DKIM-Signature:") {
+		t.Errorf("unexpected DKIM-Signature without a stored key")
 	}
 }

--- a/internal/hitlnotify/notifier_test.go
+++ b/internal/hitlnotify/notifier_test.go
@@ -37,7 +37,7 @@ func newNotifier(t *testing.T) (
 		FromDomain: notifyFromDomain,
 	})
 	signer := approvaltoken.NewSigner(notifySecret)
-	n := hitlnotify.New(store, relay, signer, notifyFromDomain, publicURL)
+	n := hitlnotify.New(store, relay, signer, notifyFromDomain, "", "", publicURL)
 	return n, store, signer, smtpDone
 }
 
@@ -93,7 +93,7 @@ func TestNotifierSendsEmailToOwner(t *testing.T) {
 	sent := msgs[0]
 
 	// From / To envelope
-	if want := "hitl-noreply@" + notifyFromDomain; sent.From != want {
+	if want := "approvals@" + notifyFromDomain; sent.From != want {
 		t.Errorf("envelope from = %q, want %q", sent.From, want)
 	}
 	if sent.To != "owner-send-email@reviewer.test" {
@@ -138,7 +138,7 @@ func TestNotifierSendsEmailToOwner(t *testing.T) {
 		t.Error("missing Subject header")
 	}
 	// Reply-To points back at the platform, not the agent
-	if !strings.Contains(data, "Reply-To: hitl-noreply@"+notifyFromDomain) {
+	if !strings.Contains(data, "Reply-To: approvals@"+notifyFromDomain) {
 		t.Errorf("Reply-To header should be platform sender, got:\n%s", data)
 	}
 }
@@ -299,4 +299,93 @@ func extractToken(t *testing.T, data, prefix string) string {
 		end = len(rest)
 	}
 	return rest[:end]
+}
+
+// A configured notifications.reply_to must reach the wire, and the From must
+// not advertise a noreply identity while doing so. Before this, Reply-To was
+// hardcoded to the sender on the platform relay domain — which has no mailbox,
+// so a reviewer who hit Reply was talking to the bounce endpoint. Approvals are
+// time-boxed and a reviewer who cannot sign in has only the magic links, so
+// that silent dead end was the worst place to have one.
+func TestNotifierUsesConfiguredReplyTo(t *testing.T) {
+	smtpAddr, smtpDone := testutil.FakeSMTPServer(t)
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	relay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{
+		Host: smtpAddr.Host, Port: smtpAddr.Port, FromDomain: notifyFromDomain,
+	})
+	signer := approvaltoken.NewSigner(notifySecret)
+	n := hitlnotify.New(store, relay, signer, notifyFromDomain, "", "support@inbox.test", publicURL)
+
+	agent, msg := setupPendingMessage(t, store, "replyto")
+	if err := n.NotifyPendingApproval(context.Background(), msg, agent); err != nil {
+		t.Fatalf("NotifyPendingApproval: %v", err)
+	}
+	msgs := smtpDone()
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 SMTP message, got %d", len(msgs))
+	}
+	data := string(msgs[0].Data)
+
+	if !strings.Contains(data, "Reply-To: support@inbox.test") {
+		t.Errorf("configured reply_to missing from headers:\n%s", firstHeaders(data))
+	}
+	if strings.Contains(data, "Reply-To: approvals@"+notifyFromDomain) {
+		t.Errorf("reply_to was configured but Reply-To still points at the sender")
+	}
+	// The From stays the sender identity; only Reply-To moves.
+	if want := "From: e2a <approvals@" + notifyFromDomain + ">"; !strings.Contains(data, want) {
+		t.Errorf("From changed unexpectedly, want %q in:\n%s", want, firstHeaders(data))
+	}
+	if strings.Contains(data, "noreply") {
+		t.Errorf("a replyable notification must not carry a noreply identity:\n%s", firstHeaders(data))
+	}
+}
+
+// firstHeaders trims a composed message to its header block for readable
+// failure output.
+func firstHeaders(data string) string {
+	if i := strings.Index(data, "\r\n\r\n"); i > 0 {
+		return data[:i]
+	}
+	if len(data) > 600 {
+		return data[:600]
+	}
+	return data
+}
+
+// Setting notifications.from_address consolidates both notification senders
+// into one identity. Verify it overrides the package default here too, and
+// that the Message-ID domain follows the configured address rather than
+// claiming the relay domain the From no longer uses.
+func TestNotifierHonoursConfiguredFromAddress(t *testing.T) {
+	smtpAddr, smtpDone := testutil.FakeSMTPServer(t)
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	relay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{
+		Host: smtpAddr.Host, Port: smtpAddr.Port, FromDomain: notifyFromDomain,
+	})
+	signer := approvaltoken.NewSigner(notifySecret)
+	n := hitlnotify.New(store, relay, signer, notifyFromDomain, "alerts@mail.test", "", publicURL)
+
+	agent, msg := setupPendingMessage(t, store, "fromaddr")
+	if err := n.NotifyPendingApproval(context.Background(), msg, agent); err != nil {
+		t.Fatalf("NotifyPendingApproval: %v", err)
+	}
+	msgs := smtpDone()
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 SMTP message, got %d", len(msgs))
+	}
+	sent := msgs[0]
+	data := string(sent.Data)
+
+	if sent.From != "alerts@mail.test" {
+		t.Errorf("envelope from = %q, want the configured address", sent.From)
+	}
+	if !strings.Contains(data, "From: e2a <alerts@mail.test>") {
+		t.Errorf("From header ignored the configured address:\n%s", firstHeaders(data))
+	}
+	if strings.Contains(data, "Message-ID: <") && !strings.Contains(data, "@mail.test>") {
+		t.Errorf("Message-ID domain should follow the configured From, got:\n%s", firstHeaders(data))
+	}
 }

--- a/internal/webhooknotify/notifier.go
+++ b/internal/webhooknotify/notifier.go
@@ -18,11 +18,18 @@ import (
 // when notifications.from_address is not configured: the email then sends
 // from <notifyLocalPart>@<outbound_smtp.from_domain>, exactly the
 // hitlnotify pattern, so self-host works with zero configuration. Hosted
-// deployments set notifications.from_address to a replyable support
-// address instead — the address is CONFIGURATION, never a constant,
-// because a hardcoded operator address would make every self-host try to
-// send as an identity it does not own.
-const notifyLocalPart = "webhooks-noreply"
+// deployments can set notifications.from_address instead — the address is
+// CONFIGURATION, never a constant, because a hardcoded operator address
+// would make every self-host try to send as an identity it does not own.
+//
+// Deliberately distinct from hitlnotify's default so the two notification
+// kinds stay separately filterable. Setting notifications.from_address
+// collapses them into one identity; leaving it unset keeps them apart.
+//
+// Not "webhooks-noreply": this email invites a reply whenever
+// notifications.reply_to is configured, and a From that reads "noreply"
+// contradicts that in the most visible field in the client.
+const notifyLocalPart = "webhooks"
 
 // maxReasonLen bounds the failure-reason string echoed into the email.
 // The source (webhook_subscriber_deliveries.last_error) is already

--- a/internal/webhooknotify/notifier_test.go
+++ b/internal/webhooknotify/notifier_test.go
@@ -70,7 +70,7 @@ func TestNotifier_DisabledEmailContent(t *testing.T) {
 	if len(relay.to) != 1 || relay.to[0] != "owner@example.com" {
 		t.Errorf("recipients = %v, want the account owner", relay.to)
 	}
-	if relay.from != "webhooks-noreply@send.example.com" {
+	if relay.from != "webhooks@send.example.com" {
 		t.Errorf("envelope from = %q, want the fallback local part on from_domain", relay.from)
 	}
 	msg := string(relay.message)


### PR DESCRIPTION
## The bug

HITL approval mail has shipped with a **Reply-To that goes nowhere**. Confirmed in a live inbox:

```
from:      e2a <hitl-noreply@send.e2a.dev>
reply-to:  hitl-noreply@send.e2a.dev
```

Reply-To was hardcoded to the sender address, on the platform relay domain — whose MX points at SES's feedback endpoint, so it has no mailbox. The original intent was right (*"point replies back at the platform, not the agent"*) but the destination can't receive.

A reviewer who hits Reply gets silence. That's the worst place for it: an approval is **time-boxed**, and a reviewer who can't sign in has only the magic links.

## Changes

- **`hitlnotify` reads `notifications.from_address` / `notifications.reply_to`** — the same keys `webhooknotify` already uses. Resolution logic mirrors `webhooknotify.New` so the two can't drift.
- **Reply-To** is the configured inbox when set; unset falls back to today's exact behaviour, so unconfigured self-hosts are unchanged.
- **Sender local parts drop "noreply"**: `hitl-noreply` → `approvals`, `webhooks-noreply` → `webhooks`.

Once `reply_to` points at a real inbox, a From that reads `noreply` tells the reader the opposite — in the most visible field in their client. (`hitl` was also internal jargon that had leaked onto a customer-facing address.)

## Why distinct rather than consolidated

The two defaults stay **distinct**. An approval is time-boxed; routine webhook-health mail isn't. Keeping them separately filterable is worth more than one shared identity — and the existing comment on the `hitlnotify` constant says the fixed local part exists precisely so clients can group on it.

Setting `notifications.from_address` still collapses both into one identity, so consolidation is one line of config away if that turns out to be preferable.

## Tests

- a configured `reply_to` reaches the wire, and does **not** leave the sender in Reply-To
- From is unchanged by it — only Reply-To moves
- no `noreply` survives anywhere in a replyable message
- a configured `from_address` overrides the default, and the Message-ID domain follows it rather than claiming a relay domain the From no longer uses

Both packages green; repo-wide `go test -short` at 0 failures.

## ⚠️ Release notes

**The From address on HITL approval emails changes from `hitl-noreply@` to `approvals@`.** Any customer filter matching the old address stops matching. This is unavoidable once the mail becomes replyable, but it shouldn't arrive silently.

## Follow-on (ops repo, not here)

This adds the seam; the hosted values still need setting:

```yaml
notifications:
  reply_to: support@agents.e2a.dev
```

`config.prod.yaml` is a risky-config path, so that lands via a staging cycle. Until it does, both senders keep their current (now non-noreply) defaults and no Reply-To header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)