### PR TITLE
test(metrics): live + conformance coverage for the beta metrics endpoints

### DIFF
--- a/sdks/typescript/test/e2e-metrics.test.ts
+++ b/sdks/typescript/test/e2e-metrics.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Live ergonomic coverage: the beta delivery-metrics surface. See
+ * test/e2e.test.ts's header for the coverage-gate contract this suite
+ * participates in.
+ *
+ * This file owns: messages.getMetrics, account.metrics.
+ *
+ * Both are asserted on SHAPE and INVARIANTS rather than on specific counts:
+ * these run against a shared staging deployment whose traffic is not ours to
+ * control, so any assertion on a particular number would be flaky by
+ * construction. The invariants below are the contract's actual promises and
+ * hold at any traffic level, including zero.
+ *
+ * This suite deliberately creates NOTHING. Metrics are read-only, and the
+ * staging accounts these run against are Free-plan (3 agents). An earlier
+ * draft created its own agent for isolation and pushed e2e-agents.test.ts over
+ * the cap — two failures in a file this one never touches. Reading the env's
+ * existing agent costs no quota and cannot destabilise a sibling suite.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { E2AClient } from "../src/v1/index.js";
+import { walkErgonomicSurface } from "./coverage/introspect.js";
+import { recordSurface, recordCovered, flushCoverage } from "./coverage/recorder.js";
+import { loadLiveEnv } from "./coverage/helpers.js";
+
+const env = loadLiveEnv();
+
+describe.skipIf(!env)("ts sdk live e2e: metrics (beta)", () => {
+  let client: E2AClient;
+  beforeAll(() => {
+    client = new E2AClient({ apiKey: env!.apiKey, baseUrl: env!.baseUrl });
+    recordSurface(walkErgonomicSurface(client));
+  });
+
+  afterAll(() => {
+    flushCoverage();
+  });
+
+  it("messages.getMetrics() returns a cohort window with coherent counters", async () => {
+    const m = await client.messages.getMetrics(env!.agentEmail);
+
+    // The window is always present and ordered, whether or not it saw traffic.
+    expect(m.start.getTime()).toBeLessThan(m.end.getTime());
+    expect(m.agentEmail).toBe(env!.agentEmail);
+
+    // Ledger-coverage honesty: the aggregate reports how much of the window it
+    // could actually see, so a gap is a visible number rather than a silent
+    // undercount that reads as lost mail.
+    expect(m.messagesInWindow).toBeGreaterThanOrEqual(0);
+    expect(m.messagesWithLifecycle).toBeGreaterThanOrEqual(0);
+    expect(m.messagesWithLifecycle).toBeLessThanOrEqual(m.messagesInWindow);
+
+    // The contract's sharpest promise: a zero denominator yields null — NOT 0,
+    // which would be indistinguishable from "everything failed". Conditional
+    // because this agent may legitimately have traffic on a shared staging
+    // deployment; when it does, a rate must be a real number in [0,1].
+    if (m.messagesInWindow === 0) {
+      expect(m.rates.bounceRate).toBeNull();
+      expect(m.rates.complaintRate).toBeNull();
+      expect(m.rates.deliveredRate).toBeNull();
+    } else {
+      for (const r of [m.rates.deliveredRate, m.rates.bounceRate, m.rates.complaintRate]) {
+        if (r !== null) {
+          expect(r).toBeGreaterThanOrEqual(0);
+          expect(r).toBeLessThanOrEqual(1);
+        }
+      }
+    }
+
+    recordCovered("messages.getMetrics");
+  });
+
+  it("messages.getMetrics() honours an explicit cohort window", async () => {
+    const end = new Date();
+    const start = new Date(end.getTime() - 7 * 24 * 60 * 60 * 1000);
+
+    const m = await client.messages.getMetrics(env!.agentEmail, { start, end });
+
+    // The server echoes the requested window (it may normalise precision, so
+    // compare to the second rather than by identity).
+    expect(Math.abs(m.start.getTime() - start.getTime())).toBeLessThan(1000);
+    expect(Math.abs(m.end.getTime() - end.getTime())).toBeLessThan(1000);
+
+    recordCovered("messages.getMetrics");
+  });
+
+  it("account.metrics() aggregates across the account and can group by agent", async () => {
+    const flat = await client.account.metrics();
+
+    expect(flat.start.getTime()).toBeLessThan(flat.end.getTime());
+    expect(flat.messagesInWindow).toBeGreaterThanOrEqual(0);
+    expect(flat.messagesWithLifecycle).toBeLessThanOrEqual(flat.messagesInWindow);
+    if (flat.messagesInWindow === 0) {
+      expect(flat.rates.bounceRate).toBeNull();
+    }
+
+    // groupBy is the only shape-changing parameter, so it is worth exercising:
+    // the per-agent rows must not claim more messages than the account total
+    // they were aggregated from.
+    const grouped = await client.account.metrics({ groupBy: "agent" });
+    const perAgentTotal = (grouped.agents ?? []).reduce(
+      (sum, a) => sum + a.messagesInWindow,
+      0,
+    );
+    expect(perAgentTotal).toBeLessThanOrEqual(grouped.messagesInWindow);
+
+    recordCovered("account.metrics");
+  });
+});

