### PR TITLE
chore: cleanup follow-ups from #908/#911 reviews

### DIFF
--- a/docs/design/sender-identity-mailfrom.md
+++ b/docs/design/sender-identity-mailfrom.md
@@ -268,22 +268,18 @@ it refuses ownership on a live domain, and a plain log line on every
 successful adoption, so this is now operator-observable rather than a silent
 unbounded hourly retry.
 
-**Steps 4, 6, and 7 are NOT simply "unaffected."** An earlier draft of this
-amendment claimed the IAM hardening in step 4 is independent of adoption
-because it is a provider-side condition "that a client-side ownership check
-cannot close" — that framing is now only half true. The `aws:ResourceTag`
-condition still closes the check-then-mutate RACE (adoption's own tag check
-and its `TagResource` call are not atomic with respect to a concurrent
-out-of-band change). But adoption itself is a client that WRITES the tag —
-the very thing step 4's IAM condition exists to gate — so the two are no
-longer independent controls in the way the original doc implied: a bug in
-`canAdoptIdentity` is no longer caught by IAM the way a bug in some
-hypothetical OTHER client-side tagger would be, because IAM's job here is to
-stop *untrusted* principals from tagging, not to second-guess e2a's own
-adoption logic. Step 4's IAM policy remains necessary (it is still the only
-thing stopping a compromised or misconfigured OTHER principal from tagging
-or mutating), just not sufficient on its own to catch an adoption-logic bug
-the way the original phrasing suggested. Steps 6 and 7 (the blue/green
+**Steps 4, 6, and 7 are NOT simply "unaffected."** Step 4's IAM hardening
+remains necessary, but it is not fully independent of adoption. The
+`aws:ResourceTag` condition closes the check-then-mutate RACE (adoption's
+own tag check and its `TagResource` call are not atomic with respect to a
+concurrent out-of-band change). But adoption itself is a client that WRITES
+the tag — the very thing step 4's IAM condition exists to gate — so a bug in
+`canAdoptIdentity` is not caught by IAM the way a bug in some hypothetical
+OTHER client-side tagger would be: IAM's job here is to stop *untrusted*
+principals from tagging, not to second-guess e2a's own adoption logic. Step
+4's IAM policy is still the only thing stopping a compromised or
+misconfigured OTHER principal from tagging or mutating, just not sufficient
+on its own to catch an adoption-logic bug. Steps 6 and 7 (the blue/green
 rollout choreography) are genuinely unaffected — adoption runs entirely
 inside `Provision`/`Status`, which the rollout sequencing already treats as
 opaque provider calls.
@@ -313,6 +309,16 @@ The ownership tag is a deliberate migration gate. Do not bulk-adopt everything
 returned by `ListEmailIdentities`: an AWS account/region may contain identities
 owned by another application.
 
+Steps 1–3 describe the original manual, one-time tagging pass and are no
+longer required for any identity `canAdoptIdentity` can adopt automatically
+(see the amendment above) — `SESProvider` tags those inline, per domain, the
+first time `Provision`/`Status` runs against them, with no export/review
+step needed. Run 1–3 only if you want to pre-emptively tag a specific
+identity you know is e2a's own before the strict IAM policy in step 4 goes
+live (e.g. one that won't satisfy `canAdoptIdentity`'s strict criteria, such
+as a stale selector), or to positively confirm which SES-only identities
+belong to a different application before locking anything down.
+
 1. Before deploying this release, export the customer-owned domains for which
    the existing e2a database records sender-identity work (`sending_status !=
    'none'`). Separately inventory SES identities in the configured region.
@@ -331,10 +337,16 @@ owned by another application.
    tagged `CreateEmailIdentity` calls, in addition to the Create/Get/List/Put/
    Delete actions above. Apply request-tag conditions to create/tag and the
    resource-tag condition to both Put operations and delete.
-5. Re-run both inventories and apply the strict tag-conditioned IAM policy.
-   An untagged legacy e2a identity fails
-   closed with `identity not owned`; audit and tag it explicitly rather than
-   weakening the ownership check.
+5. Re-run both inventories and apply the strict tag-conditioned IAM policy. By
+   this point most e2a-managed identities that satisfy `canAdoptIdentity`'s
+   criteria will already be tagged automatically (see the amendment above),
+   independently of whether you ran steps 1–3. An identity still untagged
+   here either genuinely belongs to another application (correctly fails
+   closed with `identity not owned`) or simply has not yet had a
+   `Provision`/`Status` poll run against it — the ALERT log line on refusal
+   (`internal/senderidentity/worker.go`) distinguishes WHY, and the reaper
+   keeps retrying hourly. Investigate via that log before assuming a domain
+   needs a manual tag.
 6. Freeze domain verification, domain deletion, and account deletion, then
    deploy with `sender_identity.legacy_job_compat: true`. After cutover, wait
    for the previous slot to stop and for the post-drain convergence window;
@@ -378,7 +390,14 @@ owned by another application.
   largest post-upgrade sweep could turn into exactly this PR's own failure
   mode); a successful resolution is cached permanently; resolution runs on
   `context.WithoutCancel(ctx)` with its own explicit timeout so it is never
