### PR TITLE
fix(mcp): describe every runtime tool parameter

### DIFF
--- a/mcp/src/tools/legacy.ts
+++ b/mcp/src/tools/legacy.ts
@@ -52,18 +52,46 @@ export function registerLegacyTools(server: McpServer, client: McpClient): void 
       title: "Deprecated alias: send_message",
       annotations: { destructiveHint: false },
       description:
-        "DEPRECATED: use `send_message`. This compatibility alias preserves the historical body/html_body/agent_email inputs for cached MCP clients.",
+        "DEPRECATED — use `send_message` instead. Sends a new email from the agent's inbox to one or more recipients, identical to `send_message` except that it keeps the historical field names (`body`/`html_body`/`agent_email` rather than `text`/`html`/`email`). It exists only for MCP clients pinned to the old schema and gains no new features: templates and scheduled sending are unavailable here. Like `send_message`, it starts a NEW thread — use `reply_to_message` to respond to a message you can see. **`accepted` and `pending_review` are both success, not failure — do NOT re-send.** `accepted` means the send was durably persisted and queued; `pending_review` means a human review hold caught it first. The terminal outcome arrives later via webhook events or by polling `get_message`, not by retrying.",
       inputSchema: strictInputSchema({
         to: z.array(z.string()).describe("Recipient email addresses (one or more)."),
-        subject: z.string(),
+        subject: z.string().describe("Subject line of the new message."),
         body: z.string().describe("Plain-text body. Use html_body for HTML."),
-        html_body: z.string().optional(),
-        cc: z.array(z.string()).optional(),
-        bcc: z.array(z.string()).optional(),
+        html_body: z
+          .string()
+          .optional()
+          .describe(
+            "Optional HTML body, sent alongside `body` as a multipart alternative. `body` stays required — it is what recipients with HTML disabled receive. (`send_message` calls this field `html`.)",
+          ),
+        cc: z
+          .array(z.string())
+          .optional()
+          .describe("Carbon-copy addresses. Visible to every recipient."),
+        bcc: z
+          .array(z.string())
+          .optional()
+          .describe(
+            "Blind-carbon-copy addresses. NOT visible to any other recipient, and absent from the headers the recipient sees.",
+          ),
         attachments: attachmentsArraySchema,
-        conversation_id: z.string().optional(),
-        idempotency_key: z.string().optional(),
-        agent_email: z.string().optional(),
+        conversation_id: z
+          .string()
+          .optional()
+          .describe(
+            "Optional stable conversation grouping ID; reuse it across related sends so e2a grouping follows your runtime's own thread. Maximum 200 characters; no CR/LF. Server generates one if omitted.",
+          ),
+        idempotency_key: z
+          .string()
+          .optional()
+          .describe(
+            "Stable key for retry-safe sends. Set it to deduplicate when the caller has its own retry loop; omit to let the SDK mint a fresh UUIDv4 per call, which protects against network-layer retries only.",
+          ),
+        agent_email: z
+          .string()
+          .optional()
+          .describe(
+            "Sending agent's inbox (full email address). REQUIRED when the credential is account-scoped, since such a credential owns many agents and has no bound agent to default to. Defaults to the bound agent for agent-scoped credentials (omit it there). (`send_message` calls this field `email`.)",
+          ),
       }),
     },
     async (args) =>
@@ -99,11 +127,24 @@ export function registerLegacyTools(server: McpServer, client: McpClient): void 
       title: "Deprecated alias: get_attachment",
       annotations: { readOnlyHint: true },
       description:
-        "DEPRECATED: use `get_attachment` with inline:true. This compatibility alias preserves attachment_index/agent_email inputs and the historical inline base64 response. The current 256 KB inline limit applies.",
+        "DEPRECATED — use `get_attachment` with `inline: true` instead. Returns one attachment's metadata plus its bytes as base64 `data`, always inline. It exists only for MCP clients pinned to the old schema, and it is strictly weaker than `get_attachment`: it cannot return a short-lived `download_url`, so every fetch streams the whole file through your context, and attachments over the 256 KB inline limit fail outright rather than falling back to a URL. Prefer `get_attachment` and hand the `download_url` to whatever needs the file.",
       inputSchema: strictInputSchema({
-        message_id: z.string(),
-        attachment_index: z.number().int().min(0),
-        agent_email: z.string().optional(),
+        message_id: z
+          .string()
+          .describe("ID of the message the attachment belongs to (e.g. msg_…)."),
+        attachment_index: z
+          .number()
+          .int()
+          .min(0)
+          .describe(
+            "0-based index from `get_message`'s `attachments[].index` (stable for a given message_id).",
+          ),
+        agent_email: z
+          .string()
+          .optional()
+          .describe(
+            "Owning agent's inbox (full email address). REQUIRED when the credential is account-scoped; defaults to the bound agent for agent-scoped credentials. (`get_attachment` calls this field `email`.)",
+          ),
       }),
     },
     async (args) =>

--- a/mcp/src/tools/messages.ts
+++ b/mcp/src/tools/messages.ts
@@ -109,6 +109,22 @@ const sendAtField = z
     'Beta: scheduled sending may change before it is declared stable. Optional scheduled-send time in RFC 3339 format with an explicit UTC offset. When set to a future instant, the message is accepted immediately with status "scheduled" and submitted at approximately that time ("not before", accurate to seconds). A value at or before now sends immediately; more than 90 days ahead is rejected. A future send_at whose only recipient is the sending agent\'s own address returns 400 invalid_request because self-delivery is an immediate loopback with no scheduled arm — even when the message would otherwise be held for review. Scheduling survives a review hold: if held, send_at is preserved on the pending_review message (surfaced as scheduled_at) and re-armed on approval — submitted at send_at if still in the future, or immediately if it has already passed. Moving the message to trash before provider submission starts prevents submission; if submission already has a fresh lease, delete returns 409 send_in_progress. Restoring before send_at re-arms it; restoring at or after send_at returns it live with delivery_status=failed and leaves the send canceled.',
   );
 
