### PR TITLE
fix: guard against accidental credential publication

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,11 @@ jobs:
           node-version: "22"
       - run: scripts/check-repository-text-integrity.sh
       - run: node --test scripts/sync-agent-docs.test.mjs
+      # Backstop against accidental credential publication. GitHub push
+      # protection cannot catch e2a's own key format, and .gitignore does not
+      # stop a force-add — see the script header for the 2026-08-08 incident
+      # this exists to keep from recurring.
+      - run: scripts/check-no-committed-credentials.sh
 
   harness-tests:
     name: Test harnesses (e2e-prod unit, sdk-monitor)

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,56 @@ cli/test/reports/
 
 # Isolated feature worktrees.
 .worktrees/
+
+# --- Accidental-publication guards -------------------------------------------
+# On 2026-08-08 three commits pushed a 48,147-file agent sandbox HOME into this
+# PUBLIC repo (Go module cache, macOS Library, npm cache, .codex state) because
+# an agent working directory was neither ignored nor reviewed before `git add`.
+# Buried in it were a .e2a/config.json and a bootstrap.log containing a
+# plaintext `e2a_acct_` API key. That key turned out to be minted against an
+# ephemeral localhost instance and has no production account, so it was inert —
+# but the same path would have published a live credential just as easily.
+# GitHub still serves those (now unreferenced) commits by SHA, and forks share
+# the object store, so publication is effectively irreversible.
+#
+# These entries are cheap insurance against a repeat. Do not remove them
+# without replacing them with something better.
+
+# Agent/tool scratch output. `outputs/` in particular has held a full sandbox
+# HOME; it must never be committed to a public repo.
+outputs/
+.playwright-mcp/
+
+# Screenshots dropped at the repo root by browser tooling. Real UI screenshots
+# can carry account identifiers, addresses, and message content.
+/*.png
+/*.jpg
+/*.jpeg
+/*.gif
+/*.webp
+
+# Credential-bearing file types. Absent before 2026-08-19; `*.pem` / `*.key`
+# is the one that matters most for a mail service — DKIM private keys.
+*.pem
+*.key
+*.p12
+*.pfx
+*-credentials.json
+*_credentials.json
+service-account*.json
+
+# Terraform state embeds provider secrets in plaintext.
+*.tfstate
+*.tfstate.*
+.terraform/
+
+# Only bare `.env` was matched before, so `.env.local` / `.env.production`
+# could be committed. `.env.example` stays tracked via the negation below.
+.env.*
+!.env.example
+!.env*.example
+
+# Database dumps and captured HTTP sessions.
+*.dump
+dump.sql
+cookies.txt

--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -163,6 +163,21 @@ func main() {
 		}
 		fmt.Printf("User:    %s (id=%s)\nAPI key: %s\n", user.Email, user.ID, key.PlaintextKey)
 		fmt.Fprintln(os.Stderr, "save the API key now — it will not be shown again")
+		// Printing the key IS the feature — there is no other way to hand it
+		// over. The realistic failure is not the print, it is the print being
+		// REDIRECTED: on 2026-08-08 a `-bootstrap-email … > bootstrap.log`
+		// captured a live key into a file that was then committed to a public
+		// repo, where it remains served by SHA (and by every fork) even after
+		// the commit was unreferenced. Publication is effectively irreversible,
+		// so the only useful moment to intervene is here, before the redirect
+		// lands. A non-TTY stdout is exactly that signal.
+		if !isTerminal(os.Stdout) {
+			fmt.Fprintln(os.Stderr,
+				"WARNING: stdout is not a terminal — this output contains a LIVE credential.\n"+
+					"         If you are redirecting to a file, delete it once the key is stored\n"+
+					"         somewhere safe, and never commit it. A key committed to a public\n"+
+					"         repository cannot be fully retracted; treat it as burned and rotate.")
+		}
 		return
 	}
 
@@ -1025,4 +1040,20 @@ func scheduledSendMonthlyQuotaResult(err error) (bool, error) {
 		return limitErr.Resource == "messages_month", nil
 	}
 	return false, err
+}
+
+// isTerminal reports whether f is an interactive terminal rather than a pipe or
+// a file. Used only to decide whether printing a bootstrap credential warrants
+// an extra "this is going somewhere persistent" warning.
+//
+// Stdlib-only on purpose — a TTY check is not worth a dependency. Note the
+// failure direction: any error, or an unexpected mode, returns false and so
+// prints the warning. An unnecessary warning costs a line of output; a missed
+// one costs a published credential.
+func isTerminal(f *os.File) bool {
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeCharDevice != 0
 }

--- a/scripts/check-no-committed-credentials.sh
+++ b/scripts/check-no-committed-credentials.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# Fail if anything credential-shaped, or any agent/tool scratch directory, is
+# tracked in this PUBLIC repository.
+#
+# WHY THIS EXISTS
+# On 2026-08-08 three commits pushed a 48,147-file agent sandbox HOME into this
+# repo. Inside it were a `.e2a/config.json` and a `bootstrap.log` containing a
+# live-format `e2a_acct_` API key. The commits were later unreferenced, but that
+# does NOT retract them: GitHub still serves them by SHA, and all forks share
+# the object store. That key turned out to be minted against an ephemeral
+# localhost instance with no production account, so it was inert — but nothing
+# about the path that published it depended on that luck.
+#
+# GitHub push protection did not stop it, and could not have: it has no detector
+# for e2a's own key format. This script is the repo-side backstop that does.
+#
+# It checks TRACKED CONTENT ONLY. .gitignore is the first line of defence; this
+# is the second, for the case where something is force-added or an ignore rule
+# is removed. Both are cheap; neither alone is sufficient.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+fail=0
+note() { printf '  %s\n' "$*"; }
+
+# --- 1. First-party API keys -------------------------------------------------
+# generateAPIKey (internal/identity/store.go) mints 32 crypto-random bytes as
+# lowercase hex behind a scope prefix, so a real key is exactly
+# e2a_(acct|agt)_ + 64 hex. Anchoring on the full 64 keeps synthetic fixtures
+# like `e2a_agt_synthetic_do_not_leak` and `e2a_acct_should_not_escape` — which
+# the test suite legitimately contains — from tripping this.
+KEY_RE='e2a_(acct|agt)_[0-9a-f]{64}'
+if hits=$(git grep -InE "$KEY_RE" -- . ':(exclude)scripts/check-no-committed-credentials.sh' 2>/dev/null); then
+  echo "FAIL: live-format e2a API key(s) in tracked content:"
+  printf '%s\n' "$hits" | sed -E 's/(e2a_(acct|agt)_)[0-9a-f]{64}/\1<REDACTED>/g' | sed 's/^/  /'
+  note ""
+  note "A key committed to a public repo cannot be retracted — unreferencing the"
+  note "commit does not remove it, and forks keep their own copy. Rotate the key,"
+  note "then remove it from tracked content."
+  fail=1
+fi
+
+# --- 2. Credential-bearing file types ----------------------------------------
+# *.pem / *.key matter most here: this is a mail service, and DKIM private keys
+# are exactly this shape.
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  echo "FAIL: credential-bearing file is tracked: $f"
+  fail=1
+done < <(git ls-files -- '*.pem' '*.key' '*.p12' '*.pfx' '*.tfstate' '*.tfstate.*' \
+  '*-credentials.json' '*_credentials.json' 'service-account*.json' 2>/dev/null)
+
+# --- 3. Agent / tool scratch directories -------------------------------------
+# `outputs/` is the exact directory that carried the 2026-08-08 sandbox HOME.
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  echo "FAIL: agent/tool scratch output is tracked: $f"
+  note "These directories hold sandbox state and can contain credentials."
+  fail=1
+done < <(git ls-files -- 'outputs/*' '.playwright-mcp/*' 2>/dev/null | head -20)
+
+# --- 4. Real .env files ------------------------------------------------------
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  case "$f" in
+    *.example|*.example.*|*.sample) continue ;;
+  esac
+  echo "FAIL: non-example .env file is tracked: $f"
+  fail=1
+done < <(git ls-files -- '.env' '.env.*' '**/.env' '**/.env.*' 2>/dev/null)
+
+if [ "$fail" -ne 0 ]; then
+  echo ""
+  echo "check-no-committed-credentials: FAILED"
+  exit 1
+fi
+
+echo "check-no-committed-credentials: PASS (no credential-shaped or scratch content tracked)"


