### PR TITLE
fix(prober,sdk-monitor): purge the messages the harnesses create

### DIFF
--- a/cmd/e2a-prober/serve.go
+++ b/cmd/e2a-prober/serve.go
@@ -57,9 +57,17 @@ func (p *prober) probe() *selftest.Probe {
 }
 
 func (p *prober) runOnce(ctx context.Context) run {
-	results := selftest.Run(ctx, p.probe(), selftest.All, true /* smokeOnly */)
+	probe := p.probe()
+	results := selftest.Run(ctx, probe, selftest.All, true /* smokeOnly */)
 	r := run{At: time.Now(), OK: selftest.Worst(results) == selftest.StatusPass, Results: results}
 	p.recordRun(r)
+	// Hygiene, deliberately AFTER the run is recorded: the battery's verdict is
+	// already fixed, so a cleanup failure cannot colour it. Without this the
+	// probe agent accumulates every message the battery ever created (268k on
+	// staging), until unrelated deletes on that instance start timing out.
+	if sw := probe.SweepMessages(); sw.Trashed > 0 || sw.Purged > 0 {
+		log.Printf("prober: message sweep trashed=%d purged=%d", sw.Trashed, sw.Purged)
+	}
 	return r
 }
 

--- a/internal/selftest/cleanup.go
+++ b/internal/selftest/cleanup.go
@@ -1,0 +1,126 @@
+package selftest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// Every tick the battery lands messages on the probe agent: one real inbound
+// SMTP delivery, one real outbound send, and two loopback self-sends — and a
+// loopback lands BOTH an outbound and an inbound copy. Before this sweep only
+// scenarioWebSocketRoundTrip cleaned up after itself, and only the one inbound
+// copy it knew the id of; everything else stayed live forever.
+//
+// On staging that reached 268k live messages on the single probe agent (plus
+// 92k on each sdk-monitor agent), which is enough table churn that an unrelated
+// agent delete can exceed HAProxy's 60s server timeout and come back as a 504 —
+// with HAProxy's HTML error page, which then fails the conformance suite's
+// response-schema gate because the spec documents application/json.
+//
+// The sweep is a whole-inbox pass rather than per-scenario id tracking on
+// purpose: a loopback self-send lands a copy the sending scenario never learns
+// an id for, and a scenario that fails partway leaves residue no deferred
+// cleanup would catch. Listing what is actually there covers both cases with
+// one mechanism.
+const (
+	// sweepBudget bounds one hygiene pass per phase. The battery creates well
+	// under this per tick, so the surplus also drains backlog left by earlier
+	// runs — gradually, without turning the prober into a bulk-delete client.
+	sweepBudget = 50
+	// listPageMax is the server's per-page ceiling on listMessages.
+	listPageMax = 100
+	// sweepTimeout bounds the pass on its OWN context: the battery's ctx may
+	// already be done by the time hygiene runs.
+	sweepTimeout = 30 * time.Second
+)
+
+// SweepResult reports what one hygiene pass actually did.
+type SweepResult struct {
+	Trashed int `json:"trashed"`
+	Purged  int `json:"purged"`
+}
+
+// SweepMessages trashes live probe messages and then purges the trash.
+//
+// The two steps are ordered, not alternatives: "delete forever" only accepts a
+// message that is ALREADY in the trash (the store returns ErrNotInTrash, surfaced
+// as 409 not_in_trash), so a live message has to be trashed first. Trashing is
+// idempotent, so re-trashing a row another pass already moved is harmless.
+//
+// Best-effort by construction: it runs AFTER every scenario has reported, takes
+// its own context, and returns no error. A failed cleanup is hygiene debt, never
+// a red battery — the same contract trashMessage and the sdk-monitor's _cleanup
+// already follow, and for the same reason: a webhook redelivery or a flaky
+// delete must not be able to turn a healthy stack red.
+func (p *Probe) SweepMessages() SweepResult {
+	ctx, cancel := context.WithTimeout(context.Background(), sweepTimeout)
+	defer cancel()
+
+	var res SweepResult
+	// Live → trash. direction=all and read_status=all are both load-bearing:
+	// the endpoint defaults to inbound-only, and for inbound to unread-only,
+	// so the defaults would walk straight past every outbound copy and every
+	// inbound message a scenario had already read.
+	for _, id := range p.listMessageIDs(ctx, "direction=all&read_status=all") {
+		if p.deleteMessage(ctx, id, false) {
+			res.Trashed++
+		}
+	}
+	// Trash → gone. Picks up what was just trashed plus anything an earlier
+	// run trashed and left sitting for the 30-day janitor.
+	for _, id := range p.listMessageIDs(ctx, "deleted=true&direction=all&read_status=all") {
+		if p.deleteMessage(ctx, id, true) {
+			res.Purged++
+		}
+	}
+	return res
+}
+
+// listMessageIDs returns up to sweepBudget message ids for one filter. A list
+// failure yields nothing rather than an error: the next tick retries, and a
+// sweep that cannot list is not a reason to report anything about the stack.
+func (p *Probe) listMessageIDs(ctx context.Context, query string) []string {
+	limit := sweepBudget
+	if limit > listPageMax {
+		limit = listPageMax
+	}
+	u := fmt.Sprintf("%s/v1/agents/%s/messages?%s&limit=%d",
+		p.HTTPBaseURL, url.PathEscape(p.AgentEmail), query, limit)
+	st, body, err := p.do(ctx, http.MethodGet, u, nil)
+	if err != nil || st != http.StatusOK {
+		return nil
+	}
+	var page struct {
+		Items []struct {
+			ID string `json:"id"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(body, &page); err != nil {
+		return nil
+	}
+	ids := make([]string, 0, len(page.Items))
+	for _, it := range page.Items {
+		if it.ID != "" {
+			ids = append(ids, it.ID)
+		}
+	}
+	return ids
+}
+
+// deleteMessage trashes (permanent=false) or purges (permanent=true) one
+// message, reporting whether the row actually moved. A 409 — a message held for
+// review, or one whose provider submission is still in flight — counts as
+// skipped and is retried next tick, rather than being booked as done.
+func (p *Probe) deleteMessage(ctx context.Context, id string, permanent bool) bool {
+	u := p.HTTPBaseURL + "/v1/agents/" + url.PathEscape(p.AgentEmail) +
+		"/messages/" + url.PathEscape(id)
+	if permanent {
+		u += "?permanent=true&confirm=DELETE"
+	}
+	st, _, err := p.do(ctx, http.MethodDelete, u, nil)
+	return err == nil && st == http.StatusOK
+}

--- a/internal/selftest/cleanup_test.go
+++ b/internal/selftest/cleanup_test.go
@@ -1,0 +1,155 @@
+package selftest
+
+// Sweep tests. The sweep is the only part of the battery that deletes data the
+// battery did not create in that same tick, so the ordering (trash BEFORE
+// purge), the query parameters (defaults would skip most of the inbox), and the
+// best-effort contract (never surfaces an error) are all load-bearing.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type sweepCall struct {
+	method string
+	path   string
+	query  string
+}
+
+// sweepServer serves two pages of message ids — live, then trash — and records
+// every request so a test can assert on order and query shape.
+func sweepServer(t *testing.T, live, trashed []string) (*httptest.Server, *[]sweepCall) {
+	t.Helper()
+	var mu sync.Mutex
+	var calls []sweepCall
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		calls = append(calls, sweepCall{method: r.Method, path: r.URL.Path, query: r.URL.RawQuery})
+		mu.Unlock()
+
+		if r.Method == http.MethodGet {
+			ids := live
+			if r.URL.Query().Get("deleted") == "true" {
+				ids = trashed
+			}
+			items := make([]map[string]string, 0, len(ids))
+			for _, id := range ids {
+				items = append(items, map[string]string{"id": id})
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": items, "next_cursor": nil})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"deleted":true}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &calls
+}
+
+func TestSweepMessagesTrashesLiveThenPurgesTrash(t *testing.T) {
+	srv, calls := sweepServer(t, []string{"msg_live1", "msg_live2"}, []string{"msg_tr1"})
+	p := failProbe(srv.URL, "", nil)
+
+	got := p.SweepMessages()
+	if got.Trashed != 2 || got.Purged != 1 {
+		t.Fatalf("SweepMessages() = %+v, want {Trashed:2 Purged:1}", got)
+	}
+
+	var deletes []sweepCall
+	for _, c := range *calls {
+		if c.method == http.MethodDelete {
+			deletes = append(deletes, c)
+		}
+	}
+	if len(deletes) != 3 {
+		t.Fatalf("got %d DELETEs, want 3: %+v", len(deletes), deletes)
+	}
+	// The first two are trash (no permanent flag); the last is the purge. A
+	// purge before its trash would 409 not_in_trash against the real server.
+	for i, c := range deletes[:2] {
+		if c.query != "" {
+			t.Errorf("delete[%d] query = %q, want empty (a plain trash)", i, c.query)
+		}
+	}
+	if deletes[2].query != "permanent=true&confirm=DELETE" {
+		t.Errorf("purge query = %q, want permanent=true&confirm=DELETE", deletes[2].query)
+	}
+}
+
+// The list endpoint defaults to inbound-only and, for inbound, unread-only.
+// Without both overrides the sweep would silently leave every outbound copy and
+// every already-read inbound message live forever — which is exactly the leak
+// this sweep exists to close.
+func TestSweepMessagesListsAllDirectionsAndReadStates(t *testing.T) {
+	srv, calls := sweepServer(t, nil, nil)
+	p := failProbe(srv.URL, "", nil)
+	p.SweepMessages()
+
+	var lists []sweepCall
+	for _, c := range *calls {
+		if c.method == http.MethodGet {
+			lists = append(lists, c)
+		}
+	}
+	if len(lists) != 2 {
+		t.Fatalf("got %d list calls, want 2 (live, then trash): %+v", len(lists), lists)
+	}
+	for _, c := range lists {
+		for _, want := range []string{"direction=all", "read_status=all", "limit=50"} {
+			if !strings.Contains(c.query, want) {
+				t.Errorf("list query %q missing %q", c.query, want)
+			}
+		}
+	}
+	if strings.Contains(lists[0].query, "deleted=true") {
+		t.Errorf("first list should be LIVE messages, got %q", lists[0].query)
+	}
+	if !strings.Contains(lists[1].query, "deleted=true") {
+		t.Errorf("second list should be the TRASH, got %q", lists[1].query)
+	}
+}
+
+// Cleanup is hygiene, not a health signal: a server that fails every call must
+// yield zero counts and no panic, so the caller's battery verdict is untouched.
+func TestSweepMessagesIsBestEffort(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	got := failProbe(srv.URL, "", nil).SweepMessages()
+	if got.Trashed != 0 || got.Purged != 0 {
+		t.Fatalf("SweepMessages() = %+v, want zero counts on a failing server", got)
+	}
+}
+
+// A 409 (message held for review, or provider submission in flight) must not be
+// counted as deleted — it is retried on the next tick.
+func TestSweepMessagesDoesNotCountConflicts(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			if r.URL.Query().Get("deleted") == "true" {
+				_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{}, "next_cursor": nil})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items":       []map[string]string{{"id": "msg_held"}},
+				"next_cursor": nil,
+			})
+			return
+		}
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"error":{"code":"message_held"}}`))
+	}))
+	defer srv.Close()
+
+	got := failProbe(srv.URL, "", nil).SweepMessages()
+	if got.Trashed != 0 {
+		t.Fatalf("Trashed = %d, want 0 — a 409 is skipped, not booked as done", got.Trashed)
+	}
+}

