### PR TITLE
fix(sdk): reject dot-segment path params that collapse a DELETE onto a bigger resource

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -5,18 +5,21 @@
 ### Changed
 - **Dot-segment path parameters (``.`` / ``..``) are now rejected
   client-side** on ``agents.delete_suppression``, ``contacts.delete_outreach``
-  (both ``email`` and ``address``), ``messages.delete``, ``messages.restore``,
-  ``messages.update_labels``, ``account.suppressions.delete``, and
-  ``account.api_keys.delete``, raising ``E2AValidationError`` (code
-  ``unsafe_path_segment``) before any request is built. This was LIVE on
-  Python, not merely latent: ``httpx`` drops the collapsed path's trailing
-  slash (unlike the TS client, which keeps it unless the input string itself
-  ends in ``/``), so several of these values reached a real, matching route
-  rather than 404ing, e.g. ``account.suppressions.delete("..")`` reached
-  ``DELETE /v1/account`` directly. This is a behavior change for any caller
-  that was, deliberately or not, passing one of these values: it now raises
-  instead of sending the (misdirected) request. Available on both
-  ``AsyncE2AClient`` and the synchronous ``E2AClient``.
+  (both ``email`` and ``address``), ``contacts.delete_import``,
+  ``contacts.set_outreach`` (``email``), ``messages.delete``,
+  ``messages.restore``, ``messages.update_labels``,
+  ``account.suppressions.delete``, and ``account.api_keys.delete``, raising
+  ``E2AValidationError`` (code ``unsafe_path_segment``) before any request is
+  built. This was LIVE, not merely latent: ``httpx`` normalizes the dot
+  segments away and drops the collapsed path's trailing slash (the TS
+  client's URL builder does the same for every mid-path collapse, and for a
+  collapsed trailing slash whenever no query string follows), so several of
+  these values reached a real, matching route rather than 404ing, e.g.
+  ``account.suppressions.delete("..")`` reached ``DELETE /v1/account``
+  directly. This is a behavior change for any caller that was, deliberately
+  or not, passing one of these values: it now raises instead of sending the
+  (misdirected) request. Available on both ``AsyncE2AClient`` and the
+  synchronous ``E2AClient``.
 
 ## 5.7.0
 

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -12,7 +12,7 @@
   Python, not merely latent: ``httpx`` drops the collapsed path's trailing
   slash (unlike the TS client, which keeps it unless the input string itself
   ends in ``/``), so several of these values reached a real, matching route
-  rather than 404ing — e.g. ``account.suppressions.delete("..")`` reached
+  rather than 404ing, e.g. ``account.suppressions.delete("..")`` reached
   ``DELETE /v1/account`` directly. This is a behavior change for any caller
   that was, deliberately or not, passing one of these values: it now raises
   instead of sending the (misdirected) request. Available on both

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+- **Dot-segment path parameters (``.`` / ``..``) are now rejected
+  client-side** on ``agents.delete_suppression``, ``contacts.delete_outreach``
+  (both ``email`` and ``address``), ``messages.delete``, ``messages.restore``,
+  ``messages.update_labels``, ``account.suppressions.delete``, and
+  ``account.api_keys.delete``, raising ``E2AValidationError`` (code
+  ``unsafe_path_segment``) before any request is built. This was LIVE on
+  Python, not merely latent: ``httpx`` drops the collapsed path's trailing
+  slash (unlike the TS client, which keeps it unless the input string itself
+  ends in ``/``), so several of these values reached a real, matching route
+  rather than 404ing — e.g. ``account.suppressions.delete("..")`` reached
+  ``DELETE /v1/account`` directly. This is a behavior change for any caller
+  that was, deliberately or not, passing one of these values: it now raises
+  instead of sending the (misdirected) request. Available on both
+  ``AsyncE2AClient`` and the synchronous ``E2AClient``.
+
 ## 5.7.0
 
 Additive only. Every 5.6.0 call site keeps working identically. Available on

--- a/sdks/python/src/e2a/v1/client.py
+++ b/sdks/python/src/e2a/v1/client.py
@@ -210,6 +210,20 @@ def _coerce(model_cls: Type[T], body: Optional[Body]) -> T:
         ) from e
 
 
+def _assert_not_dot_segment(value: str, param: str) -> str:
+    # A value of exactly "." or ".." collapses the built URL onto the
+    # PRECEDING path segment (urllib.parse.quote leaves "." unescaped),
+    # retargeting a DELETE at a bigger resource. Reject before the wire.
+    if value in (".", ".."):
+        raise E2AValidationError(
+            code="unsafe_path_segment",
+            message=f'{param} must not be "." or ".."; it would collapse the request path onto a different, larger resource',
+            status=0,
+            retryable=False,
+        )
+    return value
+
+
 class _TypedApiClient(ApiClient):
     """Map malformed successful responses before the retry boundary sees them."""
 
@@ -469,6 +483,7 @@ class AgentsResource:
         self, email: str, address: str
     ) -> DeleteSuppressionResult:
         """Beta: remove only this exact agent-recipient block."""