### PR DESCRIPTION
## What happened

On **2026-08-08**, three commits pushed a **48,147-file agent sandbox HOME** into this public repo — Go module cache, macOS `Library`, npm cache, `.codex` state. Inside it were a `.e2a/config.json` and a `bootstrap.log` containing a **live-format `e2a_acct_` API key**.

**That key was inert.** It was minted against an ephemeral localhost instance (`audit@e2a.localhost`, 83 migrations, local Postgres) and the account does not exist in production — verified by direct query. Nothing about the path that published it depended on that luck.

The commits were later unreferenced. **That does not retract them:** GitHub still serves the file by SHA today, and all 22 forks share the object store. Publication of a credential to a public repository is effectively irreversible — so the only useful place to intervene is *before* it happens.

## Three layers, none sufficient alone

**1. `.gitignore`** — `outputs/` (the exact directory that carried the sandbox), `.playwright-mcp/`, root images, and credential file types. `*.pem` / `*.key` matters most for a mail service: DKIM private keys are that shape. Also closes `.env.local` / `.env.production`, which bare `.env` never matched.

Verified: catches the real payload, and **zero currently-tracked files become ignored** (`.env.example`, `config.example.yaml`, etc. stay tracked).

**2. `scripts/check-no-committed-credentials.sh`**, wired into the existing `repository-integrity` CI job. `.gitignore` does not stop a force-add or a removed ignore rule; this checks *tracked content*.

