### PR TITLE
docs: document e2a metrics CLI command, fix stale MCP tool counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ domains/webhooks in the **web dashboard**.
 | `e2a suppressions list\|add\|remove` | Inspect and manage recipient block lists (account-wide GA; agent-scoped is beta) |
 | `e2a send` / `e2a reply` | Send an email as the agent, or reply in-thread |
 | `e2a messages list\|get` | List or fetch messages for an agent |
+| `e2a metrics [<email>]` | Print delivery counters — account rollup, or one inbox (`--by-agent`, `--by-day`, `--json`) |
 | `e2a listen --agent <email>` | Stream inbound email for an agent over WebSocket (real-time; `--json` for raw, `--forward <url>` to bridge to a local HTTP handler) |
 | `e2a config [list\|get\|set]` | View or update the local config |
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -257,6 +257,25 @@ a server-owned, read-only mailbox-local identity. Human-readable formats do
 not change, and there is no `threadId` request flag, filter, or thread
 endpoint.
 
+### `e2a metrics`
+
+Print delivery counters for the account, or a single inbox.
+
+```bash
+e2a metrics                                          # account rollup
+e2a metrics bot@acme.com                              # one inbox
+e2a metrics --by-agent --json                         # account rollup broken down per agent
+e2a metrics --by-day --start 2026-08-01T00:00:00Z --json
+```
+
+With no positional argument this prints the account rollup; with one, that
+inbox's counters (accepted/submitted/delivered, bounces by class, complaints,
+suppressions, inbound DMARC results, review outcomes, and webhook delivery
+health). Flags: `--start`/`--end` (RFC 3339 window bounds), `--by-agent`
+(break the account rollup down per agent — account rollup only), `--by-day`
+(UTC daily buckets — account rollup only), `--json` (print the full metrics
+view as JSON instead of the human-readable summary).
+
 ### `e2a contacts` (beta)
 
 Manage account-level contact identity and per-agent outreach state, with

--- a/docs/runbooks/mcp-server.md
+++ b/docs/runbooks/mcp-server.md
@@ -116,7 +116,7 @@ design.
 
 - **Symptoms**: requests succeed, but the credential is served at
   least-privilege **agent scope**: account-scoped callers see the tool list
-  shrink from 76 tools to the 20 runtime tools, and the per-request default
+  shrink from 78 tools to the 21 runtime tools, and the per-request default
   agent is unset (explicit `email` required).
 - **Detection**: `auth_resolution` WARNING `whoami probe failed; serving
   least-privilege fallback`; `mcp_auth_resolutions_total{result="fallback"}`.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -121,15 +121,15 @@ Hosts that support OAuth connectors can instead add `https://api.e2a.dev/mcp` as
 
 ## Tools
 
-The server exposes up to **76** tools spanning agents, messages, human-in-the-loop
+The server exposes up to **78** tools spanning agents, messages, human-in-the-loop
 approval, attachments, domains, events, webhooks, API keys, contacts/outreach,
 email templates (beta), and suppressions.
 **The visible set depends on your credential's scope:** an **agent**-scoped