-  itself at the mercy of the caller's deadline. Non-production guard:
+  itself at the mercy of the caller's deadline. ARN partition: `arnPartition`
+  extracts the partition segment from STS's own `Arn` field (`aws`,
+  `aws-us-gov`, `aws-cn`), degrading to the `aws` default on a nil or
+  unparseable ARN; the adopted-identity ARN built for `TagResource` uses
+  whichever partition was resolved, not a hardcoded one
+  (`TestIdentityFromCallerIdentity`,
+  `TestSESProvider_AdoptIdentityUsesResolvedPartitionInARN`). Non-production
+  guard:
   `SESProvider.refuseAdoption` (set from `NewSESProviderFromConfig`'s
   `production` parameter) refuses adoption of an identity that would
   otherwise satisfy every `canAdoptIdentity` criterion — see the caveat
@@ -419,5 +438,5 @@ owned by another application.
   itself. That would be strictly stronger evidence (no dependency on SES's
   own verification having run correctly) but means plumbing DNS resolution
   into the provider layer, which currently has none — deliberately out of
-  scope for the BATCH A fix. Revisit only if `DkimAttributes.Status` alone
+  scope for the adoption work above. Revisit only if `DkimAttributes.Status` alone
   proves insufficient in practice.

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.36
 	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.66.5
 	github.com/aws/aws-sdk-go-v2/service/sts v1.45.5
+	github.com/aws/smithy-go v1.27.7
 	github.com/coreos/go-oidc/v3 v3.20.0
 	github.com/danielgtaylor/huma/v2 v2.39.1
 	github.com/emersion/go-msgauth v0.7.0
@@ -45,7 +46,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signin v1.5.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.33.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.5 // indirect
-	github.com/aws/smithy-go v1.27.7 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -1392,16 +1392,29 @@ func (s *Store) ClearSendingIdentityProviderPending(ctx context.Context, domain,
 }
 
 // ForgetSendingIdentityManaged removes the ledger row for domain UNLESS
-// domain still exists in domains with a live owner (a non-NULL user_id). Only
-// the ErrIdentityNotOwned handlers in internal/senderidentity/worker.go call
-// this (an ownership failure, not a confirmed provider deletion — that path
-// is FinalizeSendingIdentityTombstone instead); forgetting the ledger row for
-// a domain that is still live and owned would permanently strand it, because
-// nothing else ever revisits a domain absent from this ledger. The guard is
-// expressed as part of the DELETE's WHERE clause rather than a
+// domain still exists in domains with a live owner (a non-NULL user_id).
+//
+// As of #908, this method has ZERO callers: both ErrIdentityNotOwned
+// handlers in internal/senderidentity/worker.go that used to call it after
+// an ownership failure were changed to call nothing instead, not to call
+// something else here. It is kept rather than deleted: doing so would also
+// require rewriting the rationale comments in those two handlers (which cite
+// this method's guard by name while explaining why they must never call it)
+// and the poisoned-fake regression tests in
+// internal/senderidentity/worker_test.go that exist specifically to catch a
+// reintroduced call — a larger, riskier change than this method's own
+// dead-code status justifies in a hygiene pass. If a future change ever adds
+// a call to this method again, it must NOT be from an ownership-failure
+// branch: an ownership failure is never evidence of teardown, and forgetting
+// the ledger row for a domain that is still live and owned would permanently
+// strand it, because nothing else ever revisits a domain absent from this
+// ledger. FinalizeSendingIdentityTombstone is the method for confirmed-
+// teardown ledger cleanup.
+//
+// The guard is expressed as part of the DELETE's WHERE clause rather than a
 // check-then-act at the call site: WithSendingIdentityMutationLock (held by
