### PR TITLE
fix(contract): strict-decode scenarios.yaml so a typo'd key is a decode error

### DIFF
--- a/tests/contract/contract_test.go
+++ b/tests/contract/contract_test.go
@@ -919,17 +919,55 @@ func extractEmailFromWSPath(path string) string {
 
 // ── Entry point ────────────────────────────────────────────────────
 
+// decodeScenarios parses scenario YAML with strict field checking, so an
+// unknown key (a typo) is a decode error instead of a silently dropped field.
+func decodeScenarios(data []byte) (scenarioFile, error) {
+	var sf scenarioFile
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&sf); err != nil {
+		return scenarioFile{}, err
+	}
+	return sf, nil
+}
+
 func loadScenarios(t *testing.T) []scenario {
 	t.Helper()
 	data, err := os.ReadFile("scenarios.yaml")
 	if err != nil {
 		t.Fatalf("load scenarios.yaml: %v", err)
 	}
-	var sf scenarioFile
-	if err := yaml.Unmarshal(data, &sf); err != nil {
+	sf, err := decodeScenarios(data)
+	if err != nil {
 		t.Fatalf("parse scenarios.yaml: %v", err)
 	}
 	return sf.Scenarios
+}
+
+// TestDecodeScenariosRejectsUnknownFields pins decodeScenarios: a misspelled
+// key must fail the decode instead of silently vanishing.
+func TestDecodeScenariosRejectsUnknownFields(t *testing.T) {
+	const badYAML = `
+scenarios:
+  - name: typo
+    description: a typo'd assertion key must not be silently ignored
+    steps:
+      - id: s1
+        action: request
+        method: GET
+        path: /v1/health
+        expect:
+          status: 200
+          body_matchs:
+            ok: true
+`
+	_, err := decodeScenarios([]byte(badYAML))
+	if err == nil {
+		t.Fatal("decodeScenarios silently accepted an unknown field (body_matchs); want a strict-decode error")
+	}
+	if !strings.Contains(err.Error(), "body_matchs") {
+		t.Fatalf("decode error = %q, want it to name the unknown field", err)
+	}
 }
 
 // requireCappedKey fails a scenario that asks for the capped account when the


### PR DESCRIPTION
## Summary

`loadScenarios` (`tests/contract/contract_test.go`) parses `scenarios.yaml` with plain `yaml.Unmarshal`, which silently drops any key with no matching struct field. A scenario author who misspells the assertion block key (`body_matchs:` instead of `body_match:`) gets a scenario that still runs and still reports PASS, having asserted nothing about the response body.

`decodeScenarios` now decodes with `yaml.NewDecoder(...).KnownFields(true)`, so an unknown key fails the decode with the field name in the error instead of vanishing. `loadScenarios` calls it and fails the test with that error, same as it already fails on a malformed YAML document.

Refs #823. This covers the issue's proposed fix (the Go loader) and, since all three runners read the same `scenarios.yaml`, the Go contract job now gates the file for TypeScript and Python too. It does not touch the runners' own unknown-*setup*-key handling that the issue separately flags in its last paragraph (`if key in step` dispatch in the TS/Python runners), which is a different code path than the assertion-key decode this PR fixes.

## Test plan

- New `TestDecodeScenariosRejectsUnknownFields` exercises `decodeScenarios` directly with a `body_matchs` typo and asserts the decode error names the field. It cannot compile against `origin/main` (`decodeScenarios` does not exist there); it passes on this branch.
- Full `TestScenarios` suite (32 scenarios) against a real Postgres 16 container: all pass, so the strict decode does not flag any pre-existing key in the real `scenarios.yaml`.
- `go vet -tags integration ./tests/contract/...` and `gofmt -l` clean on the changed file.
- Not verified: the TypeScript and Python contract runners' own setup-key handling (out of scope for this PR, see above).
