### PR TITLE
fix(db): index the two hot unindexed FK referencing columns

### DIFF
--- a/migrations/106_wsd_message_id_idx.sql
+++ b/migrations/106_wsd_message_id_idx.sql
@@ -1,0 +1,65 @@
+-- 106_wsd_message_id_idx.sql
+-- e2a:no-transaction
+--
+-- Index backing the FOREIGN KEY enforcement on
+-- webhook_subscriber_deliveries.message_id, declared in 025 as
+--     message_id TEXT REFERENCES messages(id) ON DELETE SET NULL
+-- and never indexed since.
+--
+-- Postgres auto-indexes the REFERENCED side of a foreign key (messages.id, via
+-- its primary key) but never the REFERENCING side. ON DELETE SET NULL is
+-- implemented as an internal per-row trigger that fires once for EVERY deleted
+-- parent row and runs
+--     UPDATE ONLY webhook_subscriber_deliveries SET message_id = NULL
+--      WHERE message_id = $1
+-- With no index on that column the only plan is a sequential scan of the whole
+-- table — per deleted message, not per statement.
+--
+-- Measured on staging (2026-08-23), where the table had reached 421,319 rows /
+-- 88,177 pages, against its structurally identical sibling webhook_events,
+-- which HAS such an index (idx_webhook_events_message_created, 026):
+--
+--   webhook_subscriber_deliveries  Seq Scan     cost 93443.49   (no index)
+--   webhook_events                 Index Scan   cost     8.44   (454,487 rows)
+--
+-- ~11,000x, on a table that is not even the larger of the two. A 1000-message
+-- delete batch was ~88M page visits; every batch aborted on a 60s
+-- statement_timeout, and a plain agent delete blew the 60s proxy budget and
+-- returned an HTML 504 — which then failed the conformance suite's
+-- response-schema gate, because the spec documents application/json. The same
+-- slow deletes pinned both slots of the per-account concurrent-destructive cap,
+-- so unrelated deletes 429'd. One missing index, four unrelated-looking
+-- symptoms.
+--
+-- 025's own header notes message_id is ON DELETE SET NULL "so the 30-day
+-- messages [retention] purge" can proceed — i.e. the design depends on exactly
+-- the path that was unindexed. Retention purges get progressively more
+-- expensive as this table grows, so this is a latent production problem, not a
+-- staging-only one.
+--
+-- NOT partial, unlike idx_webhook_events_message_created's
+-- WHERE message_id IS NOT NULL. Not because a partial index would fail — the
+-- EXPLAIN above proves the planner uses that partial sibling for exactly this
+-- predicate shape — but because it would buy nothing here: 419,593 of 424,276
+-- rows (98.9%) carry a message_id, so the partial and plain indexes are within
+-- ~1% of each other in size. Compare 107, where the same column shape is 0.79%
+-- non-null and partial is the obvious choice.
+--
+-- CREATE INDEX CONCURRENTLY so the build takes no write lock on this
+-- delivery-volume-scaled table (a plain CREATE INDEX would block webhook
+-- fan-out inserts for the whole build). The e2a:no-transaction directive skips
+-- the BeginTx wrapper — Postgres rejects CONCURRENTLY inside a transaction
+-- block — and that runner requires a single statement.
+--
+-- OPS NOTE — invalid-index recovery: if the CONCURRENTLY build is interrupted,
+-- Postgres leaves an INVALID index of this name. On the next startup this
+-- migration re-runs, but CREATE ... IF NOT EXISTS sees the name and SKIPS the
+-- rebuild, marking the migration applied over a broken index — FK enforcement
+-- silently falls back to a seq scan (a performance, not correctness,
+-- regression). To recover:
+--     DROP INDEX CONCURRENTLY IF EXISTS idx_wsd_message_id;
+-- then re-run this statement. Check validity with:
+--     SELECT indisvalid FROM pg_index
+--      WHERE indexrelid = 'idx_wsd_message_id'::regclass;
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_wsd_message_id
+    ON webhook_subscriber_deliveries (message_id);