-// both callers) and the domain-delete transaction's advisory locks use
-// different lock names and do not exclude each other, so a separate
+// both former callers) and the domain-delete transaction's advisory locks
+// use different lock names and do not exclude each other, so a separate
 // existence check beforehand could race a concurrent domain delete. A
 // genuinely deleted (or ownerless system) domain still has its row removed
 // here exactly as before; a DB failure leaves the ledger row for a later

--- a/internal/senderidentity/fakestore_test.go
+++ b/internal/senderidentity/fakestore_test.go
@@ -121,7 +121,7 @@ func (s *fakeStore) setStatus(domain string, st Status) {
 // deleteDomain models a genuine `domains` row delete: gone from status
 // (LoadSendingIdentityState reads pgx.ErrNoRows, mirroring the real d.domain
 // join) AND ownerless (DomainOwner reads "" for an absent row in production,
-// COALESCE(d.user_id::text, '') — never leave a stale owner behind).
+// COALESCE(d.user_id::text, "") — never leave a stale owner behind).
 func (s *fakeStore) deleteDomain(domain string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -318,7 +318,7 @@ func (s *fakeStore) ClearSendingIdentityProviderPending(ctx context.Context, dom
 
 // ForgetSendingIdentityManaged mirrors the production guard: never delete the
 // ledger row for a domain that still has a live owner (owners[domain] != "",
-// matching DomainOwner/COALESCE(d.user_id::text, '') reading non-empty for a
+// matching DomainOwner/COALESCE(d.user_id::text, "") reading non-empty for a
 // live owned row). forgetErr simulates a query-level failure and is checked
 // first, same as the real conditional DELETE still round-tripping to the DB
 // even when its WHERE clause matches nothing.

--- a/internal/senderidentity/ses.go
+++ b/internal/senderidentity/ses.go
@@ -640,7 +640,7 @@ func (p *SESProvider) adoptionDecision(out *sesv2.GetEmailIdentityOutput, eviden
 func (p *SESProvider) adoptIdentity(ctx context.Context, domain string) error {
 	accountID, partition, err := p.identityForAdoption(ctx)
 	if err != nil {
-		return fmt.Errorf("%w: aws account id unavailable: %v", ErrIdentityNotOwned, err)
+		return fmt.Errorf("%w: aws account id unavailable: %w", ErrIdentityNotOwned, err)
 	}
 	arn := identityARN(partition, p.region, accountID, domain)
 	_, err = p.api.TagResource(ctx, &sesv2.TagResourceInput{

--- a/internal/senderidentity/ses_test.go
+++ b/internal/senderidentity/ses_test.go
@@ -888,6 +888,7 @@ func TestSESProvider_ProvisionRefusesForeignConfiguration(t *testing.T) {
 				DkimAttributes: &sestypes.DkimAttributes{
 					SigningAttributesOrigin: sestypes.DkimSigningAttributesOriginExternal,
 					Tokens:                  []string{"e2a202607"},
+					Status:                  sestypes.DkimStatusSuccess,
 				},
 			},
 		}
@@ -912,6 +913,7 @@ func TestSESProvider_ProvisionRefusesForeignConfiguration(t *testing.T) {
 				DkimAttributes: &sestypes.DkimAttributes{
 					SigningAttributesOrigin: sestypes.DkimSigningAttributesOriginExternal,
 					Tokens:                  []string{"e2a202607"},
+					Status:                  sestypes.DkimStatusSuccess,
 				},
 			},
 		}
@@ -1314,6 +1316,7 @@ func TestSESProvider_StatusRefusesMismatchedSelector(t *testing.T) {
 			DkimAttributes: &sestypes.DkimAttributes{
 				SigningAttributesOrigin: sestypes.DkimSigningAttributesOriginExternal,
 				Tokens:                  []string{"someone-elses-selector"},
+				Status:                  sestypes.DkimStatusSuccess,
 			},
 		},
 	}

--- a/internal/senderidentity/worker.go
+++ b/internal/senderidentity/worker.go
@@ -78,6 +78,9 @@ type Store interface {
 	// once the provider agrees or a terminal transition is committed.
 	ObserveSendingIdentityProviderPending(ctx context.Context, domain, incarnation string, olderThan time.Duration) (bool, error)
 	ClearSendingIdentityProviderPending(ctx context.Context, domain, incarnation string) error
+	// ForgetSendingIdentityManaged currently has no callers in this package —
+	// see the doc comment on *identity.Store's implementation for why it is
+	// kept anyway, and why an ownership failure must never call it.
 	ForgetSendingIdentityManaged(ctx context.Context, domain string) error
 	// FinalizeSendingIdentityTombstone removes the ledger row ONLY when its
 	// last mutation (updated_at) is older than olderThan. An audit or sweep

--- a/internal/senderidentity/worker.go
+++ b/internal/senderidentity/worker.go
@@ -375,9 +375,9 @@ func reconcileProviderIdentity(ctx context.Context, domain, incarnation string, 
 		}
 	})
 	// Fire before the error check: a terminal status may have committed even
-	// when a later store call in the same locked section failed (e.g. the
-	// ledger Forget after a not-owned failure). The retry short-circuits on
-	// status != pending, so this attempt is the event's only chance.
+	// when a later step in the same locked section fails. The retry
+	// short-circuits on status != pending, so this attempt is the event's
+	// only chance.
 	if out.changed {
 		fireOwner(ctx, fire, domain, out.owner, out.status, out.errMsg)
 	}
@@ -653,8 +653,9 @@ func syncProviderIdentityWithInspection(ctx context.Context, domain string, stor
 			if err := store.SetSendingStatus(lockedCtx, domain, state.Incarnation, StatusFailed, "", "", reason, nil); err != nil {
 				return err
 			}
-			// out before Forget: the failed status is committed, so the event
-			// must fire even when the ledger cleanup errors and the job retries.
+			// out before FinalizeSendingIdentityTombstone: the failed status is
+			// committed, so the event must fire even when the ledger cleanup
+			// errors and the job retries.
 			out = syncOutcome{changed: true, statusChanged: state.Status != StatusFailed, incarnation: state.Incarnation, owner: state.Owner, status: StatusFailed, errMsg: reason}
 			if finalizeDeletion {
 				if err := store.FinalizeSendingIdentityTombstone(lockedCtx, domain, postDrainConvergenceDelay); err != nil {
@@ -696,9 +697,9 @@ func syncProviderIdentityWithInspection(ctx context.Context, domain string, stor
 		if err := store.SetSendingStatus(lockedCtx, domain, state.Incarnation, res.Status, res.DkimStatus, res.MailFromStatus, res.Error, res.DNSRecords); err != nil {
 			return err
 		}
-		// out before the ledger calls below, same rule as the two branches
-		// above: the status is committed, so a terminal transition must fire
-		// even when Forget/MarkApplied errors and the job retries.
+		// out before the ledger calls below: the status is committed, so a
+		// terminal transition must fire even when FinalizeSendingIdentityTombstone
+		// or MarkSendingIdentityApplied errors and the job retries.
 		out = syncOutcome{changed: true, statusChanged: res.Status != state.Status, incarnation: state.Incarnation, owner: state.Owner, status: res.Status, errMsg: res.Error}
 		if res.Status == StatusFailed {
 			if finalizeDeletion {
@@ -712,11 +713,12 @@ func syncProviderIdentityWithInspection(ctx context.Context, domain string, stor
 		return nil
 	})
 	// Fire terminal TRANSITIONS before the error check: the status write is
-	// already committed, and after a later store error (e.g. the ledger
-	// Forget) the retry's rewrite is same→same and will not fire — this
-	// attempt is the event's only chance. Gating on statusChanged (not
-	// changed) is what keeps that retry, and every forced hourly re-sweep of
-	// a stuck domain, from duplicating the webhook.
+	// already committed, and after a later store error (e.g. from
+	// FinalizeSendingIdentityTombstone or MarkSendingIdentityApplied) the
+	// retry's rewrite is same→same and will not fire — this attempt is the
+	// event's only chance. Gating on statusChanged (not changed) is what
+	// keeps that retry, and every forced hourly re-sweep of a stuck domain,
+	// from duplicating the webhook.
 	if out.statusChanged && (out.status == StatusVerified || out.status == StatusFailed) {
 		fireOwner(ctx, fire, domain, out.owner, out.status, out.errMsg)
 	}

--- a/internal/senderidentity/worker_test.go
+++ b/internal/senderidentity/worker_test.go
@@ -1457,16 +1457,19 @@ func TestSyncWorker_NotOwnedRetainsLedgerForLiveDomain(t *testing.T) {
 // TestReapWorker_GenuineDeleteStillFinalizesTombstone pins case 6: a
 // genuinely deleted domain's teardown/tombstone path is unaffected by the
 // ledger-retention fix above. It goes through FinalizeSendingIdentityTombstone
-// (age-gated on the ledger row's last mutation), never through
-// ForgetSendingIdentityManaged — the two are called from disjoint branches of
-// syncProviderIdentityWithInspection (deletion vs. ownership-failure).
+// (age-gated on the ledger row's last mutation). ForgetSendingIdentityManaged
+// has no production callers at all (see its doc comment in
+// internal/identity/store.go), so the ForgetCalls assertion below is a
+// belt-and-suspenders check, not evidence of disambiguating two live call
+// sites — this test does not, and cannot, prove anything about a branch that
+// is not reached.
 //
-// The `len(store.managed)` check alone can't tell WHICH of the two deletion
-// methods emptied the ledger map — both simply delete the same entry in the
-// fake. What actually pins "never through ForgetSendingIdentityManaged" is
-// the explicit ForgetCalls/FinalizeTombstoneCalls assertion below; the
-// prov.List() check is independent, real evidence that Deprovision itself
-// genuinely ran (not implied by the ledger going empty).
+// The `len(store.managed)` check alone can't tell WHICH deletion method
+// emptied the ledger map — both would delete the same entry in the fake if
+// either were called. The FinalizeTombstoneCalls assertion below is what
+// actually pins "through FinalizeSendingIdentityTombstone"; the prov.List()
+// check is independent, real evidence that Deprovision itself genuinely ran
+// (not implied by the ledger going empty).
 func TestReapWorker_GenuineDeleteStillFinalizesTombstone(t *testing.T) {
 	const domain = "genuinely-deleted.example"
 	store := newFakeStore()


### PR DESCRIPTION
## Summary

Small mechanical cleanup PR closing out the leftover findings from the two Opus reviews of #908 and #911 (both merged). **Cosmetic/hygiene only — no runtime behavior change**, except item 6 which changes what's reachable via `errors.Is`/`errors.As` on one error chain (no call site or test currently depends on that, confirmed below).

Re-verified every item against current `main` (`467295318`) before touching anything, since the findings were written against `abb1faff5` and earlier and line numbers were stale.

## Items

**1. `ForgetSendingIdentityManaged` dead code — kept, not removed.**
Confirmed zero non-test callers repo-wide (both `ErrIdentityNotOwned` call sites were removed by #908). I evaluated full removal (method, `Store` interface entry, `storeAdapter` shim, both fakes) first, per the task's stated preference.

Its retain/delete DB-test coverage is **not actually at risk either way**: `TestFinalizeSendingIdentityTombstoneRetainsLedgerForLiveOwnedDomain` and `TestFinalizeSendingIdentityTombstoneRemovesLedgerForGenuinelyDeletedDomain` in `internal/identity/sender_identity_lock_test.go` already pin the identical retain/delete invariant for `FinalizeSendingIdentityTombstone` (added in a later batch). So "folding tests" turned out to be a non-issue.

What made removal genuinely more invasive than it looked: `internal/senderidentity/worker.go`'s two former call sites carry rationale comments that cite this method's guard **by name** while explaining why they must never call it, and `internal/senderidentity/worker_test.go` has three purpose-built regression tests (`TestReconcileWorker_NotOwnedRetainsLedgerForLiveDomain`, `TestSyncWorker_NotOwnedRetainsLedgerForLiveDomain`, `TestReapWorker_GenuineDeleteStillFinalizesTombstone`) that poison a fake implementation of this exact method and assert zero calls to it — built specifically to catch a reintroduced call. Removing the method would mean rewriting all of that to argue from compile-time absence instead, which is a bigger, riskier change than a hygiene pass warrants, with real risk of silently weakening deliberately-designed defense-in-depth tests.

**Chose the fallback: kept the method**, rewrote its doc comment (`internal/identity/store.go`) to state plainly it has no callers, why it's kept anyway, and that any future caller must not be an ownership-failure branch. Added a matching one-line pointer on the `Store` interface entry in `worker.go`.

**2. Stale "Forget" comments in `worker.go`** — fixed 3 (plus one analogous instance not explicitly called out but the same category): the removed-call-site example in `reconcileProviderIdentity`'s closing comment, "out before Forget" → "out before FinalizeSendingIdentityTombstone", and "same rule as the two branches above ... Forget/MarkApplied" (that comparison no longer holds — the two ownership branches have no follow-on store call anymore — so it's dropped and the actual calls named).

**3. Doc drift in `docs/design/sender-identity-mailfrom.md`:**
- `accountIDFromCallerIdentity` — **already fixed**, zero occurrences anywhere in the repo. No change needed.
- "BATCH A fix" → reworded to "the adoption work above."
- "An earlier draft of this amendment claimed..." narration → rewritten to state the current position directly (same substance).
- **Step 5 was actively wrong** ("audit and tag it explicitly") now that adoption tags matching identities automatically — reconciled steps 1–3 (marked optional, with a lead-in explaining why) and rewrote step 5 to point at the ALERT log instead of prescribing a manual tag.
- Added the ARN-partition derivation to the Verification section (it had test coverage the doc never mentioned).

**4. Two (really three) `ses_test.go` stubs passing for the wrong reason** — `TestSESProvider_ProvisionRefusesForeignConfiguration`'s two subtests and `TestSESProvider_StatusRefusesMismatchedSelector` built `DkimAttributes` without `Status: DkimStatusSuccess`, so `canAdoptIdentity`'s DKIM-SUCCESS gate could pass the test even with the named guard deleted. Added the missing `Status`. **Verified by mutation**: temporarily disabled the foreign-config guard → `TestSESProvider_ProvisionRefusesForeignConfiguration` failed as expected (both subtests); temporarily disabled the selector-match guard → `TestSESProvider_StatusRefusesMismatchedSelector` failed as expected. Both restored; full suite green.

**5. `TestReapWorker_GenuineDeleteStillFinalizesTombstone` comment overstated what it proves** — fixed comment only, no assertion changes, per the task's instruction.

**6. Inconsistent error-wrapping in `ses.go`** — `adoptIdentity`'s account-id-unavailable wrap used `%w: ...: %v` (making the underlying error unreachable via `errors.Is`/`errors.As`) while `classifyAdoptionError` deliberately double-wraps a few lines below. Switched to `%w: ...: %w` for consistency. Confirmed no test or call site depends on the original being unreachable: `TestSESProvider_AdoptionDegradesWhenAccountIDUnavailable` and `TestSESProvider_AccountIDResolutionCachesOnlySuccess` only assert `errors.Is(err, ErrIdentityNotOwned)`, never against the wrapped resolver error.

**7. `go mod tidy`** — one-line diff as predicted: `github.com/aws/smithy-go` moved from indirect to direct (it's imported directly by `ses.go` for `smithy.APIError`). `go.sum` unchanged.

**8. `gofmt`** — `internal/senderidentity/fakestore_test.go` had two doc comments (immediately preceding a func decl) writing SQL's empty-string literal as two adjacent straight quotes (`''`); Go's doc-comment reformatter collapses that specific adjacent pair into a single stray Unicode right-double-quote character. Switched to `""`, which the reformatter leaves alone. Confirmed the several other gofmt-dirty files in the repo (`internal/agent/...`, `internal/limits/...`, `internal/oauth/...`, `internal/outbound/compose.go`, `internal/webhook/ssrf_test.go`, `internal/webhookpub/outbox_integration_test.go`) are pre-existing on `main`, not touched here.

## Verification

```
go build ./...                                                            # clean
go vet ./internal/senderidentity/... ./internal/identity/...              # clean
gofmt -l ./internal/senderidentity ./internal/identity                    # clean
go test ./internal/senderidentity/... -count=1                            # ok
go test ./internal/identity/ -run 'SendingIdentity|Tombstone|Forget|Managed' -count=1   # ok
```

Per instructions, did **not** run the full `./internal/identity/...` suite (known-unreliable, DB-shared, baseline-required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