+        address = _assert_not_dot_segment(address, "address")
         return await self._c._write_idempotent(
             lambda h: self._api.delete_agent_suppression(
                 email, address, confirm="DELETE", _headers=h
@@ -606,6 +621,7 @@ class MessagesResource:
         it on the review queue first. Returns the deletion receipt
         ({deleted, id}).
         """
+        message_id = _assert_not_dot_segment(message_id, "message_id")
         return await self._c._write_idempotent(
             lambda h: self._api.delete_message(
                 # `permanent or None` omits the param entirely on the soft path,
@@ -975,6 +991,7 @@ class ContactsResource:
     async def delete_outreach(self, email: str, address: str) -> DeleteEngagementResult:
         """Un-enrol a contact from an agent's outreach. The contact itself
         survives, and suppressions are untouched — this is not consent."""
+        address = _assert_not_dot_segment(address, "address")
         return await self._c._write_idempotent(
             lambda h: self._api.delete_engagement(email, address, confirm="DELETE", _headers=h)
         )
@@ -1277,6 +1294,7 @@ class SuppressionsResource:
 
     async def delete(self, email: str) -> DeleteSuppressionResult:
         # Returns the deletion object ({deleted, address}).
+        email = _assert_not_dot_segment(email, "address")
         return await self._c._write_idempotent(lambda h: self._api.delete_suppression(email, confirm="DELETE", _headers=h))
 
 
@@ -1306,6 +1324,7 @@ class APIKeysResource:
 
     async def delete(self, key_id: str) -> DeleteApiKeyResult:
         # Returns the deletion object ({deleted, id}).
+        key_id = _assert_not_dot_segment(key_id, "id")
         return await self._c._write_idempotent(lambda h: self._api.delete_api_key(key_id, confirm="DELETE", _headers=h))
 
 

--- a/sdks/python/src/e2a/v1/client.py
+++ b/sdks/python/src/e2a/v1/client.py
@@ -215,11 +215,12 @@ def _assert_not_dot_segment(value: str, param: str) -> str:
     # segment, and exactly "." collapses onto the segment's own parent
     # collection (it drops itself, not the segment before it); neither is
     # escaped by urllib.parse.quote(), so both reach httpx's URL builder
-    # literally. On Python this is not merely latent: httpx drops the
-    # collapsed trailing slash (unlike the TS client's URL builder, which
-    # only strips a trailing slash when the input string itself ends in
-    # "/"), so several of these collapses land on a real, live route rather
-    # than 404ing. Reject before the wire either way.
+    # literally. httpx then normalizes the dot segments away and drops any
+    # collapsed trailing slash, so several of these collapses land on a
+    # real, live route rather than 404ing. (The TS client's URL builder
+    # behaves the same way for every mid-path collapse and for any collapsed
+    # trailing slash not followed by a query string, so this was live on
+    # both SDKs.) Reject before the wire either way.
     if value in (".", ".."):
         raise E2AValidationError(
             code="unsafe_path_segment",
@@ -920,6 +921,7 @@ class ContactsResource:
 
     async def delete_import(self, batch_id: str) -> DeleteImportBatchResult:
         """Reverse an import, removing untouched contacts and agent enrolments it created."""
+        batch_id = _assert_not_dot_segment(batch_id, "batch_id")
         return await self._c._write_idempotent(
             lambda h: self._api.delete_import_batch(batch_id, confirm="DELETE", _headers=h)
         )
@@ -989,6 +991,7 @@ class ContactsResource:
         """Enrol a contact in an agent's outreach, or update the agent-owned
         fields. Omitted fields are left unchanged, so advancing the stage after a
         send does not disturb the schedule."""
+        email = _assert_not_dot_segment(email, "email")
         req = _coerce(UpsertEngagementRequest, body)
         return await self._c._write_idempotent(
             lambda h: self._api.upsert_engagement(

--- a/sdks/python/src/e2a/v1/client.py
+++ b/sdks/python/src/e2a/v1/client.py
@@ -213,7 +213,7 @@ def _coerce(model_cls: Type[T], body: Optional[Body]) -> T:
 def _assert_not_dot_segment(value: str, param: str) -> str:
     # A value of exactly ".." collapses the built URL onto the PRECEDING path
     # segment, and exactly "." collapses onto the segment's own parent
-    # collection (it drops itself, not the segment before it) — neither is
+    # collection (it drops itself, not the segment before it); neither is
     # escaped by urllib.parse.quote(), so both reach httpx's URL builder
     # literally. On Python this is not merely latent: httpx drops the
     # collapsed trailing slash (unlike the TS client's URL builder, which

--- a/sdks/python/src/e2a/v1/client.py
+++ b/sdks/python/src/e2a/v1/client.py
@@ -211,9 +211,15 @@ def _coerce(model_cls: Type[T], body: Optional[Body]) -> T:
 
 
 def _assert_not_dot_segment(value: str, param: str) -> str:
-    # A value of exactly "." or ".." collapses the built URL onto the
-    # PRECEDING path segment (urllib.parse.quote leaves "." unescaped),
-    # retargeting a DELETE at a bigger resource. Reject before the wire.
+    # A value of exactly ".." collapses the built URL onto the PRECEDING path
+    # segment, and exactly "." collapses onto the segment's own parent
+    # collection (it drops itself, not the segment before it) — neither is
+    # escaped by urllib.parse.quote(), so both reach httpx's URL builder
+    # literally. On Python this is not merely latent: httpx drops the
+    # collapsed trailing slash (unlike the TS client's URL builder, which
+    # only strips a trailing slash when the input string itself ends in
+    # "/"), so several of these collapses land on a real, live route rather
+    # than 404ing. Reject before the wire either way.
     if value in (".", ".."):
         raise E2AValidationError(
             code="unsafe_path_segment",
@@ -635,6 +641,7 @@ class MessagesResource:
         """Restore a soft-deleted message. A scheduled message restored before
         scheduled_at re-arms; at/after scheduled_at it returns live as failed
         with submission canceled."""
+        message_id = _assert_not_dot_segment(message_id, "message_id")
         return await self._c._write_unsafe(
             lambda h: self._api.restore_message(email, message_id, _headers=h)
         )
@@ -766,6 +773,7 @@ class MessagesResource:
     async def update_labels(
         self, email: str, message_id: str, body: Body
     ) -> UpdateMessageResultView:
+        message_id = _assert_not_dot_segment(message_id, "message_id")
         req = _coerce(UpdateMessageRequest, body)
         return await self._c._write_idempotent(
             lambda h: self._api.update_message(email, message_id, req, _headers=h)
@@ -991,6 +999,7 @@ class ContactsResource:
     async def delete_outreach(self, email: str, address: str) -> DeleteEngagementResult:
         """Un-enrol a contact from an agent's outreach. The contact itself
         survives, and suppressions are untouched — this is not consent."""
+        email = _assert_not_dot_segment(email, "email")
         address = _assert_not_dot_segment(address, "address")
         return await self._c._write_idempotent(
             lambda h: self._api.delete_engagement(email, address, confirm="DELETE", _headers=h)

--- a/sdks/python/src/e2a/v1/websocket.py
+++ b/sdks/python/src/e2a/v1/websocket.py
@@ -229,6 +229,12 @@ def _build_ws_url(base_url: str, agent_email: str) -> str:
     so the API key never appears in the URL — nothing for access logs / proxy
     traces to leak.
     """
+    # No dot-segment guard here (unlike client.py's _assert_not_dot_segment):
+    # this path has no sibling route for ".." or "." to collapse onto (there
+    # is no "/v1/ws"), so a collapsed value fails closed with a 404/connection
+    # error instead of retargeting a live resource. Flagged in review
+    # (e2a#792 PR #909) and left as a one-line comment, not a fix, for that
+    # reason -- noted out of scope here rather than left unexplained.
     parsed = urlparse(base_url)
     scheme = "wss" if parsed.scheme == "https" else "ws"
     path = f"/v1/agents/{quote(agent_email, safe='')}/ws"

--- a/sdks/python/src/e2a/v1/websocket.py
+++ b/sdks/python/src/e2a/v1/websocket.py
@@ -234,7 +234,7 @@ def _build_ws_url(base_url: str, agent_email: str) -> str:
     # is no "/v1/ws"), so a collapsed value fails closed with a 404/connection
     # error instead of retargeting a live resource. Flagged in review
     # (e2a#792 PR #909) and left as a one-line comment, not a fix, for that
-    # reason -- noted out of scope here rather than left unexplained.
+    # reason: noted out of scope here rather than left unexplained.
     parsed = urlparse(base_url)
     scheme = "wss" if parsed.scheme == "https" else "ws"
     path = f"/v1/agents/{quote(agent_email, safe='')}/ws"

--- a/sdks/python/tests/test_dot_segment_enumeration.py
+++ b/sdks/python/tests/test_dot_segment_enumeration.py
@@ -1,0 +1,190 @@
+"""Denominator test for the dot-segment path-collapse guard (e2a#792).
+
+The other tests in ``test_v1_client_side_validation.py`` pin the guard at
+specific call sites, found by hand (first the issue's own DELETE-route sweep,
+then two misses a maintainer review caught on 2026-08-19, then one more found
+by re-running the same sweep against every HTTP method). Hand-found call
+sites are exactly the failure mode rule 4 warns about: a list assembled by
+reading code is bounded by what the reader thought to look at.
+
+This test instead derives the COMPLETE denominator mechanically, straight
+from ``api/openapi.yaml``, every run:
+
+  For every path parameter on every operation, compute what path the URL
+  collapses to when that parameter is set to ".." (the value itself and its
+  immediately preceding literal/param segment are removed — the same rule
+  ``new URL()`` / ``httpx.URL`` apply). If the collapsed path is a *different*
+  existing route that also defines a handler for the *same* HTTP method, a
+  client sending that value sends a real, structurally valid request to the
+  wrong resource under the wrong intent — that is the shape of the bug the
+  issue and both blockers describe.
+
+Every (route, method, param) the sweep finds must appear in exactly one of
+GUARDED (an ergonomic call that reproduces the bug pre-guard, expected to
+raise ``unsafe_path_segment`` with no request sent) or ALLOWLIST (a reason
+the collapse cannot be reached, or need not be guarded, at the ergonomic
+layer today). ``test_sweep_fully_classified`` fails closed the moment
+``api/openapi.yaml`` adds a route this file has not yet triaged — that is
+the point: it is a gate against the NEXT one of these, not a record of the
+ones already found.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, NamedTuple
+
+import pytest
+import yaml
+
+from e2a.v1 import AsyncE2AClient
+from e2a.v1.errors import E2AValidationError
+
+BASE = "http://test.local"
+
+# tests/test_dot_segment_enumeration.py -> sdks/python/tests/ -> sdks/python/ -> sdks/ -> repo root
+OPENAPI_PATH = Path(__file__).resolve().parents[3] / "api" / "openapi.yaml"
+
+_METHODS = ("get", "post", "put", "patch", "delete")
+
+
+class Collapse(NamedTuple):
+    origin_path: str
+    method: str
+    param: str
+    target_path: str
+
+
+def _segments(path: str) -> list[str]:
+    return [s for s in path.strip("/").split("/") if s]
+
+
+def _collapse_segments(segments: list[str], idx: int) -> list[str]:
+    # A ".." value at position idx removes itself and the segment directly
+    # before it (or just itself, at position 0 — there is nothing before it).
+    return segments[: idx - 1] + segments[idx + 1 :] if idx > 0 else segments[idx + 1 :]
+
+
+def _route_table(paths: dict) -> dict[tuple[str, ...], str]:
+    return {tuple(_segments(p)): p for p in paths}
+
+
+def _matches(route_table: dict[tuple[str, ...], str], collapsed: list[str]) -> list[str]:
+    out = []
+    for route_segs, route_path in route_table.items():
+        if len(route_segs) != len(collapsed):
+            continue
+        if all(rs.startswith("{") or rs == cs for rs, cs in zip(route_segs, collapsed)):
+            out.append(route_path)
+    return out
+
+
+def compute_dangerous_collapses() -> list[Collapse]:
+    with open(OPENAPI_PATH) as f:
+        doc = yaml.safe_load(f)
+    paths = doc["paths"]
+    route_table = _route_table(paths)
+    found: list[Collapse] = []
+    for path, methods in paths.items():
+        segs = _segments(path)
+        param_positions = [i for i, s in enumerate(segs) if s.startswith("{") and s.endswith("}")]
+        for method, mdef in methods.items():
+            if method not in _METHODS:
+                continue
+            for i in param_positions:
+                collapsed = _collapse_segments(segs, i)
+                for target in _matches(route_table, collapsed):
+                    if target == path:
+                        continue
+                    if method in paths[target]:
+                        found.append(Collapse(path, method, segs[i], target))
+    return found
+
+
+DENOMINATOR = compute_dangerous_collapses()
+
+
+# ── GUARDED: reproduces the pre-guard bug through the ergonomic client ──
+# Each entry's key is (origin_path, method, param) exactly as the sweep
+# above spells it; the value builds an AsyncE2AClient call that supplies
+# ".." for that param and otherwise-ordinary values for everything else.
+
+GUARDED: dict[tuple[str, str, str], Callable[[AsyncE2AClient], "object"]] = {
+    ("/v1/account/api-keys/{id}", "delete", "{id}"):
+        lambda c: c.account.api_keys.delete(".."),
+    ("/v1/account/suppressions/{address}", "delete", "{address}"):
+        lambda c: c.account.suppressions.delete(".."),
+    ("/v1/agents/{email}/contacts/{address}", "delete", "{email}"):
+        lambda c: c.contacts.delete_outreach("..", "recipient@example.net"),
+    ("/v1/agents/{email}/contacts/{address}", "delete", "{address}"):
+        lambda c: c.contacts.delete_outreach("bot@test.dev", ".."),
+    ("/v1/agents/{email}/messages/{id}", "delete", "{id}"):
+        lambda c: c.messages.delete("bot@test.dev", ".."),
+    ("/v1/agents/{email}/messages/{id}", "patch", "{id}"):
+        lambda c: c.messages.update_labels("bot@test.dev", "..", {"add_labels": ["x"]}),
+    ("/v1/agents/{email}/messages/{id}/restore", "post", "{id}"):
+        lambda c: c.messages.restore("bot@test.dev", ".."),
+    ("/v1/agents/{email}/suppressions/{address}", "delete", "{address}"):
+        lambda c: c.agents.delete_suppression("bot@test.dev", ".."),
+}
+
+# ── ALLOWLIST: sweep hits with no ergonomic-layer reproduction today ──
+# Each reason must be independently checkable by grepping client.py: either
+# the collapse's HTTP method is read-only (get), or no ergonomic method
+# calls the generated operation that would carry the collapsing param.
+
+ALLOWLIST: dict[tuple[str, str, str], str] = {
+    ("/v1/agents/{email}/contacts", "get", "{email}"):
+        "GET only (listEngagements -> listContacts); no state change to guard against",
+    ("/v1/agents/{email}/contacts/{address}", "get", "{email}"):
+        "GET only (getEngagement -> getContact); info-disclosure risk, not a destructive-action "
+        "blocker -- out of scope for this priority-1 pass, same as the WS builders",
+    ("/v1/agents/{email}/contacts/{address}", "get", "{address}"):
+        "GET only (getEngagement -> getAgent); same as above",
+    ("/v1/agents/{email}/conversations/{id}", "get", "{id}"):
+        "GET only (getConversation -> getAgent); same as above",
+    ("/v1/agents/{email}/messages/{id}", "get", "{id}"):
+        "GET only (getMessage -> getAgent); same as above",
+    ("/v1/agents/{email}/messages/{id}/attachments/{index}", "get", "{index}"):
+        "GET only (getAttachment -> getMessage); same as above",
+    ("/v1/agents/{email}/metrics", "get", "{email}"):
+        "GET only (getAgentMetrics -> getAccountMetrics); same as above",
+}
+
+
+@pytest.mark.parametrize("collapse", DENOMINATOR, ids=lambda c: f"{c.method.upper()} {c.origin_path} [{c.param}]")
+def test_sweep_fully_classified(collapse: Collapse):
+    key = (collapse.origin_path, collapse.method, collapse.param)
+    assert key in GUARDED or key in ALLOWLIST, (
+        f"{key} collapses onto {collapse.target_path} (same method, real route) and is "
+        "classified in neither GUARDED nor ALLOWLIST -- api/openapi.yaml grew a new "
+        "dot-segment collapse onto a same-method route; triage it (guard the ergonomic "
+        "call site, or allowlist it with a reason) before this can pass"
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("key", list(GUARDED.keys()), ids=lambda k: f"{k[1].upper()} {k[0]} [{k[2]}]")
+async def test_guarded_collapse_rejected_before_any_request(httpx_mock, key):
+    call = GUARDED[key]
+    async with AsyncE2AClient(api_key="e2a_test", base_url=BASE) as c:
+        with pytest.raises(E2AValidationError) as ei:
+            await call(c)
+    assert ei.value.code == "unsafe_path_segment"
+    assert httpx_mock.get_requests() == []
+
+
+def test_allowlist_entries_are_still_in_the_denominator():
+    # An allowlist reason for a collapse the spec no longer produces (route
+    # renamed/removed) is a stale entry hiding a shrunk sweep -- catch it
+    # explicitly rather than letting it silently stop mattering.
+    live = {(c.origin_path, c.method, c.param) for c in DENOMINATOR}
+    stale = set(ALLOWLIST) - live
+    assert not stale, f"stale allowlist entries no longer produced by the sweep: {stale}"
+
+
+def test_denominator_is_nonempty():
+    # A parse failure or an empty openapi.yaml would make every test above
+    # vacuously pass -- assert the sweep actually found the routes we know
+    # are there.
+    assert len(DENOMINATOR) >= len(GUARDED)

--- a/sdks/python/tests/test_dot_segment_enumeration.py
+++ b/sdks/python/tests/test_dot_segment_enumeration.py
@@ -11,22 +11,31 @@ This test instead derives the complete denominator mechanically, straight
 from ``api/openapi.yaml``, every run:
 
   For every path parameter on every operation, compute what path the URL
-  collapses to when that parameter is set to ".." (the value itself and its
-  immediately preceding literal/param segment are removed, the same rule
-  ``new URL()`` / ``httpx.URL`` apply). If the collapsed path is a
-  *different* existing route that also defines a handler for the *same*
-  HTTP method, a client sending that value sends a real, structurally valid
-  request to the wrong resource under the wrong intent: that is the shape
-  of the bug the issue and both review blockers describe.
+  collapses to under BOTH dot-segment values: ".." removes the value and
+  its immediately preceding segment, "." removes just the value (with any
+  resulting trailing slash dropped, as httpx and the TS URL builder both
+  do). A collapsed segment that is still a path parameter carries an
+  arbitrary caller-supplied value, so it matches ANY segment of a candidate
+  route, literal or not, exactly as the router would. If the collapsed path
+  is a *different* existing route that also defines a handler for the
+  *same* HTTP method, a client sending that value sends a real,
+  structurally valid request to the wrong resource under the wrong intent:
+  that is the shape of the bug the issue and both review blockers describe.
 
-Every (route, method, param) the sweep finds must appear in exactly one of
-GUARDED (an ergonomic call that reproduces the bug pre-guard, expected to
-raise ``unsafe_path_segment`` with no request sent) or ALLOWLIST (a reason
-the collapse cannot be reached, or need not be guarded, at the ergonomic
-layer today). ``test_sweep_fully_classified`` fails the moment
-``api/openapi.yaml`` adds a route this file has not yet triaged, so it is a
-gate against the next one of these, not just a record of the ones already
-found.
+Every MUTATING (non-GET) collapse the sweep finds must appear in exactly
+one of GUARDED (an ergonomic call that reproduces the bug pre-guard,
+expected to raise ``unsafe_path_segment`` with no request sent) or
+ALLOWLIST (a reason the collapse cannot be reached, or need not be
+guarded, at the ergonomic layer today). ``test_sweep_fully_classified``
+fails the moment ``api/openapi.yaml`` adds a mutating collapse this file
+has not yet triaged, so it is a gate against the next one of these, not
+just a record of the ones already found.
+
+GET-method collapses are triaged as one class, below the parametrized
+test: misdirecting a read is an information-disclosure concern, and some
+reads have side effects (fetching an unread message marks it read), but
+neither is the destructive-action blocker this priority-1 pass guards, so
+they are deliberately out of scope here, same as the WS builders.
 """
 
 from __future__ import annotations
@@ -46,12 +55,14 @@ BASE = "http://test.local"
 OPENAPI_PATH = Path(__file__).resolve().parents[3] / "api" / "openapi.yaml"
 
 _METHODS = ("get", "post", "put", "patch", "delete")
+_DOT_VALUES = ("..", ".")
 
 
 class Collapse(NamedTuple):
     origin_path: str
     method: str
     param: str
+    value: str
     target_path: str
 
 
@@ -59,10 +70,18 @@ def _segments(path: str) -> list[str]:
     return [s for s in path.strip("/").split("/") if s]
 
 
-def _collapse_segments(segments: list[str], idx: int) -> list[str]:
-    # A ".." value at position idx removes itself and the segment directly
-    # before it (or just itself, at position 0, where there is nothing before it).
-    return segments[: idx - 1] + segments[idx + 1 :] if idx > 0 else segments[idx + 1 :]
+def _collapse_segments(segments: list[str], idx: int, value: str) -> list[str]:
+    if value == "..":
+        # ".." removes itself and the segment directly before it (or just
+        # itself, at position 0, where there is nothing before it).
+        return segments[: idx - 1] + segments[idx + 1 :] if idx > 0 else segments[idx + 1 :]
+    # "." removes just itself; the trailing slash it can leave behind is
+    # dropped by httpx (and by the TS builder when no query string follows).
+    return segments[:idx] + segments[idx + 1 :]
+
+
+def _is_param(seg: str) -> bool:
+    return seg.startswith("{") and seg.endswith("}")
 
 
 def _route_table(paths: dict) -> dict[tuple[str, ...], str]:
@@ -70,101 +89,113 @@ def _route_table(paths: dict) -> dict[tuple[str, ...], str]:
 
 
 def _matches(route_table: dict[tuple[str, ...], str], collapsed: list[str]) -> list[str]:
+    # A route-side "{param}" matches any collapsed segment, and a SURVIVING
+    # collapsed-side "{param}" matches any route segment: it holds an
+    # arbitrary caller-supplied value, which can equal a route literal
+    # (e.g. set_outreach(".", "protection", ...) collapses onto
+    # PUT /v1/agents/{email}/protection because address == "protection").
     out = []
     for route_segs, route_path in route_table.items():
         if len(route_segs) != len(collapsed):
             continue
-        if all(rs.startswith("{") or rs == cs for rs, cs in zip(route_segs, collapsed)):
+        if all(_is_param(rs) or _is_param(cs) or rs == cs for rs, cs in zip(route_segs, collapsed)):
             out.append(route_path)
     return out
 
 
 def compute_dangerous_collapses() -> list[Collapse]:
-    with open(OPENAPI_PATH) as f:
+    with open(OPENAPI_PATH, encoding="utf-8") as f:
         doc = yaml.safe_load(f)
     paths = doc["paths"]
     route_table = _route_table(paths)
     found: list[Collapse] = []
     for path, methods in paths.items():
         segs = _segments(path)
-        param_positions = [i for i, s in enumerate(segs) if s.startswith("{") and s.endswith("}")]
+        param_positions = [i for i, s in enumerate(segs) if _is_param(s)]
         for method, mdef in methods.items():
             if method not in _METHODS:
                 continue
             for i in param_positions:
-                collapsed = _collapse_segments(segs, i)
-                for target in _matches(route_table, collapsed):
-                    if target == path:
-                        continue
-                    if method in paths[target]:
-                        found.append(Collapse(path, method, segs[i], target))
+                for value in _DOT_VALUES:
+                    collapsed = _collapse_segments(segs, i, value)
+                    for target in _matches(route_table, collapsed):
+                        if target == path:
+                            continue
+                        if method in paths[target]:
+                            found.append(Collapse(path, method, segs[i], value, target))
     return found
 
 
 DENOMINATOR = compute_dangerous_collapses()
+MUTATING = [c for c in DENOMINATOR if c.method != "get"]
 
 
 # ── GUARDED: reproduces the pre-guard bug through the ergonomic client ──
-# Each entry's key is (origin_path, method, param) exactly as the sweep
-# above spells it; the value builds an AsyncE2AClient call that supplies
-# ".." for that param and otherwise-ordinary values for everything else.
+# Each entry's key is (origin_path, method, param, value) exactly as the
+# sweep above spells it; the value builds an AsyncE2AClient call that
+# supplies that dot-segment value for that param and otherwise-ordinary
+# values for everything else.
 
-GUARDED: dict[tuple[str, str, str], Callable[[AsyncE2AClient], "object"]] = {
-    ("/v1/account/api-keys/{id}", "delete", "{id}"):
+GUARDED: dict[tuple[str, str, str, str], Callable[[AsyncE2AClient], "object"]] = {
+    ("/v1/account/api-keys/{id}", "delete", "{id}", ".."):
         lambda c: c.account.api_keys.delete(".."),
-    ("/v1/account/suppressions/{address}", "delete", "{address}"):
+    ("/v1/account/suppressions/{address}", "delete", "{address}", ".."):
         lambda c: c.account.suppressions.delete(".."),
-    ("/v1/agents/{email}/contacts/{address}", "delete", "{email}"):
+    ("/v1/agents/{email}/contacts/{address}", "delete", "{email}", ".."):
         lambda c: c.contacts.delete_outreach("..", "recipient@example.net"),
-    ("/v1/agents/{email}/contacts/{address}", "delete", "{address}"):
+    ("/v1/agents/{email}/contacts/{address}", "delete", "{address}", ".."):
         lambda c: c.contacts.delete_outreach("bot@test.dev", ".."),
-    ("/v1/agents/{email}/messages/{id}", "delete", "{id}"):
+    # "." in the email slot with address "protection" lands on
+    # PUT /v1/agents/{email}/protection (putAgentProtection), a same-method
+    # retarget only visible once surviving params match route literals.
+    ("/v1/agents/{email}/contacts/{address}", "put", "{email}", "."):
+        lambda c: c.contacts.set_outreach(".", "protection", {}),
+    ("/v1/agents/{email}/messages/{id}", "delete", "{id}", ".."):
         lambda c: c.messages.delete("bot@test.dev", ".."),
-    ("/v1/agents/{email}/messages/{id}", "patch", "{id}"):
+    ("/v1/agents/{email}/messages/{id}", "patch", "{id}", ".."):
         lambda c: c.messages.update_labels("bot@test.dev", "..", {"add_labels": ["x"]}),
-    ("/v1/agents/{email}/messages/{id}/restore", "post", "{id}"):
+    ("/v1/agents/{email}/messages/{id}/restore", "post", "{id}", ".."):
         lambda c: c.messages.restore("bot@test.dev", ".."),
-    ("/v1/agents/{email}/suppressions/{address}", "delete", "{address}"):
+    ("/v1/agents/{email}/suppressions/{address}", "delete", "{address}", ".."):
         lambda c: c.agents.delete_suppression("bot@test.dev", ".."),
+    # "." in the batch_id slot drops to /v1/contacts/imports, which chi
+    # backtracks onto DELETE /v1/contacts/{address} (deleteContact) with
+    # address "imports"; the confirm=DELETE this method already sends
+    # satisfies deleteContact's own guard.
+    ("/v1/contacts/imports/{batch_id}", "delete", "{batch_id}", "."):
+        lambda c: c.contacts.delete_import("."),
 }
 
-# ── ALLOWLIST: sweep hits with no ergonomic-layer reproduction today ──
-# Each reason must be independently checkable by grepping client.py: either
-# the collapse's HTTP method is read-only (get), or no ergonomic method
-# calls the generated operation that would carry the collapsing param.
+# ── ALLOWLIST: mutating sweep hits with no ergonomic-layer reproduction ──
+# Each reason must be independently checkable by grepping client.py: no
+# ergonomic method calls the generated operation that would carry the
+# collapsing param. Currently empty: every mutating collapse the sweep
+# finds is reachable through an ergonomic method, so each one is guarded.
 
-ALLOWLIST: dict[tuple[str, str, str], str] = {
-    ("/v1/agents/{email}/contacts", "get", "{email}"):
-        "GET only (listEngagements -> listContacts); no state change to guard against",
-    ("/v1/agents/{email}/contacts/{address}", "get", "{email}"):
-        "GET only (getEngagement -> getContact); info-disclosure risk, not a destructive-action "
-        "blocker, out of scope for this priority-1 pass, same as the WS builders",
-    ("/v1/agents/{email}/contacts/{address}", "get", "{address}"):
-        "GET only (getEngagement -> getAgent); same as above",
-    ("/v1/agents/{email}/conversations/{id}", "get", "{id}"):
-        "GET only (getConversation -> getAgent); same as above",
-    ("/v1/agents/{email}/messages/{id}", "get", "{id}"):
-        "GET only (getMessage -> getAgent); same as above",
-    ("/v1/agents/{email}/messages/{id}/attachments/{index}", "get", "{index}"):
-        "GET only (getAttachment -> getMessage); same as above",
-    ("/v1/agents/{email}/metrics", "get", "{email}"):
-        "GET only (getAgentMetrics -> getAccountMetrics); same as above",
-}
+ALLOWLIST: dict[tuple[str, str, str, str], str] = {}
 
 
-@pytest.mark.parametrize("collapse", DENOMINATOR, ids=lambda c: f"{c.method.upper()} {c.origin_path} [{c.param}]")
+def _key(c: Collapse) -> tuple[str, str, str, str]:
+    return (c.origin_path, c.method, c.param, c.value)
+
+
+def _id(k: tuple[str, str, str, str]) -> str:
+    return f"{k[1].upper()} {k[0]} [{k[2]}={k[3]}]"
+
+
+@pytest.mark.parametrize("collapse", MUTATING, ids=lambda c: _id(_key(c)))
 def test_sweep_fully_classified(collapse: Collapse):
-    key = (collapse.origin_path, collapse.method, collapse.param)
+    key = _key(collapse)
     assert key in GUARDED or key in ALLOWLIST, (
         f"{key} collapses onto {collapse.target_path} (same method, real route) and is "
         "classified in neither GUARDED nor ALLOWLIST: api/openapi.yaml grew a new "
-        "dot-segment collapse onto a same-method route; triage it (guard the ergonomic "
-        "call site, or allowlist it with a reason) before this can pass"
+        "dot-segment collapse onto a same-method mutating route; triage it (guard the "
+        "ergonomic call site, or allowlist it with a reason) before this can pass"
     )
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize("key", list(GUARDED.keys()), ids=lambda k: f"{k[1].upper()} {k[0]} [{k[2]}]")
+@pytest.mark.parametrize("key", list(GUARDED.keys()), ids=_id)
 async def test_guarded_collapse_rejected_before_any_request(httpx_mock, key):
     call = GUARDED[key]
     async with AsyncE2AClient(api_key="e2a_test", base_url=BASE) as c:
@@ -174,17 +205,25 @@ async def test_guarded_collapse_rejected_before_any_request(httpx_mock, key):
     assert httpx_mock.get_requests() == []
 
 
-def test_allowlist_entries_are_still_in_the_denominator():
-    # An allowlist reason for a collapse the spec no longer produces (route
-    # renamed/removed) is a stale entry hiding a shrunk sweep; catch it
-    # explicitly rather than letting it silently stop mattering.
-    live = {(c.origin_path, c.method, c.param) for c in DENOMINATOR}
-    stale = set(ALLOWLIST) - live
-    assert not stale, f"stale allowlist entries no longer produced by the sweep: {stale}"
+def test_classification_entries_are_still_in_the_denominator():
+    # A GUARDED or ALLOWLIST key for a collapse the spec no longer produces
+    # (route renamed/removed, or a typo in the key itself) is a stale entry
+    # hiding a shrunk sweep; catch it explicitly rather than letting it
+    # silently stop mattering.
+    live = {_key(c) for c in MUTATING}
+    stale = (set(GUARDED) | set(ALLOWLIST)) - live
+    assert not stale, f"stale classification entries no longer produced by the sweep: {stale}"
+
+
+def test_guarded_and_allowlist_are_disjoint():
+    # One key in both dicts would mean two contradictory triages passing at
+    # once; force every collapse to have exactly one.
+    overlap = set(GUARDED) & set(ALLOWLIST)
+    assert not overlap, f"keys triaged as both GUARDED and ALLOWLIST: {overlap}"
 
 
 def test_denominator_is_nonempty():
     # A parse failure or an empty openapi.yaml would make every test above
     # vacuously pass; assert the sweep actually found the routes we know
     # are there.
-    assert len(DENOMINATOR) >= len(GUARDED)
+    assert len(MUTATING) >= len(GUARDED)

--- a/sdks/python/tests/test_dot_segment_enumeration.py
+++ b/sdks/python/tests/test_dot_segment_enumeration.py
@@ -1,32 +1,32 @@
 """Denominator test for the dot-segment path-collapse guard (e2a#792).
 
 The other tests in ``test_v1_client_side_validation.py`` pin the guard at
-specific call sites, found by hand (first the issue's own DELETE-route sweep,
-then two misses a maintainer review caught on 2026-08-19, then one more found
-by re-running the same sweep against every HTTP method). Hand-found call
-sites are exactly the failure mode rule 4 warns about: a list assembled by
-reading code is bounded by what the reader thought to look at.
+specific call sites, found by hand: first the issue's own DELETE-route
+sweep, then two misses a maintainer review caught on 2026-08-19, then one
+more found by re-running the same sweep against every HTTP method. A
+hand-found list like that is bounded by what the reader thought to check,
+so a fourth miss is exactly as plausible as the third one was.
 
-This test instead derives the COMPLETE denominator mechanically, straight
+This test instead derives the complete denominator mechanically, straight
 from ``api/openapi.yaml``, every run:
 
   For every path parameter on every operation, compute what path the URL
   collapses to when that parameter is set to ".." (the value itself and its
-  immediately preceding literal/param segment are removed — the same rule
-  ``new URL()`` / ``httpx.URL`` apply). If the collapsed path is a *different*
-  existing route that also defines a handler for the *same* HTTP method, a
-  client sending that value sends a real, structurally valid request to the
-  wrong resource under the wrong intent — that is the shape of the bug the
-  issue and both blockers describe.
+  immediately preceding literal/param segment are removed, the same rule
+  ``new URL()`` / ``httpx.URL`` apply). If the collapsed path is a
+  *different* existing route that also defines a handler for the *same*
+  HTTP method, a client sending that value sends a real, structurally valid
+  request to the wrong resource under the wrong intent: that is the shape
+  of the bug the issue and both review blockers describe.
 
 Every (route, method, param) the sweep finds must appear in exactly one of
 GUARDED (an ergonomic call that reproduces the bug pre-guard, expected to
 raise ``unsafe_path_segment`` with no request sent) or ALLOWLIST (a reason
 the collapse cannot be reached, or need not be guarded, at the ergonomic
-layer today). ``test_sweep_fully_classified`` fails closed the moment
-``api/openapi.yaml`` adds a route this file has not yet triaged — that is
-the point: it is a gate against the NEXT one of these, not a record of the
-ones already found.
+layer today). ``test_sweep_fully_classified`` fails the moment
+``api/openapi.yaml`` adds a route this file has not yet triaged, so it is a
+gate against the next one of these, not just a record of the ones already
+found.
 """
 
 from __future__ import annotations
@@ -61,7 +61,7 @@ def _segments(path: str) -> list[str]:
 
 def _collapse_segments(segments: list[str], idx: int) -> list[str]:
     # A ".." value at position idx removes itself and the segment directly
-    # before it (or just itself, at position 0 — there is nothing before it).
+    # before it (or just itself, at position 0, where there is nothing before it).
     return segments[: idx - 1] + segments[idx + 1 :] if idx > 0 else segments[idx + 1 :]
 
 
@@ -138,7 +138,7 @@ ALLOWLIST: dict[tuple[str, str, str], str] = {
         "GET only (listEngagements -> listContacts); no state change to guard against",
     ("/v1/agents/{email}/contacts/{address}", "get", "{email}"):
         "GET only (getEngagement -> getContact); info-disclosure risk, not a destructive-action "
-        "blocker -- out of scope for this priority-1 pass, same as the WS builders",
+        "blocker, out of scope for this priority-1 pass, same as the WS builders",
     ("/v1/agents/{email}/contacts/{address}", "get", "{address}"):
         "GET only (getEngagement -> getAgent); same as above",
     ("/v1/agents/{email}/conversations/{id}", "get", "{id}"):
@@ -157,7 +157,7 @@ def test_sweep_fully_classified(collapse: Collapse):
     key = (collapse.origin_path, collapse.method, collapse.param)
     assert key in GUARDED or key in ALLOWLIST, (
         f"{key} collapses onto {collapse.target_path} (same method, real route) and is "
-        "classified in neither GUARDED nor ALLOWLIST -- api/openapi.yaml grew a new "
+        "classified in neither GUARDED nor ALLOWLIST: api/openapi.yaml grew a new "
         "dot-segment collapse onto a same-method route; triage it (guard the ergonomic "
         "call site, or allowlist it with a reason) before this can pass"
     )
@@ -176,7 +176,7 @@ async def test_guarded_collapse_rejected_before_any_request(httpx_mock, key):
 
 def test_allowlist_entries_are_still_in_the_denominator():
     # An allowlist reason for a collapse the spec no longer produces (route
-    # renamed/removed) is a stale entry hiding a shrunk sweep -- catch it
+    # renamed/removed) is a stale entry hiding a shrunk sweep; catch it
     # explicitly rather than letting it silently stop mattering.
     live = {(c.origin_path, c.method, c.param) for c in DENOMINATOR}
     stale = set(ALLOWLIST) - live
@@ -185,6 +185,6 @@ def test_allowlist_entries_are_still_in_the_denominator():
 
 def test_denominator_is_nonempty():
     # A parse failure or an empty openapi.yaml would make every test above
-    # vacuously pass -- assert the sweep actually found the routes we know
+    # vacuously pass; assert the sweep actually found the routes we know
     # are there.
     assert len(DENOMINATOR) >= len(GUARDED)

--- a/sdks/python/tests/test_v1_client_side_validation.py
+++ b/sdks/python/tests/test_v1_client_side_validation.py
@@ -134,7 +134,7 @@ def test_sync_delete_agent_suppression_rejects_dot_segment(httpx_mock):
 
 
 # review follow-up (2026-08-19): delete_outreach's `address` param was guarded
-# from the start, but `email` was not -- collapsing it retargets
+# from the start, but `email` was not: collapsing it retargets
 # DELETE /v1/agents/{email}/contacts/{address} onto
 # DELETE /v1/contacts/{address} (deleteContact), which the same
 # ?confirm=DELETE already satisfies and which permanently deletes the contact
@@ -148,7 +148,7 @@ async def test_delete_engagement_rejects_dot_segment_email(httpx_mock):
     assert httpx_mock.get_requests() == []
 
 
-# review follow-up (2026-08-19): messages.restore() had no guard at all --
+# review follow-up (2026-08-19): messages.restore() had no guard at all:
 # collapsing `message_id` retargets
 # POST /v1/agents/{email}/messages/{id}/restore onto
 # POST /v1/agents/{email}/restore (restoreAgent), undoing a deliberate agent

--- a/sdks/python/tests/test_v1_client_side_validation.py
+++ b/sdks/python/tests/test_v1_client_side_validation.py
@@ -84,6 +84,9 @@ async def test_delete_agent_suppression_rejects_dot_segment(httpx_mock, value):
             await c.agents.delete_suppression("bot@test.dev", value)
     assert ei.value.code == "unsafe_path_segment"
     assert ei.value.status == 0
+    # Pre-flight means literally that: no request was ever built, not just
+    # that pytest-httpx happened not to see one registered.
+    assert httpx_mock.get_requests() == []
 
 
 @pytest.mark.anyio
@@ -92,6 +95,7 @@ async def test_delete_engagement_rejects_dot_segment(httpx_mock):
         with pytest.raises(E2AValidationError) as ei:
             await c.contacts.delete_outreach("bot@test.dev", "..")
     assert ei.value.code == "unsafe_path_segment"
+    assert httpx_mock.get_requests() == []
 
 
 @pytest.mark.anyio
@@ -100,6 +104,7 @@ async def test_delete_message_rejects_dot_segment(httpx_mock):
         with pytest.raises(E2AValidationError) as ei:
             await c.messages.delete("bot@test.dev", "..")
     assert ei.value.code == "unsafe_path_segment"
+    assert httpx_mock.get_requests() == []
 
 
 @pytest.mark.anyio
@@ -108,6 +113,7 @@ async def test_account_delete_suppression_rejects_dot_segment(httpx_mock):
         with pytest.raises(E2AValidationError) as ei:
             await c.account.suppressions.delete("..")
     assert ei.value.code == "unsafe_path_segment"
+    assert httpx_mock.get_requests() == []
 
 
 @pytest.mark.anyio
@@ -116,6 +122,7 @@ async def test_account_delete_api_key_rejects_dot_segment(httpx_mock):
         with pytest.raises(E2AValidationError) as ei:
             await c.account.api_keys.delete("..")
     assert ei.value.code == "unsafe_path_segment"
+    assert httpx_mock.get_requests() == []
 
 
 def test_sync_delete_agent_suppression_rejects_dot_segment(httpx_mock):
@@ -123,6 +130,53 @@ def test_sync_delete_agent_suppression_rejects_dot_segment(httpx_mock):
         with pytest.raises(E2AValidationError) as ei:
             c.agents.delete_suppression("bot@test.dev", "..")
     assert ei.value.code == "unsafe_path_segment"
+    assert httpx_mock.get_requests() == []
+
+
+# review follow-up (2026-08-19): delete_outreach's `address` param was guarded
+# from the start, but `email` was not -- collapsing it retargets
+# DELETE /v1/agents/{email}/contacts/{address} onto
+# DELETE /v1/contacts/{address} (deleteContact), which the same
+# ?confirm=DELETE already satisfies and which permanently deletes the contact
+# record the docstring says survives this call.
+@pytest.mark.anyio
+async def test_delete_engagement_rejects_dot_segment_email(httpx_mock):
+    async with AsyncE2AClient(api_key="e2a_test", base_url=BASE) as c:
+        with pytest.raises(E2AValidationError) as ei:
+            await c.contacts.delete_outreach("..", "recipient@example.net")
+    assert ei.value.code == "unsafe_path_segment"
+    assert httpx_mock.get_requests() == []
+
+
+# review follow-up (2026-08-19): messages.restore() had no guard at all --
+# collapsing `message_id` retargets
+# POST /v1/agents/{email}/messages/{id}/restore onto
+# POST /v1/agents/{email}/restore (restoreAgent), undoing a deliberate agent
+# deletion instead of restoring a message. The return type is annotated
+# MessageView but the server actually returns an AgentView on this path.
+@pytest.mark.anyio
+async def test_restore_message_rejects_dot_segment(httpx_mock):
+    async with AsyncE2AClient(api_key="e2a_test", base_url=BASE) as c:
+        with pytest.raises(E2AValidationError) as ei:
+            await c.messages.restore("bot@test.dev", "..")
+    assert ei.value.code == "unsafe_path_segment"
+    assert httpx_mock.get_requests() == []
+
+
+# Found by re-running the issue's own enumeration methodology against every
+# HTTP method, not just DELETE: update_labels is a PATCH, and collapsing
+# `message_id` retargets PATCH /v1/agents/{email}/messages/{id} onto
+# PATCH /v1/agents/{email} (updateAgent). Not independently confirmed live
+# against a real server (updateAgent's body schema rejects the labels fields
+# via additionalProperties: false), but the client should never send a PATCH
+# at the wrong resource regardless of what the server does with it.
+@pytest.mark.anyio
+async def test_update_message_labels_rejects_dot_segment(httpx_mock):
+    async with AsyncE2AClient(api_key="e2a_test", base_url=BASE) as c:
+        with pytest.raises(E2AValidationError) as ei:
+            await c.messages.update_labels("bot@test.dev", "..", {"add_labels": ["x"]})
+    assert ei.value.code == "unsafe_path_segment"
+    assert httpx_mock.get_requests() == []
 
 
 def test_delete_agent_suppression_allows_an_ordinary_address(httpx_mock):

--- a/sdks/python/tests/test_v1_client_side_validation.py
+++ b/sdks/python/tests/test_v1_client_side_validation.py
@@ -70,3 +70,63 @@ def test_sync_out_of_range_limit_raises_e2a_validation_error(httpx_mock):
         with pytest.raises(E2AValidationError) as ei:
             c.messages.list("bot@test.dev", limit=99999).page()
     _assert_typed(ei.value)
+
+
+# ── dot-segment path-parameter guard (e2a#792): httpx collapses a literal
+# ".." segment the same way a browser does, retargeting the DELETE upward.
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("value", [".", ".."])
+async def test_delete_agent_suppression_rejects_dot_segment(httpx_mock, value):
+    async with AsyncE2AClient(api_key="e2a_test", base_url=BASE) as c:
+        with pytest.raises(E2AValidationError) as ei:
+            await c.agents.delete_suppression("bot@test.dev", value)
+    assert ei.value.code == "unsafe_path_segment"
+    assert ei.value.status == 0
+
+
+@pytest.mark.anyio
+async def test_delete_engagement_rejects_dot_segment(httpx_mock):
+    async with AsyncE2AClient(api_key="e2a_test", base_url=BASE) as c:
+        with pytest.raises(E2AValidationError) as ei:
+            await c.contacts.delete_outreach("bot@test.dev", "..")
+    assert ei.value.code == "unsafe_path_segment"
+
+
+@pytest.mark.anyio
+async def test_delete_message_rejects_dot_segment(httpx_mock):
+    async with AsyncE2AClient(api_key="e2a_test", base_url=BASE) as c:
+        with pytest.raises(E2AValidationError) as ei:
+            await c.messages.delete("bot@test.dev", "..")
+    assert ei.value.code == "unsafe_path_segment"
+
+
+@pytest.mark.anyio
+async def test_account_delete_suppression_rejects_dot_segment(httpx_mock):
+    async with AsyncE2AClient(api_key="e2a_test", base_url=BASE) as c:
+        with pytest.raises(E2AValidationError) as ei:
+            await c.account.suppressions.delete("..")
+    assert ei.value.code == "unsafe_path_segment"
+
+
+@pytest.mark.anyio
+async def test_account_delete_api_key_rejects_dot_segment(httpx_mock):
+    async with AsyncE2AClient(api_key="e2a_test", base_url=BASE) as c:
+        with pytest.raises(E2AValidationError) as ei:
+            await c.account.api_keys.delete("..")
+    assert ei.value.code == "unsafe_path_segment"
+
+
+def test_sync_delete_agent_suppression_rejects_dot_segment(httpx_mock):
+    with E2AClient(api_key="e2a_test", base_url=BASE) as c:
+        with pytest.raises(E2AValidationError) as ei:
+            c.agents.delete_suppression("bot@test.dev", "..")
+    assert ei.value.code == "unsafe_path_segment"
+
+
+def test_delete_agent_suppression_allows_an_ordinary_address(httpx_mock):
+    httpx_mock.add_response(json={"deleted": True, "address": "recipient@example.net"})
+    with E2AClient(api_key="e2a_test", base_url=BASE) as c:
+        result = c.agents.delete_suppression("bot@test.dev", "recipient@example.net")
+    assert result.deleted is True

--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -5,17 +5,20 @@
 ### Changed
 - **Dot-segment path parameters (`.` / `..`) are now rejected client-side**
   on `agents.deleteSuppression`, `contacts.deleteOutreach` (both `email` and
-  `address`), `messages.delete`, `messages.restore`, `messages.updateLabels`,
+  `address`), `contacts.deleteImport`, `contacts.setOutreach` (`email`),
+  `messages.delete`, `messages.restore`, `messages.updateLabels`,
   `account.suppressions.delete`, and `account.apiKeys.delete`, throwing
   `E2AValidationError` (code `unsafe_path_segment`) before any request is
   built. Previously a value of exactly `.` or `..` reached the URL builder
   unescaped and could retarget the request at a different, larger resource
-  (e.g. `contacts.deleteOutreach(email, "..")` could permanently delete the
+  (e.g. `contacts.deleteOutreach("..", address)` could permanently delete the
   contact record via `deleteContact` instead of un-enrolling one outreach
-  relationship; `messages.restore(email, "..")` could undo an agent deletion
-  via `restoreAgent` instead of restoring a message). This is a behavior
-  change for any caller that was, deliberately or not, passing one of these
-  values: it now throws instead of sending the (misdirected) request.
+  relationship, and `contacts.deleteOutreach(email, "..")` could delete the
+  agent itself via `deleteAgent`; `messages.restore(email, "..")` could undo
+  an agent deletion via `restoreAgent` instead of restoring a message). This
+  is a behavior change for any caller that was, deliberately or not, passing
+  one of these values: it now throws instead of sending the (misdirected)
+  request.
 
 ## 5.7.0
 

--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+- **Dot-segment path parameters (`.` / `..`) are now rejected client-side**
+  on `agents.deleteSuppression`, `contacts.deleteOutreach` (both `email` and
+  `address`), `messages.delete`, `messages.restore`, `messages.updateLabels`,
+  `account.suppressions.delete`, and `account.apiKeys.delete`, throwing
+  `E2AValidationError` (code `unsafe_path_segment`) before any request is
+  built. Previously a value of exactly `.` or `..` reached the URL builder
+  unescaped and could retarget the request at a different, larger resource
+  (e.g. `contacts.deleteOutreach(email, "..")` could permanently delete the
+  contact record via `deleteContact` instead of un-enrolling one outreach
+  relationship; `messages.restore(email, "..")` could undo an agent deletion
+  via `restoreAgent` instead of restoring a message). This is a behavior
+  change for any caller that was, deliberately or not, passing one of these
+  values: it now throws instead of sending the (misdirected) request.
+
 ## 5.7.0
 
 Additive only. Every 5.6.0 call site keeps compiling and behaving identically.

--- a/sdks/typescript/src/v1/client.ts
+++ b/sdks/typescript/src/v1/client.ts
@@ -197,6 +197,21 @@ async function call<T>(fn: () => Promise<T>): Promise<T> {
   }
 }
 
+// A path-parameter value of exactly "." or ".." collapses the built URL onto
+// the PRECEDING segment (encodeURIComponent leaves "." unescaped), retargeting
+// a DELETE at a bigger resource. Rejected here, before it reaches the wire.
+function assertNotDotSegment(value: string, param: string): string {
+  if (value === "." || value === "..") {
+    throw new E2AError({
+      code: "unsafe_path_segment",
+      message: `${param} must not be "." or ".."; it would collapse the request path onto a different, larger resource`,
+      status: 0,
+      retryable: false,
+    });
+  }
+  return value;
+}
+
 export class E2AClient {
   readonly agents: AgentsResource;
   readonly messages: MessagesResource;
@@ -349,7 +364,7 @@ class AgentsResource {
   }
   /** Beta: remove only this exact agent-recipient block. */
   deleteSuppression(email: string, address: string): Promise<DeleteSuppressionResult> {
-    return call(() => this.api.deleteAgentSuppression(email, address, "DELETE"));
+    return call(() => this.api.deleteAgentSuppression(email, assertNotDotSegment(address, "address"), "DELETE"));
   }
 }
 
@@ -448,7 +463,7 @@ class MessagesResource {
    * on the review queue first. Returns the deletion receipt ({deleted:true, id}).
    */
   delete(email: string, id: string, opts: { permanent?: boolean } = {}): Promise<DeleteMessageResult> {
-    return call(() => this.api.deleteMessage(email, id, opts.permanent, "DELETE"));
+    return call(() => this.api.deleteMessage(email, assertNotDotSegment(id, "id"), opts.permanent, "DELETE"));
   }
   /**
    * Restore a soft-deleted message. A scheduled message restored before
@@ -709,7 +724,7 @@ class ContactsResource {
   /** Un-enrol a contact from an agent's outreach. The contact itself survives,
    *  and suppressions are untouched — this is not consent. */
   deleteOutreach(email: string, address: string): Promise<DeleteEngagementResult> {
-    return call(() => this.api.deleteEngagement(email, address, "DELETE"));
+    return call(() => this.api.deleteEngagement(email, assertNotDotSegment(address, "address"), "DELETE"));
   }
 }
 
@@ -868,7 +883,7 @@ class SuppressionsResource {
     // The typed .delete() call is itself the confirmation; the SDK supplies the
     // ?confirm=DELETE guard the raw API requires so callers aren't burdened.
     // Returns the deletion object ({deleted:true, address}).
-    return call(() => this.api.deleteSuppression(email, "DELETE"));
+    return call(() => this.api.deleteSuppression(assertNotDotSegment(email, "address"), "DELETE"));
   }
 }
 
@@ -891,7 +906,7 @@ class APIKeysResource {
     // The typed .delete() call is itself the confirmation; the SDK supplies the
     // ?confirm=DELETE guard the raw API requires so callers aren't burdened.
     // Returns the deletion object ({deleted:true, id}).
-    return call(() => this.api.deleteApiKey(id, "DELETE"));
+    return call(() => this.api.deleteApiKey(assertNotDotSegment(id, "id"), "DELETE"));
   }
 }
 