--- a/tests/e2e-prod/suites/37-metrics.test.ts
+++ b/tests/e2e-prod/suites/37-metrics.test.ts
@@ -1,0 +1,154 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient } from "../harness/client.ts";
+import { info, writeReport } from "../harness/report.ts";
+
+// Black-box conformance for the beta delivery-metrics surface:
+// getAgentMetrics (GET /v1/agents/{email}/metrics) and getAccountMetrics
+// (GET /v1/metrics).
+//
+// Asserted on SHAPE and INVARIANTS, never on specific counts. These run
+// against a shared deployment whose traffic is not this suite's to control, so
+// any assertion on a particular number would be flaky by construction. The
+// invariants below are the contract's actual promises and hold at any traffic
+// level, including zero.
+//
+// This suite creates NOTHING. Metrics are read-only, and a suite that mints
+// agents to get a clean fixture competes for the account's agent cap with
+// every other suite in the run.
+const SUITE = "37-metrics";
+const client = new ApiClient();
+
+interface Rates {
+  delivered_rate: number | null;
+  bounce_rate: number | null;
+  complaint_rate: number | null;
+  suppression_block_rate: number | null;
+}
+interface MetricsBase {
+  start: string;
+  end: string;
+  messages_in_window: number;
+  messages_with_lifecycle: number;
+  reconstructed_observations: number;
+  summary: Record<string, number>;
+  rates: Rates;
+}
+interface AgentMetricsView extends MetricsBase {
+  agent_email: string;
+}
+interface AccountMetricsView extends MetricsBase {
+  agents: Array<{ agent_email: string; messages_in_window: number }> | null;
+  agents_truncated: boolean;
+}
+
+/** Shared invariants both shapes must satisfy. */
+function assertMetricsInvariants(m: MetricsBase, label: string) {
+  assert.ok(
+    Date.parse(m.start) < Date.parse(m.end),
+    `${label}: window must be ordered (start < end)`,
+  );
+
+  // Ledger-coverage honesty: the aggregate reports how much of the window it
+  // could actually see, so a gap is a visible number rather than a silent
+  // undercount that would read as lost mail.
+  assert.ok(m.messages_in_window >= 0, `${label}: messages_in_window >= 0`);
+  assert.ok(
+    m.messages_with_lifecycle <= m.messages_in_window,
+    `${label}: messages_with_lifecycle (${m.messages_with_lifecycle}) must not exceed messages_in_window (${m.messages_in_window})`,
+  );
+
+  // The contract's sharpest promise: a zero denominator yields null, NEVER 0 —
+  // 0% is indistinguishable from total delivery failure.
+  for (const [k, v] of Object.entries(m.rates)) {
+    if (v === null) continue;
+    assert.ok(
+      typeof v === "number" && v >= 0 && v <= 1,
+      `${label}: rate ${k} must be null or within [0,1], got ${v}`,
+    );
+  }
+  if (m.messages_in_window === 0) {
+    assert.equal(m.rates.bounce_rate, null, `${label}: zero denominator must yield null bounce_rate, not 0`);
+    assert.equal(m.rates.delivered_rate, null, `${label}: zero denominator must yield null delivered_rate, not 0`);
+  }
+}
+
+test("agent metrics: default cohort window returns coherent counters", async () => {
+  const email = client.env.primaryAgentEmail;
+  const r = await client.get<AgentMetricsView>(`/v1/agents/${encodeURIComponent(email)}/metrics`);
+  assert.equal(r.status, 200, `expected 200, got ${r.status}: ${r.raw.slice(0, 200)}`);
+
+  const m = r.body!;
+  assert.equal(m.agent_email, email, "response must echo the agent it describes");
+  assertMetricsInvariants(m, "agent metrics");
+
+  info(SUITE, "agent-default-window", `window ${m.start} → ${m.end}`, {
+    messages_in_window: m.messages_in_window,
+    messages_with_lifecycle: m.messages_with_lifecycle,
+  });
+});
+
+test("agent metrics: an explicit window is honoured", async () => {
+  const email = client.env.primaryAgentEmail;
+  const end = new Date();
+  const start = new Date(end.getTime() - 7 * 24 * 60 * 60 * 1000);
+
+  const r = await client.get<AgentMetricsView>(
+    `/v1/agents/${encodeURIComponent(email)}/metrics` +
+      `?start=${encodeURIComponent(start.toISOString())}&end=${encodeURIComponent(end.toISOString())}`,
+  );
+  assert.equal(r.status, 200, `expected 200, got ${r.status}: ${r.raw.slice(0, 200)}`);
+
+  // The server may normalise RFC 3339 precision, so compare instants rather
+  // than strings.
+  const m = r.body!;
+  assert.ok(
+    Math.abs(Date.parse(m.start) - start.getTime()) < 1000,
+    `echoed start ${m.start} should match the requested ${start.toISOString()}`,
+  );
+  assert.ok(
+    Math.abs(Date.parse(m.end) - end.getTime()) < 1000,
+    `echoed end ${m.end} should match the requested ${end.toISOString()}`,
+  );
+  assertMetricsInvariants(m, "agent metrics (explicit window)");
+});
+
+test("account metrics: aggregates the account and groups by agent", async () => {
+  const flat = await client.get<AccountMetricsView>("/v1/metrics");
+  assert.equal(flat.status, 200, `expected 200, got ${flat.status}: ${flat.raw.slice(0, 200)}`);
+  assertMetricsInvariants(flat.body!, "account metrics");
+
+  // group_by is the only shape-changing parameter, so it is worth exercising.
+  const grouped = await client.get<AccountMetricsView>("/v1/metrics?group_by=agent");
+  assert.equal(grouped.status, 200, `expected 200, got ${grouped.status}: ${grouped.raw.slice(0, 200)}`);
+  const g = grouped.body!;
+  assertMetricsInvariants(g, "account metrics (group_by=agent)");
+
+  // Per-agent rows are a partition of the account total, so they cannot claim
+  // more messages than the whole they came from. Skipped when the response is
+  // truncated, where the rows are deliberately a subset.
+  if (!g.agents_truncated) {
+    const perAgent = (g.agents ?? []).reduce((sum, a) => sum + a.messages_in_window, 0);
+    assert.ok(
+      perAgent <= g.messages_in_window,
+      `per-agent total (${perAgent}) must not exceed the account total (${g.messages_in_window})`,
+    );
+  }
+
+  info(SUITE, "account-group-by-agent", `${(g.agents ?? []).length} agent row(s)`, {
+    truncated: g.agents_truncated,
+    messages_in_window: g.messages_in_window,
+  });
+});
+
+test("agent metrics: an unknown agent is rejected, not silently empty", async () => {
+  const r = await client.get(`/v1/agents/${encodeURIComponent("no-such-agent@invalid.test")}/metrics`);
+  assert.ok(
+    r.status === 404 || r.status === 400,
+    `an unknown agent must fail cleanly (404/400), got ${r.status}: zeroed metrics for a nonexistent agent would read as "your mail stopped"`,
+  );
+});
+
+after(() => {
+  writeReport(`reports/${SUITE}.json`);
+});


