### PR TITLE
fix(web): stop hero explainer link colliding with CTA buttons

### DIFF
--- a/web/src/app/page.test.tsx
+++ b/web/src/app/page.test.tsx
@@ -199,6 +199,30 @@ describe("Landing page", () => {
     const getStartedLinks = screen.getAllByText(/Get started free/i);
     expect(getStartedLinks.length).toBeGreaterThan(0);
   });
+
+  // Regression: the CTA button rows were `inline-flex`, so in the hero the
+  // "What is email infrastructure…" explainer link (itself inline) flowed
+  // onto the SAME line and sat jammed against "Get started free" instead of
+  // stacking above it. jsdom doesn't compute layout, so the guard is
+  // structural: every CTA row must be a block-level flex container.
+  it("renders the CTA button rows as block-level flex containers", () => {
+    render(<Home />);
+    const rows = screen
+      .getAllByRole("link", { name: /Get started free/ })
+      .map((link) => link.parentElement!);
+    expect(rows).toHaveLength(2); // hero + closing CTA
+    for (const row of rows) {
+      const classes = row.className.split(/\s+/);
+      expect(classes).toContain("flex");
+      expect(classes).not.toContain("inline-flex");
+    }
+    // The hero explainer link the row collided with is still present above.
+    expect(
+      screen.getByRole("link", {
+        name: /What is email infrastructure for AI agents\?/,
+      }),
+    ).toBeInTheDocument();
+  });
 });
 
 // The landing page is the site's main answer surface. These assertions guard

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -373,7 +373,7 @@ export default function Home() {
           >
             What is email infrastructure for AI agents? <span className="font-mono ml-1">→</span>
           </Link>
-          <div className="inline-flex flex-wrap items-center justify-center gap-2.5">
+          <div className="flex flex-wrap items-center justify-center gap-2.5">
             <Link
               href="/get-started"
               className="inline-flex items-center gap-2 px-4 py-2.5 text-[14px] font-medium transition"
@@ -1027,7 +1027,7 @@ export default function Home() {
           >
             Free to start. No credit card. Up and running in under two minutes.
           </p>
-          <div className="inline-flex flex-wrap items-center justify-center gap-2.5">
+          <div className="flex flex-wrap items-center justify-center gap-2.5">
             <Link
               href="/get-started"
               className="inline-flex items-center gap-2 px-4 py-2.5 text-[14px] font-medium"


### PR DESCRIPTION
## Summary

On the marketing landing page, the hero's "What is email infrastructure for AI agents?" explainer link rendered on the same line as the "Get started free" button, jammed up against it. Both the link and the CTA button row were `inline-flex` (inline-level), so they flowed side by side instead of stacking. This makes the CTA rows block-level `flex` containers (`justify-center` keeps them centered) in both places the pattern appears — the hero and the closing CTA section, the latter being the same latent issue that just hadn't collided yet.

Web-only visual fix; no API or client surface touched.

## Operational risk

None — static marketing page markup only.

## Test plan

- [x] New structural regression test in `web/src/app/page.test.tsx`: both CTA rows must be `flex` and not `inline-flex`; verified it fails with the bug reintroduced and passes with the fix
- [x] Full landing-page Jest suite passes (25/25)
- [x] Verified visually against the local dev server — link now stacks centered above the buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)