### PR TITLE
test(metrics): close the remaining coverage gaps — timeout split + MCP tools

### DIFF
--- a/sdks/typescript/test/e2e-metrics.test.ts
+++ b/sdks/typescript/test/e2e-metrics.test.ts
@@ -20,7 +20,11 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { E2AClient } from "../src/v1/index.js";
 import { walkErgonomicSurface } from "./coverage/introspect.js";
-import { recordSurface, recordCovered, flushCoverage } from "./coverage/recorder.js";
+import {
+  recordSurface,
+  recordCovered,
+  flushCoverage,
+} from "./coverage/recorder.js";
 import { loadLiveEnv } from "./coverage/helpers.js";
 
 const env = loadLiveEnv();
@@ -59,7 +63,11 @@ describe.skipIf(!env)("ts sdk live e2e: metrics (beta)", () => {
       expect(m.rates.complaintRate).toBeNull();
       expect(m.rates.deliveredRate).toBeNull();
     } else {
-      for (const r of [m.rates.deliveredRate, m.rates.bounceRate, m.rates.complaintRate]) {
+      for (const r of [
+        m.rates.deliveredRate,
+        m.rates.bounceRate,
+        m.rates.complaintRate,
+      ]) {
         if (r !== null) {
           expect(r).toBeGreaterThanOrEqual(0);
           expect(r).toBeLessThanOrEqual(1);
@@ -84,26 +92,43 @@ describe.skipIf(!env)("ts sdk live e2e: metrics (beta)", () => {
     recordCovered("messages.getMetrics");
   });
 
-  it("account.metrics() aggregates across the account and can group by agent", async () => {
+  it("account.metrics() aggregates across the account", async () => {
     const flat = await client.account.metrics();
 
     expect(flat.start.getTime()).toBeLessThan(flat.end.getTime());
     expect(flat.messagesInWindow).toBeGreaterThanOrEqual(0);
-    expect(flat.messagesWithLifecycle).toBeLessThanOrEqual(flat.messagesInWindow);
+    expect(flat.messagesWithLifecycle).toBeLessThanOrEqual(
+      flat.messagesInWindow,
+    );
     if (flat.messagesInWindow === 0) {
       expect(flat.rates.bounceRate).toBeNull();
     }
 
-    // groupBy is the only shape-changing parameter, so it is worth exercising:
-    // the per-agent rows must not claim more messages than the account total
-    // they were aggregated from.
-    const grouped = await client.account.metrics({ groupBy: "agent" });
-    const perAgentTotal = (grouped.agents ?? []).reduce(
-      (sum, a) => sum + a.messagesInWindow,
-      0,
-    );
-    expect(perAgentTotal).toBeLessThanOrEqual(grouped.messagesInWindow);
-
     recordCovered("account.metrics");
   });
+
+  // Split from the flat read, and the only test in this suite carrying an
+  // explicit timeout. group_by=agent fans the aggregate out per agent, so its
+  // cost scales with how many agents the account owns — unbounded and
+  // environment-dependent. Two of these calls in one test exceeded vitest's 5s
+  // default on a populated account while passing comfortably on a small one.
+  // Do not "tidy" this back to the default: it will pass locally and fail the
+  // release pipeline.
+  it("account.metrics({ groupBy: 'agent' }) partitions the account total", async () => {
+    const grouped = await client.account.metrics({ groupBy: "agent" });
+    expect(grouped.start.getTime()).toBeLessThan(grouped.end.getTime());
+
+    // Per-agent rows are a partition of the account total, so they cannot
+    // claim more messages than the whole they came from. Skipped when the
+    // response is truncated, where the rows are deliberately a subset.
+    if (!grouped.agentsTruncated) {
+      const perAgentTotal = (grouped.agents ?? []).reduce(
+        (sum, a) => sum + a.messagesInWindow,
+        0,
+      );
+      expect(perAgentTotal).toBeLessThanOrEqual(grouped.messagesInWindow);
+    }
+
+    recordCovered("account.metrics");
+  }, 30_000);
 });

--- a/tests/e2e-prod/suites/38-mcp-metrics.test.ts
+++ b/tests/e2e-prod/suites/38-mcp-metrics.test.ts
@@ -1,0 +1,153 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient } from "../harness/client.ts";
+import { HttpMcpClient, callTool, type McpToolResult } from "../harness/mcp.ts";
+import { info, writeReport } from "../harness/report.ts";
+
+// Black-box MCP conformance for the beta delivery-metrics tools against the
+// DEPLOYED streamable-HTTP /mcp server. This is the MCP analogue of suite
+// 37-metrics.test.ts (REST) — same domain, same server-side semantics, but
+// every call goes through tools/call so mcp_coverage_gate.py credits the tool.
+//
+// Tools exercised (both):
+//   get_agent_metrics    (runtime tier)
+//   get_account_metrics  (admin tier)
+//
+// The metrics surface shipped across four surfaces, each with its own live
+// coverage gate: REST operationIds, the TS SDK ergonomic facade, the Python
+// SDK facade, and these MCP tools. Three had coverage; this file closes the
+// fourth.
+//
+// Asserted on SHAPE and INVARIANTS, never on specific counts — these run
+// against a shared deployment whose traffic is not this suite's to control.
+// The invariants are the contract's real promises and hold at any traffic
+// level, including zero. Creates nothing: metrics are read-only, and minting
+// an agent for a clean fixture competes for the account's agent cap with every
+// other suite in the run.
+const SUITE = "38-mcp-metrics";
+const apiClient = new ApiClient();
+const mcp = new HttpMcpClient(apiClient.env.mcpUrl, apiClient.env.apiKey);
+
+interface Rates {
+  delivered_rate: number | null;
+  bounce_rate: number | null;
+  complaint_rate: number | null;
+  suppression_block_rate: number | null;
+}
+interface MetricsBase {
+  start: string;
+  end: string;
+  messages_in_window: number;
+  messages_with_lifecycle: number;
+  rates: Rates;
+}
+interface AgentMetricsResult extends MetricsBase {
+  agent_email: string;
+}
+interface AccountMetricsResult extends MetricsBase {
+  agents?: Array<{ agent_email: string; messages_in_window: number }> | null;
+  agents_truncated?: boolean;
+}
+
+// Both tools must stay advertised: a silent removal would otherwise look like
+// coverage passing, since an unadvertised tool is simply never counted.
+const REQUIRED_TOOLS = ["get_agent_metrics", "get_account_metrics"];
+
+function extractText(r: McpToolResult): string {
+  return r.content?.find((c) => c.type === "text")?.text ?? "";
+}
+
+function parseOk<T>(r: McpToolResult, label: string): T {
+  assert.equal(r.isError, undefined, `${label} isError: ${extractText(r).slice(0, 300)}`);
+  const text = extractText(r);
+  assert.ok(text.length > 0, `${label}: empty tool result`);
+  return JSON.parse(text) as T;
+}
+
+function assertMetricsInvariants(m: MetricsBase, label: string) {
+  assert.ok(Date.parse(m.start) < Date.parse(m.end), `${label}: window must be ordered`);
+  assert.ok(m.messages_in_window >= 0, `${label}: messages_in_window >= 0`);
+  assert.ok(
+    m.messages_with_lifecycle <= m.messages_in_window,
+    `${label}: messages_with_lifecycle (${m.messages_with_lifecycle}) must not exceed messages_in_window (${m.messages_in_window})`,
+  );
+  for (const [k, v] of Object.entries(m.rates ?? {})) {
+    if (v === null) continue;
+    assert.ok(
+      typeof v === "number" && v >= 0 && v <= 1,
+      `${label}: rate ${k} must be null or within [0,1], got ${v}`,
+    );
+  }
+  // The contract's sharpest promise: a zero denominator yields null, NEVER 0 —
+  // 0% is indistinguishable from total delivery failure.
+  if (m.messages_in_window === 0) {
+    assert.equal(m.rates.bounce_rate, null, `${label}: zero denominator must yield null, not 0`);
+  }
+}
+
+test("mcp-metrics: tools/list advertises both metrics tools", async () => {
+  const list = await mcp.call<{ tools: Array<{ name: string }> }>("tools/list");
+  const names = new Set(list.tools.map((t) => t.name));
+  const missing = REQUIRED_TOOLS.filter((n) => !names.has(n));
+  assert.deepEqual(
+    missing,
+    [],
+    `deployed MCP server must advertise every metrics tool; missing: ${missing.join(", ")}`,
+  );
+  info(SUITE, "tools-list", `server advertises ${list.tools.length} tools`);
+});
+
+test("mcp-metrics: get_agent_metrics returns a coherent cohort window", async () => {
+  const email = apiClient.env.primaryAgentEmail;
+  const r = await callTool(mcp, "get_agent_metrics", { email });
+  const m = parseOk<AgentMetricsResult>(r, "get_agent_metrics");
+
+  assert.equal(m.agent_email, email, "result must echo the agent it describes");
+  assertMetricsInvariants(m, "get_agent_metrics");
+
+  info(SUITE, "agent-metrics", `window ${m.start} → ${m.end}`, {
+    messages_in_window: m.messages_in_window,
+  });
+});
+
+test("mcp-metrics: get_account_metrics aggregates, and groups by agent", async () => {
+  const flat = parseOk<AccountMetricsResult>(
+    await callTool(mcp, "get_account_metrics", {}),
+    "get_account_metrics",
+  );
+  assertMetricsInvariants(flat, "get_account_metrics");
+
+  const grouped = parseOk<AccountMetricsResult>(
+    await callTool(mcp, "get_account_metrics", { group_by: "agent" }),
+    "get_account_metrics(group_by=agent)",
+  );
+  assertMetricsInvariants(grouped, "get_account_metrics(group_by=agent)");
+
+  // Per-agent rows are a partition of the account total, so they cannot claim
+  // more than the whole they came from. Skipped when truncated, where the rows
+  // are deliberately a subset.
+  if (!grouped.agents_truncated) {
+    const perAgent = (grouped.agents ?? []).reduce((sum, a) => sum + a.messages_in_window, 0);
+    assert.ok(
+      perAgent <= grouped.messages_in_window,
+      `per-agent total (${perAgent}) must not exceed the account total (${grouped.messages_in_window})`,
+    );
+  }
+
+  info(SUITE, "account-metrics", `${(grouped.agents ?? []).length} agent row(s)`, {
+    truncated: grouped.agents_truncated,
+  });
+});
+
+test("mcp-metrics: an unknown agent is a tool error, not zeroed metrics", async () => {
+  const r = await callTool(mcp, "get_agent_metrics", { email: "no-such-agent@invalid.test" });
+  assert.equal(
+    r.isError,
+    true,
+    "an unknown agent must surface as a tool error: zeroed metrics would read to an agent as \"my mail stopped\"",
+  );
+});
+
+after(() => {
+  writeReport(`reports/${SUITE}.json`);
+});


### PR DESCRIPTION
## Two fixes, one tag

v1.7.1 failed **both** gates again, for two different reasons. Both are fixed here so one tag closes them.

### 1. Client-surface gate — my own test timed out

Not a coverage gap; #867 fixed that and nothing is uncovered in that run. It failed on:

```
FAIL account.metrics() aggregates across the account and can group by agent
Error: Test timed out in 5000ms.
```

The test made **two sequential `account.metrics()` calls**, and `group_by=agent` fans the aggregate out per agent, so its cost scales with the account's agent count — unbounded and environment-dependent. It passed against a small local account and blew vitest's 5s default against the pipeline's populated one. Every other test passed, 33/34.

**Fix:** split into two tests so each gets its own budget; the grouped read carries an explicit 30s timeout — the only override in the suite, with the reason inline so nobody tidies it back and reintroduces a test that passes locally and fails the pipeline. Also adds the `agentsTruncated` guard the conformance suite already had.

### 2. Conformance gate — MCP tools uncovered

The operationId gate **passed** (#867 worked). A *different* gate failed:

```
mcp_coverage_gate.py
Advertised tools : 78
Covered          : 72
UNCOVERED (2): get_account_metrics, get_agent_metrics
```

**Fix:** `tests/e2e-prod/suites/38-mcp-metrics.test.ts`, mirroring the REST suite through `tools/call` so the recorder credits the tools.

## The real lesson

#861 shipped the metrics surface in **four** places, each with its own live coverage gate:

| surface | gate | status |
|---|---|---|
| REST operationIds | `coverage_gate.py` | fixed in #867 |
| TS SDK ergonomic facade | sdk `coverage:gate` | fixed in #867 |
| Python SDK facade | `resource_coverage_gate.py` | **already covered by #861** |
| MCP tools | `mcp_coverage_gate.py` | **this PR** |

Fixing two gates and re-cutting twice was the wrong approach. The right question was *"how many coverage gates exist, and does this feature touch all of them?"* — the answer was four, and #861 had covered one. I've now enumerated them rather than discovering them one tag at a time.

## Verification (live staging, not asserted)

- SDK metrics suite: **4/4**
- conformance suite 38: **4/4**
- `mcp_coverage_gate.py`: neither tool listed (`Covered: 2` from suite 38 alone)
- `coverage_gate.py` (operationIds): already passing on v1.7.1

## Worth knowing beyond the tests

The timeout is a real signal. Measured on staging: ~200ms flat and grouped on an **empty** account — identical to `/v1/account` at 193ms, so zero query cost at zero data. But two indirect points show it scaling: ~1s/call at ~52 agent rows, and >2.5s/call on the pipeline's account. `group_by=agent` backs a **dashboard page**, so that curve deserves measuring against a large account before the endpoint leaves beta. Out of scope here.

Test-only change — no product code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)