### PR TITLE
fix(emailauth): IDNA-encode domains before DMARC DNS lookups

### DIFF
--- a/internal/emailauth/checker.go
+++ b/internal/emailauth/checker.go
@@ -11,6 +11,7 @@ import (
 
 	"blitiri.com.ar/go/spf"
 	"github.com/emersion/go-msgauth/dkim"
+	"golang.org/x/net/idna"
 )
 
 var defaultDMARCEvaluator = newDMARCEvaluator(netTXTResolver{resolver: net.DefaultResolver})
@@ -120,8 +121,15 @@ func aggregateLegacyDKIM(results []DKIMResult) CheckResult {
 	return CheckResult{Status: results[0].Status, Detail: results[0].Detail}
 }
 
+// normDomain lowercases and IDNA-normalizes a domain (same pattern as
+// internal/identity.normalizeDomain), so the "_dmarc."+domain DNS queries
+// below use the label the resolver actually serves records under.
 func normDomain(d string) string {
-	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(d)), ".")
+	d = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(d)), ".")
+	if ascii, err := idna.Lookup.ToASCII(d); err == nil {
+		return ascii
+	}
+	return d
 }
 
 type AuthorIdentity struct {

--- a/internal/emailauth/dmarc_test.go
+++ b/internal/emailauth/dmarc_test.go
@@ -42,6 +42,23 @@ func TestEvaluateDMARCAlignedDKIM(t *testing.T) {
 	}
 }
 
+func TestEvaluateDMARCEncodesUnicodeFromDomainForLookup(t *testing.T) {
+	r := &fakeTXTResolver{records: map[string][]string{
+		"_dmarc.xn--mnchen-3ya.example": {"v=DMARC1; p=reject"},
+	}}
+	dkimDomain, selector := "xn--mnchen-3ya.example", "s1"
+	got := evaluateDMARC(context.Background(), r, "münchen.example",
+		SPFResult{Status: StatusNone},
+		[]DKIMResult{{Status: StatusPass, Domain: &dkimDomain, Selector: &selector}},
+	)
+	if len(r.lookups) == 0 || r.lookups[0] != "_dmarc.xn--mnchen-3ya.example" {
+		t.Fatalf("lookups = %v, want the punycode label queried first", r.lookups)
+	}
+	if got.Status != StatusPass || got.Policy == nil || *got.Policy != DMARCPolicyReject {
+		t.Fatalf("got %+v, want the record found under the punycode name to apply", got)
+	}
+}
+
 func TestEvaluateDMARCRejectsBarePublicSuffixAuthor(t *testing.T) {
 	r := &fakeTXTResolver{records: map[string][]string{
 		"_dmarc.github.io": {"v=DMARC1; p=reject"},


### PR DESCRIPTION
## Summary

`normDomain` lowercased and trimmed a domain but never converted it to
its ASCII/punycode form. The DMARC tree walk builds every
`_dmarc.<domain>` TXT lookup from that value (`discoverDMARCRecordWithEvaluator`,
`walkDMARCTree`), so a message with an internationalized From domain
queried the raw Unicode label instead of the label the DNS zone
actually publishes records under, and evaluation silently degraded to
`policy=none`. `internal/identity.normalizeDomain` already does
lowercase + `idna.Lookup.ToASCII` for stored domains; this applies the
same pattern to the inbound auth path, with the same fallback to the
unmodified string on an encoding error.

## Operational risk

None outside the emailauth package. `normDomain` also feeds the
displayed SPF/DKIM domain fields; those are already-ASCII values in
practice (SMTP HELO and DKIM `d=` tags), and the full existing suite
for this package (including those cases) is unchanged by this diff.

## Test plan

- [x] `TestEvaluateDMARCEncodesUnicodeFromDomainForLookup` (new):
      fails on `main` (queries `_dmarc.münchen.example`, the record
      under the punycode name is never found), passes on this branch.
- [x] `go test ./internal/emailauth/...`: full package suite green.
- [x] `go build ./...` and `go test ./...`: unaffected elsewhere.
- Not checked: real DNS resolution against a live internationalized
  domain (`fakeTXTResolver` only); the query-name construction is what
  this fix changes and what the test asserts.

Fixes #608
