### PR TITLE
fix(availability): probe readiness off the request path, cap concurrent deletes

### DIFF
--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -735,7 +735,11 @@ func main() {
 	// /readyz — instance-local readiness (DB reachable + migrations applied).
 	// Distinct from /api/health (shallow liveness); operational, not part of the
 	// /v1 contract, so it lives on this mux and never enters api/openapi.yaml.
-	router.HandleFunc("/readyz", readyzHandler(pool, &draining)).Methods(http.MethodGet)
+	// The verdict is refreshed on a background ticker, so this handler never
+	// competes for a pooled connection — see readyz.go for why that matters.
+	readiness := newReadinessMonitor(pool, &draining)
+	defer readiness.Stop()
+	router.HandleFunc("/readyz", readiness.handler()).Methods(http.MethodGet)
 	// /selftest — deep dependency diagnostics (health+json), auth-gated by the
 	// internal API secret. Operational, not part of the /v1 contract. The full
 	// SMTP→webhook round-trip lives in the external e2a-prober, not here.

--- a/cmd/e2a/readyz.go
+++ b/cmd/e2a/readyz.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -15,33 +16,167 @@ import (
 	"github.com/tokencanopy/e2a/migrations"
 )
 
-// readyzHandler reports instance-local readiness: the DB is reachable and the
-// latest embedded migration is recorded as applied. Unlike /api/health (shallow
-// liveness — never restart on a DB blip), /readyz signals "ready to serve" and
-// is the direct guard against the deploy-but-migration-didn't-apply failure
-// mode. It must NOT exercise downstream/round-trip dependencies — that is
-// /selftest's job (see docs/design/prober-selftest.md).
+// Readiness is evaluated on a background ticker rather than inside the request,
+// and a failing probe only flips readiness once it has been failing for
+// readinessFailureGrace.
 //
-// draining (nil-safe) flips readiness to 503 the moment shutdown begins, ahead
-// of every dependency check: a terminating instance must leave the LB rotation
-// even though its DB is healthy — while /api/health stays green so the
-// orchestrator doesn't hard-kill it mid-drain.
-func readyzHandler(pool *pgxpool.Pool, draining *atomic.Bool) http.HandlerFunc {
-	latest := latestMigration()
+// The request-path version of this check was an availability hazard. It called
+// pool.Ping with a 2s deadline, so when the pool was saturated the check queued
+// behind real work and timed out — reporting "database unreachable" for a
+// database that was merely busy. HAProxy's L7 check then marked the only
+// backend DOWN and served its own 503 to everything, including endpoints that
+// never touch the database. A burst of six concurrent cascading deletes was
+// enough to take a whole slot out of rotation that way; the database never
+// actually went away.
+//
+// Probing off the request path fixes both halves. The handler no longer
+// competes for a pooled connection, so it answers instantly under load, and the
+// grace window means transient saturation degrades latency instead of removing
+// the instance. A genuinely unreachable database still flips readiness within
+// the grace window, which is what the check is actually for.
+const (
+	readinessProbeInterval = 2 * time.Second
+	readinessProbeTimeout  = 5 * time.Second
+	readinessFailureGrace  = 15 * time.Second
+)
+
+type readinessState struct {
+	ready  bool
+	reason string
+}
+
+// readinessMonitor keeps an instance-local readiness verdict fresh in the
+// background so /readyz can answer without touching the pool.
+type readinessMonitor struct {
+	pool     *pgxpool.Pool
+	draining *atomic.Bool
+	latest   string
+
+	interval time.Duration
+	grace    time.Duration
+	timeout  time.Duration
+
+	mu     sync.Mutex // guards lastOK
+	lastOK time.Time
+
+	state    atomic.Pointer[readinessState]
+	stop     chan struct{}
+	stopOnce sync.Once
+}
+
+// newReadinessMonitor probes once synchronously, then keeps the verdict fresh
+// in the background. The first probe is synchronous so a just-started instance
+// never reports a stale "starting" to the load balancer, and so the verdict is
+// deterministic for callers (and tests) immediately after construction.
+//
+// Before that first success the instance is not ready, which preserves the
+// guarantee this check exists for: a freshly deployed instance whose migrations
+// did not apply never joins the rotation.
+func newReadinessMonitor(pool *pgxpool.Pool, draining *atomic.Bool) *readinessMonitor {
+	return newReadinessMonitorWithConfig(pool, draining,
+		readinessProbeInterval, readinessFailureGrace, readinessProbeTimeout)
+}
+
+func newReadinessMonitorWithConfig(pool *pgxpool.Pool, draining *atomic.Bool, interval, grace, timeout time.Duration) *readinessMonitor {
+	m := &readinessMonitor{
+		pool:     pool,
+		draining: draining,
+		latest:   latestMigration(),
+		interval: interval,
+		grace:    grace,
+		timeout:  timeout,
+		stop:     make(chan struct{}),
+	}
+	m.state.Store(&readinessState{ready: false, reason: "starting"})
+	m.evaluate()
+	go m.run()
+	return m
+}
+
+func (m *readinessMonitor) Stop() {
+	m.stopOnce.Do(func() { close(m.stop) })
+}
+
+// evaluate runs one probe and folds it into the published verdict.
+func (m *readinessMonitor) evaluate() {
+	reason, err := m.probe()
+	now := time.Now()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if err == nil {
+		m.lastOK = now
+		m.state.Store(&readinessState{ready: true})
+		return
+	}
+	// Hold the previous verdict while the failure is still inside the grace
+	// window: a busy database is not an absent one, and evicting the instance
+	// for transient pressure is what turned a slow database into a total
+	// outage. Before the first success lastOK is zero, so an instance that has
+	// never been ready flips immediately rather than being granted a grace
+	// period it has not earned.
+	if m.lastOK.IsZero() || now.Sub(m.lastOK) > m.grace {
+		m.state.Store(&readinessState{ready: false, reason: reason})
+	}
+}
+
+func (m *readinessMonitor) run() {
+	ticker := time.NewTicker(m.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-m.stop:
+			return
+		case <-ticker.C:
+			m.evaluate()
+		}
+	}
+}
+
+// probe returns a not-ready reason and the underlying error, or a nil error
+// when the instance is serviceable.
+func (m *readinessMonitor) probe() (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), m.timeout)
+	defer cancel()
+
+	if err := m.pool.Ping(ctx); err != nil {
+		return "database unreachable", err
+	}
+	applied, err := latestMigrationApplied(ctx, m.pool, m.latest)
+	if err != nil {
+		return "database unreachable", err
+	}
+	if !applied {
+		return "migrations not applied", errNotApplied
+	}
+	return "", nil
+}
+
+var errNotApplied = fmt.Errorf("latest migration not applied")
+
+// handler reports instance-local readiness from the background verdict. Unlike
+// /api/health (shallow liveness — never restart on a DB blip), /readyz signals
+// "ready to serve" and is the direct guard against the deploy-but-migration-
+// didn't-apply failure mode. It must NOT exercise downstream/round-trip
+// dependencies — that is /selftest's job (see docs/design/prober-selftest.md).
+//
+// draining flips readiness to 503 the moment shutdown begins, ahead of the
+// dependency verdict: a terminating instance must leave the LB rotation even
+// though its DB is healthy — while /api/health stays green so the orchestrator
+// does not hard-kill it mid-drain.
+func (m *readinessMonitor) handler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if draining != nil && draining.Load() {
+		if m.draining != nil && m.draining.Load() {
 			writeNotReady(w, "draining")
 			return
 		}
-		ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
-		defer cancel()
-
-		if err := pool.Ping(ctx); err != nil {
-			writeNotReady(w, "database unreachable")
-			return
-		}
-		if applied, err := latestMigrationApplied(ctx, pool, latest); err != nil || !applied {
-			writeNotReady(w, "migrations not applied")
+		st := m.state.Load()
+		if st == nil || !st.ready {
+			reason := "starting"
+			if st != nil && st.reason != "" {
+				reason = st.reason
+			}
+			writeNotReady(w, reason)
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")

--- a/cmd/e2a/readyz.go
+++ b/cmd/e2a/readyz.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/tokencanopy/e2a/migrations"
@@ -38,6 +40,9 @@ const (
 	readinessProbeInterval = 2 * time.Second
 	readinessProbeTimeout  = 5 * time.Second
 	readinessFailureGrace  = 15 * time.Second
+	// poolProbeTimeout bounds the pool-usability check. Short on purpose: it
+	// distinguishes "closed/broken" from "busy" and must never wait on capacity.
+	poolProbeTimeout = 250 * time.Millisecond
 )
 
 type readinessState struct {
@@ -58,6 +63,13 @@ type readinessMonitor struct {
 
 	mu     sync.Mutex // guards lastOK
 	lastOK time.Time
+
+	// The monitor's own connection, deliberately outside the pool — see probe().
+	connMu sync.Mutex
+	conn   *pgx.Conn
+
+	// probeFn overrides the real probe in tests.
+	probeFn func() (string, error)
 
 	state    atomic.Pointer[readinessState]
 	stop     chan struct{}
@@ -94,7 +106,10 @@ func newReadinessMonitorWithConfig(pool *pgxpool.Pool, draining *atomic.Bool, in
 }
 
 func (m *readinessMonitor) Stop() {
-	m.stopOnce.Do(func() { close(m.stop) })
+	m.stopOnce.Do(func() {
+		close(m.stop)
+		m.closeProbeConn()
+	})
 }
 
 // evaluate runs one probe and folds it into the published verdict.
@@ -135,21 +150,89 @@ func (m *readinessMonitor) run() {
 
 // probe returns a not-ready reason and the underlying error, or a nil error
 // when the instance is serviceable.
+//
+// It runs on a connection the monitor owns, NOT one borrowed from the shared
+// pool. Probing through the pool would reintroduce the bug in slower motion:
+// pool.Ping has to acquire a pooled connection, so a saturated pool starves the
+// probe exactly as it starved the old inline check, and a saturation lasting
+// longer than the grace window would still evict the instance. A dedicated
+// connection makes the probe measure what it claims to measure — whether the
+// database is reachable — independently of how busy the pool is.
 func (m *readinessMonitor) probe() (string, error) {
+	if m.probeFn != nil {
+		return m.probeFn()
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), m.timeout)
 	defer cancel()
 
-	if err := m.pool.Ping(ctx); err != nil {
-		return "database unreachable", err
+	// The dedicated connection deliberately cannot observe the pool, so check
+	// the pool's own usability separately: an instance whose pool is closed or
+	// broken cannot serve, however reachable the database is. A short deadline
+	// keeps this from becoming the starvation path it replaces — under
+	// saturation the acquire simply times out, and a timeout means BUSY, which
+	// is precisely the condition readiness must tolerate. Any other error means
+	// the pool itself is unusable.
+	acqCtx, acqCancel := context.WithTimeout(ctx, poolProbeTimeout)
+	c, err := m.pool.Acquire(acqCtx)
+	acqCancel()
+	switch {
+	case err == nil:
+		c.Release()
+	case errors.Is(err, context.DeadlineExceeded), errors.Is(err, context.Canceled):
+		// Saturated, not broken. Keep going.
+	default:
+		return "connection pool unavailable", err
 	}
-	applied, err := latestMigrationApplied(ctx, m.pool, m.latest)
+
+	conn, err := m.probeConn(ctx)
 	if err != nil {
 		return "database unreachable", err
+	}
+	if err := conn.Ping(ctx); err != nil {
+		// A connection the server has since closed looks identical to an
+		// unreachable database on first use. Drop it so the next tick redials
+		// rather than reporting a stale socket as an outage forever.
+		m.closeProbeConn()
+		return "database unreachable", err
+	}
+	applied, err := latestMigrationApplied(ctx, conn, m.latest)
+	if err != nil {
+		m.closeProbeConn()
+		// The database answered the ping, so this is a failing query rather
+		// than an unreachable server — do not mislabel it in the readiness
+		// reason or the operator chases the wrong thing.
+		return "migration check failed", err
 	}
 	if !applied {
 		return "migrations not applied", errNotApplied
 	}
 	return "", nil
+}
+
+// probeConn lazily dials (and memoizes) the monitor's own connection, built
+// from the pool's connection config so it targets the same database with the
+// same credentials.
+func (m *readinessMonitor) probeConn(ctx context.Context) (*pgx.Conn, error) {
+	m.connMu.Lock()
+	defer m.connMu.Unlock()
+	if m.conn != nil && !m.conn.IsClosed() {
+		return m.conn, nil
+	}
+	conn, err := pgx.ConnectConfig(ctx, m.pool.Config().ConnConfig)
+	if err != nil {
+		return nil, err
+	}
+	m.conn = conn
+	return conn, nil
+}
+
+func (m *readinessMonitor) closeProbeConn() {
+	m.connMu.Lock()
+	defer m.connMu.Unlock()
+	if m.conn != nil {
+		_ = m.conn.Close(context.Background())
+		m.conn = nil
+	}
 }
 
 var errNotApplied = fmt.Errorf("latest migration not applied")
@@ -194,7 +277,13 @@ func writeNotReady(w http.ResponseWriter, reason string) {
 // latestMigrationApplied reports whether the given migration filename is
 // recorded in schema_migrations. An empty filename (no embedded migrations)
 // trivially counts as applied.
-func latestMigrationApplied(ctx context.Context, pool *pgxpool.Pool, latest string) (bool, error) {
+// querier is satisfied by both *pgxpool.Pool and *pgx.Conn, so the migration
+// check can run on the monitor's dedicated connection.
+type querier interface {
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+func latestMigrationApplied(ctx context.Context, pool querier, latest string) (bool, error) {
 	if latest == "" {
 		return true, nil
 	}

--- a/cmd/e2a/readyz_test.go
+++ b/cmd/e2a/readyz_test.go
@@ -115,14 +115,9 @@ func TestReadyzHandler_Draining(t *testing.T) {
 // Previously /readyz called pool.Ping inline, so pool exhaustion timed out the
 // check and reported "database unreachable". HAProxy marked the only backend
 // DOWN and answered every request — including ones that never touch the DB —
-// with its own 503. Here a monitor that has been healthy keeps reporting ready
-// while probes fail inside the grace window.
+// with its own 503.
 func TestReadinessToleratesTransientFailureWithinGrace(t *testing.T) {
-	healthy := migratedTestDB(t)
-
-	// Start healthy so lastOK is set, then swap in a dead pool to simulate the
-	// probe failing without the database having actually gone away.
-	m := newReadinessMonitorWithConfig(healthy, nil, time.Hour, time.Hour, 2*time.Second)
+	m := newReadinessMonitorWithConfig(migratedTestDB(t), nil, time.Hour, time.Hour, 2*time.Second)
 	defer m.Stop()
 
 	rec := httptest.NewRecorder()
@@ -131,13 +126,8 @@ func TestReadinessToleratesTransientFailureWithinGrace(t *testing.T) {
 		t.Fatalf("precondition: status = %d, want 200", rec.Code)
 	}
 
-	dead, err := pgxpool.New(context.Background(), testutil.TestDBURL())
-	if err != nil {
-		t.Fatalf("open pool: %v", err)
-	}
-	dead.Close()
-	m.pool = dead
-	m.evaluate() // probe fails, but we are well inside the grace window
+	m.probeFn = func() (string, error) { return "database unreachable", errNotApplied }
+	m.evaluate() // fails, but we are well inside the grace window
 
 	rec = httptest.NewRecorder()
 	m.handler()(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
@@ -150,16 +140,10 @@ func TestReadinessToleratesTransientFailureWithinGrace(t *testing.T) {
 // A failure that outlives the grace window must still flip readiness — the
 // tolerance above must not become "never report a dead database".
 func TestReadinessFlipsAfterGraceExpires(t *testing.T) {
-	healthy := migratedTestDB(t)
-	m := newReadinessMonitorWithConfig(healthy, nil, time.Hour, 0, 2*time.Second)
+	m := newReadinessMonitorWithConfig(migratedTestDB(t), nil, time.Hour, 0, 2*time.Second)
 	defer m.Stop()
 
-	dead, err := pgxpool.New(context.Background(), testutil.TestDBURL())
-	if err != nil {
-		t.Fatalf("open pool: %v", err)
-	}
-	dead.Close()
-	m.pool = dead
+	m.probeFn = func() (string, error) { return "database unreachable", errNotApplied }
 	time.Sleep(2 * time.Millisecond) // ensure now-lastOK exceeds the zero grace
 	m.evaluate()
 
@@ -167,6 +151,46 @@ func TestReadinessFlipsAfterGraceExpires(t *testing.T) {
 	m.handler()(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status = %d, want 503 once the grace window has expired", rec.Code)
+	}
+}
+
+// The probe must not borrow from the pool. Probing through pool.Ping would
+// reintroduce the original bug in slower motion: a saturated pool starves the
+// probe just as it starved the inline check, so a saturation outlasting the
+// grace window would evict the instance anyway. Here every pooled connection is
+// held open and the probe must still succeed.
+func TestReadinessProbeSurvivesPoolExhaustion(t *testing.T) {
+	pool := migratedTestDB(t)
+	m := newReadinessMonitorWithConfig(pool, nil, time.Hour, 0, 3*time.Second)
+	defer m.Stop()
+
+	ctx := context.Background()
+	held := make([]*pgxpool.Conn, 0, pool.Config().MaxConns)
+	for i := int32(0); i < pool.Config().MaxConns; i++ {
+		c, err := pool.Acquire(ctx)
+		if err != nil {
+			t.Fatalf("acquire %d: %v", i, err)
+		}
+		held = append(held, c)
+	}
+	defer func() {
+		for _, c := range held {
+			c.Release()
+		}
+	}()
+	if pool.Stat().AcquiredConns() != pool.Config().MaxConns {
+		t.Fatalf("precondition: pool not exhausted (%d/%d acquired)",
+			pool.Stat().AcquiredConns(), pool.Config().MaxConns)
+	}
+
+	// grace is 0, so any probe failure flips readiness immediately.
+	m.evaluate()
+
+	rec := httptest.NewRecorder()
+	m.handler()(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: an exhausted pool made the probe report the database unreachable; body=%s",
+			rec.Code, rec.Body.String())
 	}
 }
 

--- a/cmd/e2a/readyz_test.go
+++ b/cmd/e2a/readyz_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -45,7 +46,7 @@ func TestLatestMigration(t *testing.T) {
 func TestReadyzHandler_Ready(t *testing.T) {
 	pool := migratedTestDB(t)
 	rec := httptest.NewRecorder()
-	readyzHandler(pool, nil)(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	newReadinessMonitor(pool, nil).handler()(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
@@ -70,7 +71,7 @@ func TestReadyzHandler_DBUnreachable(t *testing.T) {
 	pool.Close()
 
 	rec := httptest.NewRecorder()
-	readyzHandler(pool, nil)(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	newReadinessMonitor(pool, nil).handler()(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status = %d, want 503", rec.Code)
 	}
@@ -96,7 +97,7 @@ func TestReadyzHandler_Draining(t *testing.T) {
 	var drain atomic.Bool
 	drain.Store(true)
 	rec := httptest.NewRecorder()
-	readyzHandler(pool, &drain)(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	newReadinessMonitor(pool, &drain).handler()(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status = %d, want 503", rec.Code)
 	}
@@ -104,5 +105,89 @@ func TestReadyzHandler_Draining(t *testing.T) {
 	_ = json.Unmarshal(rec.Body.Bytes(), &out)
 	if out.Status != "not_ready" || out.Reason != "draining" {
 		t.Errorf("got status=%q reason=%q, want not_ready/draining", out.Status, out.Reason)
+	}
+}
+
+// TestReadinessToleratesTransientFailureWithinGrace is the regression guard for
+// the outage this monitor exists to prevent: a saturated (not absent) database
+// must not evict the instance from the load balancer.
+//
+// Previously /readyz called pool.Ping inline, so pool exhaustion timed out the
+// check and reported "database unreachable". HAProxy marked the only backend
+// DOWN and answered every request — including ones that never touch the DB —
+// with its own 503. Here a monitor that has been healthy keeps reporting ready
+// while probes fail inside the grace window.
+func TestReadinessToleratesTransientFailureWithinGrace(t *testing.T) {
+	healthy := migratedTestDB(t)
+
+	// Start healthy so lastOK is set, then swap in a dead pool to simulate the
+	// probe failing without the database having actually gone away.
+	m := newReadinessMonitorWithConfig(healthy, nil, time.Hour, time.Hour, 2*time.Second)
+	defer m.Stop()
+
+	rec := httptest.NewRecorder()
+	m.handler()(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("precondition: status = %d, want 200", rec.Code)
+	}
+
+	dead, err := pgxpool.New(context.Background(), testutil.TestDBURL())
+	if err != nil {
+		t.Fatalf("open pool: %v", err)
+	}
+	dead.Close()
+	m.pool = dead
+	m.evaluate() // probe fails, but we are well inside the grace window
+
+	rec = httptest.NewRecorder()
+	m.handler()(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200: a transient probe failure inside the grace window evicted the instance; body=%s",
+			rec.Code, rec.Body.String())
+	}
+}
+
+// A failure that outlives the grace window must still flip readiness — the
+// tolerance above must not become "never report a dead database".
+func TestReadinessFlipsAfterGraceExpires(t *testing.T) {
+	healthy := migratedTestDB(t)
+	m := newReadinessMonitorWithConfig(healthy, nil, time.Hour, 0, 2*time.Second)
+	defer m.Stop()
+
+	dead, err := pgxpool.New(context.Background(), testutil.TestDBURL())
+	if err != nil {
+		t.Fatalf("open pool: %v", err)
+	}
+	dead.Close()
+	m.pool = dead
+	time.Sleep(2 * time.Millisecond) // ensure now-lastOK exceeds the zero grace
+	m.evaluate()
+
+	rec := httptest.NewRecorder()
+	m.handler()(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503 once the grace window has expired", rec.Code)
+	}
+}
+
+// The handler must never block on the pool: that head-of-line blocking is what
+// let a busy database stall the health check in the first place.
+func TestReadinessHandlerDoesNotTouchPool(t *testing.T) {
+	dead, err := pgxpool.New(context.Background(), testutil.TestDBURL())
+	if err != nil {
+		t.Fatalf("open pool: %v", err)
+	}
+	dead.Close()
+
+	m := newReadinessMonitorWithConfig(dead, nil, time.Hour, time.Hour, 2*time.Second)
+	defer m.Stop()
+
+	start := time.Now()
+	for i := 0; i < 50; i++ {
+		rec := httptest.NewRecorder()
+		m.handler()(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("50 readiness responses took %s: the handler is waiting on the pool", elapsed)
 	}
 }

--- a/internal/httpapi/destructive_cap_test.go
+++ b/internal/httpapi/destructive_cap_test.go
@@ -79,3 +79,30 @@ func TestAcquireDestructiveIsConcurrencySafe(t *testing.T) {
 		t.Errorf("admitted %d concurrent destructive ops, want exactly %d", admitted, maxConcurrentDestructive)
 	}
 }
+
+// The capped set must cover every delete whose cost scales with accumulated
+// data. deleteAccount is the sharpest case — one transaction that locks every
+// agent the account owns — and was missed on the first pass.
+func TestDestructiveOpsCoversUnboundedCascades(t *testing.T) {
+	for _, op := range []string{
+		"deleteAgent",       // cascades every message
+		"deleteDomain",      // cascades the domain's agents
+		"deleteAccount",     // counts 9 tables, locks all agents, one transaction
+		"deleteImportBatch", // bulk-deletes a whole batch of contacts
+	} {
+		if !destructiveOps[op] {
+			t.Errorf("%s performs an unbounded cascade but is not concurrency-capped", op)
+		}
+	}
+
+	// Bounded single-row deletes stay uncapped: capping them would add 429s to
+	// ordinary CRUD for no availability benefit.
+	for _, op := range []string{
+		"deleteMessage", "deleteApiKey", "deleteContact", "deleteTemplate",
+		"deleteWebhook", "deleteSuppression", "deleteAgentSuppression", "deleteEngagement",
+	} {
+		if destructiveOps[op] {
+			t.Errorf("%s removes a bounded number of rows and should not be capped", op)
+		}
+	}
+}

--- a/internal/httpapi/destructive_cap_test.go
+++ b/internal/httpapi/destructive_cap_test.go
@@ -1,0 +1,81 @@
+package httpapi
+
+import (
+	"sync"
+	"testing"
+)
+
+// The per-account cap is the guard against the failure mode where several
+// unbounded cascades run at once, each holding a pooled connection: six
+// concurrent permanent agent deletes saturated the pool, starved the readiness
+// probe, and took a whole slot out of the load balancer.
+func TestAcquireDestructiveCapsConcurrencyPerAccount(t *testing.T) {
+	s := &Server{}
+
+	for i := 0; i < maxConcurrentDestructive; i++ {
+		if !s.acquireDestructive("user-a") {
+			t.Fatalf("acquire %d/%d was refused below the cap", i+1, maxConcurrentDestructive)
+		}
+	}
+	if s.acquireDestructive("user-a") {
+		t.Fatalf("acquire above the cap of %d succeeded", maxConcurrentDestructive)
+	}
+
+	// The cap is per account: a busy tenant must not block anyone else.
+	if !s.acquireDestructive("user-b") {
+		t.Error("a different account was blocked by user-a's in-flight work")
+	}
+
+	// Releasing frees exactly one slot, so sequential deletes never stall.
+	s.releaseDestructive("user-a")
+	if !s.acquireDestructive("user-a") {
+		t.Error("a slot freed by release was not reusable")
+	}
+}
+
+// A refused acquire must not consume a slot, or the account would leak its way
+// to a permanent lockout.
+func TestRefusedAcquireDoesNotLeakSlots(t *testing.T) {
+	s := &Server{}
+	for i := 0; i < maxConcurrentDestructive; i++ {
+		s.acquireDestructive("u")
+	}
+	for i := 0; i < 25; i++ {
+		if s.acquireDestructive("u") {
+			t.Fatal("acquire above the cap succeeded")
+		}
+	}
+	for i := 0; i < maxConcurrentDestructive; i++ {
+		s.releaseDestructive("u")
+	}
+	if !s.acquireDestructive("u") {
+		t.Error("account stayed locked out after every in-flight delete finished: refusals leaked slots")
+	}
+}
+
+// The counter is touched from concurrent requests, so it must be race-free and
+// must never admit more than the cap.
+func TestAcquireDestructiveIsConcurrencySafe(t *testing.T) {
+	s := &Server{}
+	const goroutines = 64
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	admitted := 0
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if s.acquireDestructive("shared") {
+				mu.Lock()
+				admitted++
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if admitted != maxConcurrentDestructive {
+		t.Errorf("admitted %d concurrent destructive ops, want exactly %d", admitted, maxConcurrentDestructive)
+	}
+}

--- a/internal/httpapi/httpapi.go
+++ b/internal/httpapi/httpapi.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -462,6 +463,12 @@ type Server struct {
 	Router chi.Router
 	API    huma.API
 	deps   Deps
+
+	// destructiveInFlight counts in-flight destructiveOps per account ID
+	// (values are *int64). Process-local by design: it bounds what one
+	// instance's connection pool can be asked to do at once, which is the
+	// resource actually at risk, so it needs no shared state across slots.
+	destructiveInFlight sync.Map
 }
 
 // New builds the v1 server. It installs the e2a error envelope globally,

--- a/internal/httpapi/ratelimit.go
+++ b/internal/httpapi/ratelimit.go
@@ -51,9 +51,24 @@ var pollLimitedOps = map[string]bool{
 // A rate limiter sized to allow legitimate bulk cleanup would not have stopped
 // that; a concurrency cap does, while still letting a caller delete as much as
 // they like sequentially.
+// The set is every delete whose cost scales with accumulated data rather than
+// with the request. The rest of the delete surface (deleteMessage, deleteApiKey,
+// deleteContact, deleteTemplate, deleteWebhook, deleteSuppression,
+// deleteAgentSuppression, deleteEngagement) removes a bounded number of rows and
+// is deliberately left uncapped.
 var destructiveOps = map[string]bool{
-	"deleteAgent":  true,
+	// Cascades every message the agent ever received.
+	"deleteAgent": true,
+	// Cascades the agents registered under the domain.
 	"deleteDomain": true,
+	// The largest cascade in the API, and all of it in ONE transaction: it
+	// counts across nine tables (including a join over every message), locks
+	// every agent the account owns with SELECT ... FOR UPDATE, cancels each
+	// linked durable send, then deletes. Strictly worse than deleteAgent.
+	"deleteAccount": true,
+	// Bulk-deletes every contact in the batch in a single statement; the batch
+	// is as large as whatever was imported.
+	"deleteImportBatch": true,
 }
 
 // maxConcurrentDestructive is the per-account in-flight ceiling for

--- a/internal/httpapi/ratelimit.go
+++ b/internal/httpapi/ratelimit.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -35,6 +36,47 @@ var pollLimitedOps = map[string]bool{
 	"listMessages": true, "getMessage": true,
 	"listConversations": true, "getConversation": true,
 	"listWebhooks": true, "getWebhook": true, "listWebhookDeliveries": true,
+}
+
+// destructiveOps are mutations whose server-side cost is unbounded by the
+// request: the row named in the path is cheap, but the cascade behind it scales
+// with everything the caller has ever accumulated under it. Nothing else in the
+// API lets one call do an unbounded amount of write work.
+//
+// These are governed by a per-account CONCURRENCY cap rather than a rate
+// limiter. The hazard is not request frequency — it is several expensive
+// cascades running at once, each holding a pooled connection while it works.
+// Six concurrent permanent agent deletes were enough to saturate the pool,
+// starve the readiness probe, and take an entire slot out of the load balancer.
+// A rate limiter sized to allow legitimate bulk cleanup would not have stopped
+// that; a concurrency cap does, while still letting a caller delete as much as
+// they like sequentially.
+var destructiveOps = map[string]bool{
+	"deleteAgent":  true,
+	"deleteDomain": true,
+}
+
+// maxConcurrentDestructive is the per-account in-flight ceiling for
+// destructiveOps. Two keeps sequential cleanup (the e2e harness, a customer
+// draining an account) at full speed while bounding the blast radius.
+const maxConcurrentDestructive = 2
+
+// acquireDestructive reserves an in-flight slot for userID, reporting false
+// when the account is already at its ceiling.
+func (s *Server) acquireDestructive(userID string) bool {
+	v, _ := s.destructiveInFlight.LoadOrStore(userID, new(int64))
+	n := v.(*int64)
+	if atomic.AddInt64(n, 1) > maxConcurrentDestructive {
+		atomic.AddInt64(n, -1)
+		return false
+	}
+	return true
+}
+
+func (s *Server) releaseDestructive(userID string) {
+	if v, ok := s.destructiveInFlight.Load(userID); ok {
+		atomic.AddInt64(v.(*int64), -1)
+	}
 }
 
 // rateLimit is the Huma middleware that enforces the per-user poll limiter on
@@ -103,6 +145,40 @@ func (s *Server) rateLimit(ctx huma.Context, next func(huma.Context)) {
 			}
 		}
 		snap, key = s.deps.RegLimit, clientIP(r)
+	case destructiveOps[op.OperationID]:
+		r := RequestFromContext(ctx.Context())
+		if r == nil {
+			next(ctx)
+			return
+		}
+		p, err := s.resolvePrincipal(r)
+		if err != nil {
+			// Unauthenticated: let the handler emit the canonical 401 rather
+			// than masking a missing credential as a concurrency decision.
+			next(ctx)
+			return
+		}
+		ctx = huma.WithContext(ctx, withPrincipal(ctx.Context(), p))
+		// Deliberately NOT exempt for ClassSystem/ClassInternal, unlike every
+		// other limiter here. Those exemptions exist because the rate limiters
+		// bound user abuse, and trusted first-party traffic is not abuse. This
+		// cap is not about abuse — it protects the instance from itself, and
+		// the outage that motivated it was caused by an internal-class client.
+		// Exempting the classes most likely to run bulk operations would leave
+		// the actual failure mode wide open.
+		if !s.acquireDestructive(p.User.ID) {
+			ctx.SetHeader("Retry-After", "1")
+			writeEnvelope(ctx, NewError(http.StatusTooManyRequests, "rate_limited",
+				"too many concurrent delete operations for this account").
+				WithDetails(map[string]any{
+					"retry_after_seconds": 1,
+					"max_concurrent":      maxConcurrentDestructive,
+				}))
+			return
+		}
+		defer s.releaseDestructive(p.User.ID)
+		next(ctx)
+		return
 	default:
 		next(ctx)
 		return


### PR DESCRIPTION
Closes the failure mode found while purging test fixtures on staging: six concurrent permanent agent deletes saturated the connection pool, and the instance was then **evicted from the load balancer** even though the database was merely busy.

Evidence from the staging incident:

```
03:34:04 leadership.Elector: reelection timed out after 5s
03:34:16 producer: JobGetAvailable timed out after 10s  (every queue)
         Server be_http/e2a-green is DOWN, reason: Layer7 timeout, check duration: 2000ms.
         0 active and 0 backup servers left.
         http_in be_http/<NOSRV> ... 503
```

Note `<NOSRV>`: requests never reached the app. That is why even `/api/health` — which touches nothing — returned 503.

## 1. Readiness is evaluated off the request path

`/readyz` called `pool.Ping` with a 2s deadline. Under pool exhaustion the check queued behind real work and timed out, reporting `database unreachable` for a database that was still there. So *saturation was indistinguishable from a dead database*, and HAProxy's L7 check removed the only backend.

Now a background ticker keeps the verdict fresh and the handler serves it from an atomic — it never competes for a pooled connection. A failing probe only flips readiness after a **15s grace window**, so transient pressure degrades latency instead of removing the instance.

The probe itself runs on a **connection the monitor owns, outside the pool** (added after review). Probing via `pool.Ping` would have reintroduced the bug in slower motion: it acquires a pooled connection, so a saturation outlasting the grace window would starve the probe and evict the instance anyway. Pool usability is checked separately with a 250ms acquire, where a timeout means *busy* (tolerated) and any other error means the pool is closed or broken (not ready) — otherwise a dead pool would read as healthy.

**The startup guarantee is preserved**, which matters for the deploy pipeline:
- The first probe runs **synchronously**, and the instance reports not-ready until it succeeds — a deploy whose migrations didn't apply still never joins the rotation.
- `draining` still short-circuits ahead of the dependency verdict, so blue/green drain is unchanged.

## 2. Per-account concurrency cap on destructive operations

`deleteAgent` and `deleteDomain` were in **no limiter at all** — not the poll limiter (7 read ops), not the per-IP `createAgent` limiter. Now capped at **2 in-flight per account**.

A concurrency cap rather than a rate limiter, because the hazard isn't request frequency — it's several unbounded cascades running at once, each holding a pooled connection. A rate limiter loose enough to permit legitimate bulk cleanup wouldn't have stopped this. Sequential deletion is unaffected, so the e2e harness and any customer draining an account still run at full speed.

**Deliberately not exempt for `ClassSystem`/`ClassInternal`**, unlike every other limiter here. Those exemptions exist because the rate limiters bound *user abuse*, and first-party traffic isn't abuse. This cap protects the instance from itself — and the incident that motivated it was caused by an internal-class client. Exempting the classes most likely to run bulk operations would leave the actual failure mode open.

## Verification

- `go test ./internal/httpapi/ ./cmd/e2a/` green; cap tests also pass under `-race`.
- The tolerance test is **not vacuous**: reverting the grace logic to the old always-flip behavior makes it fail with exactly the original symptom — `503 {"status":"not_ready","reason":"database unreachable"}`.
- Concurrency test asserts exactly `maxConcurrentDestructive` of 64 racing goroutines are admitted, and that refusals don't leak slots into a permanent lockout.

## Not fixed here

The root cause — `permanent=true` performing an unbounded cascade **synchronously inside the request** — remains. The standard shape is to mark and enqueue, letting a batched sweeper do the work (the webhook retention sweep in this repo already deletes in ctid-bounded chunks of 5,000). That changes the response contract, since the endpoint currently returns a real `messages_deleted` count, so it wants its own design rather than a patch.

Also worth noting independently: prod's Cloud SQL is `db-g1-small` — identical to staging — so prod had no more headroom than the environment that fell over.