It anchors on the real key shape — `generateAPIKey` mints 32 crypto-random bytes as hex, so a live key is exactly `e2a_(acct|agt)_` + 64 hex. That precision matters: the synthetic fixtures the test suite legitimately contains (`e2a_agt_synthetic_do_not_leak`, `e2a_acct_should_not_escape`) do **not** trip it.

Verified against the actual leaked file — fails on two independent rules, and **redacts the key in its own output** so CI logs don't re-leak it:

```
FAIL: live-format e2a API key(s) in tracked content:
  outputs/.../.e2a/config.json:2:  "api_key": "e2a_acct_<REDACTED>",
FAIL: agent/tool scratch output is tracked: outputs/.../config.json
```

**3. A non-TTY warning on `-bootstrap-email`.** Printing the key *is* the feature — there's no other way to hand it over. The failure was the print being **redirected** into a file that was then committed. A non-terminal stdout is exactly that signal. The TTY check is stdlib-only (not worth a dependency) and **fails toward warning**: a spurious warning costs a line of output, a missed one costs a published credential.

## Server-side control this does not cover

GitHub push protection did not stop the original incident **and could not have** — it has no detector for e2a's own key format. The matching control is a custom secret-scanning pattern:

```
e2a_(acct|agt)_[0-9a-f]{64}
```

That must be added in repo settings (UI only — there is no REST API for repo-level custom patterns), and is tracked separately.

## Note on the 5 open secret-scanning alerts

All five resolve to `outputs/docs-audit/sandbox/home/go/pkg/mod/golang.org/x/oauth2@.../` — upstream library test fixtures, including AWS's canonical `AKIAIOSFODNN7EXAMPLE`. **Genuine false positives**, but they point at the right tree for the wrong reason, so they're best dismissed only once the underlying cleanup is done.