+// Shared recipient fields. Same wording everywhere the field appears so an
+// agent learns one rule, not three (mirrors emailSelector's reasoning in
+// util.ts). Bcc is called out as invisible: a model that cannot see the
+// difference from the schema will otherwise treat cc and bcc as synonyms.
+const ccField = z
+  .array(z.string())
+  .optional()
+  .describe("Carbon-copy addresses. Visible to every recipient.");
+
+const bccField = z
+  .array(z.string())
+  .optional()
+  .describe(
+    "Blind-carbon-copy addresses. NOT visible to any other recipient, and absent from the headers the recipient sees.",
+  );
+
 export function registerMessageTools(server: McpServer, client: McpClient): void {
   server.registerTool(
     "send_message",
@@ -121,7 +137,12 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
         to: z.array(z.string()).describe("Recipient email addresses (one or more)."),
         subject: z.string().optional().describe("Literal subject. Required unless a template reference is used (then it must be omitted)."),
         text: z.string().optional().describe("Literal plain-text body; use `html` for HTML. Required unless a template reference is used (then it must be omitted)."),
-        html: z.string().optional(),
+        html: z
+          .string()
+          .optional()
+          .describe(
+            "Optional HTML body, sent alongside `text` as a multipart alternative. Always pass `text` too — it is what recipients with HTML disabled receive.",
+          ),
         template_id: z
           .string()
           .optional()
@@ -140,8 +161,8 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
           .describe(
             "Variables for the referenced template ({{name}}, dot paths into nested objects). Missing variables render as EMPTY strings — no error. For raw {{{…_html}}} fragment slots, HTML-escape any user content you splice in. Requires template_id or template_alias. Beta.",
           ),
-        cc: z.array(z.string()).optional(),
-        bcc: z.array(z.string()).optional(),
+        cc: ccField,
+        bcc: bccField,
         attachments: attachmentsArraySchema,
         conversation_id: z
           .string()
@@ -210,13 +231,18 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
       inputSchema: strictInputSchema({
         message_id: z.string().describe("ID of the message to reply to — inbound or one the agent sent (e.g. msg_…)."),
         text: z.string().describe("Plain-text reply body."),
-        html: z.string().optional(),
+        html: z
+          .string()
+          .optional()
+          .describe(
+            "Optional HTML reply body, sent alongside `text` as a multipart alternative. `text` stays required — it is what recipients with HTML disabled receive.",
+          ),
         reply_all: z
           .boolean()
           .optional()
           .describe("If true, copy the original message's Cc list."),
-        cc: z.array(z.string()).optional(),
-        bcc: z.array(z.string()).optional(),
+        cc: ccField,
+        bcc: bccField,
         attachments: attachmentsArraySchema,
         conversation_id: z
           .string()
@@ -286,15 +312,20 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
       inputSchema: strictInputSchema({
         message_id: z.string().describe("ID of the message to forward — inbound or one the agent sent (e.g. msg_…)."),
         to: z.array(z.string()).describe("Forward target addresses (one or more)."),
-        cc: z.array(z.string()).optional(),
-        bcc: z.array(z.string()).optional(),
+        cc: ccField,
+        bcc: bccField,
         text: z
           .string()
           .optional()
           .describe(
             "Optional plain-text comment to prepend above the forwarded content. The original body is appended automatically.",
           ),
-        html: z.string().optional(),
+        html: z
+          .string()
+          .optional()
+          .describe(
+            "Optional HTML version of your prepended comment. The original body and its header block are appended automatically, same as for `text`.",
+          ),
         attachments: attachmentsArraySchema,
         conversation_id: z
           .string()
@@ -429,7 +460,11 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
       description:
         "Returns the full application conversation group — aggregate counts, the participants union (sender + recipient + to + cc + bcc across members), the labels union, and every live member message in chronological order (oldest first). This groups by `conversation_id`, which is independent of email thread topology. Returns a not-found error when no live messages exist for `(agent, conversation_id)`. Use this after `list_conversations` (or whenever you have a `conversation_id` from an inbound/outbound payload) to read the full group.",
       inputSchema: strictInputSchema({
-        conversation_id: z.string(),
+        conversation_id: z
+          .string()
+          .describe(
+            "The grouping ID to read, as returned by `list_conversations` or carried on an inbound/outbound message payload.",
+          ),
         email: emailSelector,
       }),
     },
@@ -451,7 +486,12 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
           .describe(
             "Which folder to list: `inbound` = Inbox (received, default), `outbound` = Sent (this agent's sent mail + held drafts), `all` = both.",
           ),
-        read_status: z.enum(["unread", "read", "all"]).optional(),
+        read_status: z
+          .enum(["unread", "read", "all"])
+          .optional()
+          .describe(
+            "Filter received mail by read state. Defaults to `unread` — pass `all` to see the whole folder, not just what you have yet to open. Applies to inbound only; sent mail has no read state.",
+          ),
         ...paginationInput,
         sort: z
           .enum(["asc", "desc"])
@@ -593,7 +633,11 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
       description:
         "Use after `list_messages` to read one inbound or outbound message in full; for outbound messages, this is also how you poll a send's terminal outcome. Returns text + HTML, direction, labels, delivery/review lifecycle, suspicious-message flags and protection findings, header_from, envelope_from, verified_domain, SPF/DKIM/DMARC evidence, conversation id, and attachment metadata. `truncated:true` means the inbound parser clipped the decoded body. A non-null verified_domain means DMARC passed for the RFC 5322 From domain; it does not authenticate the mailbox local part, a person, or message content. Pass the message's `id` from the list response. **Side effect:** fetching an unread inbound message marks it read — there is no peek-without-consuming and no mark-unread, so only open a message when you mean to consume it. Attachment bytes and raw MIME are intentionally omitted to protect context; the response lists each attachment's filename, content_type, 0-based `index`, and size_bytes. Call `get_attachment` with that index to fetch one file by reference.",
       inputSchema: strictInputSchema({
-        message_id: z.string(),
+        message_id: z
+          .string()
+          .describe(
+            "ID of the message to read (e.g. msg_…), taken from `list_messages`. Opening an unread inbound message marks it read.",
+          ),
         email: emailSelector,
       }),
     },
@@ -615,10 +659,13 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
       description:
         "Beta: returns the ordered transitions e2a observed for one persisted inbound or outbound message; the lifecycle contract may change before it is declared stable. SMTP acceptance, upstream submission, provider delivery feedback, and complaint feedback remain distinct; this does not claim inbox placement. **Cursor-paginated:** returns one page in `transitions` plus `next_cursor` only when more pages remain; pass it back as `cursor` to continue, and stop when it is absent.",
       inputSchema: strictInputSchema({
-        message_id: z.string(),
+        message_id: z
+          .string()
+          .describe("ID of the message whose lifecycle you want (e.g. msg_…)."),
         email: emailSelector,
-        cursor: z.string().optional(),
-        limit: z.number().int().min(1).max(100).optional(),
+        // Share the standard cursor/limit wording rather than re-declaring an
+        // equivalent shape: one pagination rule across every paged tool.
+        ...paginationInput,
       }),
     },
     async (args) =>
@@ -649,7 +696,9 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
       description:
         "Returns one attachment's metadata plus a short-lived `download_url` (+ `expires_at`) — fetch the bytes out of band so binary content never streams through your context (no size limit). `attachment_index` is the 0-based `attachments[].index` from `get_message`. Pass `inline: true` to ALSO get base64 `data` for small attachments (≤256 KB; larger inline requests error) — use this only when you must re-attach the bytes (e.g. forwarding a small file via `send_message`'s `attachments[]`); otherwise hand the `download_url` to whatever needs the file.",
       inputSchema: strictInputSchema({
-        message_id: z.string(),
+        message_id: z
+          .string()
+          .describe("ID of the message the attachment belongs to (e.g. msg_…)."),
         attachment_index: z
           .number()
           .int()


### PR DESCRIPTION
## Summary

Fills in the missing parameter documentation on the agent-scoped MCP tool surface, and rewrites the two deprecated aliases that sit inside it. Description-only — no tool names, schemas, optionality, or handler behavior change.

MCP directories and agent runtimes score servers on tool-definition quality, and they read each tool **standalone**, without the surrounding README or sibling tools for context. Anything the schema doesn't say, the consumer doesn't know.

Three things were wrong:

- **24 parameters across 10 tools had no description at all.** `cc`/`bcc` were bare on all three send paths, so nothing told a model that bcc is invisible to the other recipients. `html` was bare everywhere, with no hint that `text` is still required as the plain-text alternative. `read_status` was a bare enum even though its `unread` default is what makes a naive "show me my inbox" call silently omit already-read mail.
- **`send_email` and `get_attachment_data` described no behavior.** Both said only that they were deprecated and named their replacement. Read on their own they say nothing about what they do. Both now state their behavior, map each historical field to its canonical name (`body`→`text`, `agent_email`→`email`), and say concretely why the replacement is better — `get_attachment_data` cannot return a `download_url`, so it streams every file through the caller's context and hard-fails over the 256 KB inline limit.
- **`get_message_lifecycle` had hand-rolled `cursor`/`limit`,** duplicating `paginationInput`'s shape without its wording. Now shares it, so every paged tool states the same stop condition.

`cc`/`bcc` are also hoisted into shared fields so the wording can't drift between send, reply, and forward — same reasoning as the existing `emailSelector` and `sendAtField`.

## Client surface checklist

Only the MCP surface is touched, and only its prose. Every other row is genuinely N/A: no handler, spec, SDK, CLI, or migration change.

- [x] MCP tools in `mcp/src/tools/` — existing registry assertions in `mcp/tests/{tools,http}.test.ts` still pass unchanged
- [ ] ~~Go handler / migration / OpenAPI / TS SDK / Python SDK / CLI~~ — N/A, no API change

No new tests: the existing suites already assert on description *content* (`tools.test.ts` checks the send-path retry guidance, `delivery-metrics.test.ts` the beta caveats, `list-messages-filter.test.ts` the filter grammar), and these edits are additive to text those tests pin.

## Operational risk

None. No user data, auth, billing, or external integration is touched. The only runtime effect is the text a connecting MCP client sees in `tools/list`. Rollback is a revert.

## Test plan

- [x] `npm test --workspace @e2a/mcp-server` — 322 passed
- [x] `npm run build --workspace @e2a/mcp-server` — clean
- [x] Type tests (`tsc -p tsconfig.type-tests.json`) — clean

Note: `tests/version.test.ts > the live handshake defaults to root VERSION` times out at its 5s limit on a slow machine. **Pre-existing on `main`** — reproduced with this branch's changes stashed — and passes with `--testTimeout=30000`. Unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)