### PR TITLE
fix(metrics): exclude trashed agents from account rollups

### DIFF
--- a/internal/messagelifecycle/account_metrics.go
+++ b/internal/messagelifecycle/account_metrics.go
@@ -41,9 +41,20 @@ type AccountMetrics struct {
 // CountByReasonCode (see its doc comment: half-open, anchored on the message's
 // own created_at, feedback still settling for ~72h).
 //
-// Trashed agents and trashed-but-unpurged messages are both included: that
-// mail was still sent, and dropping it would let account housekeeping restate
-// past delivery rates.
+// Trashed-but-unpurged MESSAGES are included: that mail was still sent, and
+// dropping it would let inbox housekeeping restate past delivery rates.
+//
+// Trashed AGENTS are excluded. That mail was also still sent, so this does
+// restate history slightly — the tradeoff is deliberate. A deleted agent is
+// gone from every other account-scoped surface (quota counts, list, get
+// without an explicit opt-in), so counting it only here was the odd one out;
+// and because agent deletion is soft, an account that churns agents keeps
+// every tombstone for the whole 30-day retention window. Past a few thousand
+// of them the planner abandons idx_messages_agent_created and sequentially
+// scans the entire messages/transitions tables: measured on a test account
+// with ~7k trashed agents, the same aggregate went 22ms → 1015ms. Scoping to
+// live agents keeps the cost proportional to what the account currently owns
+// rather than to everything it has ever owned.
 //
 // When groupByAgent is set, the busiest MaxMetricsAgents agents also come back
 // individually. Totals are computed independently of that cap.
@@ -112,6 +123,7 @@ func accountTotalsTx(ctx context.Context, tx pgx.Tx, userID string, start, end t
 		JOIN agent_identities a ON a.id = m.agent_id
 		JOIN message_lifecycle_transitions t ON t.message_id = m.id
 		WHERE a.user_id = $1
+		  AND a.deleted_at IS NULL
 		  AND m.created_at >= $2
 		  AND m.created_at < $3
 		GROUP BY t.reason_code, t.stage, t.outcome, t.retryable
@@ -148,6 +160,7 @@ func accountTotalsTx(ctx context.Context, tx pgx.Tx, userID string, start, end t
 		FROM messages m
 		JOIN agent_identities a ON a.id = m.agent_id
 		WHERE a.user_id = $1
+		  AND a.deleted_at IS NULL
 		  AND m.created_at >= $2
 		  AND m.created_at < $3
 	`, userID, start, end).Scan(&totals.MessagesInWindow, &totals.MessagesWithLifecycle)
@@ -174,6 +187,7 @@ func accountAgentCoverageTx(ctx context.Context, tx pgx.Tx, userID string, start
 		FROM messages m
 		JOIN agent_identities a ON a.id = m.agent_id
 		WHERE a.user_id = $1
+		  AND a.deleted_at IS NULL
 		  AND m.created_at >= $2
 		  AND m.created_at < $3
 		GROUP BY m.agent_id

--- a/internal/messagelifecycle/account_metrics_integration_test.go
+++ b/internal/messagelifecycle/account_metrics_integration_test.go
@@ -79,6 +79,58 @@ func TestAccountMetricsSumsEveryAgentAndExcludesOtherAccounts(t *testing.T) {
 	}
 }
 
+// TestAccountMetricsExcludesTrashedAgents: a deleted agent leaves the account
+// rollup, in both the totals and the per-agent breakdown.
+//
+// Agent deletion is soft, so without this the rollup keeps aggregating over
+// every agent the account has ever owned for the whole 30-day retention
+// window. That is both inconsistent with the other account-scoped surfaces
+// (quota counts, list, get) and a scaling cliff: past a few thousand
+// tombstones the planner drops idx_messages_agent_created and seq-scans the
+// whole table. Note this is deliberately NOT symmetric with trashed
+// *messages*, which stay counted — see TestCountByReasonCodeIncludesTrashedMessages.
+func TestAccountMetricsExcludesTrashedAgents(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := messagelifecycle.NewStore(pool)
+	ctx := context.Background()
+
+	live := seedMetricsAgent(t, pool, "accttrashlive")
+	doomed := seedAccountAgent(t, pool, "usr_accttrashlive", "accttrashdead")
+
+	// One send each, so an accidental inclusion doubles the total.
+	for i, agentID := range []string{live, doomed} {
+		id := fmt.Sprintf("msg_accttrash_%d", i)
+		seedMetricsMessage(t, pool, id, agentID, "outbound", metricsBaseTime)
+		appendMetricsObservation(t, pool, id, "outbound", "accept", messagelifecycle.ReasonAcceptanceOutboundAPI, metricsBaseTime)
+	}
+
+	// Trash the second agent, leaving its messages in place — exactly the
+	// state a plain (non-permanent) DELETE /v1/agents leaves behind.
+	if _, err := pool.Exec(ctx,
+		`UPDATE agent_identities SET deleted_at = now() WHERE id = $1`, doomed); err != nil {
+		t.Fatal(err)
+	}
+
+	metrics, err := store.CountByReasonCodeForAccount(ctx, "usr_accttrashlive",
+		metricsBaseTime.Add(-time.Hour), metricsBaseTime.Add(time.Hour), true)
+	if err != nil {
+		t.Fatalf("CountByReasonCodeForAccount: %v", err)
+	}
+
+	if got := accountCountsByCode(metrics.Totals)[messagelifecycle.ReasonAcceptanceOutboundAPI].Messages; got != 1 {
+		t.Errorf("accepted messages = %d, want 1: a trashed agent's mail is still in the totals", got)
+	}
+	if metrics.Totals.MessagesInWindow != 1 {
+		t.Errorf("messages_in_window = %d, want 1: a trashed agent's mail is still counted", metrics.Totals.MessagesInWindow)
+	}
+	if len(metrics.Agents) != 1 {
+		t.Fatalf("agents = %d, want 1: the trashed agent still has a breakdown row", len(metrics.Agents))
+	}
+	if metrics.Agents[0].AgentEmail != live {
+		t.Errorf("breakdown agent = %q, want the live agent %q", metrics.Agents[0].AgentEmail, live)
+	}
+}
+
 // TestAccountMetricsGroupByAgentOrdersByVolume: the breakdown must be busiest
 // first, and each agent's slice must carry only its own traffic.
 func TestAccountMetricsGroupByAgentOrdersByVolume(t *testing.T) {


### PR DESCRIPTION
## What

Account metrics aggregated over **every agent a user had ever owned**, including soft-deleted ones. This scopes the three account-level joins to `a.deleted_at IS NULL`.

**This reverses a documented decision.** The previous doc comment argued trashed agents should stay counted because "that mail was still sent". That rationale is real, and the change does restate history slightly — mail from a later-deleted agent stops counting. The comment now records the tradeoff and why it flipped.

## Why

**Consistency.** A deleted agent is already gone from every other account-scoped surface — quota counts (`store.go:876/1113/1326`), list, and `getAgent` without an explicit `includeDeleted`. Metrics were the only place still counting it.

**Scale.** Agent deletion is soft, so an account that churns agents holds every tombstone for the full 30-day retention window. Past a few thousand, the planner abandons `idx_messages_agent_created` and sequentially scans the whole `messages` + `message_lifecycle_transitions` tables. Measured on a staging account carrying ~7k trashed agents:

| scope | time |
|---|---|
| including trashed agents | 1015ms |
| live agents only | **22.5ms** |

Forcing the index path instead (`enable_seqscan=off`) was **worse**, not better — 1176ms warm — so this is not fixable at the planner level while keeping the old semantics.

## Deliberately not symmetric with trashed *messages*

Those stay counted. Inbox housekeeping shouldn't restate delivery rates, and unlike agent churn the volume is bounded by the account's own mail. `TestCountByReasonCodeIncludesTrashedMessages` still guards that, unchanged.

## Blast radius

`/v1/metrics` is beta and has **never shipped to prod** — 1.6.0 is live, and 1.7.0/1/2 were tagged but never promoted. No deployed client depends on the current numbers, so this is free to change now and expensive later.

## Verification

`go test -tags=integration ./internal/messagelifecycle/...` passes. The new `TestAccountMetricsExcludesTrashedAgents` fails without the fix on all three assertions (totals, coverage, breakdown), confirming it isn't vacuous.