--- a/tests/sdk-monitor/monitor.py
+++ b/tests/sdk-monitor/monitor.py
@@ -99,6 +99,10 @@ MCP_URL = os.environ.get("E2A_MONITOR_MCP_URL", "")
 # A reply older than this is a stale redelivery, not a fresh success — it must
 # never refresh the alert's "last seen" clock.
 MAX_AGE_MS = int(os.environ.get("E2A_MONITOR_MAX_AGE_MS", "900000"))
+# Per-tick ceiling on the hygiene sweep, per inbox and per phase. The tick
+# creates a handful of messages, so the surplus also drains backlog from
+# earlier ticks without turning the monitor into a bulk-delete client.
+SWEEP_BUDGET = int(os.environ.get("E2A_MONITOR_SWEEP_BUDGET", "50"))
 PORT = int(os.environ.get("PORT", "8080"))
 
 # Every interface this service exercises, in the fixed order /tick fires them.
@@ -621,6 +625,78 @@ def _cleanup(strategy: Interface, iface: str, nonce: str, *, inbox: str, message
     log("monitor_deleted", iface=iface, nonce=nonce, inbox=inbox, message_id=message_id)
 
 
+def _sweep_api(path: str, method: str = "GET") -> dict:
+    """One raw-API call for the hygiene sweep.
+
+    Deliberately NOT routed through an Interface strategy: the per-leg
+    _cleanup already exercises each interface's delete verb, which is the
+    coverage that matters, and the cli interface has no delete verb at all.
+    The sweep is housekeeping, so it takes the shortest reliable path."""
+    req = urllib.request.Request(f"{BASE_URL.rstrip('/')}{path}", method=method)
+    req.add_header("Authorization", f"Bearer {API_KEY}")
+    req.add_header("User-Agent", USER_AGENT)
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        raw = resp.read()
+    return json.loads(raw.decode("utf-8", "replace")) if raw else {}
+
+
+def _sweep_ids(inbox: str, *, deleted: bool) -> list:
+    """Up to SWEEP_BUDGET message ids from one inbox.
+
+    direction=all and read_status=all are both load-bearing: the endpoint
+    defaults to inbound-only, and for inbound to unread-only, so the defaults
+    would walk straight past every outbound copy — which is precisely the
+    residue this sweep exists to clear (the per-leg _cleanup trashes the
+    RECEIVED copy; the sent copy in the opposite folder was never in scope)."""
+    q = (
+        f"direction=all&read_status=all&limit={SWEEP_BUDGET}"
+        f"{'&deleted=true' if deleted else ''}"
+    )
+    page = _sweep_api(f"/v1/agents/{urllib.parse.quote(inbox, safe='')}/messages?{q}")
+    return [it["id"] for it in page.get("items", []) if it.get("id")]
+
+
+def _sweep_inbox(inbox: str) -> tuple:
+    """Trash this inbox's live messages, then purge its trash.
+
+    The order is a requirement, not a preference: "delete forever" only accepts
+    a message ALREADY in the trash (409 not_in_trash otherwise), so a live
+    message has to be trashed first. Trashing is idempotent, so re-trashing a
+    row an earlier pass moved is harmless.
+
+    Best-effort, exactly like _cleanup and for the same reason: this runs after
+    the tick's sends are logged, so a failure here is hygiene debt and must
+    never change the tick's status code. Cloud Scheduler reads that code as the
+    health of the client surfaces, not of our housekeeping."""
+    trashed = purged = 0
+    try:
+        for mid in _sweep_ids(inbox, deleted=False):
+            try:
+                _sweep_api(
+                    f"/v1/agents/{urllib.parse.quote(inbox, safe='')}"
+                    f"/messages/{urllib.parse.quote(mid, safe='')}",
+                    method="DELETE",
+                )
+                trashed += 1
+            except Exception:  # noqa: BLE001,S112 - held/in-flight retries next tick
+                continue
+        for mid in _sweep_ids(inbox, deleted=True):
+            try:
+                _sweep_api(
+                    f"/v1/agents/{urllib.parse.quote(inbox, safe='')}"
+                    f"/messages/{urllib.parse.quote(mid, safe='')}"
+                    "?permanent=true&confirm=DELETE",
+                    method="DELETE",
+                )
+                purged += 1
+            except Exception:  # noqa: BLE001,S112 - retries next tick
+                continue
+    except Exception as exc:  # noqa: BLE001 - a listing failure ends this pass only
+        log("monitor_error", stage="sweep", inbox=inbox,
+            error=type(exc).__name__, detail=str(exc))
+    return trashed, purged
+
+
 def handle_tick() -> tuple[int, dict]:
     """Fire one outbound leg PER interface: agent A -> agent B, nonce
     (encoding the interface) in subject and body. A per-interface send
@@ -667,6 +743,18 @@ def handle_tick() -> tuple[int, dict]:
         # Total outage across every considered interface: Cloud Scheduler
         # needs a non-2xx so a send-side blackout doesn't read as healthy.
         status_code = 500
+
+    # Hygiene, after the verdict is fixed so it cannot colour the tick. Without
+    # it the two monitor inboxes keep every message the monitor ever sent —
+    # 47k outbound copies each on staging — until unrelated deletes on that
+    # instance start timing out.
+    for inbox in (AGENT_A, AGENT_B):
+        if not inbox:
+            continue
+        swept, gone = _sweep_inbox(inbox)
+        if swept or gone:
+            log("monitor_sweep", inbox=inbox, trashed=swept, purged=gone)
+
     return status_code, {"ok": ok, "results": results}
 
 

--- a/tests/sdk-monitor/test_monitor.py
+++ b/tests/sdk-monitor/test_monitor.py
@@ -30,6 +30,7 @@ call, no real subprocess to node/npm.
 
 import hashlib
 import hmac
+import io
 import json
 import os
 import sys
@@ -513,6 +514,21 @@ def tick_strategies(fail=(), unavailable=()):
     }
 
 
+# handle_tick ends with a hygiene sweep that talks to the API directly rather
+# than through a strategy, so the strategy fakes above do not cover it. Stub it
+# out for the aggregate/status-code checks — an offline suite must make no real
+# network call, and the sweep has its own tests below.
+_saved_sweep_inbox = monitor._sweep_inbox
+_swept_inboxes = []
+
+
+def _fake_sweep_inbox(inbox):
+    _swept_inboxes.append(inbox)
+    return (0, 0)
+
+
+monitor._sweep_inbox = _fake_sweep_inbox
+
 # All interfaces succeed -> 200, ok=True.
 monitor.STRATEGIES = tick_strategies()
 emitted.clear()
@@ -558,6 +574,12 @@ status, payload = monitor.handle_tick()
 check("tick all-fail (considered) returns 500", status, 500)
 check("tick all-fail reports ok=False", payload["ok"], False)
 check("tick all-fail still marks the skipped iface as skipped, not failed", payload["results"]["mcp"]["skipped"], True)
+
+# The sweep runs on every tick, including a total outage: residue accumulates
+# regardless of whether the client surfaces are healthy, and a stuck sweep
+# would be exactly the wrong response to an already-degraded stack.
+check("tick sweeps both monitor inboxes", sorted(set(_swept_inboxes)), sorted({monitor.AGENT_A, monitor.AGENT_B}))
+monitor._sweep_inbox = _saved_sweep_inbox
 
 
 # ---------------------------------------------------------------------------
@@ -1126,6 +1148,102 @@ _urllib_request.urlopen = _saved_urlopen
 
 check("mcp strategy reports unavailable when no URL is configured", monitor.McpStrategy("", "k").available(), False)
 check("mcp strategy reports available when a URL is configured", monitor.McpStrategy("https://x/mcp", "k").available(), True)
+
+
+# --------------------------------------------------------------------------
+# Hygiene sweep. The sweep is the only part of the monitor that deletes
+# messages the current tick did not create, so the ordering (trash BEFORE
+# purge), the query parameters (the endpoint defaults would skip exactly the
+# residue it exists to clear), and the best-effort contract all matter.
+# --------------------------------------------------------------------------
+
+
+def _sweep_urlopen(live_ids, trashed_ids, calls, fail_on=None):
+    """Serve two id pages and record every request. fail_on(url, method) may
+    raise to simulate a 409/held message."""
+
+    def _fake_urlopen(req, timeout=None):
+        url = req.full_url
+        method = req.get_method()
+        calls.append((method, url))
+        if fail_on is not None:
+            fail_on(url, method)
+        if method == "GET":
+            ids = trashed_ids if "deleted=true" in url else live_ids
+            body = {"items": [{"id": i} for i in ids], "next_cursor": None}
+        else:
+            body = {"deleted": True, "id": "x"}
+        return _FakeResponse(json.dumps(body).encode(), "application/json")
+
+    return _fake_urlopen
+
+
+_sweep_calls = []
+_urllib_request.urlopen = _sweep_urlopen(["m_live1", "m_live2"], ["m_tr1"], _sweep_calls)
+_trashed, _purged = monitor._sweep_inbox("a@x.test")
+_urllib_request.urlopen = _saved_urlopen
+
+check("sweep trashes every live message", _trashed, 2)
+check("sweep purges every trashed message", _purged, 1)
+
+_sweep_deletes = [(m, u) for m, u in _sweep_calls if m == "DELETE"]
+check("sweep issues one DELETE per message", len(_sweep_deletes), 3)
+# A purge before its trash would 409 not_in_trash against the real server.
+check(
+    "sweep trashes first (no permanent flag on the live deletes)",
+    [("permanent=true" in u) for _, u in _sweep_deletes],
+    [False, False, True],
+)
+check(
+    "sweep purge carries the confirm token",
+    "confirm=DELETE" in _sweep_deletes[-1][1],
+    True,
+)
+
+_sweep_lists = [u for m, u in _sweep_calls if m == "GET"]
+check("sweep lists live then trash", len(_sweep_lists), 2)
+# Defaults are inbound-only and, for inbound, unread-only: without both
+# overrides every outbound copy (47k per inbox on staging) stays live forever.
+check(
+    "sweep lists both directions and all read states",
+    all("direction=all" in u and "read_status=all" in u for u in _sweep_lists),
+    True,
+)
+check("sweep bounds each page by the budget", all(f"limit={monitor.SWEEP_BUDGET}" in u for u in _sweep_lists), True)
+check("sweep's first list is live messages", "deleted=true" not in _sweep_lists[0], True)
+check("sweep's second list is the trash", "deleted=true" in _sweep_lists[1], True)
+
+
+# A delete that fails (message held for review, or provider submission still in
+# flight) is skipped and retried next tick, never counted as done.
+def _fail_every_delete(url, method):
+    if method == "DELETE":
+        raise _urllib_error.HTTPError(url, 409, "conflict", {}, io.BytesIO(b'{"error":{"code":"message_held"}}'))
+
+
+_held_calls = []
+_urllib_request.urlopen = _sweep_urlopen(["m_held"], [], _held_calls, fail_on=_fail_every_delete)
+_trashed_held, _purged_held = monitor._sweep_inbox("a@x.test")
+_urllib_request.urlopen = _saved_urlopen
+check("sweep does not count a failed delete", (_trashed_held, _purged_held), (0, 0))
+
+
+# Listing failure ends the pass without raising: hygiene must never propagate
+# into the tick's status code, which Cloud Scheduler reads as stack health.
+def _fail_every_call(url, method):
+    raise _urllib_error.HTTPError(url, 500, "boom", {}, io.BytesIO(b"{}"))
+
+
+_urllib_request.urlopen = _sweep_urlopen([], [], [], fail_on=_fail_every_call)
+emitted.clear()
+_trashed_err, _purged_err = monitor._sweep_inbox("a@x.test")
+_urllib_request.urlopen = _saved_urlopen
+check("sweep returns zero counts when listing fails", (_trashed_err, _purged_err), (0, 0))
+check(
+    "sweep logs a monitor_error with stage=sweep",
+    any(e == "monitor_error" and f.get("stage") == "sweep" for e, f in emitted),
+    True,
+)
 
 
 print()


### PR DESCRIPTION
## The problem

Both standing harnesses kept every message they ever created. On staging:

| agent | inbound live | inbound trashed | outbound live | outbound trashed |
|---|---:|---:|---:|---:|
| `probe@` (prober) | 134,132 | 43,566 | 134,126 | 43,566 |
| `mon-a@` (sdk-monitor) | 10,073 | 35,244 | **47,007** | 0 |
| `mon-b@` (sdk-monitor) | 10,072 | 35,244 | **47,005** | 0 |

That's **98.5% of a 548k-row, 1.37 GB `messages` table** — on an environment whose whole purpose is to be disposable.

It isn't only untidy. It's enough table churn that an unrelated `deleteAgent` can exceed HAProxy's 60s server timeout and return a **504 carrying HAProxy's HTML error page**, which fails the conformance suite's response-schema gate (the spec documents `application/json`). The same slow deletes hold both slots of the per-account concurrent-destructive cap (`maxConcurrentDestructive = 2`), so a third delete gets 429 — even though the SDK already retries 429 and honors `Retry-After` (`retry.ts:166`, `errors.ts:84`).

One cause, three red signals: a failed conformance gate, a failed client-surface gate, and the **"e2a staging: HTTP 5xx fast burn"** page.

## The fix

A bounded **trash-then-purge** sweep in each harness. The order is a requirement, not a preference: "delete forever" only accepts a message *already* in the trash (`ErrNotInTrash` → 409 `not_in_trash`), so a live message must be trashed first.

**Prober** (`internal/selftest/cleanup.go`) — runs after the battery is recorded. Previously only `scenarioWebSocketRoundTrip` cleaned up, and only the one inbound copy it had an id for; the inbound round-trip, the outbound send, and both loopback self-sends (which land **both** an outbound and an inbound copy) all leaked.

**sdk-monitor** (`tests/sdk-monitor/monitor.py`) — the same sweep per inbox at the end of each tick. Its per-leg `_cleanup` already trashes the *received* copy through the leg's own interface, and **that interface coverage is preserved and untouched**; the *sent* copy was explicitly out of scope by design, which is the 47k outbound rows per inbox. The sweep uses the raw API rather than a strategy, because the per-leg cleanup is what exercises each interface's delete verb — and the `cli` interface has no delete verb at all.

### Design notes

- **Whole-inbox, not per-scenario id tracking.** A loopback self-send lands a copy the sender never learns an id for, and a scenario that fails partway leaves residue no deferred cleanup would catch. Listing what's actually there covers both with one mechanism.
- **Bounded per pass** (50; the monitor's is `E2A_MONITOR_SWEEP_BUDGET`). Each tick creates far less than that, so the surplus drains existing backlog gradually rather than turning either harness into a bulk-delete client.
- **`direction=all&read_status=all` are load-bearing.** The endpoint defaults to inbound-only and, for inbound, unread-only — the defaults would walk straight past every outbound copy, which is exactly the residue being cleared.
- **Best-effort, after the verdict is fixed.** A cleanup failure is hygiene debt and can never turn a healthy stack red — the contract `trashMessage` and `_cleanup` already follow. A 409 (held for review, or provider submission in flight) is skipped and retried next tick, never booked as done.

## A bug this surfaced in the tests

The monitor's `/tick` tests stub `STRATEGIES` but not the sweep, which talks to the API directly — so they would have begun making **real network calls to the configured base URL** (default `https://api.e2a.dev`). They now stub `_sweep_inbox` and assert both inboxes get swept. The suite stays fully offline.

## Tests

- 4 new Go tests: trash-before-purge ordering, the query parameters, best-effort on a failing server, and 409s not being counted.
- 10 new monitor checks covering the same contract plus the `stage=sweep` error log.
- `go test ./internal/selftest/ ./cmd/e2a-prober/` green; the monitor suite green.

## Not in scope

Doesn't drain the existing staging backlog — that's a separate one-off. This stops the regrowth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
