### PR TITLE
fix(identity): check domain ownership before the plan cap on register

### DIFF
--- a/internal/httpapi/domains.go
+++ b/internal/httpapi/domains.go
@@ -511,25 +511,14 @@ func (s *Server) handleRegisterDomain(ctx context.Context, in *registerDomainInp
 		}
 	}
 	maxDomains := 0
-	if !alreadyOwned {
-		// A richly-detailed pre-check (plan code, upgrade URL); ClaimDomain
-		// below is the race-proof source of truth for the cap itself.
-		if s.deps.EnforceDomainCreate != nil {
-			if err := s.deps.EnforceDomainCreate(ctx, user.ID); err != nil {
-				if env, ok := limitEnvelope(err); ok {
-					return nil, env
-				}
-				return nil, NewError(http.StatusInternalServerError, "internal_error", "limits check failed")
-			}
+	if !alreadyOwned && s.deps.GetLimits != nil {
+		lim, err := s.deps.GetLimits(ctx, user.ID)
+		if err != nil {
+			return nil, NewError(http.StatusInternalServerError, "internal_error", "limits check failed")
 		}
-		if s.deps.GetLimits != nil {
-			lim, err := s.deps.GetLimits(ctx, user.ID)
-			if err != nil {
-				return nil, NewError(http.StatusInternalServerError, "internal_error", "limits check failed")
-			}
-			maxDomains = lim.MaxDomains
-		}
+		maxDomains = lim.MaxDomains
 	}
+	// ClaimDomain checks a cross-account conflict before the cap (#825).
 	d, err := s.deps.ClaimDomain(ctx, normalized, user.ID, maxDomains)
 	if err != nil {
 		if errors.Is(err, identity.ErrReservedDomain) {
@@ -540,6 +529,15 @@ func (s *Server) handleRegisterDomain(ctx context.Context, in *registerDomainInp
 		}
 		var limErr *identity.DomainLimitExceededError
 		if errors.As(err, &limErr) {
+			// Ask EnforceDomainCreate for the plan/upgrade-URL details a bare
+			// DomainLimitExceededError doesn't carry.
+			if s.deps.EnforceDomainCreate != nil {
+				if enfErr := s.deps.EnforceDomainCreate(ctx, user.ID); enfErr != nil {
+					if env, ok := limitEnvelope(enfErr); ok {
+						return nil, env
+					}
+				}
+			}
 			return nil, NewError(http.StatusPaymentRequired, "limit_exceeded", limErr.Error()).
 				WithDetails(LimitExceededDetails{Resource: "domains", Limit: int64(limErr.Limit), Current: int64(limErr.Current)})
 		}

--- a/internal/httpapi/domains_limit_test.go
+++ b/internal/httpapi/domains_limit_test.go
@@ -32,22 +32,23 @@ func TestRegisterDomainAtCapAllowsReclaimOfOwnedDomain(t *testing.T) {
 	}
 }
 
-// The skip is scoped to domains the caller actually owns, so it cannot become
-// a way to bypass the cap: LookupDomain filters on user_id, so another
-// account's domain is not "already owned" and stays charged (and would then
-// be rejected as a conflict by the claim itself).
-//
-// This runs against the SHARED ownership-aware fake, not a local override, and
-// that is the point: "other-account.com" is owned by u_1 alone, so the request
-// below only 402s if the handler passes the AUTHENTICATED caller's id. An
-// earlier version of this test used a domain no fake matched for anyone, which
-// meant it exercised the fake's not-found branch and passed even with the
-// scoping removed — the mutation it exists to catch.
-func TestRegisterDomainAtCapStillChargesAnotherAccountsDomain(t *testing.T) {
-	srv := testServer(t)
+// #825: an at-cap caller asking for a domain someone else already owns
+// must get 409 domain_taken, not a 402 that tells them to upgrade a plan
+// that would not fix anything.
+func TestRegisterDomainAtCapStillReturnsConflictForAnotherAccountsDomain(t *testing.T) {
+	srv := testServer(t, func(d *Deps) {
+		// Model claimOrCreateDomain's real ordering: a cross-account name
+		// is ErrDomainTaken no matter what maxDomains is.
+		d.ClaimDomain = func(ctx context.Context, domain, userID string, maxDomains int) (*identity.Domain, error) {
+			if domain == "other-account.com" {
+				return nil, identity.ErrDomainTaken
+			}
+			return &identity.Domain{Domain: domain, Verified: false, VerificationToken: "e2a-verify=new"}, nil
+		}
+	})
 	code, body := postJSON(t, srv.URL+"/v1/domains", "overcap", map[string]any{"domain": "other-account.com"})
-	if code != 402 || errCode(body) != "limit_exceeded" {
-		t.Fatalf("want 402 limit_exceeded for a domain owned by another account, got %d %v", code, body)
+	if code != 409 || errCode(body) != "domain_taken" {
+		t.Fatalf("want 409 domain_taken for a domain owned by another account even when the caller is at cap, got %d %v", code, body)
 	}
 }
 
@@ -79,7 +80,7 @@ func TestRegisterDomainAtCapEnforcesWhenLookupErrors(t *testing.T) {
 
 // ClaimDomain is the race-proof source of truth for max_domains (#822): a
 // DomainLimitExceededError from it must still surface as 402 limit_exceeded,
-// even when EnforceDomainCreate's own pre-check already passed.
+// with EnforceDomainCreate consulted only afterward for the richer details (#825).
 func TestRegisterDomainClaimDomainLimitExceededMapsTo402(t *testing.T) {
 	srv := testServer(t, func(d *Deps) {
 		d.ClaimDomain = func(ctx context.Context, domain, userID string, maxDomains int) (*identity.Domain, error) {

--- a/internal/httpapi/httpapi.go
+++ b/internal/httpapi/httpapi.go
@@ -210,7 +210,9 @@ type Deps struct {
 	ListDomains         func(ctx context.Context, userID string, limit int, afterCreatedAt time.Time, afterDomain string) ([]identity.Domain, error)
 	SendingRampSnapshot func(ctx context.Context, userID, domain string, now time.Time) (sendramp.Snapshot, error)
 	// ClaimDomain atomically enforces maxDomains (<=0 means unlimited) and
-	// claims the domain: the race-proof backstop behind EnforceDomainCreate.
+	// claims the domain. It is the source of truth for both the cap and a
+	// cross-account conflict, checked before EnforceDomainCreate is asked
+	// for a richer plan/upgrade-URL error.
 	ClaimDomain         func(ctx context.Context, domain, userID string, maxDomains int) (*identity.Domain, error)
 	EnforceDomainCreate func(ctx context.Context, userID string) error
 	// DeleteDomain atomically either deletes the live incarnation or resolves

--- a/internal/httpapi/operations_test.go
+++ b/internal/httpapi/operations_test.go
@@ -366,6 +366,14 @@ func testServer(t *testing.T, opts ...func(*Deps)) *httptest.Server {
 			if domain == "taken.com" {
 				return nil, identity.ErrDomainTaken
 			}
+			// Mirror claimOrCreateDomain's real ordering: a cross-account
+			// name is ErrDomainTaken regardless of the caller's cap (#825).
+			if owner, ok := soleOwnerDomains[domain]; ok && owner != userID {
+				return nil, identity.ErrDomainTaken
+			}
+			if maxDomains > 0 && userID == "u_overcap" {
+				return nil, &identity.DomainLimitExceededError{Limit: maxDomains, Current: maxDomains}
+			}
 			return &identity.Domain{Domain: domain, Verified: false, VerificationToken: "e2a-verify=new"}, nil
 		},
 		EnforceDomainCreate: func(ctx context.Context, userID string) error {
@@ -916,6 +924,13 @@ func TestLegacyFallback(t *testing.T) {
 	}
 }
 
+// soleOwnerDomains are singly-owned fixtures shared by fakeLookupDomain and
+// the default ClaimDomain fake, so both agree on who owns what.
+var soleOwnerDomains = map[string]string{
+	"other-account.com": "u_1",
+	"capped-owned.com":  "u_overcap",
+}
+
 // fakeLookupDomain mirrors identity.Store.LookupDomain's USER SCOPING
 // (`WHERE domain = $1 AND user_id = $2`). Modeling ownership matters: a fake
 // that switched on the domain alone — as this one used to — cannot observe
@@ -940,14 +955,7 @@ func fakeLookupDomain(ctx context.Context, domain, userID string) (*identity.Dom
 	if row, ok := shared[domain]; ok {
 		return &row, nil
 	}
-	// Singly-owned fixtures. These are what let a test observe the user id:
-	// each is invisible to every account but its owner, so a handler that
-	// passes "" — or any other account's id — misses.
-	soleOwner := map[string]string{
-		"other-account.com": "u_1",
-		"capped-owned.com":  "u_overcap",
-	}
-	if owner, ok := soleOwner[domain]; ok && owner == userID {
+	if owner, ok := soleOwnerDomains[domain]; ok && owner == userID {
 		return &identity.Domain{Domain: domain, Verified: true}, nil
 	}
 	return nil, errors.New("not registered")


### PR DESCRIPTION
## Summary

`handleRegisterDomain` checked the caller's plan cap before checking domain
ownership. `EnforceDomainCreate` ran first and rejected any at-cap caller
with 402 `limit_exceeded`, even when the domain they were asking for was
already owned by someone else: `ClaimDomain` (`claimOrCreateDomain`), the
call that actually detects that conflict, never ran. The caller got a false,
unactionable "upgrade your plan" error for a request no plan upgrade would
fix; the real answer is 409 `domain_taken`.

`claimOrCreateDomain` already checks the cross-account conflict before the
cap internally, so this is a matter of not pre-empting it: `EnforceDomainCreate`
now runs only after `ClaimDomain` reports a genuine `DomainLimitExceededError`,
where it enriches the 402 with plan/upgrade-URL details instead of gating the
request up front.

## Operational risk

None. No schema, endpoint, or client-facing contract change: same two error
codes (`limit_exceeded`, `domain_taken`) as before, just attributed to the
right condition. No migration.

## Test plan

- `TestRegisterDomainAtCapStillReturnsConflictForAnotherAccountsDomain`
  (new): an at-cap caller registering a domain owned by another account now
  gets 409 `domain_taken`; fails on `main` (got 402 `limit_exceeded`), passes
  on this branch.
- `go test ./internal/httpapi/... ./internal/identity/... ./internal/apiserver/...`
  and the full `go test ./...` both green.
- `go tool cover -func` confirms every line touched in `handleRegisterDomain`
  is exercised by the suite (coverage for the package: 87%, above the 73%
  CI floor).
- Not verified: contention between `ClaimDomain`'s own cap check and a
  concurrent `EnforceDomainCreate` call under a real race (the two now run
  sequentially against the same store, same as before this PR).

Fixes #825