### PR DESCRIPTION
## Why — this blocks v1.7.0 promotion

The v1.7.0 staging pipeline failed **two** gates, both on the same gap. #861 shipped `GET /v1/metrics` and `GET /v1/agents/{email}/metrics` across every client surface, but neither gate that runs only against a live deployment had anything exercising them:

```
TS SDK  coverage:gate       UNCOVERED (2): account.metrics, messages.getMetrics
conformance coverage_gate   UNCOVERED (2): getAccountMetrics, getAgentMetrics
```

Both gates are invisible to OSS CI. That's why #861 could be complete against its own checklist, green in CI, and still block the release twice — worth noting as a structural gap, not a criticism of that PR.

The conformance *tests* passed (`fail 0`); only the operationId coverage gate failed.

## What's added

- **`sdks/typescript/test/e2e-metrics.test.ts`** (3 tests) — default window, explicit window, account aggregation with `group_by=agent`.
- **`tests/e2e-prod/suites/37-metrics.test.ts`** (4 tests) — the same three, plus one the SDK suite can't express: **an unknown agent must fail cleanly** (404/400) rather than return zeroed metrics. Zeros there read to a customer as *"my mail stopped."*

## Assertion strategy

Shape and invariants, never specific counts. These run against shared deployments whose traffic isn't the suite's to control, so asserting a particular number would be flaky by construction. The invariants are the contract's real promises and hold at any traffic level:

- window ordering (`start < end`)
- `messages_with_lifecycle <= messages_in_window` — the ledger-coverage honesty the feature advertises
- rates `null` or within `[0,1]`
- **a zero denominator yields `null`, never `0`** — the sharpest promise, since 0% is indistinguishable from total delivery failure

## Neither suite creates anything

Metrics are read-only. The first draft of the SDK test minted its own agent for isolation and pushed `e2e-agents.test.ts` over the Free-plan 3-agent cap — **two failures in a file it never touches**. A control run without the new file reproduced those same two failures, confirming the cap rather than the change. Reading the env's existing agent costs no quota and can't destabilise a sibling suite.

## Verified against live staging, not asserted

| | result |
|---|---|
| TS SDK suite | **34/34** across 12 files |
| TS SDK `coverage:gate` | **77/79 covered, 2 allowlisted — PASS** (was 75/79) |
| conformance suite 37 | **4/4** |
| conformance `coverage_gate.py` | `getAccountMetrics` / `getAgentMetrics` **no longer listed** |

Two shape assumptions in my first draft were wrong and are corrected: the response carries `start`/`end` at the **top level** (not nested under `window`), and the rate field is `delivered_rate` (not `delivery_rate`). Both found by reading the live payload rather than the description.

Test-only change — no product code touched.

## Next

v1.7.0 is tagged and its images published, so reusing that tag would make `ghcr.io/tokencanopy/e2a:1.7.0` mutable. This lands, then **v1.7.1** gets cut and staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)