### PR TITLE
fix(metrics): align buckets and loopback contracts

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3272,7 +3272,7 @@ components:
       additionalProperties: true
       properties:
         accepted:
-          description: Outbound messages e2a accepted from the send API. The denominator for delivered_rate and suppression_block_rate. Counts sends only — the arriving copy of an agent-to-agent loopback delivery is counted under received, not here.
+          description: Outbound messages e2a accepted from the send API. External-delivery rates use accepted minus loopback as their denominator. Counts sends only — the arriving copy of an agent-to-agent loopback delivery is counted under received, not here.
           format: int64
           type: integer
         bounced_hard:
@@ -3344,7 +3344,7 @@ components:
           format: int64
           type: integer
         submitted:
-          description: Messages an upstream provider or the loopback path accepted for delivery. The denominator for bounce_rate.
+          description: Messages an upstream provider or the loopback path accepted for delivery. Provider-outcome rates use submitted minus loopback as their denominator.
           format: int64
           type: integer
         suppressed:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3344,7 +3344,7 @@ components:
           format: int64
           type: integer
         submitted:
-          description: Messages an upstream provider or the loopback path accepted for delivery. Provider-outcome rates use submitted minus loopback as their denominator.
+          description: Messages an upstream provider or the loopback path accepted for delivery. The bounce rate uses submitted minus loopback as its denominator; complaint rate is complained ÷ delivered.
           format: int64
           type: integer
         suppressed:

--- a/internal/httpapi/metrics.go
+++ b/internal/httpapi/metrics.go
@@ -32,8 +32,8 @@ type MetricsCounterView struct {
 // (distinct messages, never attempts) so every value shares one denominator
 // basis and no stage can exceed the stage above it because of retries.
 type MetricsSummaryView struct {
-	Accepted            int64 `json:"accepted" doc:"Outbound messages e2a accepted from the send API. The denominator for delivered_rate and suppression_block_rate. Counts sends only — the arriving copy of an agent-to-agent loopback delivery is counted under received, not here."`
-	Submitted           int64 `json:"submitted" doc:"Messages an upstream provider or the loopback path accepted for delivery. The denominator for bounce_rate."`
+	Accepted            int64 `json:"accepted" doc:"Outbound messages e2a accepted from the send API. External-delivery rates use accepted minus loopback as their denominator. Counts sends only — the arriving copy of an agent-to-agent loopback delivery is counted under received, not here."`
+	Submitted           int64 `json:"submitted" doc:"Messages an upstream provider or the loopback path accepted for delivery. Provider-outcome rates use submitted minus loopback as their denominator."`
 	Delivered           int64 `json:"delivered" doc:"Messages a recipient server accepted. This is recipient-server acceptance, NOT inbox placement — no email provider exposes the latter."`
 	BouncedHard         int64 `json:"bounced_hard" doc:"Permanent bounces. These add the recipient to the suppression list."`
 	BouncedSoft         int64 `json:"bounced_soft" doc:"Transient bounces."`

--- a/internal/httpapi/metrics.go
+++ b/internal/httpapi/metrics.go
@@ -33,7 +33,7 @@ type MetricsCounterView struct {
 // basis and no stage can exceed the stage above it because of retries.
 type MetricsSummaryView struct {
 	Accepted            int64 `json:"accepted" doc:"Outbound messages e2a accepted from the send API. External-delivery rates use accepted minus loopback as their denominator. Counts sends only — the arriving copy of an agent-to-agent loopback delivery is counted under received, not here."`
-	Submitted           int64 `json:"submitted" doc:"Messages an upstream provider or the loopback path accepted for delivery. Provider-outcome rates use submitted minus loopback as their denominator."`
+	Submitted           int64 `json:"submitted" doc:"Messages an upstream provider or the loopback path accepted for delivery. The bounce rate uses submitted minus loopback as its denominator; complaint rate is complained ÷ delivered."`
 	Delivered           int64 `json:"delivered" doc:"Messages a recipient server accepted. This is recipient-server acceptance, NOT inbox placement — no email provider exposes the latter."`
 	BouncedHard         int64 `json:"bounced_hard" doc:"Permanent bounces. These add the recipient to the suppression list."`
 	BouncedSoft         int64 `json:"bounced_soft" doc:"Transient bounces."`

--- a/internal/httpapi/metrics_test.go
+++ b/internal/httpapi/metrics_test.go
@@ -103,6 +103,7 @@ func TestAgentMetricsSummaryUsesMessageGrain(t *testing.T) {
 			metricsCount(messagelifecycle.ReasonSubmissionUpstreamAccepted, 8, 8),
 			metricsCount(messagelifecycle.ReasonDeliveryRecipientServerAccepted, 6, 6),
 			metricsCount(messagelifecycle.ReasonDeliveryPermanentBounce, 2, 2),
+			metricsCount(messagelifecycle.ReasonComplaintRecipientReported, 1, 1),
 		},
 	})
 
@@ -129,6 +130,9 @@ func TestAgentMetricsSummaryUsesMessageGrain(t *testing.T) {
 	// comparable to the provider thresholds that trigger account review.
 	if got := rates["bounce_rate"].(float64); got != 0.25 {
 		t.Errorf("bounce_rate = %v, want 0.25 (2 bounced / 8 submitted)", got)
+	}
+	if got := rates["complaint_rate"].(float64); got != 1.0/6.0 {
+		t.Errorf("complaint_rate = %v, want %v (1 complaint / 6 delivered)", got, 1.0/6.0)
 	}
 
 	// The retried code must still expose its attempt count in counters[].

--- a/internal/httpapi/metrics_test.go
+++ b/internal/httpapi/metrics_test.go
@@ -235,23 +235,27 @@ func TestAgentMetricsRateIsNullForPureLoopbackTraffic(t *testing.T) {
 		MessagesInWindow:      10,
 		MessagesWithLifecycle: 10,
 		Counts: []messagelifecycle.ReasonCodeCount{
-			metricsCount(messagelifecycle.ReasonAcceptanceOutboundAPI, 5, 5),
-			metricsCount(messagelifecycle.ReasonSubmissionLocalLoopbackAccepted, 5, 5),
-			metricsCount(messagelifecycle.ReasonAcceptanceLocalLoopback, 5, 5),
+			metricsCount(messagelifecycle.ReasonAcceptanceOutboundAPI, 1, 1),
+			metricsCount(messagelifecycle.ReasonSubmissionLocalLoopbackAccepted, 1, 1),
+			metricsCount(messagelifecycle.ReasonAcceptanceLocalLoopback, 1, 1),
 		},
 	})
 
 	_, body := metricsGET(t, srv, "agent@example.com", "")
-	rates := metricsSection(t, body, "rates")
-	if rates["delivered_rate"] != nil {
-		t.Errorf("delivered_rate = %#v, want null: there is no external mail to rate", rates["delivered_rate"])
+	summary := metricsSection(t, body, "summary")
+	want := map[string]float64{
+		"accepted": 1, "submitted": 1, "loopback": 1,
+		"received": 1, "delivered": 0,
 	}
-	if rates["bounce_rate"] != nil {
-		t.Errorf("bounce_rate = %#v, want null", rates["bounce_rate"])
+	for key, expected := range want {
+		if got := summary[key].(float64); got != expected {
+			t.Errorf("summary[%s] = %v, want %v", key, got, expected)
+		}
 	}
-	// The traffic is still visible in the counters — only the rate ignores it.
-	if got := metricsSection(t, body, "summary")["received"].(float64); got != 5 {
-		t.Errorf("received = %v, want 5", got)
+	for _, key := range []string{"delivered_rate", "bounce_rate", "complaint_rate", "suppression_block_rate"} {
+		if got := metricsSection(t, body, "rates")[key]; got != nil {
+			t.Errorf("rates[%s] = %#v, want null", key, got)
+		}
 	}
 }
 

--- a/internal/messagelifecycle/account_metrics.go
+++ b/internal/messagelifecycle/account_metrics.go
@@ -314,6 +314,7 @@ func accountDaysTx(ctx context.Context, tx pgx.Tx, userID string, start, end tim
 		JOIN agent_identities a ON a.id = m.agent_id
 		JOIN message_lifecycle_transitions t ON t.message_id = m.id
 		WHERE a.user_id = $1
+		  AND a.deleted_at IS NULL
 		  AND m.created_at >= $2
 		  AND m.created_at < $3
 		GROUP BY day, t.reason_code, t.stage, t.outcome, t.retryable

--- a/internal/messagelifecycle/account_metrics_integration_test.go
+++ b/internal/messagelifecycle/account_metrics_integration_test.go
@@ -40,6 +40,23 @@ func accountCountsByCode(metrics messagelifecycle.AgentMetrics) map[messagelifec
 	return countsByCode(metrics)
 }
 
+func accountDayCountsByCode(days []messagelifecycle.DayBucket) map[messagelifecycle.ReasonCode]messagelifecycle.ReasonCodeCount {
+	result := make(map[messagelifecycle.ReasonCode]messagelifecycle.ReasonCodeCount)
+	for _, day := range days {
+		for _, count := range day.Counts {
+			current := result[count.ReasonCode]
+			current.ReasonCode = count.ReasonCode
+			current.Stage = count.Stage
+			current.Outcome = count.Outcome
+			current.Retryable = count.Retryable
+			current.Messages += count.Messages
+			current.Observations += count.Observations
+			result[count.ReasonCode] = current
+		}
+	}
+	return result
+}
+
 // TestAccountMetricsSumsEveryAgentAndExcludesOtherAccounts is the tenancy
 // test: totals must span all of the caller's agents and none of anybody else's.
 func TestAccountMetricsSumsEveryAgentAndExcludesOtherAccounts(t *testing.T) {
@@ -112,7 +129,7 @@ func TestAccountMetricsExcludesTrashedAgents(t *testing.T) {
 	}
 
 	metrics, err := store.CountByReasonCodeForAccount(ctx, "usr_accttrashlive",
-		metricsBaseTime.Add(-time.Hour), metricsBaseTime.Add(time.Hour), true, false)
+		metricsBaseTime.Add(-time.Hour), metricsBaseTime.Add(time.Hour), true, true)
 	if err != nil {
 		t.Fatalf("CountByReasonCodeForAccount: %v", err)
 	}
@@ -128,6 +145,32 @@ func TestAccountMetricsExcludesTrashedAgents(t *testing.T) {
 	}
 	if metrics.Agents[0].AgentEmail != live {
 		t.Errorf("breakdown agent = %q, want the live agent %q", metrics.Agents[0].AgentEmail, live)
+	}
+	if got := accountDayCountsByCode(metrics.Days)[messagelifecycle.ReasonAcceptanceOutboundAPI].Messages; got != 1 {
+		t.Errorf("daily accepted messages = %d, want 1: a trashed agent's mail is still in the buckets", got)
+	}
+	if got := accountDayCountsByCode(metrics.Days)[messagelifecycle.ReasonAcceptanceOutboundAPI].Messages; got != accountCountsByCode(metrics.Totals)[messagelifecycle.ReasonAcceptanceOutboundAPI].Messages {
+		t.Errorf("daily accepted messages = %d, totals accepted = %d: buckets must reconcile with totals", got, accountCountsByCode(metrics.Totals)[messagelifecycle.ReasonAcceptanceOutboundAPI].Messages)
+	}
+
+	if _, err := pool.Exec(ctx,
+		`UPDATE agent_identities SET deleted_at = NULL WHERE id = $1`, doomed); err != nil {
+		t.Fatal(err)
+	}
+
+	metrics, err = store.CountByReasonCodeForAccount(ctx, "usr_accttrashlive",
+		metricsBaseTime.Add(-time.Hour), metricsBaseTime.Add(time.Hour), true, true)
+	if err != nil {
+		t.Fatalf("CountByReasonCodeForAccount after restore: %v", err)
+	}
+	if got := accountCountsByCode(metrics.Totals)[messagelifecycle.ReasonAcceptanceOutboundAPI].Messages; got != 2 {
+		t.Errorf("restored accepted messages = %d, want 2", got)
+	}
+	if got := len(metrics.Agents); got != 2 {
+		t.Errorf("restored agents = %d, want 2", got)
+	}
+	if got := accountDayCountsByCode(metrics.Days)[messagelifecycle.ReasonAcceptanceOutboundAPI].Messages; got != 2 {
+		t.Errorf("restored daily accepted messages = %d, want 2", got)
 	}
 }
 

--- a/mcp/src/tools/metrics.ts
+++ b/mcp/src/tools/metrics.ts
@@ -25,8 +25,11 @@ const WINDOW_NOTE =
 
 const RATES_NOTE =
   "Every value in `rates` is null — never 0 — when its denominator is zero, so 'no traffic' stays " +
-  "distinguishable from 'everything failed'. Denominators are fixed by the server: delivered/accepted, " +
-  "bounced/submitted, complained/delivered, suppressed/accepted. " +
+  "distinguishable from 'everything failed'. Formulas are fixed by the server: " +
+  "`delivered_rate = delivered / (accepted - loopback)`; " +
+  "`bounce_rate = (bounced_hard + bounced_soft + bounced_undetermined) / (submitted - loopback)`; " +
+  "`complaint_rate = complained / delivered`; " +
+  "`suppression_block_rate = suppressed / (accepted - loopback)`. " +
   "`delivered` means a recipient server accepted the message; it does NOT claim inbox placement.";
 
 const COVERAGE_NOTE =

--- a/mcp/tests/delivery-metrics.test.ts
+++ b/mcp/tests/delivery-metrics.test.ts
@@ -93,6 +93,25 @@ describe("MCP delivery-metrics tools", () => {
     }
   });
 
+  it("names every rate formula in both tool descriptions", async () => {
+    const { tools } = await client.listTools();
+    for (const name of ["get_agent_metrics", "get_account_metrics"]) {
+      const desc = tools.find((t) => t.name === name)!.description!;
+      expect(desc, `${name} must name the delivery formula`).toContain(
+        "delivered_rate = delivered / (accepted - loopback)",
+      );
+      expect(desc, `${name} must name the bounce formula`).toContain(
+        "bounce_rate = (bounced_hard + bounced_soft + bounced_undetermined) / (submitted - loopback)",
+      );
+      expect(desc, `${name} must preserve the delivered complaint denominator`).toContain(
+        "complaint_rate = complained / delivered",
+      );
+      expect(desc, `${name} must name the suppression formula`).toContain(
+        "suppression_block_rate = suppressed / (accepted - loopback)",
+      );
+    }
+  });
+
   it("forwards the agent selector and parsed window", async () => {
     await client.callTool({
       name: "get_agent_metrics",

--- a/sdks/python/src/e2a/v1/generated/models/metrics_summary_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/metrics_summary_view.py
@@ -135,3 +135,4 @@ class MetricsSummaryView(BaseModel):
 
         return _obj
 
+

--- a/sdks/python/src/e2a/v1/generated/models/metrics_summary_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/metrics_summary_view.py
@@ -26,7 +26,7 @@ class MetricsSummaryView(BaseModel):
     """
     MetricsSummaryView
     """ # noqa: E501
-    accepted: StrictInt = Field(description="Outbound messages e2a accepted from the send API. The denominator for delivered_rate and suppression_block_rate. Counts sends only — the arriving copy of an agent-to-agent loopback delivery is counted under received, not here.")
+    accepted: StrictInt = Field(description="Outbound messages e2a accepted from the send API. External-delivery rates use accepted minus loopback as their denominator. Counts sends only — the arriving copy of an agent-to-agent loopback delivery is counted under received, not here.")
     bounced_hard: StrictInt = Field(description="Permanent bounces. These add the recipient to the suppression list.")
     bounced_soft: StrictInt = Field(description="Transient bounces.")
     bounced_undetermined: StrictInt = Field(description="Bounces the provider did not classify. Kept separate rather than folded into soft, which would understate hard-bounce risk.")
@@ -44,7 +44,7 @@ class MetricsSummaryView(BaseModel):
     review_held: StrictInt = Field(description="Messages placed on a human-in-the-loop review hold.")
     review_rejected: StrictInt = Field(description="Holds a reviewer explicitly rejected.")
     send_failed: StrictInt = Field(description="Messages that reached a terminal submission failure: provider rejection, local retry exhaustion, or policy cancellation. Break the three apart via counters[].")
-    submitted: StrictInt = Field(description="Messages an upstream provider or the loopback path accepted for delivery. The denominator for bounce_rate.")
+    submitted: StrictInt = Field(description="Messages an upstream provider or the loopback path accepted for delivery. The bounce rate uses submitted minus loopback as its denominator; complaint rate is complained ÷ delivered.")
     suppressed: StrictInt = Field(description="Sends blocked before submission because the recipient was on a suppression list. These never left e2a, so an agent sees no bounce and no reply — watch this counter for silent losses.")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["accepted", "bounced_hard", "bounced_soft", "bounced_undetermined", "complained", "delivered", "dmarc_error", "dmarc_fail", "dmarc_none", "dmarc_pass", "loopback", "received", "review_approved", "review_expired_approved", "review_expired_rejected", "review_held", "review_rejected", "send_failed", "submitted", "suppressed"]
@@ -134,5 +134,4 @@ class MetricsSummaryView(BaseModel):
                 _obj.additional_properties[_key] = obj.get(_key)
 
         return _obj
-
 

--- a/sdks/python/tests/test_e2e_resources.py
+++ b/sdks/python/tests/test_e2e_resources.py
@@ -253,10 +253,16 @@ async def test_messages_extended_surface_conversations_and_inbound_facade():
             assert metrics.messages_in_window > 0
             assert metrics.messages_with_lifecycle > 0
             assert metrics.counters, "expected at least one reason-code tally"
-            assert metrics.summary.accepted > 0
-            # A denominator exists now, so the rate is a real number. It stays
-            # None only when there is no traffic at all.
-            assert metrics.rates.delivered_rate is not None
+            # This test sends only to the same agent, so the message takes the
+            # local loopback path. Loopback mail never reaches a recipient
+            # server and is intentionally excluded from delivery-rate
+            # denominators; with no external send, the rate is undefined.
+            assert metrics.summary.accepted == 1
+            assert metrics.summary.submitted == 1
+            assert metrics.summary.loopback == 1
+            assert metrics.summary.received == 1
+            assert metrics.summary.delivered == 0
+            assert metrics.rates.delivered_rate is None
             assert metrics.end > metrics.start
             mark_covered("messages.get_metrics")
 

--- a/sdks/typescript/src/v1/generated/models/MetricsSummaryView.ts
+++ b/sdks/typescript/src/v1/generated/models/MetricsSummaryView.ts
@@ -14,7 +14,7 @@ import { HttpFile } from '../http/http.js';
 
 export class MetricsSummaryView {
     /**
-    * Outbound messages e2a accepted from the send API. The denominator for delivered_rate and suppression_block_rate. Counts sends only — the arriving copy of an agent-to-agent loopback delivery is counted under received, not here.
+    * Outbound messages e2a accepted from the send API. External-delivery rates use accepted minus loopback as their denominator. Counts sends only — the arriving copy of an agent-to-agent loopback delivery is counted under received, not here.
     */
     'accepted': number;
     /**
@@ -86,7 +86,7 @@ export class MetricsSummaryView {
     */
     'sendFailed': number;
     /**
-    * Messages an upstream provider or the loopback path accepted for delivery. The denominator for bounce_rate.
+    * Messages an upstream provider or the loopback path accepted for delivery. The bounce rate uses submitted minus loopback as its denominator; complaint rate is complained ÷ delivered.
     */
     'submitted': number;
     /**

--- a/web/src/app/(app)/metrics/page.test.tsx
+++ b/web/src/app/(app)/metrics/page.test.tsx
@@ -242,7 +242,9 @@ describe("metric tooltips", () => {
 
     await userEvent.click(trigger);
     const tip = screen.getByRole("tooltip");
-    expect(within(tip).getByText(/share of what was actually submitted/)).toBeInTheDocument();
+    expect(
+      within(tip).getByText(/bounces divided by submitted minus loopback/i),
+    ).toBeInTheDocument();
   });
 
   it("is reachable by keyboard, not hover only", async () => {

--- a/web/src/lib/metricDefinitions.test.ts
+++ b/web/src/lib/metricDefinitions.test.ts
@@ -6,7 +6,15 @@ describe("metric help", () => {
     expect(METRIC_HELP.submitted).toMatch(
       /upstream provider or the local loopback path/i,
     );
-    expect(METRIC_HELP.submitted).toMatch(/submitted minus loopback/i);
+    expect(METRIC_HELP.submitted).toMatch(
+      /bounce rate uses submitted minus loopback/i,
+    );
+    expect(METRIC_HELP.submitted).toMatch(
+      /complaint rate is complained divided by delivered/i,
+    );
+    expect(METRIC_HELP.submitted).not.toMatch(
+      /provider-outcome rates use submitted minus loopback/i,
+    );
     expect(METRIC_HELP.deliveredRate).toMatch(
       /delivered.*accepted minus loopback/i,
     );

--- a/web/src/lib/metricDefinitions.test.ts
+++ b/web/src/lib/metricDefinitions.test.ts
@@ -1,0 +1,19 @@
+import { METRIC_HELP } from "./metricDefinitions";
+
+describe("metric help", () => {
+  it("names loopback-adjusted external delivery denominators", () => {
+    expect(METRIC_HELP.accepted).toMatch(/accepted minus loopback/i);
+    expect(METRIC_HELP.submitted).toMatch(
+      /upstream provider or the local loopback path/i,
+    );
+    expect(METRIC_HELP.submitted).toMatch(/submitted minus loopback/i);
+    expect(METRIC_HELP.deliveredRate).toMatch(
+      /delivered.*accepted minus loopback/i,
+    );
+    expect(METRIC_HELP.bounceRate).toMatch(/submitted minus loopback/i);
+    expect(METRIC_HELP.complaintRate).toMatch(/complaints divided by delivered/i);
+    expect(METRIC_HELP.suppressionBlockRate).toMatch(
+      /accepted minus loopback/i,
+    );
+  });
+});

--- a/web/src/lib/metricDefinitions.ts
+++ b/web/src/lib/metricDefinitions.ts
@@ -6,26 +6,26 @@
 // if a definition changes on the server, it changes here in the same PR.
 //
 // Every rate definition NAMES ITS DENOMINATOR, because delivered_rate is over
-// accepted while bounce_rate is over submitted. Two numbers on one page that
-// don't reconcile is the fastest way to lose trust in all of them, and the
-// denominators are the reconciliation.
+// accepted minus loopback while bounce_rate is over submitted minus loopback.
+// Two numbers on one page that don't reconcile is the fastest way to lose
+// trust in all of them, and the denominators are the reconciliation.
 
 export const METRIC_HELP = {
   // ── Rates ──────────────────────────────────────────────
   deliveredRate:
-    "Of everything your agents asked to send OUTWARD, the share a recipient server accepted. Mail stopped by your own review or suppression list still counts against it — this is the honest 'did my mail arrive' number. Mail that actually went agent-to-agent is excluded — it never reaches a recipient server, so it can neither succeed nor fail on this measure. A send stopped before it went anywhere (review-rejected, cancelled) stays in the denominator whether its recipient was local or remote, exactly as a rejected external send does.",
+    "Delivered divided by Accepted minus Loopback. This measures outward sends only; local agent-to-agent delivery is excluded because it reaches no recipient server.",
   bounceRate:
-    "Bounced mail as a share of what was actually submitted to a provider — not of everything accepted, and not counting agent-to-agent mail. That denominator is deliberate: it matches the basis mailbox providers use for the thresholds that can put a sending account under review.",
+    "Hard, soft, and undetermined bounces divided by Submitted minus Loopback. This measures only mail actually submitted to an upstream provider.",
   complaintRate:
-    "Recipients who marked a message as spam, as a share of delivered mail. Mailbox providers compute spam rate over delivered mail, so this denominator matches theirs. This is the number most likely to get sending paused, so the threshold is far lower than it looks.",
+    "Complaints divided by Delivered. Local agent-to-agent delivery is excluded because it cannot produce provider complaint feedback.",
   suppressionBlockRate:
-    "The share of requested sends that never left e2a because the recipient was on a suppression list. These produce no bounce and no reply, so nothing else on this page will flag them — watch this for silent losses.",
+    "Suppressed sends divided by Accepted minus Loopback. This is the share of requested outward sends that never left e2a because the recipient was suppressed.",
 
   // ── Funnel stages ──────────────────────────────────────
   accepted:
-    "Outbound messages e2a accepted from the send API. Counts sends only — the arriving copy of agent-to-agent mail is counted under Received instead.",
+    "Messages e2a accepted from your agents. External-delivery rates use Accepted minus Loopback, so local agent-to-agent delivery never counts as an external success or failure.",
   submitted:
-    "Messages an upstream provider accepted for delivery. The gap between Accepted and Submitted is mail your own policy stopped: held for review, blocked by suppression, or failed before send.",
+    "Messages an upstream provider or the local loopback path accepted for delivery. Provider-outcome rates use Submitted minus Loopback; the remaining gap from Accepted is mail stopped before submission.",
   delivered:
     "Messages a recipient's mail server accepted. This is server acceptance, not inbox placement — no email provider can tell you whether a message landed in the inbox or in spam.",
   bounced:

--- a/web/src/lib/metricDefinitions.ts
+++ b/web/src/lib/metricDefinitions.ts
@@ -25,7 +25,7 @@ export const METRIC_HELP = {
   accepted:
     "Messages e2a accepted from your agents. External-delivery rates use Accepted minus Loopback, so local agent-to-agent delivery never counts as an external success or failure.",
   submitted:
-    "Messages an upstream provider or the local loopback path accepted for delivery. Provider-outcome rates use Submitted minus Loopback; the remaining gap from Accepted is mail stopped before submission.",
+    "Messages an upstream provider or the local loopback path accepted for delivery. The Bounce rate uses Submitted minus Loopback; the Complaint rate is Complained divided by Delivered. The remaining gap from Accepted is mail stopped before submission.",
   delivered:
     "Messages a recipient's mail server accepted. This is server acceptance, not inbox placement — no email provider can tell you whether a message landed in the inbox or in spam.",
   bounced:


### PR DESCRIPTION
## Summary

- Align account day buckets with the active-agent cohort.
- Clarify loopback-adjusted metric denominators in API and dashboard help.
- Preserve the governing complaint-rate contract: `complained / delivered`.

## Contracts

- The existing Python staging contract for a pure self-loopback message keeps
  `accepted`, `submitted`, `loopback`, and `received` at `1`, `delivered` at
  `0`, and `delivered_rate` at `null`.
- Dashboard help now names `accepted - loopback` for external delivery and
  suppression rates, `submitted - loopback` for bounce rate, and
  `complained / delivered` for complaint rate.
- Response shapes and runtime arithmetic are unchanged.

## Validation

- Existing Python staging contract: `sdks/python/tests/test_e2e_resources.py`
  covers the pure-loopback metrics response.
- Focused DB-backed regression:
  `env GOCACHE=/private/tmp/e2a-v178-metrics-go-cache go test -tags integration ./internal/messagelifecycle -run TestAccountMetricsExcludesTrashedAgents -count=1`
- Unit test gate:
  `env GOCACHE=/private/tmp/e2a-v178-metrics-go-cache make test-unit`
- Focused web tests:
  `npm test --prefix web -- --runInBand --runTestsByPath src/lib/metricDefinitions.test.ts 'src/app/(app)/metrics/page.test.tsx'`
- OpenAPI drift gate:
  `env GOCACHE=/private/tmp/e2a-v178-metrics-go-cache make spec-check`
