### PR TITLE
fix(senderidentity): recover failed domains when SES re-verifies

### DIFF
--- a/internal/senderidentity/worker.go
+++ b/internal/senderidentity/worker.go
@@ -498,8 +498,8 @@ func syncProviderIdentityWithInspection(ctx context.Context, domain string, stor
 		}
 		// The periodic sweep never MUTATES the DB record for a healthy applied
 		// identity through this inspect block (that would flap a verified
-		// sender back to pending), but it does inspect the two DB states that
-		// can silently rot behind an applied, present identity:
+		// sender back to pending), but it does inspect the DB states that can
+		// silently rot behind an applied, present identity:
 		//
 		//   - stuck `pending`: the reconcile budget is gone (enqueue failed or
 		//     exhausted) and nothing else would ever poll it. Verified/failed
@@ -511,9 +511,27 @@ func syncProviderIdentityWithInspection(ctx context.Context, domain string, stor
 		//     stays reported verified indefinitely. A definitive provider
 		//     `failed` commits (with axes) and fires; a provider mid-recheck
 		//     `pending` is NOT committed (no flap on a transient re-check).
+		//   - `failed` drift the other direction: a domain that failed (e.g.
+		//     the customer broke DNS) and was then repaired (DNS fixed) must
+		//     not stay `failed` forever just because nothing but a customer
+		//     POST /verify would otherwise re-check it. A provider `verified`
+		//     answer commits and fires; a provider `pending` answer (SES
+		//     mid-recheck) is deliberately NOT committed here — that would be
+		//     the failed→pending flap the `verified` bullet above already
+		//     avoids in the other direction, so `failed` stays fail-closed
+		//     until the provider is definitive. Bare status flip is safe: this
+		//     branch only runs inside `if !force`, and `force` is derived from
+		//     `applied_incarnation IS DISTINCT FROM incarnation` — so reaching
+		//     here already proves `applied_incarnation == incarnation`, i.e.
+		//     SES still holds THIS registration's selector/key. No re-Put of
+		//     the DKIM key is needed (a stale incarnation takes the forced
+		//     full-convergence path instead), which also means no
+		//     verified→pending flap risk from re-provisioning.
 		//
-		// An absent/foreign answer in either state falls through to full
-		// convergence; `failed` steady state costs no provider call.
+		// An absent/foreign answer in any state falls through to full
+		// convergence; `failed` steady state (provider still failed, or still
+		// pending) costs a provider call under inspectTerminal (the reaper)
+		// but no DB write.
 		//
 		// CAUTION: "inspect"/"READ-ONLY" above describes the DB record only,
 		// not the provider. providerStatus() above calls provider.Status,
@@ -537,7 +555,8 @@ func syncProviderIdentityWithInspection(ctx context.Context, domain string, stor
 			case serr != nil:
 				return serr
 			case state.Status == StatusPending && (res.Status == StatusVerified || res.Status == StatusFailed),
-				state.Status == StatusVerified && res.Status == StatusFailed:
+				state.Status == StatusVerified && res.Status == StatusFailed,
+				state.Status == StatusFailed && res.Status == StatusVerified:
 				if err := store.SetSendingStatus(lockedCtx, domain, state.Incarnation, res.Status, res.DkimStatus, res.MailFromStatus, res.Error, res.DNSRecords); err != nil {
 					if errors.Is(err, pgx.ErrNoRows) {
 						return nil

--- a/internal/senderidentity/worker_test.go
+++ b/internal/senderidentity/worker_test.go
@@ -1175,6 +1175,110 @@ func TestReapWorker_Work(t *testing.T) {
 			t.Fatalf("healthy identity was mutated: provision=%v deprovision=%v", prov.ProvisionCalls, prov.DeprovisionCalls)
 		}
 	})
+
+	t.Run("failed domain the provider now reports verified recovers", func(t *testing.T) {
+		// The missing transition this test locks in: a domain that failed
+		// (e.g. the customer broke DNS) and was later repaired (DNS fixed)
+		// must not stay `failed` forever just because nothing but a customer
+		// POST /verify would otherwise re-check it. applied == incarnation
+		// here, so the sweep takes the read-only inspect path rather than
+		// forcing full reprovisioning.
+		store := newFakeStore()
+		store.setStatus("recovered.example", StatusFailed)
+		store.setOwner("recovered.example", "u11")
+		store.setProvisionInputs("sel", []byte("der"), true)
+		store.managed["recovered.example"] = "recovered.example-incarnation"
+		store.applied["recovered.example"] = "recovered.example-incarnation"
+		prov := NewFakeProvider()
+		prov.SeedIdentity("recovered.example")
+		prov.SetStatus("recovered.example", Result{Status: StatusVerified})
+		firer := &recordingFirer{}
+		w := &ReapWorker{store: store, provider: prov, fire: firer.fire()}
+
+		if err := w.Work(context.Background(), reapJob()); err != nil {
+			t.Fatalf("Work: %v", err)
+		}
+		if got, _ := store.GetSendingStatus(context.Background(), "recovered.example"); got != StatusVerified {
+			t.Fatalf("status = %q, want verified once the provider recovers", got)
+		}
+		if len(prov.ProvisionCalls) != 0 {
+			t.Fatalf("recovery must be read-only, got provisions %v", prov.ProvisionCalls)
+		}
+		if firer.count() != 1 {
+			t.Fatalf("fired %d events, want exactly 1", firer.count())
+		}
+		if ev, ok := firer.last(); !ok || ev.Status != StatusVerified || ev.UserID != "u11" {
+			t.Fatalf("fired %+v ok=%v, want sending_verified for u11", ev, ok)
+		}
+	})
+
+	t.Run("failed domain mid-recheck at the provider is not flapped to pending", func(t *testing.T) {
+		// The provider reporting pending for a failed domain means SES is
+		// mid-recheck, not yet definitive. Flipping to pending here (or
+		// anything but leaving it failed) would churn on every sweep until
+		// SES resolves one way or the other.
+		store := newFakeStore()
+		store.setStatus("rechecking-failed.example", StatusFailed)
+		store.setOwner("rechecking-failed.example", "u12")
+		store.setProvisionInputs("sel", []byte("der"), true)
+		store.managed["rechecking-failed.example"] = "rechecking-failed.example-incarnation"
+		store.applied["rechecking-failed.example"] = "rechecking-failed.example-incarnation"
+		prov := NewFakeProvider()
+		prov.SeedIdentity("rechecking-failed.example")
+		prov.SetStatus("rechecking-failed.example", Result{Status: StatusPending})
+		firer := &recordingFirer{}
+		w := &ReapWorker{store: store, provider: prov, fire: firer.fire()}
+
+		if err := w.Work(context.Background(), reapJob()); err != nil {
+			t.Fatalf("Work: %v", err)
+		}
+		if got, _ := store.GetSendingStatus(context.Background(), "rechecking-failed.example"); got != StatusFailed {
+			t.Fatalf("status = %q, want failed preserved through a provider mid-recheck", got)
+		}
+		if len(store.SetStatusCalls) != 0 || len(prov.ProvisionCalls) != 0 {
+			t.Fatalf("provider-pending recheck must not mutate: writes=%d provisions=%v", len(store.SetStatusCalls), prov.ProvisionCalls)
+		}
+		if firer.count() != 0 {
+			t.Fatalf("no event expected for failed->pending, got %d", firer.count())
+		}
+	})
+
+	t.Run("failed domain refused adoption stays failed and alerts, not silently recovered", func(t *testing.T) {
+		// Ownership-refused domains short-circuit at the
+		// ErrIdentityNotFound/ErrIdentityNotOwned case (force = true) and
+		// never reach the new failed->verified case above; they must keep
+		// requiring manual review rather than being silently marked
+		// recovered.
+		store := newFakeStore()
+		store.setStatus("ownership-refused.example", StatusFailed)
+		store.setOwner("ownership-refused.example", "u13")
+		store.setProvisionInputs("sel", []byte("der"), true)
+		store.managed["ownership-refused.example"] = "ownership-refused.example-incarnation"
+		store.applied["ownership-refused.example"] = "ownership-refused.example-incarnation"
+		prov := NewFakeProvider()
+		prov.SeedIdentity("ownership-refused.example")
+		prov.SetStatusErr("ownership-refused.example", ErrIdentityNotOwned)
+		prov.SetProvisionErr(ErrIdentityNotOwned)
+		var buf bytes.Buffer
+		prevOut := log.Writer()
+		log.SetOutput(&buf)
+		defer log.SetOutput(prevOut)
+		firer := &recordingFirer{}
+		w := &ReapWorker{store: store, provider: prov, fire: firer.fire()}
+
+		if err := w.Work(context.Background(), reapJob()); err != nil {
+			t.Fatalf("Work: %v", err)
+		}
+		if got, _ := store.GetSendingStatus(context.Background(), "ownership-refused.example"); got != StatusFailed {
+			t.Fatalf("status = %q, want failed maintained pending manual review", got)
+		}
+		if !strings.Contains(buf.String(), "ALERT") || !strings.Contains(buf.String(), "manual review required") {
+			t.Fatalf("expected an ownership-refusal ALERT, got %q", buf.String())
+		}
+		if firer.count() != 0 {
+			t.Fatalf("an already-failed domain refused adoption must not fire a new event, got %d", firer.count())
+		}
+	})
 }
 
 // TestReapWorker_FiresStatusEvents pins the review fix: reaper-driven


### PR DESCRIPTION
## Summary

`syncProviderIdentityWithInspection`'s passive-path switch (the read-only
inspection the hourly reaper sweep runs when `applied_incarnation ==
incarnation`, i.e. no forced reprovisioning is needed) enumerates
provider-vs-stored status transitions: `pending→verified`, `pending→failed`,
`verified→failed`, `verified→pending`, and `verified→verified`. It had no
case for `failed→verified`, so that combination fell to `default: return
nil` and the domain stayed `failed` forever on the passive path, even after
the underlying problem was fixed.

