### PR TITLE
release(sdk): publish 5.8.0 python client and CLI 2.5.0

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 2.5.0
+
+Additive only for every input that already succeeded in 2.4.0 — no flag,
+output-field, or exit-code meaning changes to any command that shipped in
+2.4.0.
+
+**Added:** `--cc <email>` and `--bcc <email>` on `e2a send` and `e2a reply`.
+Both are repeatable and map straight onto the request's `cc` / `bcc` array
+fields, so an omitted flag sends no field at all rather than an empty array.
+On `reply` they are *additional* recipients — the primary recipients still
+come from the thread.
+
+**Changed:** `e2a send` now pre-checks the combined `--to` + `--cc` + `--bcc`
+recipient count against the server's 50-recipient cap and fails with the
+`USAGE` exit code instead of issuing a request that the server rejects. This
+only affects invocations that were already failing. `e2a reply` has no
+equivalent pre-check, because its primary recipients come from the thread
+rather than the command line.
+
 ## 2.4.0
 
 Additive only — no flag, output-field, or exit-code meaning changes to any

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2a/cli",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "CLI for e2a — give any AI agent a real, authenticated email inbox",
   "bin": {
     "e2a": "./dist/bin/e2a.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
     },
     "cli": {
       "name": "@e2a/cli",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@e2a/sdk": "^5.7.0"

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 5.8.0
 
 ### Changed
 - **Dot-segment path parameters (``.`` / ``..``) are now rejected

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "e2a"
-version = "5.7.0"
+version = "5.8.0"
 description = "Python SDK for e2a — build AI agents with authenticated email"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -760,7 +760,7 @@ wheels = [
 
 [[package]]
 name = "e2a"
-version = "5.7.0"
+version = "5.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Version bumps ahead of the **v1.7.11** cut. Both publish workflows read the in-repo version (`npm publish` from `package.json`, hatchling from `pyproject.toml`), so this has to land on `main` **before** the `cli-v2.5.0` and `python-v5.8.0` tags are pushed.

## What changes

| Package | From | To | Why |
|---|---|---|---|
| `@e2a/cli` | 2.4.0 | **2.5.0** | `--cc` / `--bcc` on `send` and `reply` (#924) |
| `e2a` (PyPI) | 5.7.0 | **5.8.0** | generated-layer dot-segment guard (#929) |
| `@e2a/sdk` | 5.7.0 | *unchanged* | devDependency bump only since v1.7.10 |

Files: `cli/package.json`, `cli/CHANGELOG.md`, `package-lock.json`, `sdks/python/pyproject.toml`, `sdks/python/uv.lock`, `sdks/python/CHANGELOG.md` (the existing `## Unreleased` section is promoted to `## 5.8.0`).

## Why the Python bump is minor, not patch

`#929`'s guard raises `E2AValidationError` (`unsafe_path_segment`) on path-parameter values that previously produced a real, *misdirected* request — the changelog already documents this as caller-visible behavior ("it now raises instead of sending the (misdirected) request"). A patch would understate it. The repo has patch precedent (`python-v4.0.1`), so this is a deliberate choice, not convention drift. Adoption is unaffected either way: both are picked up by a `^5.7.0` range.

## Reviewer note: the TypeScript half is still open

`#929` fixed only the Python half of #915/#792. `sdks/python/CHANGELOG.md` states that the TS client's URL builder performs the same dot-segment collapse — so `@e2a/sdk` 5.7.0 on npm still carries the publicly-documented issue with no fix shipped. That is **not** in scope here (this release is being cut from `main` as-is), but it should be the next client-side priority. Tracked in #915.

## Not included

`#921` (outbound rate-limit deferral backoff) is green but deliberately held for the next cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
