### PR TITLE
feat(web): first-party Umami tracking on public routes, env-gated

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -23,6 +23,12 @@ NEXT_PUBLIC_FEEDBACK_EMAIL=
 # <head> when set, so forks don't accidentally inherit upstream's property.
 NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=
 
+# Optional. Umami website record ID for cookieless web analytics. Empty means
+# no tracker script is loaded. When set, the app sends query-free pageviews for
+# an exact allowlist of public marketing pages to the first-party tracker at
+# https://umami.tokencanopy.com; authenticated and unknown routes stay off.
+NEXT_PUBLIC_UMAMI_WEBSITE_ID=
+
 # Optional. Site-relative path of the pricing page, when the deployment has
 # one. Pricing isn't part of this app — the hosted deployment serves it from
 # a separate route and sets this to /pricing so the sitemap can advertise it.

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -65,6 +65,10 @@ ARG NEXT_PUBLIC_BILLING_API=
 # chooser) is the default. Only set this when the server runs with
 # E2A_OIDC_ENABLED=true — the OIDC route doesn't exist otherwise.
 ARG NEXT_PUBLIC_E2A_SIGN_IN_URL=
+# Empty keeps the site free of web analytics. The hosted deployment sets
+# this to the e2a.dev Umami website record id so the first-party tracker
+# loads on public marketing routes only (the dashboard excludes it).
+ARG NEXT_PUBLIC_UMAMI_WEBSITE_ID=
 
 ENV NEXT_PUBLIC_SITE_URL=$NEXT_PUBLIC_SITE_URL \
     NEXT_PUBLIC_SITE_NAME=$NEXT_PUBLIC_SITE_NAME \
@@ -73,7 +77,8 @@ ENV NEXT_PUBLIC_SITE_URL=$NEXT_PUBLIC_SITE_URL \
     NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=$NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION \
     NEXT_PUBLIC_PRICING_PATH=$NEXT_PUBLIC_PRICING_PATH \
     NEXT_PUBLIC_BILLING_API=$NEXT_PUBLIC_BILLING_API \
-    NEXT_PUBLIC_E2A_SIGN_IN_URL=$NEXT_PUBLIC_E2A_SIGN_IN_URL
+    NEXT_PUBLIC_E2A_SIGN_IN_URL=$NEXT_PUBLIC_E2A_SIGN_IN_URL \
+    NEXT_PUBLIC_UMAMI_WEBSITE_ID=$NEXT_PUBLIC_UMAMI_WEBSITE_ID
 
 COPY web ./
 RUN npm run build

--- a/web/src/app/components/UmamiTracker.test.tsx
+++ b/web/src/app/components/UmamiTracker.test.tsx
@@ -2,13 +2,16 @@ import { act, render, waitFor } from "@testing-library/react";
 import { UmamiTracker } from "./UmamiTracker";
 
 let mockPathname = "/";
