### PR TITLE
fix(identity): skip DKIM keygen on a domain reclaim

### DIFF
--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -819,31 +819,6 @@ func (s *Store) claimOrCreateDomain(ctx context.Context, domain, userID string, 
 
 	verificationToken := "e2a-verify=" + generateID()
 
-	// Generate a DKIM keypair for this domain. Failures here are
-	// non-fatal — the columns are nullable and the outbound signer
-	// treats a missing key as "skip DKIM". We still log because key gen
-	// failing is a hard signal (entropy exhaustion or an OS-level
-	// CSPRNG bug) that ops should see.
-	var dkimSelector string
-	var dkimPubKey string
-	var dkimPrivKey []byte
-	if kp, kerr := dkim.GenerateKeypair(); kerr == nil {
-		// Encrypt the private key at rest (#144). On seal failure (catastrophic
-		// RNG) drop ALL three DKIM columns so we never publish a public key /
-		// selector without a usable private key — non-fatal, same posture as a
-		// keygen failure (the signer treats a missing key as "skip DKIM").
-		sealed, serr := s.sealDKIM(kp.PrivateKeyDER, domain)
-		if serr != nil {
-			log.Printf("[identity] dkim key seal failed for %s: %v", domain, serr)
-		} else {
-			dkimSelector = kp.Selector
-			dkimPubKey = kp.PublicKeyDNS
-			dkimPrivKey = sealed
-		}
-	} else {
-		log.Printf("[identity] dkim keygen failed for %s: %v", domain, kerr)
-	}
-
 	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
 		return nil, err
@@ -926,6 +901,32 @@ func (s *Store) claimOrCreateDomain(ctx context.Context, domain, userID string, 
 				return nil, &DomainLimitExceededError{Limit: maxDomains, Current: count}
 			}
 		}
