### PR TITLE
chore(web): drop red styling from consent account-scope UI

### DIFF
--- a/web/src/app/oauth/consent/page.tsx
+++ b/web/src/app/oauth/consent/page.tsx
@@ -357,11 +357,8 @@ function ConsentForm({
               className="mt-1"
             />
             <span className="text-sm">
-              <span
-                className="font-medium"
-                style={pickingAccount ? { color: "var(--danger-strong)" } : undefined}
-              >
-                Account — full workspace admin ⚠
+              <span className="font-medium">
+                Account — full workspace admin
               </span>
               <span className="block text-xs text-muted">
                 Everything Agent can do, plus: create/delete inboxes, manage
@@ -381,12 +378,7 @@ function ConsentForm({
         {pickingAccount && (
           <div
             role="alert"
-            className="p-3 text-xs border rounded"
-            style={{
-              background: "var(--danger-bg)",
-              color: "var(--danger-strong)",
-              borderColor: "var(--danger-bg)",
-            }}
+            className="p-3 text-xs border border-border rounded"
           >
             <strong>{client.client_name}</strong> will be able to administer your
             entire e2a workspace. Only continue if you started this from a tool


### PR DESCRIPTION
## What

Softens the OAuth consent screen's Account-scope visuals (`web/src/app/oauth/consent/page.tsx`):

- Removes the danger-red color on the selected "Account — full workspace admin" radio label.
- Removes the ⚠ glyph from that label.
- Removes the red background/color from the account-scope notice banner — it now renders as a plain bordered box with default text color.

The warning copy itself is unchanged, and the redirect-URI-mismatch phishing alert keeps its red danger styling.

## Tests

- `npx jest src/app/oauth/consent` — 11/11 pass.

🤖 Generated with [Kimi Code](https://www.kimi.com/code)
