### PR TITLE
test(e2e): raise the integration-suite package timeout above 10m

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,7 +139,9 @@ jobs:
   go-e2e:
     name: Go e2e tests
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    # Must stay above the 11m per-package timeout in `make test-e2e` so a wedged
+    # package fails with Go's stack dump rather than a runner kill.
+    timeout-minutes: 14
     services:
       postgres:
         image: postgres:16-alpine

--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,15 @@ test-unit:
 test-integration:
 	go test -p 4 ./internal/identity/ ./internal/agent/ ./internal/hitlworker/ ./internal/hitlnotify/ ./internal/limits/ ./internal/relay/ ./internal/sendramp/
 
+# -timeout 11m: internal/identity runs 5-6 minutes on a healthy CI run, so Go's
+# default 10-minute per-package timeout left under a 2x margin and tripped on DB
+# contention (same root cause the cover target documents below). 11m stays under
+# the workflow's 14-minute job cap so a genuine wedge still panics with a usable
+# stack instead of being killed by the runner.
 test-e2e:
 	@packages="$$(find ./cmd ./internal ./tests -name '*_test.go' -exec grep -l '^//go:build integration$$' {} + | xargs -n 1 dirname | sort -u)"; \
 	test -n "$$packages"; \
-	go test -tags integration -p 4 $$packages
+	go test -tags integration -p 4 -timeout 11m $$packages
 
 # cover writes a coverage profile across the internal packages (needs Postgres
 # on :5433, like `make test`; per-package DBs make the -p 4 parallel run safe).


### PR DESCRIPTION
## Summary

`make test-e2e` set no `-timeout`, so it inherited Go's default 10-minute
per-package cap. `internal/identity` runs 324–376s on healthy CI runs — under a
2x margin against that cap, and more than double the next-slowest package
(`internal/agent`, 162s). Routine DB contention pushed it over, and the job died
with `panic: test timed out after 10m0s`, attributed to whichever PR happened to
be running at the time.

Sampled from passing `Go e2e tests` runs on `main`:

| Run | `internal/identity` |
|---|---|
| 32309797505 | 324s |
| 32299723903 | 327s |
| 32296922154 | 343s |
| 32300814433 | 376s |

The panic stack confirmed a slow package rather than a hang: the named test had
run 1s, every other test was parked in `testing.(*T).Parallel`, and no goroutine
was stuck in a query. The `cover` target already carries a `-timeout` bump
documenting this same root cause.

Sets `-timeout 11m` and raises the job cap 12 → 14 minutes so the Go timeout
fires first — a genuine wedge still panics with a usable stack instead of being
killed by the runner.

This buys margin; it does not address why `internal/identity` costs 5–6 minutes.
That split is worth doing separately.

## Operational risk

None — CI configuration only. No runtime, API, or client surface is touched.
Worst case on a genuine hang is a job that now runs 2 minutes longer before
failing.

## Test plan

- [x] `make -n test-e2e` emits the expected command
- [x] All 8 integration-tagged packages compile and accept the flags
      (`go test -tags integration -p 4 -timeout 11m -run XXX_NoSuchTest ...`)
- [x] `.github/workflows/test.yml` parses; `go-e2e.timeout-minutes` reads 14
- [ ] `Go e2e tests` green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)