### PR TITLE
release: publish Python/TypeScript SDK 5.7.0 and CLI 2.4.0

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2.4.0
+
+Additive only — no flag, output-field, or exit-code meaning changes to any
+command that shipped in 2.3.0.
+
+**Added:** `e2a metrics --by-day` prints UTC per-day account buckets, including
+loopback-aware rates and zero-filled days for trend analysis.
+
+**Added:** `e2a reply --quote-history` (beta) asks the server to append
+mail-client-style quoted history beneath the reply body. This flag may change
+before it is declared stable.
+
+**Changed:** metric output reports loopback separately and keeps it out of
+external-delivery rate denominators, matching the API and SDKs.
+
 ## 2.3.0
 
 Additive only — no flag, output-field, or exit-code meaning changes to any

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,12 +5,17 @@
 Additive only — no flag, output-field, or exit-code meaning changes to any
 command that shipped in 2.3.0.
 
-**Added:** `e2a metrics --by-day` prints UTC per-day account buckets, including
-loopback-aware rates and zero-filled days for trend analysis.
+**Added:** `e2a metrics [<agent-email>]` prints account or per-inbox delivery
+counters. `--by-agent` breaks down account totals, and `--by-day` prints UTC
+per-day buckets with loopback-aware rates and zero-filled days for trend
+analysis.
 
 **Added:** `e2a reply --quote-history` (beta) asks the server to append
 mail-client-style quoted history beneath the reply body. This flag may change
 before it is declared stable.
+
+**Added:** `e2a messages list --filter <expr>` passes a server-side boolean
+message filter while preserving it across pagination.
 
 **Changed:** metric output reports loopback separately and keeps it out of
 external-delivery rate denominators, matching the API and SDKs.

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2a/cli",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "CLI for e2a — give any AI agent a real, authenticated email inbox",
   "bin": {
     "e2a": "./dist/bin/e2a.js"
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/tokencanopy/e2a/tree/main/cli",
   "bugs": "https://github.com/tokencanopy/e2a/issues",
   "dependencies": {
-    "@e2a/sdk": "^5.0.0"
+    "@e2a/sdk": "^5.7.0"
   },
   "devDependencies": {
     "@types/node": "^26.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,10 @@
     },
     "cli": {
       "name": "@e2a/cli",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@e2a/sdk": "^5.0.0"
+        "@e2a/sdk": "^5.7.0"
       },
       "bin": {
         "e2a": "dist/bin/e2a.js"
@@ -7915,7 +7915,7 @@
     },
     "sdks/typescript": {
       "name": "@e2a/sdk",
-      "version": "5.6.0",
+      "version": "5.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ws": "^8.21.3"

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 5.7.0
+
+Additive only. Every 5.6.0 call site keeps working identically. Available on
+both ``AsyncE2AClient`` and the synchronous ``E2AClient``.
+
+### Added
+- **Per-day account metrics** via ``client.account.metrics(bucket="day")``.
+  Buckets are UTC-day aligned and gap-filled with zeroes for charting; rate
+  denominators continue to exclude loopback traffic.
+- **Beta ``quote_history`` on ``client.messages.reply``** — when enabled, the
+  server appends mail-client-style quoted history beneath the reply body. This
+  option may change before it is declared stable.
+- **Durable domain-delete receipts** via ``client.domains.delete``. The result's
+  ``sending_teardown`` state indicates whether provider teardown is still
+  pending; pass and reuse ``idempotency_key`` when retrying an ambiguous request
+  so a later registration is not deleted accidentally.
+
 ## 5.6.0
 
 Additive only. Every 5.5.0 call site keeps working identically. Available on

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -6,6 +6,11 @@ Additive only. Every 5.6.0 call site keeps working identically. Available on
 both ``AsyncE2AClient`` and the synchronous ``E2AClient``.
 
 ### Added
+- **Message filtering** via the ``filter`` keyword on ``client.messages.list``.
+  The server pins the expression into continuation cursors so paged results
+  keep the same filter.
+- **Beta per-agent metrics** via ``client.messages.get_metrics(email, ...)``
+  for cohort-window delivery counters and ``None``-safe rates.
 - **Per-day account metrics** via ``client.account.metrics(bucket="day")``.
   Buckets are UTC-day aligned and gap-filled with zeroes for charting; rate
   denominators continue to exclude loopback traffic.

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "e2a"
-version = "5.6.0"
+version = "5.7.0"
 description = "Python SDK for e2a — build AI agents with authenticated email"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -760,7 +760,7 @@ wheels = [
 
 [[package]]
 name = "e2a"
-version = "5.5.0"
+version = "5.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 5.7.0
+
+Additive only. Every 5.6.0 call site keeps compiling and behaving identically.
+
+### Added
+- **Per-day account metrics** via `client.account.metrics({ bucket: "day" })`.
+  Buckets are UTC-day aligned and gap-filled with zeroes for charting; rate
+  denominators continue to exclude loopback traffic.
+- **Beta `quoteHistory` on `client.messages.reply`** — when enabled, the
+  server appends mail-client-style quoted history beneath the reply body.
+  This option may change before it is declared stable.
+- **Durable domain-delete receipts** via `client.domains.delete`. The result's
+  `sendingTeardown` state indicates whether provider teardown is still pending;
+  pass and reuse `idempotencyKey` when retrying an ambiguous request so a later
+  registration is not deleted accidentally.
+
 ## 5.6.0
 
 Additive only. Every 5.5.0 call site keeps compiling and behaving identically.

--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -5,6 +5,11 @@
 Additive only. Every 5.6.0 call site keeps compiling and behaving identically.
 
 ### Added
+- **Message filtering** via the `filter` option on `client.messages.list`.
+  The server pins the expression into continuation cursors so paged results
+  keep the same filter.
+- **Beta per-agent metrics** via `client.messages.getMetrics(email, ...)` for
+  cohort-window delivery counters and null-safe rates.
 - **Per-day account metrics** via `client.account.metrics({ bucket: "day" })`.
   Buckets are UTC-day aligned and gap-filled with zeroes for charting; rate
   denominators continue to exclude loopback traffic.

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2a/sdk",
-  "version": "5.6.0",
+  "version": "5.7.0",
   "description": "TypeScript SDK for e2a — build AI agents with authenticated email",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

- bump the Python SDK and TypeScript SDK to `5.7.0`
- bump the CLI to `2.4.0` and require `@e2a/sdk ^5.7.0`
- document the cumulative v1.7.6–v1.7.8 client surfaces: daily metrics buckets, loopback-aware rates, beta quote history, and durable domain-delete receipts/idempotency
- refresh the Python uv lock and npm workspace lock metadata

This is a coordinated package release only; server/web/MCP runtime bytes are unchanged.

## Verification

- `npm run build --workspace @e2a/sdk`
- `npm test --workspace @e2a/sdk` — 245 tests
- `npm run build --workspace @e2a/cli`
- `npm test --workspace @e2a/cli` — 303 tests
- `python -m pytest tests/ -q` — 554 passed, 48 skipped
- `python -m mypy`
- `python -m build --sdist --wheel`
- `uv lock --check`
- `node scripts/check-sdk-version-sync.mjs`
- npm pack dry-runs for both packages
- `git diff --check`

Publish order after merge: `ts-sdk-v5.7.0`, `python-v5.7.0`, then `cli-v2.4.0`.
