### PR TITLE
fix(ci): run plugin version gate before dependency install

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -32,6 +32,21 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: "22"
+      # The version-bump gate diffs the base against the working tree, so it
+      # must run before anything that mutates tracked files. In particular
+      # `npm ci` inside the vendored email-evals runtime rewrites its tracked
+      # node_modules on Linux (platform-specific esbuild binaries), which the
+      # gate would otherwise misread as an unbumped plugin change.
+      - name: Require plugin version bumps in pull requests
+        if: github.event_name == 'pull_request'
+        env:
+          PLUGIN_VERSION_BASE: ${{ github.event.pull_request.base.sha }}
+        run: node scripts/check-plugin-version-bump.mjs "$PLUGIN_VERSION_BASE"
+      - name: Require plugin version bumps pushed to main
+        if: github.event_name == 'push' && github.event.before != '0000000000000000000000000000000000000000'
+        env:
+          PLUGIN_VERSION_BASE: ${{ github.event.before }}
+        run: node scripts/check-plugin-version-bump.mjs "$PLUGIN_VERSION_BASE"
       - run: npm install --global "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
       - name: Install email-evals runtime dependencies
         run: npm ci --ignore-scripts --prefix plugins/e2a/skills/email-evals/runtime
@@ -45,17 +60,6 @@ jobs:
         run: |
           claude plugin validate --strict plugins/e2a
           claude plugin validate --strict plugins/e2a-labs
-      - name: Require plugin version bumps in pull requests
-        if: github.event_name == 'pull_request'
-        env:
-          PLUGIN_VERSION_BASE: ${{ github.event.pull_request.base.sha }}
-        run: node scripts/check-plugin-version-bump.mjs "$PLUGIN_VERSION_BASE"
-      - name: Require plugin version bumps pushed to main
-        if: github.event_name == 'push' && github.event.before != '0000000000000000000000000000000000000000'
-        env:
-          PLUGIN_VERSION_BASE: ${{ github.event.before }}
-        run: node scripts/check-plugin-version-bump.mjs "$PLUGIN_VERSION_BASE"
-
   agentify:
     name: Agentify deterministic suite
     runs-on: ubuntu-latest