+
+		// Generate a DKIM keypair for this domain. Only reached on a genuine
+		// new row (#826); a re-claim returns above via SELECT and never runs
+		// this. Non-fatal on failure (nullable columns; signer treats a
+		// missing key as "skip DKIM"), logged since it signals RNG/entropy
+		// trouble.
+		var dkimSelector string
+		var dkimPubKey string
+		var dkimPrivKey []byte
+		if kp, kerr := dkim.GenerateKeypair(); kerr == nil {
+			// Encrypt the private key at rest (#144). On seal failure (catastrophic
+			// RNG) drop ALL three DKIM columns so we never publish a public key /
+			// selector without a usable private key, non-fatal, same posture as a
+			// keygen failure (the signer treats a missing key as "skip DKIM").
+			sealed, serr := s.sealDKIM(kp.PrivateKeyDER, domain)
+			if serr != nil {
+				log.Printf("[identity] dkim key seal failed for %s: %v", domain, serr)
+			} else {
+				dkimSelector = kp.Selector
+				dkimPubKey = kp.PublicKeyDNS
+				dkimPrivKey = sealed
+			}
+		} else {
+			log.Printf("[identity] dkim keygen failed for %s: %v", domain, kerr)
+		}
+
 		err = tx.QueryRow(ctx,
 			`INSERT INTO domains (domain, user_id, verified, verification_token, dkim_selector, dkim_public_key, dkim_private_key)
 			 VALUES ($1, $2, false, $3, $4, $5, $6)

--- a/internal/identity/store_test.go
+++ b/internal/identity/store_test.go
@@ -2,8 +2,10 @@ package identity_test
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
+	"io"
 	"reflect"
 	"strings"
 	"testing"
@@ -137,6 +139,51 @@ func TestClaimOrCreateDomain_StableOnReclaim(t *testing.T) {
 	}
 	if !second.CreatedAt.Equal(first.CreatedAt) {
 		t.Errorf("CreatedAt changed on reclaim: first=%v second=%v", first.CreatedAt, second.CreatedAt)
+	}
+}
+
+// countingRandReader counts bytes read through crypto/rand.Reader, so a test
+// can detect an RSA-2048 keygen (tens of KB, vs. 16 bytes for a plain
+// token/ID read) without depending on timing.
+type countingRandReader struct {
+	orig io.Reader
+	n    int
+}
+
+func (c *countingRandReader) Read(p []byte) (int, error) {
+	n, err := c.orig.Read(p)
+	c.n += n
+	return n, err
+}
+
+// TestClaimOrCreateDomain_ReclaimSkipsDKIMKeygen pins #826: a reclaim must
+// not generate and discard a fresh DKIM keypair. Swaps crypto/rand.Reader
+// for a counter; the threshold sits well above generateID's 16 bytes.
+func TestClaimOrCreateDomain_ReclaimSkipsDKIMKeygen(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "owner-keygen@example.com", "Owner", "google-keygen-token")
+
+	if _, err := store.ClaimOrCreateDomain(ctx, "keygen.example.com", user.ID); err != nil {
+		t.Fatalf("first ClaimOrCreateDomain: %v", err)
+	}
+
+	orig := rand.Reader
+	counter := &countingRandReader{orig: orig}
+	rand.Reader = counter
+	_, err := store.ClaimOrCreateDomain(ctx, "keygen.example.com", user.ID)
+	rand.Reader = orig
+	if err != nil {
+		t.Fatalf("reclaim ClaimOrCreateDomain: %v", err)
+	}
+
+	// generateID() alone reads 16 bytes; RSA-2048 keygen reads tens of
+	// thousands. 256 cleanly separates "just the ID" from "also a keypair".
+	const maxExpectedBytes = 256
+	if counter.n > maxExpectedBytes {
+		t.Errorf("reclaim of an already-owned domain read %d bytes from crypto/rand (want <= %d): a DKIM keypair was generated and discarded", counter.n, maxExpectedBytes)
 	}
 }
 


### PR DESCRIPTION
## Summary

`claimOrCreateDomain` generated a fresh RSA-2048 DKIM keypair (plus the AEAD
seal over its private key, #144) before checking whether the domain row
already existed. On a reclaim, the common idempotent path the function's own
docstring describes ("the DKIM keypair are minted on first INSERT and remain
stable across re-claims"), the SELECT branch returns the existing row and the
freshly generated keypair is discarded, unused. Every re-register of an
already-owned domain paid for a full RSA-2048 keygen for nothing.

The fix moves the keygen/seal block into the `pgx.ErrNoRows` branch, right
before the INSERT that is its only consumer, so it runs once per domain
instead of once per call. Stored data is byte-for-byte identical either way;
this only removes the wasted work.


## Operational risk

None. No stored data changes, no API response changes. The keygen/seal now
runs while holding the per-domain advisory lock (previously it ran before the
transaction started), which only extends lock hold time on the once-per-domain
new-row path; the existing `TestClaimOrCreateDomain_ConcurrentParentChildClaimsDoNotSplitOwnership`
and `TestClaimOrCreateDomain_HierarchicalClaimsAreExclusiveAcrossAccounts`
tests still pass unmodified.

## Test plan

- [x] New regression test `TestClaimOrCreateDomain_ReclaimSkipsDKIMKeygen`
  (`internal/identity/store_test.go`): swaps `crypto/rand.Reader` for a
  byte-counter around a reclaim call only. Fails on unmodified `main`
  (120977 bytes read, a real RSA-2048 keygen) and passes on the branch
  (well under the 256-byte threshold, which is comfortably above
  `generateID`'s own unrelated 16-byte read on every call).
- [x] `go vet ./internal/identity/...` and `gofmt -l` on both changed files:
  clean.
- [x] Full `go test ./internal/identity/... ./internal/dkim/...`: all
  passing (505s/1s), including the pre-existing
  `TestClaimOrCreateDomain_StableOnReclaim` (DKIM key/verification token
  stability across reclaim, unaffected) and the two concurrency tests named
  above.
- [x] Docker, Go 1.26 (matching CI's `go-version: "1.26"`) against a
  `postgres:16-alpine` service on `:5433` with the CI's own credentials, the
  same shape `go-coverage`/`go-e2e` use.
- Not run: `make test-e2e` (the separately tagged integration suite) and the
  web/TS/Python/CLI/MCP jobs, none of which touch this file.

Fixes #826
