### PR TITLE
fix(web): move the DNS-provider MCP notice to the domains prompt card

### DIFF
--- a/web/src/app/(app)/domains/_components/AddDomainForm.test.tsx
+++ b/web/src/app/(app)/domains/_components/AddDomainForm.test.tsx
@@ -19,9 +19,15 @@ describe("AddDomainForm", () => {
     expect(screen.getByRole("button", { name: "Register domain" })).toBeDisabled();
   });
 
-  it("includes Cloudflare MCP guidance in the field hint", () => {
+  // The Cloudflare-MCP recommendation lives once per page, in the
+  // agent-prompt card above the form. Repeating it in the field hint made
+  // the hint three sentences long for a single-input form.
+  it("keeps the field hint to what the domain itself must be", () => {
     render(<AddDomainForm onRegistered={jest.fn()} />);
-    expect(screen.getByText(/Cloudflare MCP/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Use a subdomain you control/),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Cloudflare/)).not.toBeInTheDocument();
   });
 
   it("lowercases the domain as the user types", async () => {

--- a/web/src/app/(app)/domains/_components/AddDomainForm.tsx
+++ b/web/src/app/(app)/domains/_components/AddDomainForm.tsx
@@ -74,21 +74,7 @@ export function AddDomainForm({
         placeholder="mail.yourcompany.com"
         value={domain}
         onChange={(v) => setDomain(v.toLowerCase())}
-        hint={
-          <>
-            Use a subdomain you control. All emails to *@this-domain will be routed to e2a. If your domain is in Cloudflare, consider adding{" "}
-            <a
-              href="https://github.com/cloudflare/mcp"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline"
-              style={{ color: "var(--fg-muted)" }}
-            >
-              Cloudflare MCP
-            </a>{" "}
-            so your AI coding agent can configure DNS records automatically.
-          </>
-        }
+        hint="Use a subdomain you control. All emails to *@this-domain will be routed to e2a."
       />
       <button
         type="submit"

--- a/web/src/app/(app)/domains/_components/DomainCard.test.tsx
+++ b/web/src/app/(app)/domains/_components/DomainCard.test.tsx
@@ -108,10 +108,12 @@ describe("DomainCard — DNS records section", () => {
     expect(screen.queryByText("Prove domain ownership (also drives SPF check)")).not.toBeInTheDocument();
   });
 
-  it("shows the Cloudflare MCP reminder when DNS records are expanded", async () => {
+  // The Cloudflare-MCP reminder moved up to the page's agent-prompt card,
+  // where it is visible before the user starts hand-copying records.
+  it("does not repeat the Cloudflare MCP reminder in the DNS records", async () => {
     renderCard(makeDomain());
     await userEvent.click(screen.getByRole("button", { name: /View DNS records/ }));
-    expect(screen.getByText("Cloudflare managed?")).toBeInTheDocument();
+    expect(screen.queryByText(/Cloudflare/)).not.toBeInTheDocument();
   });
 
   it("splits MX priority into its own field instead of embedding it in the value", async () => {

--- a/web/src/app/(app)/domains/_components/DomainCard.tsx
+++ b/web/src/app/(app)/domains/_components/DomainCard.tsx
@@ -627,18 +627,6 @@ export function DomainCard({
               before verifying.
             </div>
           )}
-
-          <div
-            className="p-3 text-[12px]"
-            style={{
-              background: "var(--bg-elev)",
-              color: "var(--fg-muted)",
-              border: "1px solid var(--border-sub)",
-              borderRadius: "var(--r-md)",
-            }}
-          >
-            <strong style={{ color: "var(--fg)" }}>Cloudflare managed?</strong> Add Cloudflare MCP to your AI coding agent (e.g. Claude Code, Cursor) so it can set up all DNS records automatically.
-          </div>
         </div>
       )}
     </div>

--- a/web/src/app/components/AgentPromptCard.test.tsx
+++ b/web/src/app/components/AgentPromptCard.test.tsx
@@ -35,26 +35,31 @@ test("shows the optional outbound-review instruction for inbox setup", () => {
   render(<AgentPromptCard {...AGENT_PROMPTS.inboxes} />);
 
   const notice = screen.getByRole("note", {
-    name: "Optional outbound review setup",
+    name: "Want every outbound email reviewed first?",
   });
-  expect(notice).toHaveTextContent("Want every outbound email reviewed first?");
   expect(notice).toHaveTextContent(
     "Configure this inbox so every outbound email requires human review.",
   );
 });
 
-test("does not show the inbox-only notice on other setup cards", () => {
-  const { rerender } = render(
-    <AgentPromptCard {...AGENT_PROMPTS.templates} />,
-  );
-  expect(
-    screen.queryByRole("note", { name: "Optional outbound review setup" }),
-  ).not.toBeInTheDocument();
+// DNS records land at the registrar, not in e2a — an agent driving domain
+// setup over MCP stalls there unless it also holds a provider MCP. The
+// recommendation belongs next to the prompt the user is about to paste.
+test("recommends the Cloudflare MCP on the domain setup card", () => {
+  render(<AgentPromptCard {...AGENT_PROMPTS.domains} />);
 
-  rerender(<AgentPromptCard {...AGENT_PROMPTS.domains} />);
+  const notice = screen.getByRole("note", {
+    name: "Domain managed by Cloudflare?",
+  });
+  expect(notice).toHaveTextContent("create the DNS records for you");
   expect(
-    screen.queryByRole("note", { name: "Optional outbound review setup" }),
-  ).not.toBeInTheDocument();
+    screen.getByRole("link", { name: "https://github.com/cloudflare/mcp" }),
+  ).toHaveAttribute("href", "https://github.com/cloudflare/mcp");
+});
+
+test("shows no notice on setup cards that do not define one", () => {
+  render(<AgentPromptCard {...AGENT_PROMPTS.templates} />);
+  expect(screen.queryByRole("note")).not.toBeInTheDocument();
 });
 
 test("copy button writes the card's prompt to the clipboard and flips its label", async () => {

--- a/web/src/app/components/AgentPromptCard.tsx
+++ b/web/src/app/components/AgentPromptCard.tsx
@@ -18,8 +18,7 @@ export const AGENT_PROMPTS = {
     prompt: "Help me set up an e2a inbox using https://api.e2a.dev/mcp",
     notice: {
       label: "Want every outbound email reviewed first?",
-      instruction:
-        "Configure this inbox so every outbound email requires human review.",
+      text: "Ask your agent: “Configure this inbox so every outbound email requires human review.”",
     },
   },
   domains: {
@@ -27,6 +26,18 @@ export const AGENT_PROMPTS = {
       "Domain setup is a one-time task your coding agent can drive end to end — paste this into Claude Code, Cursor, or any agent connected to e2a.",
     prompt:
       "Help me connect a custom domain to e2a using https://api.e2a.dev/mcp",
+    // The agent can create the domain in e2a over MCP, but the DNS records
+    // land at the registrar — out of reach unless the agent also has an MCP
+    // server for the provider. Surfacing that here, next to the prompt,
+    // means the human installs it before the agent stalls halfway through.
+    notice: {
+      label: "Domain managed by Cloudflare?",
+      text: "Add Cloudflare’s MCP server to the same agent and it can create the DNS records for you too.",
+      link: {
+        href: "https://github.com/cloudflare/mcp",
+        text: "https://github.com/cloudflare/mcp",
+      },
+    },
   },
   contacts: {
     blurb:
@@ -46,8 +57,7 @@ export const AGENT_PROMPTS = {
       "Help me set up an e2a webhook using https://api.e2a.dev/mcp — register the subscription, then wire up a handler that verifies the signature with the e2a SDK.",
     notice: {
       label: "Only want events from certain inboxes?",
-      instruction:
-        "Scope this webhook to only the inboxes it should receive — an unscoped subscription gets every inbox on the account.",
+      text: "Ask your agent: “Scope this webhook to only the inboxes it should receive — an unscoped subscription gets every inbox on the account.”",
     },
   },
 } as const;
@@ -57,7 +67,11 @@ export type AgentPromptCardProps = {
   prompt: string;
   notice?: {
     label: string;
-    instruction: string;
+    // Rendered verbatim after the label, so each card phrases its own nudge
+    // (an "Ask your agent: …" instruction, a prerequisite to install, …).
+    text: string;
+    // Optional trailing link for a notice that points somewhere.
+    link?: { href: string; text: string };
   };
 };
 
@@ -134,7 +148,9 @@ export function AgentPromptCard({
       {notice ? (
         <aside
           role="note"
-          aria-label="Optional outbound review setup"
+          // Each card carries a different nudge, so the accessible name comes
+          // from the notice itself rather than a single hardcoded label.
+          aria-label={notice.label}
           className="mt-3 rounded-[var(--r-md)] border px-3.5 py-3 text-[12px] leading-[1.6]"
           style={{
             color: "var(--fg-muted)",
@@ -145,7 +161,21 @@ export function AgentPromptCard({
           <span className="font-semibold" style={{ color: "var(--fg)" }}>
             {notice.label}
           </span>{" "}
-          Ask your agent: “{notice.instruction}”
+          {notice.text}
+          {notice.link ? (
+            <>
+              {" "}
+              <a
+                href={notice.link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline"
+                style={{ color: "var(--fg)" }}
+              >
+                {notice.link.text}
+              </a>
+            </>
+          ) : null}
         </aside>
       ) : null}
     </section>


### PR DESCRIPTION
## Summary

On the Domains page the Cloudflare MCP recommendation sat *below* the
prompt it should precede — once in the add-domain field hint, once inside
a domain's expanded DNS records. An agent driving domain setup over the
e2a MCP server can create the domain, then stalls at the registrar unless
it also holds an MCP server for the DNS provider, so the recommendation
belongs next to the prompt the user is about to paste.

It now renders as a notice in the "Set up with a coding agent" card,
carrying the full `https://github.com/cloudflare/mcp` link, and the two
copies lower on the same page are gone. The onboarding flow's
`DNSSetupCard` keeps its own copy — different page, no prompt card to move
it into.

Supporting change: the `AgentPromptCard` notice contract widens from
`{label, instruction}` — always rendered as `Ask your agent: "…"` — to
`{label, text, link?}`, so a card can carry a prerequisite-to-install
nudge as well as an ask-your-agent one. The inboxes and webhooks notices
keep their exact wording. The notice's `aria-label` now comes from its own
label instead of the hardcoded `"Optional outbound review setup"`, which
was already wrong for the webhooks notice and would have been wrong here.

Web-only; no API, SDK, CLI, or MCP surface is touched, so the client
surface checklist is omitted.

## Operational risk

None. Dashboard copy and markup only — no data, auth, billing, or
external integrations.

## Test plan

- [x] `npx jest` in `web/` — 101 suites / 874 tests pass
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [ ] Post-merge: eyeball the notice on the Domains page in both light and
      dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
