### PR TITLE
fix(e2e-prod): consolidate skipped every prod-suite report, so their fail()s were decorative

### DIFF
--- a/tests/e2e-prod/consolidate.ts
+++ b/tests/e2e-prod/consolidate.ts
@@ -1,5 +1,5 @@
 import { readFileSync, readdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
 interface Finding {
   severity: "info" | "warn" | "fail";
@@ -14,11 +14,65 @@ interface Report {
 }
 
 const dir = "./reports";
-const files = readdirSync(dir).filter((f) => f.endsWith(".json") && f !== "consolidated.json");
+
+// The scan MUST be recursive. Suite reports land at reports/<suite>.json, but a
+// suite whose SUITE constant contains a slash lands in a SUBDIRECTORY, because
+// writeReport() does mkdirSync(dirname(path), { recursive: true }). Every suite
+// in suites/prod/ sets SUITE = "prod/NN-name", so all of them write to
+// reports/prod/*.json — and the original non-recursive readdirSync never saw a
+// single one. Every fail() in every prod-only suite was therefore decorative:
+// precisely the failure mode the gate at the bottom of this file exists to
+// prevent, happening to the suites that cover what staging structurally cannot
+// (real inbound MX, SES delivery feedback, sender identity).
+//
+// The scan must ALSO be shape-aware. reports/ holds five other shard families —
+// coverage/, event-coverage/, mcp-coverage/, response-samples/, target/ —
+// written for the Python gates with entirely different shapes. Recursing without
+// a shape check would throw on r.findings, or worse, silently spread garbage.
+function isSuiteReport(value: unknown): value is Report {
+  const r = value as Report | null;
+  return (
+    !!r &&
+    Array.isArray(r.findings) &&
+    !!r.counts &&
+    typeof r.counts.fail === "number"
+  );
+}
+
+const candidates = readdirSync(dir, { recursive: true, encoding: "utf-8" }).filter(
+  (f) => f.endsWith(".json") && basename(f) !== "consolidated.json",
+);
+
 const all: Finding[] = [];
-for (const f of files) {
-  const r = JSON.parse(readFileSync(join(dir, f), "utf-8")) as Report;
-  all.push(...r.findings);
+const suiteFiles: string[] = [];
+const skipped: string[] = [];
+for (const f of candidates) {
+  const parsed: unknown = JSON.parse(readFileSync(join(dir, f), "utf-8"));
+  if (!isSuiteReport(parsed)) {
+    skipped.push(f);
+    continue;
+  }
+  suiteFiles.push(f);
+  all.push(...parsed.findings);
+}
+
+// Report what was skipped rather than dropping it silently — a suite report that
+// stops matching the shape must not vanish the way reports/prod/ did.
+if (skipped.length > 0) {
+  console.log(`Skipped ${skipped.length} non-suite-report JSON file(s) (other gates' shards):`);
+  for (const f of skipped) console.log(`  - ${f}`);
+  console.log("");
+}
+
+// Fail-closed on no data. "Nothing to consolidate" must never read as "green":
+// that is indistinguishable from the bug this change fixes, and it is the same
+// discipline the Python coverage gates apply when they find no shards.
+if (suiteFiles.length === 0) {
+  console.error(
+    `consolidate: no suite reports found under ${dir}/ — refusing to report success. ` +
+      `Either no suite ran, or writeReport() output moved again.`,
+  );
+  process.exit(2);
 }
 
 const bySeverity = {
@@ -37,7 +91,7 @@ const out = {
 };
 writeFileSync(join(dir, "consolidated.json"), JSON.stringify(out, null, 2));
 
-console.log(`Consolidated ${all.length} findings from ${files.length} suite reports:`);
+console.log(`Consolidated ${all.length} findings from ${suiteFiles.length} suite report(s):`);
 console.log(`  FAIL: ${bySeverity.fail.length}`);
 console.log(`  WARN: ${bySeverity.warn.length}`);
 console.log(`  INFO: ${bySeverity.info.length}`);


### PR DESCRIPTION
## The bug

`consolidate.ts` **is** `report:gate` — the step that converts recorded `fail()` findings into a non-zero exit. Its own closing comment states exactly what is at stake:

> Without this, every `fail()` in every suite is decorative: a pipeline that runs the suites and never consolidates (or consolidates but ignores the exit code) reports green over real failures.

That is precisely what has been happening to `suites/prod/*` — in the file that warns about it.

`writeReport()` does `mkdirSync(dirname(path), { recursive: true })`, and every prod suite sets `SUITE = "prod/NN-name"`. So all five write to `reports/prod/*.json`. The scan was a **non-recursive** `readdirSync` filtered on `.endsWith(".json")`, which never matches a subdirectory entry — so not one of those reports was ever read.

**The affected suites are the prod-only ones**: real inbound MX, SES delivery feedback, quota enforcement, billing plan, sender identity. That is exactly the coverage staging structurally cannot provide — and their failures have been reporting green.

## Why the fix isn't just `recursive: true`

`reports/` also holds five other shard families — `coverage/`, `event-coverage/`, `mcp-coverage/`, `response-samples/`, `target/` — written for the Python gates with entirely different shapes (arrays, target descriptors). Recursing blindly would throw on `r.findings`, or spread garbage into the findings list.

So the scan is now recursive **and** shape-aware. Files that don't match the suite-report shape are skipped **and listed**, so a report that stops matching cannot silently vanish the way `reports/prod/` did.

## Fail-closed on no data

Added a guard: zero suite reports found now exits **2** rather than printing a cheerful zero-findings summary. "Nothing to consolidate" is indistinguishable from this exact bug, and the Python coverage gates already apply that discipline to missing shards.

## Verification

Built a fixture tree reproducing the real layout — a top-level report, a `reports/prod/` report **containing a FAIL**, plus `event-coverage/` and `target/` shards:

| | old | new |
|---|---|---|
| exit code | **0** ← the bug | **1** |
| FAIL count | **0** | **1**, attributed to `prod/31-ses-feedback` |
| other shard families | n/a (never reached) | skipped and listed |
| empty `reports/` | 0 | 2 |

`npm run typecheck`, `npm run test:unit` (64), `npm run test:unit:gates` (12) all pass.

Not exercised: a real `test:prod` run, which needs live production credentials. The fixture reproduces the directory shapes the real run produces.

## Context

Found while implementing #913 (staging sender-identity gate), which moves suite 35 out of `suites/prod/` and therefore fixes it *for that one suite* as a side effect. The other four stay broken without this change. Unrelated to that PR's purpose, so it is split out here.

This is the same failure shape as the incident that prompted all of this work: a check that runs, finds real problems, and reports success.