### PR TITLE
test(ts-sdk): give the contacts import/deleteImport test a real budget

### DIFF
--- a/sdks/typescript/test/e2e-contacts.test.ts
+++ b/sdks/typescript/test/e2e-contacts.test.ts
@@ -116,6 +116,12 @@ describe.skipIf(!env)("ts sdk live e2e: contacts", () => {
     recordCovered("contacts.list");
   });
 
+  // Carries an explicit timeout: this test does a multi-contact import and then
+  // a batch delete that reverses it, and both scale with the batch rather than
+  // being a single round trip. It has been running at ~4.9s against staging —
+  // inside vitest's 5s default by ~100ms — so ordinary run-to-run variance
+  // fails it, which is exactly what happened on v1.7.3. Do not "tidy" this back
+  // to the default; it will pass locally and fail the release pipeline.
   it("import records a batch (with an in-batch duplicate) and deleteImport reverses it", async () => {
     const first = contactAddress("imp");
     const second = contactAddress("imp");
@@ -149,7 +155,7 @@ describe.skipIf(!env)("ts sdk live e2e: contacts", () => {
 
     // The reversal removed the contacts — a follow-up read is a typed not-found.
     await expect(client.contacts.get(first)).rejects.toBeInstanceOf(E2ANotFoundError);
-  });
+  }, 30_000);
 
   it("delete removes a contact; a follow-up get is a typed not-found", async () => {
     const address = contactAddress("del");


### PR DESCRIPTION
Blocks the v1.7.3 promote. One-line timeout plus rationale.

## What happened

The v1.7.3 client-surface gate failed on:

```
× import records a batch (with an in-batch duplicate) and deleteImport reverses it  5006ms
Error: Test timed out in 5000ms.
```

**It timed out by 6ms.** The previous pipeline run passed the same test at **4898ms** — under the default by ~100ms — and vitest had already been colouring it yellow as slow. This test does a multi-contact import and then a batch delete that reverses it; both scale with the batch rather than being one round trip, so a 5s budget was always going to be decided by run-to-run variance.

## It is not a v1.7.3 regression

I checked before bumping the number, since this release adds a concurrency cap that covers `deleteImportBatch`:

- The cap is **per-account concurrency (2 in flight)**, not a rate limit. A single sequential delete is never throttled by it.
- The new middleware branch **resolves the principal once and caches it on the context**, and `requirePrincipal` reuses it — so the handler no longer authenticates a second time. If anything that removes a round trip.

The 108ms delta between runs is noise against a test sitting 100ms from its limit.

## Fix

30s, matching the budget `account.metrics({ groupBy: 'agent' })` already carries for the same reason, with a comment so it does not get tidied back to the default.

Minimal diff deliberately: this file is not prettier-clean on `main` under the prettier available locally, so running `--write` produced 47 lines of unrelated churn against a tree CI currently passes. Reverted that and hand-applied the change instead.