### PR TITLE
fix(test): align live domain suites with staging sender-identity parity

### DIFF
--- a/sdks/python/tests/test_e2e_resources.py
+++ b/sdks/python/tests/test_e2e_resources.py
@@ -459,7 +459,13 @@ async def test_domains_register_get_list_verify_delete():
             deleted = await client.domains.delete(domain)
             assert deleted.deleted is True
             assert deleted.domain == domain
-            assert deleted.sending_teardown == "confirmed"
+            # With a sending-identity provider configured, the receipt starts
+            # "pending" and is only "confirmed" when the in-request best-effort
+            # deprovision proves provider absence. Staging's provider IAM policy
+            # denies identity calls outside its own namespace, so this throwaway
+            # .example.com domain can never reach "confirmed" there — both
+            # states are contract-valid receipts for a never-verified domain.
+            assert deleted.sending_teardown in ("pending", "confirmed")
             mark_covered("domains.delete")
 
 

--- a/sdks/typescript/test/e2e-domains.test.ts
+++ b/sdks/typescript/test/e2e-domains.test.ts
@@ -65,7 +65,13 @@ describe.skipIf(!env)("ts sdk live e2e: domains", () => {
         const deleted = await client.domains.delete(domain);
         expect(deleted.deleted).toBe(true);
         expect(deleted.domain).toBe(domain);
-        expect(deleted.sendingTeardown).toBe("confirmed");
+        // With a sending-identity provider configured, the receipt starts
+        // "pending" and is only "confirmed" when the in-request best-effort
+        // deprovision proves provider absence. Staging's provider IAM policy
+        // denies identity calls outside its own namespace, so this throwaway
+        // .example.com domain can never reach "confirmed" there — both states
+        // are contract-valid receipts for a domain that never verified.
+        expect(["pending", "confirmed"]).toContain(deleted.sendingTeardown);
         cleaned = true;
         recordCovered("domains.delete");
 

--- a/tests/e2e-prod/harness/fixtures.ts
+++ b/tests/e2e-prod/harness/fixtures.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from "node:crypto";
 import type { ApiClient, RawResponse } from "./client.ts";
-import { loadEnv } from "./env.ts";
+import { isProductionTarget, loadEnv } from "./env.ts";
 
 const RUN_ID = randomBytes(3).toString("hex");
 
@@ -10,6 +10,27 @@ export function runId(): string {
 
 export function uniqueSlug(prefix = "e2etest"): string {
   return `${prefix}-${RUN_ID}-${randomBytes(3).toString("hex")}`;
+}
+
+// Environment-aware fixture-domain suffix — THE central, obvious place the
+// domain suites decide which Cloudflare zone-subtree a fixture domain lives
+// under: `<zone>` against production, `staging.<zone>` everywhere else. Do
+// NOT mint a fixture domain as a bare `${uniqueSlug(...)}.${CF_ZONE_NAME}`.
+// The staging AWS IAM policy (e2a-ops PR #318) Deny-fences every mutating
+// SES action (CreateEmailIdentity, PutEmailIdentityDkimSigningAttributes,
+// SetIdentityMailFromDomain, DeleteEmailIdentity, ...) to
+// `identity/*.staging.trymnexa.com`, and with sender_identity enabled on
+// staging EVERY registered domain touches SES: verify auto-enqueues identity
+// provisioning, and delete runs a best-effort deprovision whose AccessDenied
+// leaves the teardown receipt fail-closed at "pending" — so an out-of-fence
+// fixture strands its DNS records (cleanup is contract-gated on a
+// "confirmed" receipt) and fails the run, reading like a code bug instead of
+// a naming mismatch. Driven by the SAME apiUrl-derived signal
+// (isProductionTarget) that already gates the destructive-prod opt-in and
+// the event-coverage-gate's target detection — not a new, independently
+// settable flag.
+export function fixtureDomainSuffix(apiUrl: string, zoneName: string): string {
+  return isProductionTarget(apiUrl) ? zoneName : `staging.${zoneName}`;
 }
 
 export function uniqueSubject(label: string): string {

--- a/tests/e2e-prod/suites/22-domain-lifecycle.test.ts
+++ b/tests/e2e-prod/suites/22-domain-lifecycle.test.ts
@@ -5,7 +5,7 @@ import { ApiClient } from "../harness/client.ts";
 import { cleanupDomainFixture } from "../harness/domain-fixture-cleanup.ts";
 import { CloudflareDnsClient, cloudflareFixtureComment, type CloudflareDnsRecordRef } from "../harness/cloudflare-dns.ts";
 import { track } from "../harness/cleanup.ts";
-import { uniqueSlug } from "../harness/fixtures.ts";
+import { fixtureDomainSuffix, uniqueSlug } from "../harness/fixtures.ts";
 import { writeReport, fail, info } from "../harness/report.ts";
 
 // The FULL custom-domain lifecycle — the one flow prod e2e structurally can't do
@@ -18,7 +18,11 @@ import { writeReport, fail, info } from "../harness/report.ts";
 //   CLOUDFLARE_API_TOKEN  — a DNS:Edit token scoped to the conformance zone ONLY
 //   CLOUDFLARE_ZONE_ID    — that zone's id
 //   CLOUDFLARE_ZONE_NAME  — that zone's apex (e.g. trymnexa.com); conformance
-//                           domains are minted as <slug>.<zone-name>
+//                           domains are minted as
+//                           <slug>.<fixtureDomainSuffix(apiUrl, zone-name)> —
+//                           `staging.<zone>` off-prod so delete-time SES
+//                           deprovision stays inside the staging IAM fence
+//                           (see harness/fixtures.ts)
 //
 // TWO NON-OBVIOUS FACTS the server's verify enforces (learned the hard way):
 //  1. `verified` requires the ownership TXT *AND* the inbound MX record pointing
@@ -93,7 +97,7 @@ async function waitForPublicDns(domain: string, txtValue: string, mxHost: string
 }
 
 test("domain lifecycle: register → DNS TXT+MX → verify (happy path) → custom-domain agent → teardown", { skip }, async () => {
-  const domain = `${uniqueSlug("dl")}.${CF_ZONE_NAME}`;
+  const domain = `${uniqueSlug("dl")}.${fixtureDomainSuffix(client.env.apiUrl, CF_ZONE_NAME!)}`;
   const dnsRecords: CloudflareDnsRecordRef[] = [];
   let agentEmail: string | undefined;
   track("domain", domain);
@@ -189,7 +193,7 @@ test("domain verify NEGATIVE control: an unpublished domain does NOT verify (gua
   // test above into a tautology (green while the published DNS is never consulted).
   // This asserts the real DNS path is live. Uses its own throwaway domain that we
   // never verify for real, so poisoning its 30-min negative cache is harmless.
-  const domain = `${uniqueSlug("dlneg")}.${CF_ZONE_NAME}`;
+  const domain = `${uniqueSlug("dlneg")}.${fixtureDomainSuffix(client.env.apiUrl, CF_ZONE_NAME!)}`;
   track("domain", domain);
   try {
     const reg = await client.post("/v1/domains", { body: { domain } });

--- a/tests/e2e-prod/suites/35-domain-sending-identity.test.ts
+++ b/tests/e2e-prod/suites/35-domain-sending-identity.test.ts
@@ -8,7 +8,7 @@ import { isProductionTarget } from "../harness/env.ts";
 import { cleanupDomainFixture } from "../harness/domain-fixture-cleanup.ts";
 import { CloudflareDnsClient, cloudflareFixtureComment, type CloudflareDnsRecordRef } from "../harness/cloudflare-dns.ts";
 import { track } from "../harness/cleanup.ts";
-import { uniqueSlug } from "../harness/fixtures.ts";
+import { fixtureDomainSuffix, uniqueSlug } from "../harness/fixtures.ts";
 import { writeReport, info, warn, fail } from "../harness/report.ts";
 
 // The full custom-domain lifecycle PLUS the real SES sending identity (DKIM +
@@ -121,25 +121,12 @@ const skip =
 const cfDns = new CloudflareDnsClient(CF_ZONE ?? "", CF_TOKEN ?? "");
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-// Environment-aware fixture-domain suffix — THE central, obvious place this
-// suite decides which Cloudflare zone-subtree a fixture domain lives under.
-// Do NOT let this drift back to a bare `${uniqueSlug(...)}.${CF_ZONE_NAME}`
-// (what this suite used before it ran on staging, and what the sibling
-// suites/22-domain-lifecycle.test.ts — which never provisions a real SES
-// sending identity, so it has nothing for the fence to deny — still uses
-// today). The reason is the staging AWS IAM policy from e2a-ops PR #318,
-// which Deny-fences every mutating SES action (CreateEmailIdentity,
-// PutEmailIdentityDkimSigningAttributes, SetIdentityMailFromDomain,
-// DeleteEmailIdentity, ...) to `identity/*.staging.trymnexa.com`. A fixture
-// domain registered without that exact suffix on a staging run gets
-// AccessDenied the instant SES provisioning runs — which reads exactly like
-// a code bug, not a naming mismatch. Driven by the SAME apiUrl-derived
-// signal (isProductionTarget) that already gates the destructive-prod
-// opt-in and the event-coverage-gate's target detection — not a new,
-// independently-settable flag.
-function fixtureDomainSuffix(apiUrl: string, zoneName: string): string {
-  return isProductionTarget(apiUrl) ? zoneName : `staging.${zoneName}`;
-}
+// fixtureDomainSuffix now lives in harness/fixtures.ts (shared with
+// suites/22-domain-lifecycle.test.ts — with sender_identity enabled on
+// staging, EVERY registered domain touches SES at verify and delete, so
+// every domain suite must mint fixtures inside the staging IAM fence's
+// `identity/*.staging.trymnexa.com` namespace, not just this one). See the
+// harness doc comment for the full derivation rationale.
 
 interface DNSRecordView {
   type: string;


### PR DESCRIPTION
## Why

The v1.7.9 release pipeline (e2a-ops run 32447588478) went red on two gates — both stale **test expectations** unmasked by staging finally running `sender_identity` for real (e2a-ops #318, the 2026-08-18 incident prevention work). Server behavior is correct and documented in both cases; no server code changes here.

1. **SDK live gates** — TS `e2e-domains.test.ts` (and the identical Python assertion, which sits one step later and never ran) asserted domain-delete returns `sending_teardown: "confirmed"`. That was only ever true with no provider configured: `BeginDomainTeardownReceiptTx` starts every receipt at `pending` when a provider is configured, and the in-request best-effort deprovision can only upgrade it to `confirmed` by proving provider absence. Staging's IAM fence denies SES calls for out-of-namespace names, so a throwaway `.example.com` fixture can never confirm there.
2. **Conformance gate** — suite 22 minted `dl-*.<zone>` fixtures outside the staging fence (`identity/*.staging.trymnexa.com`). Its delete receipt fail-closed to `pending`, so the suite — correctly honoring "keep DNS published unless confirmed" — left the fixture's 2 DNS records in place and recorded `dns-cleanup-failed`. All 230+ tests passed; the one finding failed the run.

## What

- TS + Python SDK live suites now accept both contract-valid receipt states (`pending` | `confirmed`) with comments explaining why `confirmed` cannot be forced from those suites.
- Hoisted suite 35's environment-aware `fixtureDomainSuffix()` (staging → `staging.<zone>`, prod → `<zone>`) into `harness/fixtures.ts`; suite 22 now uses it for both fixture domains. In-fence, delete-time deprovision proves absence (NotFound) and the receipt confirms synchronously — same as production. Also corrects suite 35's now-stale comment claiming suite 22 "has nothing for the fence to deny."

## Notes

- Prod path unaffected: `isProductionTarget` keeps prod fixtures at the bare zone, and prod's unfenced SES user confirms teardown as before.
- Follow-up (separate issue): out-of-namespace domain deletions on staging leave a permanently-retrying async teardown job (AccessDenied can never become NotFound). This PR stops the conformance/SDK suites from generating those, but the server-side behavior for unprovable absence may deserve a read-only status probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)