### PR TITLE
fix(e2e): purge fixture agents permanently instead of trashing them

### DIFF
--- a/tests/e2e-prod/harness/cleanup.test.ts
+++ b/tests/e2e-prod/harness/cleanup.test.ts
@@ -94,6 +94,29 @@ test("cleanup deletes every tracked fixture and empties the registry", async () 
   assert.match(calls[0]!, /confirm=DELETE/);
 });
 
+test("agent cleanup purges permanently rather than trashing", async () => {
+  track("agent", "a@x.dev");
+  track("domain", "d.x.dev");
+  const { client, calls } = fakeClient(() => 204);
+
+  await cleanup(client, { sleep: noSleep });
+
+  // Without permanent=true an agent DELETE only moves the row to the trash:
+  // messages_deleted is 0, bodies stay stored against usage.storage_bytes,
+  // and the tombstone lingers for the 30-day retention window. Fixtures are
+  // never restored, so trashing them just accumulates dead agents on the test
+  // account faster than they expire — enough of them and the account-scoped
+  // metrics queries lose their index and seq-scan the whole table.
+  const agentCall = calls.find((c) => c.startsWith("/v1/agents/"));
+  assert.ok(agentCall, "expected an agent DELETE");
+  assert.match(agentCall, /permanent=true/);
+
+  // Domains have no trash state, so they must NOT grow the parameter.
+  const domainCall = calls.find((c) => c.startsWith("/v1/domains/"));
+  assert.ok(domainCall, "expected a domain DELETE");
+  assert.doesNotMatch(domainCall, /permanent=true/);
+});
+
 test("a permanently failing fixture does not block the remaining ones", async () => {
   track("agent", "first@x.dev");
   track("agent", "doomed@x.dev");

--- a/tests/e2e-prod/harness/cleanup.ts
+++ b/tests/e2e-prod/harness/cleanup.ts
@@ -148,9 +148,23 @@ function isRetryableStatus(status: number): boolean {
 function pathFor(t: Tracked): string {
   // Destructive deletes require ?confirm=DELETE (the API's irreversible-op
   // guard). Cleanup is always intentional, so we always confirm.
+  //
+  // Agents additionally need permanent=true. A plain confirmed DELETE only
+  // moves an agent to the trash: messages_deleted is 0, bodies stay stored,
+  // and the row keeps counting against usage.storage_bytes until the janitor
+  // purges it at the end of the trash-retention window (30 days). Fixtures
+  // are throwaway by definition and nothing ever restores them, so leaving
+  // them to age out just accumulates tombstones on the test account — one
+  // suite run at a time, faster than they expire.
+  //
+  // That accumulation is not only untidy: past ~7k agents on one account, the
+  // account-scoped metrics queries stop being able to use their index and
+  // fall back to sequential scans of the whole messages/transitions tables,
+  // which is what made the staging metrics gate time out. Purging here keeps
+  // the test account's agent count proportional to a single run.
   switch (t.kind) {
     case "agent":
-      return `/v1/agents/${encodeURIComponent(t.id)}?confirm=DELETE`;
+      return `/v1/agents/${encodeURIComponent(t.id)}?confirm=DELETE&permanent=true`;
     case "domain":
       return `/v1/domains/${encodeURIComponent(t.id)}?confirm=DELETE`;
   }


### PR DESCRIPTION
## What

The shared e2e teardown deletes agents with `?confirm=DELETE` only. That **trashes** rather than purges — `messages_deleted: 0`, bodies stay stored against `usage.storage_bytes`, and the row survives the 30-day retention window. Fixtures are throwaway and nothing restores them, so every run leaves tombstones behind faster than they expire.

One line in `pathFor()`, plus a regression test.

## Why it matters

The staging e2e account had reached **6,963 agents — 6,949 trashed** — against only 9,810 messages. Oldest tombstone was 26 days old, so nothing had aged out yet; this was steady-state accumulation of roughly 200–900/day.

That is not just untidy. At that cardinality the account-scoped metrics queries can no longer use `idx_messages_agent_created` and fall back to `Parallel Seq Scan` over the entire `messages` (341k) and `message_lifecycle_transitions` (512k) tables. Measured on staging, idle:

| scope | time |
|---|---|
| including the tombstones | 1015ms |
| live agents only | 22.5ms |

That is what pushed the staging metrics gate past its 5s budget under pipeline load.

## Notes

- A few suites (14, 25, 35) already passed `permanent=true` explicitly — the gap was the shared harness default, which is why they didn't contribute.
- Domains have no trash state, so they keep the plain confirmed delete. The test asserts that asymmetry in both directions.
- `AGENTS.md` already mandates `permanent=true` for e2e cleanup; this makes the shared path honor it.

## Verification

`npm run test:unit` → 39/39 pass. The new test fails without the change.

## Related

A one-time purge of the existing 6,949 tombstones is needed separately — this only stops new ones. The metrics query itself is being scoped to live agents in a companion PR.