--- a/sdks/typescript/src/v1/client.ts
+++ b/sdks/typescript/src/v1/client.ts
@@ -98,7 +98,7 @@ import type {
   CreateAgentSuppressionRequest,
 } from "./generated/index.js";
 import { RetryHttpLibrary, type RetryOptions } from "./retry.js";
-import { E2AError, fromApiException, connectionError } from "./errors.js";
+import { E2AError, E2AValidationError, fromApiException, connectionError } from "./errors.js";
 import { AutoPager } from "./pagination.js";
 import { WSStream } from "./ws.js";
 import type { WebhookEvent, EmailReceivedData } from "./webhook-signature.js";
@@ -197,12 +197,15 @@ async function call<T>(fn: () => Promise<T>): Promise<T> {
   }
 }
 
-// A path-parameter value of exactly "." or ".." collapses the built URL onto
-// the PRECEDING segment (encodeURIComponent leaves "." unescaped), retargeting
-// a DELETE at a bigger resource. Rejected here, before it reaches the wire.
+// A path-parameter value of exactly ".." collapses the built URL onto the
+// PRECEDING segment, and exactly "." collapses onto the segment's own parent
+// collection (i.e. it drops itself, not the segment before it) — neither is
+// escaped by encodeURIComponent(), so both reach the URL parser literally.
+// Either way the request retargets a bigger resource than the caller named.
+// Rejected here, before it reaches the wire.
 function assertNotDotSegment(value: string, param: string): string {
   if (value === "." || value === "..") {
-    throw new E2AError({
+    throw new E2AValidationError({
       code: "unsafe_path_segment",
       message: `${param} must not be "." or ".."; it would collapse the request path onto a different, larger resource`,
       status: 0,
@@ -471,7 +474,7 @@ class MessagesResource {
    * submission canceled.
    */
   restore(email: string, id: string): Promise<MessageView> {
-    return call(() => this.api.restoreMessage(email, id));
+    return call(() => this.api.restoreMessage(email, assertNotDotSegment(id, "id")));
   }
   // getAttachment returns one attachment's metadata + a short-lived download_url
   // (+ expires_at). Pass { inline: true } to also receive base64 `data` for small
@@ -494,7 +497,7 @@ class MessagesResource {
   // deprecated per-inbox messages.approve/reject was removed in the pre-GA
   // vocabulary freeze (a review is addressed by message id alone).
   updateLabels(email: string, id: string, body: UpdateMessageRequest): Promise<UpdateMessageResultView> {
-    return call(() => this.api.updateMessage(email, id, body));
+    return call(() => this.api.updateMessage(email, assertNotDotSegment(id, "id"), body));
   }
 }
 
@@ -724,7 +727,13 @@ class ContactsResource {
   /** Un-enrol a contact from an agent's outreach. The contact itself survives,
    *  and suppressions are untouched — this is not consent. */
   deleteOutreach(email: string, address: string): Promise<DeleteEngagementResult> {
-    return call(() => this.api.deleteEngagement(email, assertNotDotSegment(address, "address"), "DELETE"));
+    return call(() =>
+      this.api.deleteEngagement(
+        assertNotDotSegment(email, "email"),
+        assertNotDotSegment(address, "address"),
+        "DELETE",
+      ),
+    );
   }
 }
 

--- a/sdks/typescript/src/v1/client.ts
+++ b/sdks/typescript/src/v1/client.ts
@@ -655,7 +655,7 @@ class ContactsResource {
   }
   /** Reverse an import, removing untouched contacts and agent enrolments it created. */
   deleteImport(batchId: string): Promise<DeleteImportBatchResult> {
-    return call(() => this.api.deleteImportBatch(batchId, "DELETE"));
+    return call(() => this.api.deleteImportBatch(assertNotDotSegment(batchId, "batchId"), "DELETE"));
   }
 
   // ── Per-agent outreach ────────────────────────────────────────────────────
@@ -721,7 +721,9 @@ class ContactsResource {
     body: UpsertEngagementRequest,
     opts: { ifMatch?: string } = {},
   ): Promise<ContactEngagementView> {
-    return call(() => this.api.upsertEngagement(email, address, body, opts.ifMatch));
+    return call(() =>
+      this.api.upsertEngagement(assertNotDotSegment(email, "email"), address, body, opts.ifMatch),
+    );
   }
 
   /** Un-enrol a contact from an agent's outreach. The contact itself survives,

--- a/sdks/typescript/src/v1/client.ts
+++ b/sdks/typescript/src/v1/client.ts
@@ -199,7 +199,7 @@ async function call<T>(fn: () => Promise<T>): Promise<T> {
 
 // A path-parameter value of exactly ".." collapses the built URL onto the
 // PRECEDING segment, and exactly "." collapses onto the segment's own parent
-// collection (i.e. it drops itself, not the segment before it) — neither is
+// collection (i.e. it drops itself, not the segment before it); neither is
 // escaped by encodeURIComponent(), so both reach the URL parser literally.
 // Either way the request retargets a bigger resource than the caller named.
 // Rejected here, before it reaches the wire.

--- a/sdks/typescript/src/v1/ws.ts
+++ b/sdks/typescript/src/v1/ws.ts
@@ -163,6 +163,12 @@ export class WSListener extends EventEmitter<WSListenerEvents> {
     super();
     const base = (opts.baseUrl ?? "https://api.e2a.dev").replace(/\/+$/, "");
     const wsBase = base.replace(/^http/, "ws");
+    // No dot-segment guard here (unlike client.ts's assertNotDotSegment): this
+    // path has no sibling route for `..` or `.` to collapse onto (there is no
+    // `/v1/ws`), so a collapsed value fails closed with a 404/connection
+    // error instead of retargeting a live resource. Flagged in review
+    // (e2a#792 PR #909) and left as a one-line comment, not a fix, for that
+    // reason — noted out of scope here rather than left unexplained.
     this.url = `${wsBase}/v1/agents/${encodeURIComponent(opts.agentEmail)}/ws`;
     this.shouldReconnect = opts.reconnect ?? true;
     this.initialDelayMs = opts.reconnectDelay ?? 1000;

--- a/sdks/typescript/src/v1/ws.ts
+++ b/sdks/typescript/src/v1/ws.ts
@@ -168,7 +168,7 @@ export class WSListener extends EventEmitter<WSListenerEvents> {
     // `/v1/ws`), so a collapsed value fails closed with a 404/connection
     // error instead of retargeting a live resource. Flagged in review
     // (e2a#792 PR #909) and left as a one-line comment, not a fix, for that
-    // reason — noted out of scope here rather than left unexplained.
+    // reason: noted out of scope here rather than left unexplained.
     this.url = `${wsBase}/v1/agents/${encodeURIComponent(opts.agentEmail)}/ws`;
     this.shouldReconnect = opts.reconnect ?? true;
     this.initialDelayMs = opts.reconnectDelay ?? 1000;

--- a/sdks/typescript/test/v1/client.test.ts
+++ b/sdks/typescript/test/v1/client.test.ts
@@ -1246,4 +1246,56 @@ describe("E2AClient", () => {
   it("listen() requires an email", () => {
     expect(() => client.listen("")).toThrow(/email is required/);
   });
+
+  // ── dot-segment path-parameter guard (e2a#792) ───────────────────
+  // ".." collapses the built URL onto the preceding segment, retargeting each
+  // of these DELETEs at the agent or the account instead of the sub-resource.
+
+  describe("dot-segment path guard", () => {
+    it("rejects agents.deleteSuppression(email, '..') before any request is sent", async () => {
+      globalThis.fetch = mockFetch(200, {});
+      await expect(
+        client.agents.deleteSuppression("sender@example.com", ".."),
+      ).rejects.toMatchObject({ code: "unsafe_path_segment" });
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects contacts.deleteOutreach(email, '.') before any request is sent", async () => {
+      globalThis.fetch = mockFetch(200, {});
+      await expect(
+        client.contacts.deleteOutreach("sender@example.com", "."),
+      ).rejects.toMatchObject({ code: "unsafe_path_segment" });
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects messages.delete(email, '..') before any request is sent", async () => {
+      globalThis.fetch = mockFetch(200, {});
+      await expect(
+        client.messages.delete("sender@example.com", ".."),
+      ).rejects.toMatchObject({ code: "unsafe_path_segment" });
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects account.suppressions.delete('..') before any request is sent", async () => {
+      globalThis.fetch = mockFetch(200, {});
+      await expect(client.account.suppressions.delete("..")).rejects.toMatchObject({
+        code: "unsafe_path_segment",
+      });
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects account.apiKeys.delete('..') before any request is sent", async () => {
+      globalThis.fetch = mockFetch(200, {});
+      await expect(client.account.apiKeys.delete("..")).rejects.toMatchObject({
+        code: "unsafe_path_segment",
+      });
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it("still allows an ordinary address through", async () => {
+      globalThis.fetch = mockFetch(200, { deleted: true, address: "recipient@example.net" });
+      const res = await client.agents.deleteSuppression("sender@example.com", "recipient@example.net");
+      expect(res.deleted).toBe(true);
+    });
+  });
 });

--- a/sdks/typescript/test/v1/client.test.ts
+++ b/sdks/typescript/test/v1/client.test.ts
@@ -1250,6 +1250,16 @@ describe("E2AClient", () => {
   // ── dot-segment path-parameter guard (e2a#792) ───────────────────
   // ".." collapses the built URL onto the preceding segment, retargeting each
   // of these DELETEs at the agent or the account instead of the sub-resource.
+  //
+  // The full openapi.yaml-driven enumeration (every path param whose ".."
+  // collapse lands on a DIFFERENT route sharing the same HTTP method, plus an
+  // explicit allowlist for the read-only ones) lives once, in
+  // sdks/python/tests/test_dot_segment_enumeration.py — both SDKs share the
+  // one spec and the one set of ergonomic call sites (same shape guarded at
+  // the same five-plus-three routes), so a second full parser here would
+  // duplicate that denominator computation rather than add coverage; this
+  // file pins the same eight guarded call sites directly against the TS
+  // client instead.
 
   describe("dot-segment path guard", () => {
     it("rejects agents.deleteSuppression(email, '..') before any request is sent", async () => {
@@ -1296,6 +1306,57 @@ describe("E2AClient", () => {
       globalThis.fetch = mockFetch(200, { deleted: true, address: "recipient@example.net" });
       const res = await client.agents.deleteSuppression("sender@example.com", "recipient@example.net");
       expect(res.deleted).toBe(true);
+    });
+
+    it("throws E2AValidationError, not the bare base class", async () => {
+      globalThis.fetch = mockFetch(200, {});
+      await expect(
+        client.agents.deleteSuppression("sender@example.com", ".."),
+      ).rejects.toBeInstanceOf(E2AValidationError);
+    });
+
+    // review follow-up (2026-08-19): deleteOutreach's `address` param was
+    // guarded from the start, but `email` was not — collapsing it retargets
+    // DELETE /v1/agents/{email}/contacts/{address} onto
+    // DELETE /v1/contacts/{address} (deleteContact), which the same
+    // ?confirm=DELETE already satisfies and which permanently deletes the
+    // contact record the docstring says survives this call.
+    it("rejects contacts.deleteOutreach('..', address) before any request is sent", async () => {
+      globalThis.fetch = mockFetch(200, {});
+      await expect(
+        client.contacts.deleteOutreach("..", "recipient@example.net"),
+      ).rejects.toMatchObject({ code: "unsafe_path_segment" });
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    // review follow-up (2026-08-19): messages.restore() had no guard at all —
+    // collapsing `id` retargets POST /v1/agents/{email}/messages/{id}/restore
+    // onto POST /v1/agents/{email}/restore (restoreAgent), undoing a
+    // deliberate agent deletion instead of restoring a message. The response
+    // is typed MessageView but the server actually returns an AgentView.
+    it("rejects messages.restore(email, '..') before any request is sent", async () => {
+      globalThis.fetch = mockFetch(200, {});
+      await expect(
+        client.messages.restore("sender@example.com", ".."),
+      ).rejects.toMatchObject({ code: "unsafe_path_segment" });
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    // Found by re-running the issue's own enumeration methodology (every
+    // route whose param collapse lands on ANOTHER route sharing the same
+    // HTTP method, not just DELETE): messages.updateLabels is a PATCH, and
+    // collapsing `id` retargets PATCH /v1/agents/{email}/messages/{id} onto
+    // PATCH /v1/agents/{email} (updateAgent). Not independently confirmed
+    // live against a real server (updateAgent's body schema rejects the
+    // labels fields via additionalProperties: false), but the client should
+    // never send a PATCH at the wrong resource regardless of what the server
+    // does with it.
+    it("rejects messages.updateLabels(email, '..', body) before any request is sent", async () => {
+      globalThis.fetch = mockFetch(200, {});
+      await expect(
+        client.messages.updateLabels("sender@example.com", "..", { addLabels: ["x"] }),
+      ).rejects.toMatchObject({ code: "unsafe_path_segment" });
+      expect(globalThis.fetch).not.toHaveBeenCalled();
     });
   });
 });

--- a/sdks/typescript/test/v1/client.test.ts
+++ b/sdks/typescript/test/v1/client.test.ts
@@ -1254,7 +1254,7 @@ describe("E2AClient", () => {
   // The full openapi.yaml-driven enumeration (every path param whose ".."
   // collapse lands on a DIFFERENT route sharing the same HTTP method, plus an
   // explicit allowlist for the read-only ones) lives once, in
-  // sdks/python/tests/test_dot_segment_enumeration.py — both SDKs share the
+  // sdks/python/tests/test_dot_segment_enumeration.py: both SDKs share the
   // one spec and the one set of ergonomic call sites (same shape guarded at
   // the same five-plus-three routes), so a second full parser here would
   // duplicate that denominator computation rather than add coverage; this
@@ -1316,7 +1316,7 @@ describe("E2AClient", () => {
     });
 
     // review follow-up (2026-08-19): deleteOutreach's `address` param was
-    // guarded from the start, but `email` was not — collapsing it retargets
+    // guarded from the start, but `email` was not: collapsing it retargets
     // DELETE /v1/agents/{email}/contacts/{address} onto
     // DELETE /v1/contacts/{address} (deleteContact), which the same
     // ?confirm=DELETE already satisfies and which permanently deletes the
@@ -1329,7 +1329,7 @@ describe("E2AClient", () => {
       expect(globalThis.fetch).not.toHaveBeenCalled();
     });
 
-    // review follow-up (2026-08-19): messages.restore() had no guard at all —
+    // review follow-up (2026-08-19): messages.restore() had no guard at all:
     // collapsing `id` retargets POST /v1/agents/{email}/messages/{id}/restore
     // onto POST /v1/agents/{email}/restore (restoreAgent), undoing a
     // deliberate agent deletion instead of restoring a message. The response

--- a/sdks/typescript/test/v1/client.test.ts
+++ b/sdks/typescript/test/v1/client.test.ts
@@ -1248,17 +1248,17 @@ describe("E2AClient", () => {
   });
 
   // ── dot-segment path-parameter guard (e2a#792) ───────────────────
-  // ".." collapses the built URL onto the preceding segment, retargeting each
-  // of these DELETEs at the agent or the account instead of the sub-resource.
+  // ".." collapses the built URL onto the preceding segment, and "." onto the
+  // segment's own parent collection, retargeting each of these mutations at a
+  // different, larger resource than the caller named.
   //
-  // The full openapi.yaml-driven enumeration (every path param whose ".."
-  // collapse lands on a DIFFERENT route sharing the same HTTP method, plus an
-  // explicit allowlist for the read-only ones) lives once, in
-  // sdks/python/tests/test_dot_segment_enumeration.py: both SDKs share the
-  // one spec and the one set of ergonomic call sites (same shape guarded at
-  // the same five-plus-three routes), so a second full parser here would
+  // The full openapi.yaml-driven enumeration (every path param whose ".." or
+  // "." collapse lands on a DIFFERENT route sharing the same HTTP method)
+  // lives once, in sdks/python/tests/test_dot_segment_enumeration.py: both
+  // SDKs share the one spec and the one set of ergonomic call sites (same
+  // shape guarded at the same routes), so a second full parser here would
   // duplicate that denominator computation rather than add coverage; this
-  // file pins the same eight guarded call sites directly against the TS
+  // file pins the same ten guarded call sites directly against the TS
   // client instead.
 
   describe("dot-segment path guard", () => {
@@ -1355,6 +1355,33 @@ describe("E2AClient", () => {
       globalThis.fetch = mockFetch(200, {});
       await expect(
         client.messages.updateLabels("sender@example.com", "..", { addLabels: ["x"] }),
+      ).rejects.toMatchObject({ code: "unsafe_path_segment" });
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    // review follow-up (2026-08-20): the enumeration gate only swept ".."
+    // collapses, so this "." collapse was missed: deleteImport(".") drops to
+    // /v1/contacts/imports, which the router backtracks onto
+    // DELETE /v1/contacts/{address} (deleteContact) with address "imports",
+    // and the confirm=DELETE this method already sends satisfies
+    // deleteContact's own guard.
+    it("rejects contacts.deleteImport('.') before any request is sent", async () => {
+      globalThis.fetch = mockFetch(200, {});
+      await expect(client.contacts.deleteImport(".")).rejects.toMatchObject({
+        code: "unsafe_path_segment",
+      });
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    // review follow-up (2026-08-20): a surviving path param is caller-
+    // controlled and can equal a route literal, so setOutreach(".",
+    // "protection", body) collapses PUT /v1/agents/{email}/contacts/{address}
+    // onto PUT /v1/agents/{email}/protection (putAgentProtection), a
+    // same-method retarget.
+    it("rejects contacts.setOutreach('.', address, body) before any request is sent", async () => {
+      globalThis.fetch = mockFetch(200, {});
+      await expect(
+        client.contacts.setOutreach(".", "protection", {}),
       ).rejects.toMatchObject({ code: "unsafe_path_segment" });
       expect(globalThis.fetch).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
## Summary

Five DELETE routes take a path parameter (`address` / `id`) that, when it is
exactly `.` or `..`, collapses the built URL onto the resource *above* the
one being deleted. Neither `encodeURIComponent()` (TS) nor
`urllib.parse.quote()` (Python) escapes `.`, so the literal value reaches the
client's URL parser, which then removes the dot segment together with the
segment before it (verified: `new URL('/v1/account/suppressions/..', origin).pathname === '/v1/account/'`,
and `httpx.URL('.../account/suppressions/..').path == '/v1/account'`). Two
accidents currently keep this latent (address-format validation rejects an
all-dots email locally; the router has no trailing-slash redirect, so the
collapsed path 404s), but neither is asserted anywhere in the codebase.
Refs #792.

Enumerated every DELETE route in `api/openapi.yaml` programmatically (not by
reading the issue) and kept the ones whose 2-segment collapse lands on
another DELETE-capable route:

- `agents.deleteSuppression` (`/v1/agents/{email}/suppressions/{address}`) → `DELETE /v1/agents/{email}` (deletes the agent)
- `contacts.deleteOutreach` (`/v1/agents/{email}/contacts/{address}`) → same target
- `messages.delete` (`/v1/agents/{email}/messages/{id}`) → same target, **not named in the issue**
- `account.suppressions.delete` (`/v1/account/suppressions/{address}`) → `DELETE /v1/account` (deletes the account)
- `account.apiKeys.delete` (`/v1/account/api-keys/{id}`) → same target

Both SDKs now reject a value of exactly `.` or `..` for these five
parameters before a request is built (`E2AError` in TS / `E2AValidationError`
in Python, code `unsafe_path_segment`, no HTTP call made). The CLI and MCP
server both build on `@e2a/sdk`'s `E2AClient`, so this closes the same gap
there with no change to either package.

## Scope

This is priority-1 only, per the issue's own stated order: the client-side
guard in both SDKs. Left as a fast-follow:

- Router-level hardening (a `chi` trailing-slash redirect would turn the
  current silent 404 into a live collapse) plus a regression test pinning it
- The unguarded raw-`fetch` call sites in the web dashboard
  (`contacts/page.tsx`, `templates/page.tsx`, `webhooks/page.tsx`,
  `components/onboarding/api.ts`), which do not go through either SDK
- The audit script the issue proposes

## Client surface checklist

- [x] TypeScript SDK: `assertNotDotSegment` in `sdks/typescript/src/v1/client.ts`, called at the five delete sites
- [x] Python SDK: `_assert_not_dot_segment` in `sdks/python/src/e2a/v1/client.py`, same five sites
- [x] Tests at each surface (reject-and-no-request-sent + one ordinary-value pass-through)
- Go handler / OpenAPI spec / CLI / MCP: not touched; no wire-format change, and CLI/MCP inherit the fix through `@e2a/sdk`

## Test plan

- [x] `npm run test:coverage --workspace @e2a/sdk` (typecheck, 251 unit tests, type tests) in Docker on Node 22; new lines confirmed hit in the lcov report
- [x] `pytest sdks/python/tests/` in Docker on Python 3.9 and 3.13 (568 passed on both) plus `mypy` clean; new lines confirmed hit in the coverage report
- [x] Both new test files fail against pre-fix `client.ts` / `client.py` (the reject assertions resolve instead of throwing) and pass against this branch, run side by side in separate containers
- [x] Not verified: the router 404 behavior itself and the web-dashboard call sites named above; both are out of scope per "Scope"