Concretely: a domain is `verified`; the customer breaks their DNS, SES
reports failed, and the sweep correctly commits `failed` (existing
`verified→failed` case). The customer then fixes their DNS and SES starts
reporting `verified` again — but every subsequent hourly sweep hits the
switch with `state=failed, res=verified`, matches no case, and no-ops. The
domain shows `failed` indefinitely even though e2a's own provider says it's
healthy.

This only affects the **automatic/passive** recovery path. A
customer-initiated `POST /v1/domains/{domain}/verify` enqueues a job whose
worker takes the *forced* full-convergence path (`forceProvision: true`),
which skips this switch entirely and already converges correctly. So an
affected domain isn't stuck forever — a manual re-verify already unsticks
it — this fix is about the hourly sweep catching it on its own.

### The fix

Add `state.Status == StatusFailed && res.Status == StatusVerified` to the
existing case that already does the right thing (`SetSendingStatus`, then
`ClearSendingIdentityProviderPending`). `statusChanged` evaluates to
`res.Status != state.Status` → true, so `domain.sending_verified` fires
exactly once.

**Why a bare status flip (no re-provisioning) is safe:** this switch only
runs inside `if !force`, and `force` is derived from `needsProvision`
(`applied_incarnation IS DISTINCT FROM incarnation`). So reaching this
branch already proves `applied_incarnation == incarnation` — SES is still
holding *this* registration's selector/key. A stale incarnation would have
taken the forced full-convergence path instead. No re-`Put` of the DKIM key
is needed, which also avoids the verified→pending flap the surrounding
comments already warn about for the mirror-image case.

