### PR TITLE
release(sdk): publish the TypeScript client as 5.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8065,7 +8065,7 @@
     },
     "sdks/typescript": {
       "name": "@e2a/sdk",
-      "version": "5.7.0",
+      "version": "5.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ws": "^8.21.3"

--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Changelog
 
-## Unreleased
+## 5.8.0
+
+### Added
+- **`E2A_API_URL` is the canonical base-URL environment variable**, matching the
+  name the server uses for its externally visible API base. The previous
+  `E2A_BASE_URL` is still honoured so published integrations keep working, but
+  now emits a one-shot deprecation warning. Resolution order is
+  `opts.baseUrl` -> `E2A_API_URL` -> `E2A_BASE_URL` (deprecated) ->
+  `https://api.e2a.dev`.
+
+### Fixed
+- **`WSListener` now resolves its base URL the same way `E2AClient` does.** It
+  previously honoured only an explicit `opts.baseUrl` and otherwise went
+  straight to `https://api.e2a.dev`, ignoring the environment entirely — so a
+  self-hosted deployment that set the env var still had its WebSocket listener
+  pointed at the hosted service. Exporting `E2A_API_URL` now points both at the
+  same deployment.
 
 ### Changed
 - **Dot-segment path parameters (`.` / `..`) are now rejected client-side**

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2a/sdk",
-  "version": "5.7.0",
+  "version": "5.8.0",
   "description": "TypeScript SDK for e2a — build AI agents with authenticated email",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Why

`@e2a/sdk` **5.7.0** was cut on **2026-08-16** and has been four commits behind the repo ever since — including a **security fix** that has sat in an `## Unreleased` changelog section the whole time:

| commit | |
|---|---|
| **#909** | **reject dot-segment path params that retarget requests** |
| #918 | shared base-URL resolution (`E2A_API_URL`, `WSListener` parity) |
| #923 | live domain suite alignment |
| #926 | dependency bump |

Source changes: `src/v1/client.ts` (74 lines), `src/v1/env.ts` (new, 46), `src/v1/ws.ts` (13).

## This gap is my mistake in #932

I scoped the TypeScript SDK there by diffing against **`v1.7.10`** and concluded "devDependency bump only — no republish needed." The correct baseline is the last **published** tag, `ts-sdk-v5.7.0`, which predates `v1.7.10` by four days.

The consequence: the Python client shipped its dot-segment guard as 5.8.0 today while the TypeScript client kept serving 5.7.0 without one. And since `@e2a/cli` depends on `@e2a/sdk`, **every CLI install carried the unfixed URL builder underneath** — `e2a suppressions delete`, `e2a contacts delete`, `e2a messages delete` all route through that layer.

## What ships

**5.7.0 → 5.8.0.** Minor, not patch — same reasoning as the Python client: the guard throws `E2AValidationError` on path-parameter values that previously produced a real, *misdirected* request. The changelog's own worst case: `contacts.deleteOutreach("..", address)` reaching `deleteContact` and permanently deleting the contact record instead of un-enrolling one outreach relationship.

The changelog also gains the two **user-visible #918 changes it never documented**:

- `E2A_API_URL` is now canonical; `E2A_BASE_URL` still works but emits a one-shot deprecation warning
- `WSListener` now resolves its base URL like `E2AClient` does. It previously honoured only an explicit `opts.baseUrl` and otherwise went straight to `https://api.e2a.dev`, **ignoring the environment entirely** — so a self-hosted deployment that set the env var still had its WebSocket listener pointed at the hosted service

To be precise about one thing: this is **not** the fail-closed change #918 made elsewhere. The TypeScript client still falls back to `https://api.e2a.dev` by design (`opts.baseUrl ?? resolveBaseUrl() ?? DEFAULT_BASE_URL`).

## Files

`sdks/typescript/package.json`, `sdks/typescript/CHANGELOG.md`, `package-lock.json` (the `sdks/typescript` workspace entry). Version consistency verified across manifest and lockfile.

## No CLI republish needed

`@e2a/cli` 2.5.0 requires `@e2a/sdk ^5.7.0`, which 5.8.0 satisfies, so fresh installs and updates pick the fix up on resolution. CLI 2.5.0 stays correct as published.

## After merge

Push `ts-sdk-v5.8.0` to trigger the npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
