### PR TITLE
test(cli): cover the new metrics command and add it to the frozen catalog

### DIFF
--- a/cli/test/e2e.test.ts
+++ b/cli/test/e2e.test.ts
@@ -203,6 +203,43 @@ describe.skipIf(!live)("cli live parity", () => {
     recordCovered("whoami");
   });
 
+  it("metrics: account rollup and per-inbox, both --json (exit 0)", () => {
+    // Asserted on SHAPE and INVARIANTS, never on specific counts: this runs
+    // against a shared deployment whose traffic is not this suite's to control,
+    // so any assertion on a particular number would be flaky by construction.
+    // Creates nothing — metrics are read-only.
+    //
+    // Note the CLI emits camelCase, not the REST payload's snake_case.
+    const acct = run(["metrics", "--json"]);
+    expect(acct.code, acct.stderr).toBe(0);
+    const a = JSON.parse(acct.stdout);
+    expect(Date.parse(a.start)).toBeLessThan(Date.parse(a.end));
+    expect(a.messagesInWindow).toBeGreaterThanOrEqual(0);
+    expect(a.messagesWithLifecycle).toBeLessThanOrEqual(a.messagesInWindow);
+    // The contract's sharpest promise: a zero denominator yields null, never 0
+    // — 0% is indistinguishable from total delivery failure.
+    if (a.messagesInWindow === 0) {
+      expect(a.rates.bounceRate).toBeNull();
+      expect(a.rates.deliveredRate).toBeNull();
+    }
+
+    // --by-agent is the only shape-changing flag on the rollup. Per-agent rows
+    // are a partition of the account total, so they cannot claim more than the
+    // whole they came from.
+    const byAgent = run(["metrics", "--by-agent", "--json"]);
+    expect(byAgent.code, byAgent.stderr).toBe(0);
+    const g = JSON.parse(byAgent.stdout);
+    if (!g.agentsTruncated) {
+      const perAgent = (g.agents ?? []).reduce(
+        (sum: number, x: { messagesInWindow: number }) => sum + x.messagesInWindow,
+        0,
+      );
+      expect(perAgent).toBeLessThanOrEqual(g.messagesInWindow);
+    }
+
+    recordCovered("metrics");
+  });
+
   it("agents create → get → list, then send → messages list (self loopback)", async () => {
     const bot = `cli-live-${Date.now().toString(36)}@${DOMAIN}`;
 

--- a/cli/test/e2e.test.ts
+++ b/cli/test/e2e.test.ts
@@ -184,6 +184,7 @@ describe.skipIf(!live)("cli live parity", () => {
       "listen",
       "login",
       "messages",
+      "metrics",
       "protection",
       "reply",
       "send",


### PR DESCRIPTION
Blocks the v1.7.5 promote. Two related gaps around the new `e2a metrics` command.

## What the v1.7.4 gate hit

```
FAIL  cli live parity > --help advertises the full command catalog
AssertionError: expected [ 'agents', 'config', …(12) ] to deeply equal [ 'agents', 'config', …(11) ]
+   "metrics",
```

The catalog is pinned deliberately so a surface change fails loudly and specifically rather than as a silent shift in the coverage gate's denominator. It did exactly that — `e2a metrics` is new in this release.

**Correcting the catalog alone was not enough.** With it fixed, the gate itself then failed:

```
Advertised commands: 14
Covered            : 12
UNCOVERED (1):
  metrics
```

Every advertised command needs a test that invokes it and asserts a real success. This is the same pattern the metrics work already hit on three other surfaces: the endpoints shipped across REST, both SDKs, MCP and the CLI, each with its own live gate, and the gates had nothing exercising them. This closes the CLI one.

## Validated against live staging, not inferred

Rather than tag v1.7.5 and find out, I ran the suite against staging running v1.7.4:

```
Test Files  2 passed (2)
     Tests  17 passed (17)
Advertised commands: 14   Covered: 13   Allowlisted: 1 ["login"]
PASS: every advertised e2a command is exercised.
```

(Needed a raised agent cap on the throwaway staging account — a Free-plan 3-agent cap failed four unrelated tests with `limits: agents cap reached`, which is a property of my test account, not of the build.)

## Test design

Shape and invariants only, never counts — this runs against a shared deployment whose traffic isn't the suite's to control. Covers the account rollup, `--by-agent` (the only shape-changing flag), the partition invariant (per-agent totals can't exceed the account total), and the contract's sharpest promise: a zero denominator yields `null`, never `0`.

Creates nothing; metrics are read-only.

One trap worth recording: **the CLI emits camelCase** (`messagesInWindow`, `agentsTruncated`, `bounceRate`), not the REST payload's snake_case. A first draft asserting snake_case failed against the real output.