### PR TITLE
feat(cli): add --cc and --bcc to e2a send and e2a reply

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -208,7 +208,9 @@ e2a reply msg_abc123 --body "On it." --agent bot@acme.com
 
 Common `send`/`reply` flags: `--body` / `--body-file`, `--html-file` (text
 fallback derived if no `--body`), `--attach` (repeatable; max 10 files, 10 MB
-each, 25 MB total), `--reply-to` (repeatable; max 5 addresses), `--send-at`
+each, 25 MB total), `--reply-to` (repeatable; max 5 addresses), `--cc` /
+`--bcc` (each repeatable; `--to` + `--cc` + `--bcc` combined are capped at
+50 recipients on `send`), `--send-at`
 (RFC 3339 with an explicit UTC offset, at most 90 days ahead),
 `--idempotency-key`, `--agent`, `--json`
 (print the full send result). `send`-only: `--to` (repeatable), `--subject`,

--- a/cli/src/__tests__/send.test.ts
+++ b/cli/src/__tests__/send.test.ts
@@ -81,6 +81,51 @@ describe("send/reply commands", () => {
     expect(mockSend.mock.calls[0][1].replyTo).toBeUndefined();
   });
 
+  it("passes repeated --cc and --bcc through as arrays", async () => {
+    mockSend.mockResolvedValue({ messageId: "msg_cc", status: "sent" });
+    const { send } = await import("../commands/send.js");
+    await send({
+      to: ["you@example.com"],
+      subject: "hi",
+      body: "hello",
+      cc: ["cc1@example.com", "cc2@example.com"],
+      bcc: ["audit@example.com"],
+    });
+    const call = mockSend.mock.calls[0][1];
+    expect(call.cc).toEqual(["cc1@example.com", "cc2@example.com"]);
+    expect(call.bcc).toEqual(["audit@example.com"]);
+  });
+
+  it("omits cc and bcc when their lists are empty", async () => {
+    mockSend.mockResolvedValue({ messageId: "msg_nocc", status: "sent" });
+    const { send } = await import("../commands/send.js");
+    await send({ to: ["you@example.com"], subject: "hi", body: "hello", cc: [], bcc: [] });
+    const call = mockSend.mock.calls[0][1];
+    expect(call.cc).toBeUndefined();
+    expect(call.bcc).toBeUndefined();
+  });
+
+  it("accepts exactly 50 recipients combined across --to, --cc, and --bcc", async () => {
+    mockSend.mockResolvedValue({ messageId: "msg_50", status: "sent" });
+    const { send } = await import("../commands/send.js");
+    const cc = Array.from({ length: 24 }, (_, i) => `cc${i}@example.com`);
+    const bcc = Array.from({ length: 25 }, (_, i) => `bcc${i}@example.com`);
+    await send({ to: ["you@example.com"], subject: "hi", body: "hello", cc, bcc });
+    expect(mockSend).toHaveBeenCalled();
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  it("exits USAGE (2) when --to, --cc, and --bcc combined exceed 50 recipients", async () => {
+    const { send } = await import("../commands/send.js");
+    const cc = Array.from({ length: 25 }, (_, i) => `cc${i}@example.com`);
+    const bcc = Array.from({ length: 25 }, (_, i) => `bcc${i}@example.com`);
+    await expect(
+      send({ to: ["you@example.com"], subject: "hi", body: "hello", cc, bcc }),
+    ).rejects.toThrow("process.exit");
+    expect(mockExit).toHaveBeenCalledWith(2);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
   it("threads --idempotency-key through to the SDK request options", async () => {
     mockSend.mockResolvedValue({ messageId: "msg_i", status: "sent" });
     const { send } = await import("../commands/send.js");
@@ -235,6 +280,21 @@ describe("send/reply commands", () => {
       undefined,
     );
     expect(process.exitCode).toBe(3);
+  });
+
+  it("passes --cc and --bcc through on reply, with no combined-recipient cap", async () => {
+    mockReply.mockResolvedValue({ messageId: "msg_rcc", status: "sent" });
+    const { reply } = await import("../commands/send.js");
+
+    await reply("msg_orig", {
+      body: "answer",
+      cc: ["cc1@example.com"],
+      bcc: Array.from({ length: 60 }, (_, i) => `bcc${i}@example.com`),
+    });
+    const call = mockReply.mock.calls[0][2];
+    expect(call.cc).toEqual(["cc1@example.com"]);
+    expect(call.bcc).toHaveLength(60);
+    expect(mockExit).not.toHaveBeenCalled();
   });
 
   it("exits OK when an async reply is durably accepted", async () => {

--- a/cli/src/bin/e2a.ts
+++ b/cli/src/bin/e2a.ts
@@ -119,13 +119,18 @@ Usage:
         --attach <file>            Attach a file (repeatable; max 10 files, 10 MB each, 25 MB total)
         --conversation-id <id>     Application conversation/grouping id (alias: --conversation)
         --reply-to <email>         Reply-To header (where replies go; default: the agent). Repeatable to direct replies to several addresses (max 5)
+        --cc <email>               Cc recipient (repeatable)
+        --bcc <email>              Bcc recipient (repeatable)
         --send-at <rfc3339>        Beta (may change before stable): schedule for a future RFC 3339 time with an explicit UTC offset;
                                    status=scheduled, sent "not before" then. Direct self-send is unsupported;
                                    trash prevents submission; restore before send time re-arms, at/after leaves it canceled
         --idempotency-key <k>      Stable key so a retried invocation can't double-send
         --agent <email>            Sending inbox (or config agent_email / E2A_AGENT_EMAIL)
         --json                     Print the full send result as JSON
+                                   --to, --cc, and --bcc combined are capped at 50 recipients
   e2a reply <message-id> [options]  Reply in-thread (same body options as send)
+        --cc <email>               Additional Cc recipient (repeatable)
+        --bcc <email>              Additional Bcc recipient (repeatable)
         --quote-history            Beta (may change before stable): the server appends the
                                    original message beneath the reply body, mail-client style
                                    ("On <date>, <sender> wrote:" + '>'-quoted text / blockquote HTML)
@@ -664,7 +669,7 @@ async function main() {
     case "send":
       checkFlags(args, [
         "--to", "--subject", "--body", "--body-file", "--html-file", "--attach",
-        "--conversation-id", "--conversation", "--reply-to", "--send-at", "--agent", "--idempotency-key", "--json",
+        "--conversation-id", "--conversation", "--reply-to", "--cc", "--bcc", "--send-at", "--agent", "--idempotency-key", "--json",
       ]);
       getPositionals(args, 0, "usage: e2a send [options]");
       await send({
@@ -679,6 +684,8 @@ async function main() {
         // rejection) is shared via getConversationId — see FIX 3.
         conversationId: getConversationId(args),
         replyTo: getFlagsChecked(args, "--reply-to"),
+        cc: getFlagsChecked(args, "--cc"),
+        bcc: getFlagsChecked(args, "--bcc"),
         sendAt: getFlagChecked(args, "--send-at"),
         agent: getFlagChecked(args, "--agent"),
         idempotencyKey: getFlagChecked(args, "--idempotency-key"),
@@ -687,7 +694,7 @@ async function main() {
       break;
     case "reply":
       checkFlags(args, [
-        "--body", "--body-file", "--html-file", "--attach", "--reply-to", "--send-at", "--quote-history", "--agent", "--idempotency-key", "--json",
+        "--body", "--body-file", "--html-file", "--attach", "--reply-to", "--cc", "--bcc", "--send-at", "--quote-history", "--agent", "--idempotency-key", "--json",
       ]);
       await reply(getPositionals(args, 1, "usage: e2a reply <message-id> [options]")[0], {
         attach: getFlagsChecked(args, "--attach"),
@@ -695,6 +702,8 @@ async function main() {
         bodyFile: getFlagChecked(args, "--body-file"),
         htmlFile: getFlagChecked(args, "--html-file"),
         replyTo: getFlagsChecked(args, "--reply-to"),
+        cc: getFlagsChecked(args, "--cc"),
+        bcc: getFlagsChecked(args, "--bcc"),
         sendAt: getFlagChecked(args, "--send-at"),
         quoteHistory: hasFlag(args, "--quote-history"),
         agent: getFlagChecked(args, "--agent"),

--- a/cli/src/commands/send.ts
+++ b/cli/src/commands/send.ts
@@ -14,6 +14,8 @@ export interface SendOptions {
   htmlFile?: string;
   conversationId?: string;
   replyTo?: string[];
+  cc?: string[];
+  bcc?: string[];
   agent?: string;
   json?: boolean;
   idempotencyKey?: string;
@@ -26,6 +28,8 @@ export interface ReplyOptions {
   bodyFile?: string;
   htmlFile?: string;
   replyTo?: string[];
+  cc?: string[];
+  bcc?: string[];
   agent?: string;
   json?: boolean;
   idempotencyKey?: string;
@@ -42,6 +46,27 @@ export interface ReplyOptions {
 function replyToArg(replyTo?: string[]): string | string[] | undefined {
   if (!replyTo || replyTo.length === 0) return undefined;
   return replyTo.length === 1 ? replyTo[0] : replyTo;
+}
+
+// --cc/--bcc map straight onto the request's array fields (unlike --reply-to,
+// there is no pre-list scalar wire shape to stay compatible with), so an
+// empty list just needs to become undefined rather than an empty array.
+function recipientListArg(values?: string[]): string[] | undefined {
+  return values && values.length > 0 ? values : undefined;
+}
+
+const MAX_COMBINED_RECIPIENTS = 50;
+
+// Server-enforced too, but `send`'s --to/--cc/--bcc are the whole recipient
+// set, so the CLI can pre-check and fail with USAGE instead of a request
+// error. `reply` has no equivalent: its primary recipients come from the thread.
+function checkRecipientCap(total: number): void {
+  if (total > MAX_COMBINED_RECIPIENTS) {
+    fail(
+      EXIT.USAGE,
+      `--to, --cc, and --bcc combined must not exceed ${MAX_COMBINED_RECIPIENTS} recipients (got ${total})`,
+    );
+  }
 }
 
 const MIME_BY_EXT: Record<string, string> = {
@@ -76,9 +101,9 @@ function readAttachments(paths: string[] | undefined): Attachment[] | undefined 
 }
 
 const SEND_USAGE =
-  "usage: e2a send --to <email> --subject <s> (--body <text> | --body-file <f> | --html-file <f>) [--conversation-id <id>] [--reply-to <email>] [--send-at <rfc3339>] [--agent <inbox>] [--json]";
+  "usage: e2a send --to <email> --subject <s> (--body <text> | --body-file <f> | --html-file <f>) [--conversation-id <id>] [--reply-to <email>] [--cc <email>] [--bcc <email>] [--send-at <rfc3339>] [--agent <inbox>] [--json]";
 const REPLY_USAGE =
-  "usage: e2a reply <message-id> (--body <text> | --body-file <f> | --html-file <f>) [--reply-to <email>] [--send-at <rfc3339>] [--quote-history] [--agent <inbox>] [--json]";
+  "usage: e2a reply <message-id> (--body <text> | --body-file <f> | --html-file <f>) [--reply-to <email>] [--cc <email>] [--bcc <email>] [--send-at <rfc3339>] [--quote-history] [--agent <inbox>] [--json]";
 
 /**
  * Parse the optional --send-at flag into a Date for scheduled send. Requires an
@@ -175,6 +200,9 @@ function emitSendResult(result: SendResultView, json?: boolean): void {
 
 export async function send(opts: SendOptions): Promise<void> {
   if (opts.to.length === 0 || !opts.subject) fail(EXIT.USAGE, SEND_USAGE);
+  const cc = recipientListArg(opts.cc);
+  const bcc = recipientListArg(opts.bcc);
+  checkRecipientCap(opts.to.length + (cc?.length ?? 0) + (bcc?.length ?? 0));
   const { body, htmlBody } = resolveBodies(opts, SEND_USAGE);
 
   const client = createClient();
@@ -194,6 +222,8 @@ export async function send(opts: SendOptions): Promise<void> {
       html: htmlBody,
       conversationId: opts.conversationId,
       replyTo: replyToArg(opts.replyTo),
+      cc,
+      bcc,
       attachments: readAttachments(opts.attach),
       sendAt,
     },
@@ -216,6 +246,8 @@ export async function reply(messageId: string | undefined, opts: ReplyOptions): 
       text: body,
       html: htmlBody,
       replyTo: replyToArg(opts.replyTo),
+      cc: recipientListArg(opts.cc),
+      bcc: recipientListArg(opts.bcc),
       attachments: readAttachments(opts.attach),
       sendAt,
       // Beta server-side quoted history. Absent-or-false stays off the


### PR DESCRIPTION
## Summary

`e2a send`/`e2a reply` had no `--cc`/`--bcc`, even though the REST API, both
SDKs, and the MCP `send_message` tool already carry `cc`/`bcc` on send. Adds
the flags to both commands, wired straight onto the existing request fields.

## Client surface checklist

- [x] OpenAPI spec + generated types refreshed (`make generate` is clean): not touched, `cc`/`bcc` were already on `SendEmailRequest`/`ReplyRequest`
- [x] TypeScript SDK: not touched, for the same reason
- [x] Python SDK: not touched, for the same reason
- [x] CLI command or flag in `cli/src/commands/` + wired into `cli/src/bin/e2a.ts`
- [x] MCP tool: not touched, `send_message`/`reply_message` in `mcp/src/tools/legacy.ts` already accept `cc`/`bcc`
- [x] Tests at each surface above (positive + at least one negative-path / regression case)

**Skipped rows:** Go handler, migration. No server-side change, the fields already exist.

## Operational risk

None. Client-only change, no new server behavior.

## Test plan

- `npm run test:coverage --workspace @e2a/cli`: 321/321 passed (5 new). The 5 new
  cases fail on unmodified `main` (`tsc` rejects `cc`/`bcc` as unknown `SendOptions`/
  `ReplyOptions` properties) and pass on this branch.
- `npm run build --workspace @e2a/cli`: clean.
- Manual: built CLI, ran `e2a send` with 51 combined `--to`/`--cc`/`--bcc` recipients,
  confirmed it exits 2 (usage) before any request is sent, per the issue's ask.
- Not checked: a live end-to-end send through a running server (this environment
  has no e2a instance to send through); the SDK call shape is covered by the unit
  tests above instead.

The over-cap check only applies to `send`; `reply`'s primary recipients come
from the thread being replied to, so the CLI cannot compute the true combined
total the way it can for `send`.

`e2a forward` does not exist as a CLI command, so the issue's suggestion to
check it there does not apply.

Fixes #816
