### PR TITLE
perf(metrics): raise work_mem for the account-metrics aggregates

### DIFF
--- a/internal/messagelifecycle/account_metrics.go
+++ b/internal/messagelifecycle/account_metrics.go
@@ -65,32 +65,7 @@ func (s *Store) CountByReasonCodeForAccount(ctx context.Context, userID string, 
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	// Both aggregates below use count(DISTINCT message_id), which forces a
-	// GroupAggregate over a sort of every transition in the window rather than
-	// a hash aggregate. At the default 4MB that sort spills hard. Raising it
-	// for this transaction only is the whole optimisation — measured on a
-	// seeded account (50 agents / 300k messages / 900k transitions, warm
-	// cache, medians):
-	//
-	//	work_mem   totals    per-agent
-	//	4MB        ~780ms    ~1510ms
-	//	32MB       ~480ms    ~1230ms
-	//	64MB       ~450ms    ~1070ms
-	//
-	// 32MB takes most of the win; past it the curve flattens while the
-	// per-node cost keeps scaling with concurrency. Note the sort still spills
-	// even here (~60MB totals / ~70MB per-agent) — sizing work_mem to hold it
-	// outright would cost more memory than the remaining ~10% is worth.
-	//
-	// Two rewrites were measured and REJECTED, so don't re-derive them:
-	// reshaping the aggregate into a two-phase group-then-sum was ~2.5x SLOWER
-	// on the totals query and noise on the per-agent one, and a covering index
-	// on (reason_code, stage, outcome, retryable, message_id) was not adopted
-	// by the planner at all — identical plan, identical spill.
-	//
-	// SET LOCAL is scoped to this transaction and reverts on commit/rollback,
-	// so it cannot leak onto a pooled connection.
-	if _, err := tx.Exec(ctx, "SET LOCAL work_mem = '32MB'"); err != nil {
+	if err := setAccountMetricsWorkMem(ctx, tx); err != nil {
 		return metrics, fmt.Errorf("set work_mem for account metrics: %w", err)
 	}
 
@@ -128,6 +103,39 @@ func (s *Store) CountByReasonCodeForAccount(ctx context.Context, userID string, 
 	}
 	metrics.Agents = coverage
 	return metrics, nil
+}
+
+// accountMetricsWorkMem is raised above the Postgres default (4MB) for the
+// account-metrics read transaction only. Both aggregates in
+// CountByReasonCodeForAccount use count(DISTINCT message_id), which forces a
+// GroupAggregate over a sort of every transition in the window rather than a
+// hash aggregate. At the default that sort spills hard. Raising it for that
+// transaction only is the whole optimisation — measured on a seeded account
+// (50 agents / 300k messages / 900k transitions, warm cache, medians):
+//
+//	work_mem   totals    per-agent
+//	4MB        ~780ms    ~1510ms
+//	32MB       ~480ms    ~1230ms
+//	64MB       ~450ms    ~1070ms
+//
+// 32MB takes most of the win; past it the curve flattens while the per-node
+// cost keeps scaling with concurrency. Note the sort still spills even here
+// (~60MB totals / ~70MB per-agent) — sizing work_mem to hold it outright
+// would cost more memory than the remaining ~10% is worth.
+//
+// Two rewrites were measured and REJECTED, so don't re-derive them: reshaping
+// the aggregate into a two-phase group-then-sum was ~2.5x SLOWER on the
+// totals query and noise on the per-agent one, and a covering index on
+// (reason_code, stage, outcome, retryable, message_id) was not adopted by the
+// planner at all — identical plan, identical spill.
+const accountMetricsWorkMem = "32MB"
+
+// setAccountMetricsWorkMem raises work_mem for one account-metrics read
+// transaction. SET LOCAL is scoped to the transaction and reverts on
+// commit/rollback, so it cannot leak onto a pooled connection.
+func setAccountMetricsWorkMem(ctx context.Context, tx pgx.Tx) error {
+	_, err := tx.Exec(ctx, "SET LOCAL work_mem = '"+accountMetricsWorkMem+"'")
+	return err
 }
 
 func accountTotalsTx(ctx context.Context, tx pgx.Tx, userID string, start, end time.Time) (AgentMetrics, error) {

--- a/internal/messagelifecycle/account_metrics.go
+++ b/internal/messagelifecycle/account_metrics.go
@@ -65,6 +65,35 @@ func (s *Store) CountByReasonCodeForAccount(ctx context.Context, userID string, 
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
+	// Both aggregates below use count(DISTINCT message_id), which forces a
+	// GroupAggregate over a sort of every transition in the window rather than
+	// a hash aggregate. At the default 4MB that sort spills hard. Raising it
+	// for this transaction only is the whole optimisation — measured on a
+	// seeded account (50 agents / 300k messages / 900k transitions, warm
+	// cache, medians):
+	//
+	//	work_mem   totals    per-agent
+	//	4MB        ~780ms    ~1510ms
+	//	32MB       ~480ms    ~1230ms
+	//	64MB       ~450ms    ~1070ms
+	//
+	// 32MB takes most of the win; past it the curve flattens while the
+	// per-node cost keeps scaling with concurrency. Note the sort still spills
+	// even here (~60MB totals / ~70MB per-agent) — sizing work_mem to hold it
+	// outright would cost more memory than the remaining ~10% is worth.
+	//
+	// Two rewrites were measured and REJECTED, so don't re-derive them:
+	// reshaping the aggregate into a two-phase group-then-sum was ~2.5x SLOWER
+	// on the totals query and noise on the per-agent one, and a covering index
+	// on (reason_code, stage, outcome, retryable, message_id) was not adopted
+	// by the planner at all — identical plan, identical spill.
+	//
+	// SET LOCAL is scoped to this transaction and reverts on commit/rollback,
+	// so it cannot leak onto a pooled connection.
+	if _, err := tx.Exec(ctx, "SET LOCAL work_mem = '32MB'"); err != nil {
+		return metrics, fmt.Errorf("set work_mem for account metrics: %w", err)
+	}
+
 	totals, err := accountTotalsTx(ctx, tx, userID, start, end)
 	if err != nil {
 		return metrics, err

--- a/internal/messagelifecycle/account_metrics_workmem_integration_test.go
+++ b/internal/messagelifecycle/account_metrics_workmem_integration_test.go
@@ -1,0 +1,53 @@
+//go:build integration
+
+package messagelifecycle_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/tokencanopy/e2a/internal/messagelifecycle"
+	"github.com/tokencanopy/e2a/internal/testutil"
+)
+
+// TestAccountMetricsWorkMemScopedToTx pins the two properties the account
+// aggregates rely on: the raised work_mem is accepted inside the read-only
+// repeatable-read transaction they run in, and SET LOCAL reverts on rollback
+// so the raised value cannot leak onto the pooled connection the next
+// checkout gets.
+func TestAccountMetricsWorkMemScopedToTx(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+
+	var baseline string
+	if err := pool.QueryRow(ctx, "SHOW work_mem").Scan(&baseline); err != nil {
+		t.Fatalf("show baseline work_mem: %v", err)
+	}
+
+	tx, err := pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.RepeatableRead, AccessMode: pgx.ReadOnly})
+	if err != nil {
+		t.Fatalf("begin read tx: %v", err)
+	}
+	if err := messagelifecycle.SetAccountMetricsWorkMemForTest(ctx, tx); err != nil {
+		t.Fatalf("SetAccountMetricsWorkMemForTest: %v", err)
+	}
+	var inside string
+	if err := tx.QueryRow(ctx, "SHOW work_mem").Scan(&inside); err != nil {
+		t.Fatalf("show work_mem inside tx: %v", err)
+	}
+	if inside != messagelifecycle.AccountMetricsWorkMemForTest {
+		t.Errorf("work_mem inside tx = %q, want %q", inside, messagelifecycle.AccountMetricsWorkMemForTest)
+	}
+	if err := tx.Rollback(ctx); err != nil {
+		t.Fatalf("rollback: %v", err)
+	}
+
+	var after string
+	if err := pool.QueryRow(ctx, "SHOW work_mem").Scan(&after); err != nil {
+		t.Fatalf("show work_mem after rollback: %v", err)
+	}
+	if after != baseline {
+		t.Errorf("work_mem after rollback = %q, want the pre-tx %q: SET LOCAL leaked onto a pooled connection", after, baseline)
+	}
+}

--- a/internal/messagelifecycle/export_test.go
+++ b/internal/messagelifecycle/export_test.go
@@ -1,0 +1,8 @@
+package messagelifecycle
+
+// SetAccountMetricsWorkMemForTest and AccountMetricsWorkMemForTest expose the
+// unexported work_mem seam for the external test package (Go's sanctioned
+// export_test.go hook).
+var SetAccountMetricsWorkMemForTest = setAccountMetricsWorkMem
+
+const AccountMetricsWorkMemForTest = accountMetricsWorkMem


### PR DESCRIPTION
## What

Raise `work_mem` to 32MB for the account-metrics read transaction only. One `SET LOCAL`, no other change.

## Why

Both aggregates in `accountMetrics` use `count(DISTINCT message_id)`, which forces a `GroupAggregate` over a sort of every lifecycle transition in the window rather than a hash aggregate. At the default 4MB that sort spills hard, and the cost lands on `/v1/metrics` — a dashboard-facing endpoint.

Measured on a locally seeded account (50 agents / 300k messages / 900k transitions), warm cache, medians of alternating runs:

| work_mem | totals | per-agent |
|---|---|---|
| 4MB (today) | ~780ms | ~1510ms |
| **32MB (this PR)** | **~480ms** | **~1230ms** |
| 64MB | ~450ms | ~1070ms |

32MB takes most of the win; past it the curve flattens while the per-node cost keeps scaling with concurrency. The sort still spills at 32MB (~60MB totals / ~70MB per-agent) — sizing `work_mem` to hold it outright would cost far more memory than the remaining ~10% is worth.

## Alternatives measured and rejected

Recorded in the code comment so they aren't re-derived later:

- **Two-phase group-then-sum rewrite** (replacing `count(DISTINCT)` with an inner per-message grouping): **~2.5x slower** on the totals query (~1350ms vs ~520ms at matched `work_mem`) and within noise on the per-agent one. Reverted.
- **Covering index** on `(reason_code, stage, outcome, retryable, message_id) INCLUDE (reconstructed)`: **not adopted by the planner at all** — identical plan, identical spill, identical timing.

## Safety

`SET LOCAL` is scoped to the transaction and reverts on commit/rollback, so it cannot leak onto a pooled connection. Verified directly, including that it is permitted inside the existing read-only repeatable-read transaction:

```
inside tx      | 32MB
after rollback | 4MB
```

## Scope

No migration, no schema change, no OpenAPI change, no SDK or client change. Existing `messagelifecycle` integration tests pass unchanged (`go test -tags=integration ./internal/messagelifecycle/...`).

## Note on the release

This does **not** on its own resolve the `account.metrics()` client-surface test timeout that blocked v1.7.2. The queries were already comfortably under 5s warm at this scale; the timeout looks environment-driven (cold cache / small staging instance), which is why the 30s budget on the grouped test still earns its place.
