### PR TITLE
fix(web): render HTML bodies in the review-hold detail view

### DIFF
--- a/web/src/app/(app)/reviews/_components/PendingRow.test.tsx
+++ b/web/src/app/(app)/reviews/_components/PendingRow.test.tsx
@@ -171,6 +171,23 @@ describe("PendingRow", () => {
     expect(screen.queryByText("Subject")).not.toBeInTheDocument();
   });
 
+  it("renders an HTML body the way the recipient's inbox would (sandboxed iframe), not the (HTML body) placeholder", async () => {
+    stage({ body: { text: "", html: "<p>Hello, please see the <b>attached update</b>.</p>" } });
+    render(<PendingRow summary={summary} expanded onToggle={() => {}} onResolved={() => {}} />);
+    await waitFor(() => {
+      const frame = screen.getByTitle("Email body") as HTMLIFrameElement;
+      expect(frame.getAttribute("srcdoc")).toContain("please see the <b>attached update</b>");
+    });
+    expect(screen.queryByText("(HTML body)")).not.toBeInTheDocument();
+  });
+
+  it("falls back to plain text (no iframe) when the draft has no HTML part", async () => {
+    stage();
+    render(<PendingRow summary={summary} expanded onToggle={() => {}} onResolved={() => {}} />);
+    await waitFor(() => expect(screen.getByText(/your refund is on the way/)).toBeInTheDocument());
+    expect(screen.queryByTitle("Email body")).not.toBeInTheDocument();
+  });
+
   it("loads the lifecycle lazily beside Details", async () => {
     stage();
     const user = userEvent.setup();

--- a/web/src/app/(app)/reviews/_components/PendingRow.tsx
+++ b/web/src/app/(app)/reviews/_components/PendingRow.tsx
@@ -29,6 +29,7 @@ import { Chip, Dot } from "@e2a/ui";
 import { diffApproveEdits, joinCSV } from "./edits";
 import { categoryLabel, holdReasonSummary } from "./reviewReason";
 import { MessageLifecycleData } from "../../../components/messages/MessageLifecycleTimeline";
+import { EmailHtmlBody } from "../../../components/messages/EmailHtmlBody";
 
 function formatQueuedAgo(iso: string): string {
   const sec = Math.floor((Date.now() - new Date(iso).getTime()) / 1000);
@@ -447,13 +448,24 @@ export function PendingRow({
                       <MessageLifecycleData email={agentEmail} messageId={id} />
                     </div>
                   )}
-                  <div
-                    className="text-[13px] whitespace-pre-wrap"
-                    style={{ color: "var(--fg)", lineHeight: 1.6 }}
-                  >
-                    {msg.body_text ||
-                      (msg.body_html ? "(HTML body)" : "(empty body)")}
-                  </div>
+                  {msg.body_html && msg.body_html.trim() !== "" ? (
+                    // Render the way it would actually look in the recipient's
+                    // inbox (Gmail-style) — sanitized + sandboxed, same
+                    // component the inbox thread view uses.
+                    <EmailHtmlBody
+                      html={msg.body_html}
+                      attachments={msg.attachments}
+                      email={agentEmail}
+                      messageId={id}
+                    />
+                  ) : (
+                    <div
+                      className="text-[13px] whitespace-pre-wrap"
+                      style={{ color: "var(--fg)", lineHeight: 1.6 }}
+                    >
+                      {msg.body_text || "(empty body)"}
+                    </div>
+                  )}
                 </div>
               ) : (
                 /* EDITOR — opt-in via Edit draft */


### PR DESCRIPTION
## Summary

The "Pending review" hold detail (`PendingRow`) rendered every draft's body as
plain `pre-wrap` text — including a literal `"(HTML body)"` placeholder
whenever a held draft or inbound hold had no plain-text part. The HTML is
already on the wire (`body.html` / `parsed.html`) and the dashboard already
has a safe renderer for it (`EmailHtmlBody`: DOMPurify + sandboxed iframe +
CSP), used today in the inbox thread view (`ThreadBubble`) — it just wasn't
wired into this view.

This renders the HTML body the way it would actually look in the recipient's
inbox (bullets, bold, real hyperlinks) instead of raw markup-ish text, using
the same sanitized/sandboxed component already reviewed and shipped for the
thread view. Falls back to the existing plain-text rendering when a draft has
no HTML part. UI-only — no backend, OpenAPI, or SDK changes.

This PR doesn't touch the API or any client surface, so the client surface
checklist is omitted.

## Operational risk

None — pure read-path rendering change in the web dashboard, reusing an
existing, already-audited sanitization/sandboxing component. No new data is
fetched or exposed; `body_html` was already delivered to the client and
simply wasn't rendered.

## Test plan

- [x] `npm test --workspace web` — 870/870 passing, including two new cases in
      `PendingRow.test.tsx` (HTML body renders via the sandboxed iframe, not
      the `(HTML body)` placeholder; plain-text-only draft still falls back
      correctly)
- [x] `npm run lint` / `tsc --noEmit` — clean
- [x] Verified end-to-end against a local `e2a` instance (Go server + Postgres
      + Mailpit + dashboard): reproduced an outbound draft held for review
      with an HTML body and confirmed it now renders formatted (bullets,
      bold, a real link) inside the sandboxed iframe, and that a
      plain-text-only held draft still renders as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
