### PR TITLE
fix(sdk): guard the generated-layer chokepoint against dot-segment path params

### DIFF
--- a/sdks/python/src/e2a/v1/client.py
+++ b/sdks/python/src/e2a/v1/client.py
@@ -29,7 +29,7 @@ from .generated.api.reviews_api import ReviewsApi
 from .generated.api.templates_api import TemplatesApi
 from .generated.api.contacts_api import ContactsApi
 from .generated.api.webhooks_api import WebhooksApi
-from .generated.api_client import ApiClient
+from .generated.api_client import ApiClient, RequestSerialized
 from .generated.configuration import Configuration
 from .generated.models import (
     AgentView,
@@ -233,6 +233,43 @@ def _assert_not_dot_segment(value: str, param: str) -> str:
 
 class _TypedApiClient(ApiClient):
     """Map malformed successful responses before the retry boundary sees them."""
+
+    def param_serialize(
+        self,
+        method: str,
+        resource_path: str,
+        path_params: Optional[Mapping[str, Any]] = None,
+        query_params: Optional[Any] = None,
+        header_params: Optional[Any] = None,
+        body: Optional[Any] = None,
+        post_params: Optional[Any] = None,
+        files: Optional[Any] = None,
+        auth_settings: Optional[Any] = None,
+        collection_formats: Optional[Any] = None,
+        _host: Optional[str] = None,
+        _request_auth: Optional[Any] = None,
+    ) -> RequestSerialized:
+        # Every generated *Api method builds its URL through this one call, so
+        # checking here covers every path parameter of every resource, not just
+        # the 10 sites the ergonomic wrapper classes above happen to name.
+        if path_params:
+            for name, value in path_params.items():
+                if isinstance(value, str):
+                    _assert_not_dot_segment(value, name)
+        return super().param_serialize(
+            method,
+            resource_path,
+            path_params,
+            query_params,
+            header_params,
+            body,
+            post_params,
+            files,
+            auth_settings,
+            collection_formats,
+            _host,
+            _request_auth,
+        )
 
     def response_deserialize(self, response_data: Any, response_types_map: Any = None) -> Any:
         try:

--- a/sdks/python/tests/test_generated_layer_dot_segment_guard.py
+++ b/sdks/python/tests/test_generated_layer_dot_segment_guard.py
@@ -1,0 +1,49 @@
+"""Regression test for e2a#915: the dot-segment guard must cover the
+generated-layer chokepoint, not just the 10 ergonomic call sites pinned in
+``test_dot_segment_enumeration.py``.
+
+That file already proves every ergonomic method (``client.agents.delete``,
+``client.contacts.delete_outreach``, ...) rejects a dot-segment value before
+any request is built. It cannot prove anything about a caller who imports a
+generated ``*Api`` class directly and calls it against the SDK's own
+``_TypedApiClient`` instance, skipping the ergonomic wrapper entirely,
+which is exactly the gap #915 reports: the per-call-site
+``_assert_not_dot_segment`` checks live in the ergonomic layer, not in the
+one place (``ApiClient.param_serialize``) every generated method routes
+through.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from e2a.v1 import AsyncE2AClient
+from e2a.v1.errors import E2AValidationError
+from e2a.v1.generated.api.agents_api import AgentsApi
+
+BASE = "http://test.local"
+
+
+@pytest.mark.anyio
+async def test_generated_api_called_directly_still_rejects_dot_segment(httpx_mock):
+    async with AsyncE2AClient(api_key="e2a_test", base_url=BASE) as c:
+        # Bypasses AgentsResource (and its explicit _assert_not_dot_segment
+        # call) entirely, but still goes through the SDK's _TypedApiClient.
+        raw_api = AgentsApi(c._api_client)
+        with pytest.raises(E2AValidationError) as ei:
+            await raw_api.delete_agent_suppression(
+                email="foo@example.com", address="..", confirm="DELETE"
+            )
+    assert ei.value.code == "unsafe_path_segment"
+    assert httpx_mock.get_requests() == []
+
+
+@pytest.mark.anyio
+async def test_generated_api_called_directly_allows_ordinary_value(httpx_mock):
+    httpx_mock.add_response(json={"address": "bar@example.com", "deleted": True})
+    async with AsyncE2AClient(api_key="e2a_test", base_url=BASE) as c:
+        raw_api = AgentsApi(c._api_client)
+        result = await raw_api.delete_agent_suppression(
+            email="foo@example.com", address="bar@example.com", confirm="DELETE"
+        )
+    assert result.deleted is True


### PR DESCRIPTION
## Summary

#915 (filed during review of #909) shows that the per-call-site dot-segment
guard in the ergonomic wrapper classes (`client.agents`, `client.contacts`, ...)
never runs if a caller instead uses a generated `*Api` class directly against
the SDK's own client. This PR adds the guard at the one place every generated
method actually routes through: `_TypedApiClient.param_serialize`
(`sdks/python/src/e2a/v1/client.py`).

`ApiClient.param_serialize` (the generated base) substitutes path parameters
via `quote()` with no dot-segment check and is marked "Do not edit the class
manually" (overwritten by `make generate-sdk`), so the fix overrides
`param_serialize` in `_TypedApiClient`, the hand-written subclass every
`AsyncE2AClient`/`E2AClient` request already constructs its `*Api` objects
against. It checks every path parameter for a bare `.` or `..` before
delegating to the base implementation, matching #915's own proposed fix.

**Scope:** this is the Python half of #915's corrected plan. The TypeScript
half needs a codegen post-processing pass over `generated/http.ts` (a hand
edit there is overwritten by `make generate`), which is a separate, larger
change, not attempted here, so this closes only the Python gap (`Refs #915`,
not `Fixes #915`).

Deleted the client-surface checklist below: this changes no API surface, no
generated types, and no other client. It is a Python-SDK-only hardening fix.

## Test plan

- New `tests/test_generated_layer_dot_segment_guard.py`: constructs the
  generated `AgentsApi` directly against a real `AsyncE2AClient`'s
  `_api_client`, bypassing the ergonomic wrapper. Confirmed against
  unmodified `main`: the request is built and sent (httpx_mock reports no
  matching mock, i.e. a real request would reach the network) rather than
  raising. On this branch it raises `E2AValidationError(code="unsafe_path_segment")`
  before any request is built; an ordinary (non-dot) value still passes
  through unchanged.
- Full suite (`pytest tests/ -v`) and `mypy`, both from this repo's own
  `python-sdk` CI job recipe, in a `python:3.12-slim` container matching that
  job's version: 611 passed, 48 skipped, 94.12% coverage (repo gate is 90%),
  mypy clean.
- Not independently verified: the TypeScript SDK's equivalent gap, since this
  PR does not touch it.