+let mockWebsiteId = "website_test";
 
 jest.mock("next/navigation", () => ({
   usePathname: () => mockPathname,
 }));
 
 jest.mock("../../lib/site", () => ({
-  UMAMI_WEBSITE_ID: "website_test",
+  get UMAMI_WEBSITE_ID() {
+    return mockWebsiteId;
+  },
 }));
 
 jest.mock("next/script", () => {
@@ -40,6 +43,7 @@ const track = jest.fn<void, [TrackArgument]>();
 
 beforeEach(() => {
   mockPathname = "/";
+  mockWebsiteId = "website_test";
   window.history.replaceState({}, "", "/");
   Object.defineProperty(window, "umami", {
     configurable: true,
@@ -55,6 +59,19 @@ afterEach(() => {
 });
 
 describe("UmamiTracker", () => {
+  it("does not load or track when analytics is not configured", async () => {
+    mockWebsiteId = "";
+    render(<UmamiTracker />);
+
+    await act(async () => {});
+    expect(
+      document.querySelector(
+        'script[src="https://umami.tokencanopy.com/script.js"]',
+      ),
+    ).toBeNull();
+    expect(track).not.toHaveBeenCalled();
+  });
+
   it("loads an inert tracker and manually records one public pageview without query data", async () => {
     window.history.replaceState({}, "", "/?campaign=sensitive");
     render(<UmamiTracker />);
@@ -77,14 +94,33 @@ describe("UmamiTracker", () => {
   });
 
   it.each([
+    "/",
     "/api-docs",
+    "/blog",
+    "/blog/build-ecommerce-agent-with-email",
+    "/blog/build-procurement-agent-with-email",
+    "/blog/build-recruiting-agent-with-email",
+    "/blog/build-sales-agent-with-email",
+    "/blog/build-voice-follow-up-agent-with-email",
+    "/blog/email-agent-with-google-adk",
+    "/blog/email-for-openclaw-agents",
+    "/blog/human-in-the-loop-for-agent-email",
     "/blog/send-email-from-python-agent",
     "/compare/e2a-vs-agentmail",
+    "/docs",
     "/docs/python",
     "/email-api-for-ai-agents",
     "/mcp",
     "/python-sdk",
-    "/use-cases/customer-support",
+    "/use-cases",
+    "/use-cases/ai-receptionist",
+    "/use-cases/ecommerce-agent",
+    "/use-cases/procurement-agent",
+    "/use-cases/recruiting-agent",
+    "/use-cases/sales-agent",
+    "/use-cases/scheduling-agent",
+    "/use-cases/support-agent",
+    "/use-cases/voice-agent",
   ])("tracks the known public route %s", async (pathname) => {
     mockPathname = pathname;
     window.history.replaceState({}, "", pathname);
@@ -98,6 +134,7 @@ describe("UmamiTracker", () => {
     "/get-started",
     "/oauth/consent",
     "/future-authenticated-route",
+    "/blog/future-private-route",
   ])("fails closed and does not load or track %s", async (pathname) => {
     mockPathname = pathname;
     window.history.replaceState({}, "", `${pathname}?id=resource_private`);
@@ -128,6 +165,28 @@ describe("UmamiTracker", () => {
     expect(track).toHaveBeenCalledTimes(1);
   });
 
+  it("starts tracking only after a private-to-public transition and stops again on private routes", async () => {
+    mockPathname = "/oauth/consent";
+    window.history.replaceState({}, "", "/oauth/consent?state=private");
+    const { rerender } = render(<UmamiTracker />);
+
+    await act(async () => {});
+    expect(track).not.toHaveBeenCalled();
+
+    mockPathname = "/docs";
+    window.history.pushState({}, "", "/docs?source=private");
+    rerender(<UmamiTracker />);
+    await waitFor(() => expect(track).toHaveBeenCalledTimes(1));
+    expect(track.mock.calls[0][0]({}).referrer).toBe("");
+
+    mockPathname = "/inboxes";
+    window.history.pushState({}, "", "/inboxes?id=private");
+    rerender(<UmamiTracker />);
+
+    await act(async () => {});
+    expect(track).toHaveBeenCalledTimes(1);
+  });
+
   it("drops any attempted private payload and strips public query strings", async () => {
     render(<UmamiTracker />);
     await waitFor(() => expect(window.tcUmamiBeforeSend).toBeDefined());
@@ -146,5 +205,10 @@ describe("UmamiTracker", () => {
       referrer: "https://search.example/",
       url: "http://localhost/docs",
     });
+    expect(
+      window.tcUmamiBeforeSend?.("event", {
+        url: "http://user:secret@localhost/docs?resource=private",
+      }),
+    ).toMatchObject({ url: "http://localhost/docs" });
   });
 });

--- a/web/src/app/components/UmamiTracker.test.tsx
+++ b/web/src/app/components/UmamiTracker.test.tsx
@@ -1,0 +1,150 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { UmamiTracker } from "./UmamiTracker";
+
+let mockPathname = "/";
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => mockPathname,
+}));
+
+jest.mock("../../lib/site", () => ({
+  UMAMI_WEBSITE_ID: "website_test",
+}));
+
+jest.mock("next/script", () => {
+  const React = jest.requireActual<typeof import("react")>("react");
+
+  return function MockScript(props: React.ComponentProps<"script"> & {
+    onReady?: () => void;
+    strategy?: string;
+  }) {
+    const { onReady } = props;
+    const scriptProps = { ...props };
+    delete scriptProps.onReady;
+    delete scriptProps.strategy;
+    React.useEffect(() => {
+      onReady?.();
+    }, [onReady]);
+    return <script {...scriptProps} />;
+  };
+});
+
+type UmamiPayload = Record<string, unknown> & {
+  referrer?: string;
+  url?: string;
+};
+
+type TrackArgument = (payload: UmamiPayload) => UmamiPayload;
+
+const track = jest.fn<void, [TrackArgument]>();
+
+beforeEach(() => {
+  mockPathname = "/";
+  window.history.replaceState({}, "", "/");
+  Object.defineProperty(window, "umami", {
+    configurable: true,
+    value: { track },
+    writable: true,
+  });
+  track.mockReset();
+});
+
+afterEach(() => {
+  delete (window as Window & { umami?: unknown }).umami;
+  delete (window as Window & { tcUmamiBeforeSend?: unknown }).tcUmamiBeforeSend;
+});
+
+describe("UmamiTracker", () => {
+  it("loads an inert tracker and manually records one public pageview without query data", async () => {
+    window.history.replaceState({}, "", "/?campaign=sensitive");
+    render(<UmamiTracker />);
+
+    const script = document.querySelector(
+      'script[src="https://umami.tokencanopy.com/script.js"]',
+    );
+    expect(script).toHaveAttribute("data-auto-track", "false");
+    expect(script).toHaveAttribute("data-exclude-search", "true");
+    expect(script).toHaveAttribute("data-exclude-hash", "true");
+    expect(script).toHaveAttribute("data-before-send", "tcUmamiBeforeSend");
+
+    await waitFor(() => expect(track).toHaveBeenCalledTimes(1));
+    const payload = track.mock.calls[0][0]({
+      referrer: "https://search.example/?q=private",
+      url: "http://localhost/?campaign=sensitive",
+    });
+    expect(payload.url).toBe("http://localhost/");
+    expect(payload.referrer).toBe("");
+  });
+
+  it.each([
+    "/api-docs",
+    "/blog/send-email-from-python-agent",
+    "/compare/e2a-vs-agentmail",
+    "/docs/python",
+    "/email-api-for-ai-agents",
+    "/mcp",
+    "/python-sdk",
+    "/use-cases/customer-support",
+  ])("tracks the known public route %s", async (pathname) => {
+    mockPathname = pathname;
+    window.history.replaceState({}, "", pathname);
+    render(<UmamiTracker />);
+
+    await waitFor(() => expect(track).toHaveBeenCalledTimes(1));
+  });
+
+  it.each([
+    "/inboxes/messages/view",
+    "/get-started",
+    "/oauth/consent",
+    "/future-authenticated-route",
+  ])("fails closed and does not load or track %s", async (pathname) => {
+    mockPathname = pathname;
+    window.history.replaceState({}, "", `${pathname}?id=resource_private`);
+    render(<UmamiTracker />);
+
+    await act(async () => {});
+    expect(
+      document.querySelector(
+        'script[src="https://umami.tokencanopy.com/script.js"]',
+      ),
+    ).toBeNull();
+    expect(track).not.toHaveBeenCalled();
+  });
+
+  it("does not track a client-side transition from marketing into the dashboard", async () => {
+    const { rerender } = render(<UmamiTracker />);
+    await waitFor(() => expect(track).toHaveBeenCalledTimes(1));
+
+    mockPathname = "/inboxes/messages/view";
+    window.history.pushState(
+      {},
+      "",
+      "/inboxes/messages/view?email=agent%40example.com&id=msg_private",
+    );
+    rerender(<UmamiTracker />);
+
+    await act(async () => {});
+    expect(track).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops any attempted private payload and strips public query strings", async () => {
+    render(<UmamiTracker />);
+    await waitFor(() => expect(window.tcUmamiBeforeSend).toBeDefined());
+
+    expect(
+      window.tcUmamiBeforeSend?.("event", {
+        url: "http://localhost/oauth/consent?state=secret",
+      }),
+    ).toBeUndefined();
+    expect(
+      window.tcUmamiBeforeSend?.("event", {
+        referrer: "https://search.example/?q=private",
+        url: "http://localhost/docs?resource=private#fragment",
+      }),
+    ).toMatchObject({
+      referrer: "https://search.example/",
+      url: "http://localhost/docs",
+    });
+  });
+});

--- a/web/src/app/components/UmamiTracker.tsx
+++ b/web/src/app/components/UmamiTracker.tsx
@@ -30,23 +30,44 @@ declare global {
  * group. Unknown routes therefore stay untracked if a new product surface is
  * added without updating this component.
  */
-const PUBLIC_MARKETING_SEGMENTS = new Set([
-  "api-docs",
-  "blog",
-  "compare",
-  "docs",
-  "email-api-for-ai-agents",
-  "mcp",
-  "python-sdk",
-  "use-cases",
+const PUBLIC_MARKETING_PATHS = new Set([
+  "/",
+  "/api-docs",
+  "/blog",
+  "/blog/build-ecommerce-agent-with-email",
+  "/blog/build-procurement-agent-with-email",
+  "/blog/build-recruiting-agent-with-email",
+  "/blog/build-sales-agent-with-email",
+  "/blog/build-voice-follow-up-agent-with-email",
+  "/blog/email-agent-with-google-adk",
+  "/blog/email-for-openclaw-agents",
+  "/blog/human-in-the-loop-for-agent-email",
+  "/blog/send-email-from-python-agent",
+  "/compare/e2a-vs-agentmail",
+  "/docs",
+  "/docs/python",
+  "/email-api-for-ai-agents",
+  "/mcp",
+  "/python-sdk",
+  "/use-cases",
+  "/use-cases/ai-receptionist",
+  "/use-cases/ecommerce-agent",
+  "/use-cases/procurement-agent",
+  "/use-cases/recruiting-agent",
+  "/use-cases/sales-agent",
+  "/use-cases/scheduling-agent",
+  "/use-cases/support-agent",
+  "/use-cases/voice-agent",
 ]);
 
-export function isPublicMarketingPath(pathname: string | null): boolean {
-  if (pathname === "/") return true;
-  if (!pathname?.startsWith("/")) return false;
+function normalizePathname(pathname: string): string {
+  if (pathname === "/") return pathname;
+  return pathname.replace(/\/+$/, "");
+}
 
-  const segment = pathname.split("/")[1] ?? "";
-  return PUBLIC_MARKETING_SEGMENTS.has(segment);
+export function isPublicMarketingPath(pathname: string | null): boolean {
+  if (!pathname?.startsWith("/")) return false;
+  return PUBLIC_MARKETING_PATHS.has(normalizePathname(pathname));
 }
 
 function sanitizePublicURL(raw: string, origin: string): string | undefined {
@@ -55,9 +76,9 @@ function sanitizePublicURL(raw: string, origin: string): string | undefined {
     if (url.origin !== origin || !isPublicMarketingPath(url.pathname)) {
       return undefined;
     }
-    url.search = "";
-    url.hash = "";
-    return url.toString();
+    // Rebuild rather than mutating the parsed URL so userinfo, search data,
+    // and fragments can never survive into the analytics payload.
+    return new URL(normalizePathname(url.pathname), origin).toString();
   } catch {
     return undefined;
   }

--- a/web/src/app/components/UmamiTracker.tsx
+++ b/web/src/app/components/UmamiTracker.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { UMAMI_WEBSITE_ID } from "../../lib/site";
+
+/**
+ * Loads the Umami tracker on public marketing routes only.
+ *
+ * e2a.dev serves the public marketing site and the authenticated dashboard
+ * from one Next.js app; the dashboard is a route group ((app)) with
+ * unprefixed URLs, so there is no structural way to exclude it in the
+ * layout tree. These are the dashboard's top-level path segments, whose
+ * URLs carry inbox/agent/resource ids that must not land in analytics
+ * (the public-sites-only decision in
+ * tokencanopy/docs/superpowers/specs/2026-08-10-umami-web-analytics-design.md).
+ * Keep this list in sync with the (app) route group.
+ */
+const DASHBOARD_SEGMENTS = new Set([
+  "api-keys",
+  "billing",
+  "contacts",
+  "dashboard",
+  "domains",
+  "feedback",
+  "get-started",
+  "inboxes",
+  "metrics",
+  "reviews",
+  "settings",
+  "templates",
+  "trash",
+  "webhook-secrets",
+  "webhooks",
+]);
+
+export function UmamiTracker() {
+  const pathname = usePathname();
+
+  if (!UMAMI_WEBSITE_ID) return null;
+
+  const segment = pathname.split("/")[1] ?? "";
+  if (DASHBOARD_SEGMENTS.has(segment)) return null;
+
+  return (
+    <script
+      async
+      defer
+      src="https://umami.tokencanopy.com/script.js"
+      data-website-id={UMAMI_WEBSITE_ID}
+    />
+  );
+}

--- a/web/src/app/components/UmamiTracker.tsx
+++ b/web/src/app/components/UmamiTracker.tsx
@@ -1,52 +1,164 @@
 "use client";
 
+import Script from "next/script";
+import { useEffect, useRef, useState } from "react";
 import { usePathname } from "next/navigation";
 import { UMAMI_WEBSITE_ID } from "../../lib/site";
 
+type UmamiPayload = Record<string, unknown> & {
+  referrer?: string;
+  title?: string;
+  url?: string;
+};
+
+type UmamiBeforeSend = (
+  type: string,
+  payload: UmamiPayload,
+) => UmamiPayload | undefined;
+
+declare global {
+  interface Window {
+    tcUmamiBeforeSend?: UmamiBeforeSend;
+    umami?: {
+      track: (transform: (payload: UmamiPayload) => UmamiPayload) => void;
+    };
+  }
+}
+
 /**
- * Loads the Umami tracker on public marketing routes only.
- *
- * e2a.dev serves the public marketing site and the authenticated dashboard
- * from one Next.js app; the dashboard is a route group ((app)) with
- * unprefixed URLs, so there is no structural way to exclude it in the
- * layout tree. These are the dashboard's top-level path segments, whose
- * URLs carry inbox/agent/resource ids that must not land in analytics
- * (the public-sites-only decision in
- * tokencanopy/docs/superpowers/specs/2026-08-10-umami-web-analytics-design.md).
- * Keep this list in sync with the (app) route group.
+ * Public pages are an allowlist, not the inverse of the authenticated route
+ * group. Unknown routes therefore stay untracked if a new product surface is
+ * added without updating this component.
  */
-const DASHBOARD_SEGMENTS = new Set([
-  "api-keys",
-  "billing",
-  "contacts",
-  "dashboard",
-  "domains",
-  "feedback",
-  "get-started",
-  "inboxes",
-  "metrics",
-  "reviews",
-  "settings",
-  "templates",
-  "trash",
-  "webhook-secrets",
-  "webhooks",
+const PUBLIC_MARKETING_SEGMENTS = new Set([
+  "api-docs",
+  "blog",
+  "compare",
+  "docs",
+  "email-api-for-ai-agents",
+  "mcp",
+  "python-sdk",
+  "use-cases",
 ]);
 
-export function UmamiTracker() {
-  const pathname = usePathname();
-
-  if (!UMAMI_WEBSITE_ID) return null;
+export function isPublicMarketingPath(pathname: string | null): boolean {
+  if (pathname === "/") return true;
+  if (!pathname?.startsWith("/")) return false;
 
   const segment = pathname.split("/")[1] ?? "";
-  if (DASHBOARD_SEGMENTS.has(segment)) return null;
+  return PUBLIC_MARKETING_SEGMENTS.has(segment);
+}
+
+function sanitizePublicURL(raw: string, origin: string): string | undefined {
+  try {
+    const url = new URL(raw, origin);
+    if (url.origin !== origin || !isPublicMarketingPath(url.pathname)) {
+      return undefined;
+    }
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+function sanitizeReferrer(raw: string, origin: string): string {
+  if (!raw) return "";
+
+  try {
+    const url = new URL(raw, origin);
+    if (url.origin === origin) {
+      return sanitizePublicURL(url.toString(), origin) ?? "";
+    }
+
+    // Cross-origin attribution needs only the referring origin. Never carry a
+    // third party's query string or fragment into our analytics store.
+    return `${url.origin}/`;
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Loads Umami only for known public routes and keeps its automatic runtime
+ * disabled. Umami normally installs persistent History API hooks for SPA
+ * pageviews; removing its script tag on a dashboard navigation does not undo
+ * those hooks. Manual pageviews let this root-layout component fail closed.
+ */
+export function UmamiTracker() {
+  const pathname = usePathname();
+  const isPublicPath = isPublicMarketingPath(pathname);
+  const [trackerReady, setTrackerReady] = useState(false);
+  // undefined = first page in this document; "" = a private route was visited.
+  const lastTrackedURL = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    const beforeSend: UmamiBeforeSend = (_type, payload) => {
+      if (!isPublicMarketingPath(window.location.pathname)) return undefined;
+
+      const url = sanitizePublicURL(
+        typeof payload.url === "string" ? payload.url : window.location.href,
+        window.location.origin,
+      );
+      if (!url) return undefined;
+
+      return {
+        ...payload,
+        url,
+        referrer: sanitizeReferrer(
+          typeof payload.referrer === "string" ? payload.referrer : "",
+          window.location.origin,
+        ),
+      };
+    };
+
+    window.tcUmamiBeforeSend = beforeSend;
+    return () => {
+      if (window.tcUmamiBeforeSend === beforeSend) {
+        delete window.tcUmamiBeforeSend;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isPublicPath) {
+      // Do not attribute a later public pageview through an authenticated page.
+      lastTrackedURL.current = "";
+      return;
+    }
+    if (!trackerReady || !window.umami || !pathname) return;
+
+    const url = sanitizePublicURL(pathname, window.location.origin);
+    if (!url || lastTrackedURL.current === url) return;
+
+    const referrer =
+      lastTrackedURL.current === undefined
+        ? sanitizeReferrer(document.referrer, window.location.origin)
+        : lastTrackedURL.current;
+
+    window.umami.track((payload) => ({
+      ...payload,
+      referrer,
+      title: document.title,
+      url,
+    }));
+    lastTrackedURL.current = url;
+  }, [isPublicPath, pathname, trackerReady]);
+
+  if (!UMAMI_WEBSITE_ID || !isPublicPath) return null;
 
   return (
-    <script
-      async
-      defer
+    <Script
+      id="tc-umami-tracker"
       src="https://umami.tokencanopy.com/script.js"
+      strategy="afterInteractive"
       data-website-id={UMAMI_WEBSITE_ID}
+      data-auto-track="false"
+      data-before-send="tcUmamiBeforeSend"
+      data-exclude-search="true"
+      data-exclude-hash="true"
+      onReady={() => setTrackerReady(true)}
     />
   );
 }

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -7,6 +7,7 @@ import "./globals.css";
 import { AuthProvider } from "./components/AuthProvider";
 import { ThemeProvider } from "./components/ThemeProvider";
 import { JsonLd } from "./components/JsonLd";
+import { UmamiTracker } from "./components/UmamiTracker";
 import { SITE_URL, SITE_NAME, GOOGLE_SITE_VERIFICATION } from "../lib/site";
 import { organization, softwareApplication, website } from "../lib/jsonld";
 
@@ -115,6 +116,7 @@ export default function RootLayout({
     >
       <body className="min-h-screen flex flex-col">
         <JsonLd data={rootJsonLd} />
+        <UmamiTracker />
         <AuthProvider>
           <ThemeProvider>
             {children}

--- a/web/src/lib/site.ts
+++ b/web/src/lib/site.ts
@@ -33,6 +33,13 @@ export const FEEDBACK_EMAIL = process.env.NEXT_PUBLIC_FEEDBACK_EMAIL || "";
 export const GOOGLE_SITE_VERIFICATION =
   process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION || "";
 
+// Umami web analytics (self-hosted at umami.tokencanopy.com). The e2a.dev
+// website record id, created in the Umami dashboard. Empty in the OSS
+// build and for self-hosters (no tracking); the hosted deployment bakes in
+// NEXT_PUBLIC_UMAMI_WEBSITE_ID at image build time. The tracker is gated to
+// public marketing routes only — the authenticated dashboard is not tracked.
+export const UMAMI_WEBSITE_ID = process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID || "";
+
 // Site-relative path of the pricing page, when the deployment has one.
 //
 // Pricing is NOT part of this app. The hosted deployment serves it from the


### PR DESCRIPTION
## Summary

Add opt-in, first-party Umami analytics to the web app's known public marketing pages, driven by build-time `NEXT_PUBLIC_UMAMI_WEBSITE_ID`.

The OSS and self-hosted defaults remain empty and load no tracker. The coordinated hosted deployment supplies the e2a.dev website record.

## Privacy boundary

- Exact allowlist of the 27 statically exported marketing paths; authenticated, OAuth, unknown, and future nested routes fail closed.
- Umami automatic tracking is disabled, avoiding persistent SPA History API and click hooks. Pageviews are sent manually only while the current route is public.
- URL query strings, fragments, and userinfo are removed. Cross-origin referrers are reduced to their origin, and private-route referral chains are cleared.
- The `before-send` guard checks the live browser location and drops private, unknown, or cross-origin payloads.
- Empty configuration loads and sends nothing.

## Changes

- `web/src/lib/site.ts` — empty-default hosted website ID.
- `web/src/app/components/UmamiTracker.tsx` — exact route allowlist, inert script, manual tracking, payload sanitization.
- `web/src/app/components/UmamiTracker.test.tsx` — route, configuration, navigation-lifecycle, and sanitization coverage.
- `web/src/app/layout.tsx` — root-layout mount.
- `web/Dockerfile` and `web/.env.example` — build-time contract and self-host documentation.

## Verification

- `npm test -- --runInBand` — 98 suites, 857 tests passed.
- `npm run lint` — passed.
- Synthetic-ID production `npm run build` — 59 static pages generated, TypeScript passed.
- Static output inspection — tracker appears on exactly the 27 known marketing pages and is absent from dashboard, OAuth, 404, and unknown pages.
- Browser smoke — public page loads the inert tracker; SPA navigation into the dashboard records no additional pageview; direct OAuth load has no tracker.

## Rollout

The hosted ID lives in coordinated e2a-ops PR #309. Analytics on the Next.js marketing pages activates only after a release containing this PR is cut and promoted; the currently pinned hosted release predates this change.