-credential sees the 20 runtime/inbox tools (read, send, reply, restore
+credential sees the 21 runtime/inbox tools (read, send, reply, restore
 messages, per-agent outreach); an **account**-scoped credential also sees the
-56 admin/setup tools (agent/domain/webhook/event/template/API-key/contact/
+57 admin/setup tools (agent/domain/webhook/event/template/API-key/contact/
 suppression management — **and HITL review discovery plus approve/reject, which
-is an account-owner action, never agent self-approval**) — all 76.
+is an account-owner action, never agent self-approval**) — all 78.
 Every tool carries MCP annotations (`readOnlyHint`/`destructiveHint`/
 `idempotentHint`) so hosts can auto-approve reads and flag destructive actions.
 The tables below highlight the most commonly used ones — your MCP host's tool list

--- a/mcp/examples/README.md
+++ b/mcp/examples/README.md
@@ -12,7 +12,7 @@ End-to-end demos showing how to wire the e2a MCP surface into popular agent fram
 
 ## One hosted endpoint, same tool surface
 
-Each example exercises the same e2a tool surface (76 tools; the visible set depends on your key's scope) against the hosted MCP server. The Python framework examples ship an `agent.py` script; the Codex example ships a TOML block (Codex is itself the agent, so you configure it instead of writing a script).
+Each example exercises the same e2a tool surface (78 tools; the visible set depends on your key's scope) against the hosted MCP server. The Python framework examples ship an `agent.py` script; the Codex example ships a TOML block (Codex is itself the agent, so you configure it instead of writing a script).
 
 Every example connects to `https://api.e2a.dev/mcp` over Streamable HTTP with an
 agent-scoped API key in the `Authorization` header. Set `E2A_MCP_URL` to point

--- a/mcp/examples/codex/README.md
+++ b/mcp/examples/codex/README.md
@@ -2,7 +2,7 @@
 
 [Codex CLI](https://github.com/openai/codex) is OpenAI's terminal coding agent (peer to Claude Code). It speaks MCP natively — you declare servers in `~/.codex/config.toml` and Codex connects to them at session start, then surfaces their tools to whatever model you're running.
 
-Unlike the [LangChain](../langchain/), [CrewAI](../crewai/), [Google ADK](../adk/), and [OpenAI Agents SDK](../openai-agents/) examples — which are Python scripts you run — Codex is itself the agent. The "example" here is the TOML you paste into your Codex config to add e2a's MCP tools (76 total; the visible set depends on your key's scope).
+Unlike the [LangChain](../langchain/), [CrewAI](../crewai/), [Google ADK](../adk/), and [OpenAI Agents SDK](../openai-agents/) examples — which are Python scripts you run — Codex is itself the agent. The "example" here is the TOML you paste into your Codex config to add e2a's MCP tools (78 total; the visible set depends on your key's scope).
 
 Codex opens a Streamable HTTP session to the hosted endpoint at `https://api.e2a.dev/mcp` with your API key in the `Authorization: Bearer …` header — no Node toolchain on the host (works on CI runners, dev containers, remote app servers, etc.).
 


### PR DESCRIPTION
## Summary

Repo-wide documentation audit found two confirmed, verified issues (see notes below on what was deliberately excluded).

## Changes by file

- **`cli/README.md`, `README.md`** — `e2a metrics` shipped in CLI `2.4.0` (see `cli/CHANGELOG.md`, `cli/src/commands/metrics.ts`, wired into `cli/src/bin/e2a.ts`) but had no `README.md` command-table row and no `cli/README.md` section. Added both, matching the flags actually implemented (`--start`/`--end`, `--by-agent`, `--by-day`, `--json`).
- **`mcp/README.md`, `docs/runbooks/mcp-server.md`, `mcp/examples/README.md`, `mcp/examples/codex/README.md`** — these said the MCP surface is 76 tools (20 runtime + 56 admin), which disagreed with the plugin manifests (`.claude-plugin/plugin.json`, marketplace listings) and `plugins/e2a/skills/e2a/SKILL.md`, which already say 78 (21 runtime + 57 admin). Counted `RUNTIME_TOOLS`/`ADMIN_TOOLS` directly in `mcp/src/tools/tiers.ts`: 21 + 57 = 78, confirming the manifests were right and these four docs were stale. Fixed all four to 78/21/57.

## Notes on scope

Before starting, I checked for prior unmerged doc-audit work: no currently open PR touches documentation (the one open PR, #627, is an unrelated feature). Five earlier documentation-audit branches/PRs (#716, #812, #666, #763, #731) exist but were all closed without merging — each one proposed a "MCP tool count" bump that had already drifted again by review time. To avoid repeating that failure mode, this PR keeps the tool-count fix narrow (verified against the actual `tiers.ts` registry, not against another doc) and leads with a more substantive, durable finding (the missing `metrics` command docs) rather than centering on tool-count churn. A broader audit pass (README/AGENTS.md/docs/*, package READMEs, plugin docs, `web/public/*.md`, changelogs) turned up no other high-confidence issues — see PR description for what was checked and found clean.

## Test plan

- [x] Verified `e2a metrics` flags/behavior by reading `cli/src/commands/metrics.ts` and its wiring in `cli/src/bin/e2a.ts`
- [x] Verified the 78-tool count by counting `RUNTIME_TOOLS`/`ADMIN_TOOLS` in `mcp/src/tools/tiers.ts` directly (not by trusting another doc)
- [x] Grepped the repo for any remaining stale `76 tool`/`20 runtime`/`56 admin` mentions — none found outside `docs/design/`/`docs/superpowers/` (historical, out of scope)

---
_Generated by [Claude Code](https://claude.ai/code/session_0157wC9CQ9eSZBvnkB3ZzfGt)_