### Deliberately out of scope

- **`failed → pending`**: a failed domain whose provider now reports
  `pending` means SES is mid-recheck, not yet definitive. Flipping to
  anything here would churn every sweep until SES resolves one way or the
  other, so it's left as a no-op (covered by a new regression test).
- **Ownership-refused domains**: these short-circuit earlier, at
  `errors.Is(serr, ErrIdentityNotOwned) → force = true`, and never reach
  this switch at all — they keep taking the forced path, which alerts and
  requires manual review rather than auto-recovering. Also covered by a new
  regression test to make sure this change doesn't touch that path.

## Operational risk

Low. The change adds one new `case` arm to an existing `switch`; all other
arms are untouched. It only fires a customer-visible `domain.sending_verified`
webhook for a domain that was already `failed` and that SES itself now
reports as `verified` — strictly a bug fix for a stuck state, no new writes
to the provider, no schema change.

## Test plan

- `go build ./...`
- `go vet ./internal/senderidentity/...` (repo-wide `go vet ./...` has
  pre-existing unrelated findings in `internal/agent`, confirmed present on
  `main` before this change)
- `go test ./internal/senderidentity/...` — all green, including the
  existing `TestReapWorker_StuckFailedDomainDoesNotRefireHourly`, which
  turned out to exercise a different path (ownership-refused → forced
  convergence) and did not need updating
- `go test ./internal/identity/ -run 'SendingIdentity|Tombstone|Forget|Managed' -count=1` — green
- Added three table-driven cases to `TestReapWorker_Work`:
  - [x] `failed` → `verified` (applied_incarnation == incarnation) converges
    to `verified` and fires `domain.sending_verified` exactly once
  - [x] `failed` + provider `pending` stays `failed`, no event (no flap)
  - [x] ownership-refused stays `failed`, still ALERT-logged, not silently
    recovered
- Confirmed by hand that the new `failed→verified` case fails against the
  pre-fix switch (falls into `default: return nil`) and passes with the fix
  applied