--- a/migrations/107_messages_reviewed_by_idx.sql
+++ b/migrations/107_messages_reviewed_by_idx.sql
@@ -1,0 +1,43 @@
+-- 107_messages_reviewed_by_idx.sql
+-- e2a:no-transaction
+--
+-- The second unindexed FOREIGN KEY referencing column, found by the same audit
+-- that produced 106:
+--     messages.reviewed_by_user_id -> users(id) ON DELETE SET NULL
+--
+-- Same mechanism as 106. Postgres indexes the referenced side (users.id) but
+-- never the referencing side, so ON DELETE SET NULL fires a per-row
+--     UPDATE ONLY messages SET reviewed_by_user_id = NULL
+--      WHERE reviewed_by_user_id = $1
+-- which, unindexed, sequentially scans all of messages — on staging 549,579
+-- rows — once per deleted user.
+--
+-- Rarer than 106's path (users are deleted far less often than messages), but
+-- worse per occurrence and on a path that matters: deleteAccount is in
+-- destructiveOps (internal/httpapi/ratelimit.go), so it runs under the same
+-- concurrency cap and the same proxy timeout budget that 106's seq scan was
+-- already blowing. Account deletion is also a data-rights path, where "it timed
+-- out" is a bad answer.
+--
+-- PARTIAL here, unlike 106: only 4,333 of 549,579 rows (0.79%) carry a
+-- reviewed_by_user_id, since the column is set only on HITL-reviewed messages.
+-- The partial index is ~127x smaller than a plain one and covers every row the
+-- FK check can match, because `reviewed_by_user_id = $1` implies
+-- `reviewed_by_user_id IS NOT NULL` — the same implication the planner already
+-- exploits for idx_webhook_events_message_created (026), verified by EXPLAIN on
+-- staging showing an Index Scan through that partial index for this exact
+-- predicate shape.
+--
+-- CREATE INDEX CONCURRENTLY + e2a:no-transaction for the same reasons as 106:
+-- messages is the hottest table in the schema and a plain CREATE INDEX would
+-- block inbound writes for the whole build.
+--
+-- OPS NOTE — invalid-index recovery: an interrupted CONCURRENTLY build leaves an
+-- INVALID index, and CREATE ... IF NOT EXISTS will then skip the rebuild on the
+-- next startup, marking this applied over a broken index. To recover:
+--     DROP INDEX CONCURRENTLY IF EXISTS idx_messages_reviewed_by_user_id;
+-- then re-run this statement. Check validity with:
+--     SELECT indisvalid FROM pg_index
+--      WHERE indexrelid = 'idx_messages_reviewed_by_user_id'::regclass;
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_messages_reviewed_by_user_id
+    ON messages (reviewed_by_user_id) WHERE reviewed_by_user_id IS NOT NULL;


### PR DESCRIPTION
## The bug

Postgres auto-indexes the **referenced** side of a foreign key (the PK) but never the **referencing** side. Both columns below are `ON DELETE SET NULL`, which Postgres implements as an internal per-row trigger firing once for **every deleted parent row**:

```sql
UPDATE ONLY child SET fk = NULL WHERE fk = $1
```

Unindexed, that's a sequential scan of the entire child table — **per deleted row**, not per statement.

## The measurement

Same database, same moment, same predicate shape, same FK action. The only difference is the index:

| table | rows | pages | index on FK column | plan | **cost** |
|---|---:|---:|---|---|---:|
| `webhook_subscriber_deliveries` | 421,319 | 88,177 | **none** | `Seq Scan` | **93,443.49** |
| `webhook_events` | 454,487 | 98,432 | `idx_webhook_events_message_created` (026) | `Index Scan` | **8.44** |

**~11,000×** — and `webhook_events` is the *larger* table.

## Why it mattered

A 1000-message delete batch was ~88M page visits. Every batch aborted on a 60s `statement_timeout`. Downstream, one missing index produced four symptoms that looked unrelated:

1. `deleteAgent` exceeded the 60s proxy budget → **HTML 504**
2. that HTML body failed the conformance suite's **response-schema gate** (spec documents `application/json`)
3. the slow deletes pinned both slots of `maxConcurrentDestructive`, so unrelated deletes **429'd**
4. two of those 504s in one 5m window fired the **HTTP 5xx fast burn** alert

**Latent in production, not staging-specific.** `025`'s own header says `message_id` is `ON DELETE SET NULL` *so the 30-day retention purge can proceed* — the design depends on exactly the path that was unindexed, and the cost scales with table size.

## The two migrations

**`106`** — `webhook_subscriber_deliveries.message_id`, **plain** index. 419,593 of 424,276 rows (98.9%) are non-null, so a partial index would be within ~1% of the same size.

**`107`** — `messages.reviewed_by_user_id`, **partial** index. Only 4,333 of 549,579 rows (0.79%) are non-null, making partial **~127× smaller**. The FK check still uses it because `col = $1` implies `col IS NOT NULL` — the same implication the planner already exploits for the partial `idx_webhook_events_message_created`, confirmed by `EXPLAIN`. Rarer path, but worse per occurrence, and `deleteAccount` is itself in `destructiveOps`, so it runs under the same cap and timeout budget — and "the account deletion timed out" is a poor answer on a data-rights path.

Both use `CREATE INDEX CONCURRENTLY` with `e2a:no-transaction`, following **059**, which added an index to this same table for this same class of problem. Both carry the invalid-index recovery note 059 established.

## Deliberately not in scope

The audit found **9 more** single-column FKs with no leading index, all on tables that are currently empty or never-analyzed on staging:

```
contact_engagements.contact_id (CASCADE)      oauth_refresh_tokens.user_id (CASCADE)
oauth_auth_codes.user_id (CASCADE)            oauth_clients.created_by_user_id (SET NULL)
oauth_refresh_tokens.client_id (CASCADE)      oauth_auth_codes.client_id (CASCADE)
user_sessions.user_id (CASCADE)               sending_ramp_reservations.user_id (CASCADE)
oauth_pkce_requests.client_id (CASCADE)
```

I did **not** blanket-index these: indexes cost write throughput, and a seq scan of an empty table is free. But several are per-user tables that grow (`user_sessions`, `oauth_refresh_tokens`), and I can't size them on prod from staging. Worth a follow-up audit against prod row counts, plus a schema test with an explicit allowlist so a *new* unindexed FK becomes a deliberate decision rather than an accident.

## Tests

`go test ./internal/identity/ -run Migrat -short` green; `go build ./...` clean. The migration runner's `e2a:no-transaction` single-statement requirement is satisfied by both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