--- a/scripts/plugin-packaging.test.mjs
+++ b/scripts/plugin-packaging.test.mjs
@@ -105,9 +105,14 @@ test("plugin CI is consolidated into parallel package and skill lanes", async ()
 
 test("consolidated plugin CI preserves release gates and fixture isolation", async () => {
   const workflow = await readFile(".github/workflows/plugin-tests.yml", "utf8");
+  const pullRequestVersionGate = workflow.indexOf("name: Require plugin version bumps in pull requests");
+  const pushVersionGate = workflow.indexOf("name: Require plugin version bumps pushed to main");
+  const runtimeInstall = workflow.indexOf("name: Install email-evals runtime dependencies");
 
   assert.match(workflow, /github\.event\.pull_request\.base\.sha/);
   assert.match(workflow, /github\.event\.before/);
+  assert.ok(pullRequestVersionGate >= 0 && pullRequestVersionGate < runtimeInstall);
+  assert.ok(pushVersionGate >= 0 && pushVersionGate < runtimeInstall);
   assert.match(workflow, /plugins\/e2a-labs\/skills\/agentify\/templates\/runtime-skill/);
   assert.match(workflow, /plugins\/e2a-labs\/skills\/agentify\/templates\/workflows\/feedback-triage\.yml\.tmpl/);
   assert.match(workflow, /plugins\/e2a-labs\/skills\/agentify\/examples\/e2a\/autonomous-repo\.config\.yml/);

--- a/scripts/plugin-packaging.test.mjs
+++ b/scripts/plugin-packaging.test.mjs
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import { access, readdir, readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { test } from "node:test";
+
+const require = createRequire(import.meta.url);
+const { parse: parseYaml } = require("../plugins/e2a/skills/email-evals/runtime/node_modules/yaml");
 
 const skillNames = async (plugin) => (await readdir(`plugins/${plugin}/skills`, { withFileTypes: true }))
   .filter((entry) => entry.isDirectory())
@@ -105,30 +109,50 @@ test("plugin CI is consolidated into parallel package and skill lanes", async ()
 
 test("consolidated plugin CI preserves release gates and fixture isolation", async () => {
   const workflow = await readFile(".github/workflows/plugin-tests.yml", "utf8");
-  const packageJob = workflow.match(/^  package:\n([\s\S]*?)(?=^  agentify:\n)/m)?.[1];
-  assert.ok(packageJob, "package job must exist before the agentify job");
-  const packageLines = packageJob.split("\n");
-
-  const stepIndex = (step) => {
-    const marker = `      - ${step}`;
-    const matches = packageLines
-      .map((line, index) => ({ line, index }))
-      .filter(({ line }) => line === marker);
-    assert.equal(matches.length, 1, `${step} must appear exactly once in the package job`);
-    return matches[0].index;
+  const steps = parseYaml(workflow).jobs.package.steps;
+  const onlyStep = (label, predicate) => {
+    const matches = steps
+      .map((step, index) => ({ step, index }))
+      .filter(({ step }) => predicate(step));
+    assert.equal(matches.length, 1, `${label} must appear exactly once in the package job`);
+    return matches[0];
   };
-  const orderedSteps = [
-    "uses: actions/checkout@v7",
-    "uses: actions/setup-node@v7",
-    "name: Require plugin version bumps in pull requests",
-    "name: Require plugin version bumps pushed to main",
-    "run: npm install --global \"@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}\"",
-    "name: Install email-evals runtime dependencies",
-  ].map(stepIndex);
+  const checkout = onlyStep("checkout", (step) => step.uses === "actions/checkout@v7");
+  const setupNode = onlyStep("Node setup", (step) => step.uses === "actions/setup-node@v7");
+  const pullRequestGate = onlyStep(
+    "pull-request version gate",
+    (step) => step.name === "Require plugin version bumps in pull requests",
+  );
+  const pushGate = onlyStep(
+    "push version gate",
+    (step) => step.name === "Require plugin version bumps pushed to main",
+  );
+  const globalInstall = onlyStep(
+    "Claude Code install",
+    (step) => step.run === "npm install --global \"@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}\"",
+  );
+  const runtimeInstall = onlyStep(
+    "email-evals runtime install",
+    (step) => step.run === "npm ci --ignore-scripts --prefix plugins/e2a/skills/email-evals/runtime",
+  );
 
-  assert.match(workflow, /github\.event\.pull_request\.base\.sha/);
-  assert.match(workflow, /github\.event\.before/);
-  assert.deepEqual(orderedSteps, [...orderedSteps].sort((left, right) => left - right));
+  assert.deepEqual(checkout.step.with, { "fetch-depth": 0 });
+  assert.ok(checkout.index < setupNode.index);
+  for (const gate of [pullRequestGate, pushGate]) {
+    assert.ok(setupNode.index < gate.index);
+    assert.ok(gate.index < globalInstall.index);
+    assert.ok(gate.index < runtimeInstall.index);
+    assert.equal(gate.step.run, "node scripts/check-plugin-version-bump.mjs \"$PLUGIN_VERSION_BASE\"");
+  }
+  assert.equal(pullRequestGate.step.if, "github.event_name == 'pull_request'");
+  assert.deepEqual(pullRequestGate.step.env, {
+    PLUGIN_VERSION_BASE: "${{ github.event.pull_request.base.sha }}",
+  });
+  assert.equal(
+    pushGate.step.if,
+    "github.event_name == 'push' && github.event.before != '0000000000000000000000000000000000000000'",
+  );
+  assert.deepEqual(pushGate.step.env, { PLUGIN_VERSION_BASE: "${{ github.event.before }}" });
   assert.match(workflow, /plugins\/e2a-labs\/skills\/agentify\/templates\/runtime-skill/);
   assert.match(workflow, /plugins\/e2a-labs\/skills\/agentify\/templates\/workflows\/feedback-triage\.yml\.tmpl/);
   assert.match(workflow, /plugins\/e2a-labs\/skills\/agentify\/examples\/e2a\/autonomous-repo\.config\.yml/);

--- a/scripts/plugin-packaging.test.mjs
+++ b/scripts/plugin-packaging.test.mjs
@@ -105,14 +105,30 @@ test("plugin CI is consolidated into parallel package and skill lanes", async ()
 
 test("consolidated plugin CI preserves release gates and fixture isolation", async () => {
   const workflow = await readFile(".github/workflows/plugin-tests.yml", "utf8");
-  const pullRequestVersionGate = workflow.indexOf("name: Require plugin version bumps in pull requests");
-  const pushVersionGate = workflow.indexOf("name: Require plugin version bumps pushed to main");
-  const runtimeInstall = workflow.indexOf("name: Install email-evals runtime dependencies");
+  const packageJob = workflow.match(/^  package:\n([\s\S]*?)(?=^  agentify:\n)/m)?.[1];
+  assert.ok(packageJob, "package job must exist before the agentify job");
+  const packageLines = packageJob.split("\n");
+
+  const stepIndex = (step) => {
+    const marker = `      - ${step}`;
+    const matches = packageLines
+      .map((line, index) => ({ line, index }))
+      .filter(({ line }) => line === marker);
+    assert.equal(matches.length, 1, `${step} must appear exactly once in the package job`);
+    return matches[0].index;
+  };
+  const orderedSteps = [
+    "uses: actions/checkout@v7",
+    "uses: actions/setup-node@v7",
+    "name: Require plugin version bumps in pull requests",
+    "name: Require plugin version bumps pushed to main",
+    "run: npm install --global \"@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}\"",
+    "name: Install email-evals runtime dependencies",
+  ].map(stepIndex);
 
   assert.match(workflow, /github\.event\.pull_request\.base\.sha/);
   assert.match(workflow, /github\.event\.before/);
-  assert.ok(pullRequestVersionGate >= 0 && pullRequestVersionGate < runtimeInstall);
-  assert.ok(pushVersionGate >= 0 && pushVersionGate < runtimeInstall);
+  assert.deepEqual(orderedSteps, [...orderedSteps].sort((left, right) => left - right));
   assert.match(workflow, /plugins\/e2a-labs\/skills\/agentify\/templates\/runtime-skill/);
   assert.match(workflow, /plugins\/e2a-labs\/skills\/agentify\/templates\/workflows\/feedback-triage\.yml\.tmpl/);
   assert.match(workflow, /plugins\/e2a-labs\/skills\/agentify\/examples\/e2a\/autonomous-repo\.config\.yml/);

--- a/scripts/plugin-packaging.test.mjs
+++ b/scripts/plugin-packaging.test.mjs
@@ -136,12 +136,20 @@ test("consolidated plugin CI preserves release gates and fixture isolation", asy
     (step) => step.run === "npm ci --ignore-scripts --prefix plugins/e2a/skills/email-evals/runtime",
   );
 
-  assert.deepEqual(checkout.step.with, { "fetch-depth": 0 });
-  assert.ok(checkout.index < setupNode.index);
+  assert.equal(String(checkout.step.with["fetch-depth"]), "0");
+  assert.equal(checkout.index, 0);
+  assert.equal(setupNode.index, 1);
+  assert.deepEqual(
+    [pullRequestGate.index, pushGate.index].sort((left, right) => left - right),
+    [2, 3],
+  );
   for (const gate of [pullRequestGate, pushGate]) {
-    assert.ok(setupNode.index < gate.index);
     assert.ok(gate.index < globalInstall.index);
     assert.ok(gate.index < runtimeInstall.index);
+    assert.ok(
+      gate.step["continue-on-error"] === undefined || gate.step["continue-on-error"] === false,
+      `${gate.step.name} must fail closed`,
+    );
     assert.equal(gate.step.run, "node scripts/check-plugin-version-bump.mjs \"$PLUGIN_VERSION_BASE\"");
   }
   assert.equal(pullRequestGate.step.if, "github.event_name == 'pull_request'");


### PR DESCRIPTION
## Summary
- run plugin version-bump checks on the pristine checkout
- prevent Linux dependency installation from creating false plugin-change failures
- pin the required step ordering with a regression assertion

## Verification
- plugin contract suite: 62/62
- email-evals runtime suite: 293/293
- Agentify deterministic suite: pass
- Autopilot suite: 117/117
- Tether self-test: pass
- plugin validator: pass

No product behavior or release artifacts change.