### PR TITLE
fix(contract): raise on an unrecognized setup step

### DIFF
--- a/sdks/python/tests/test_contract.py
+++ b/sdks/python/tests/test_contract.py
@@ -257,14 +257,15 @@ class Runner:
                 resp = self._raw("POST", "/v1/domains", {"domain": domain})
                 if resp.status_code >= 400 and resp.status_code != 409:
                     resp.raise_for_status()
-
-            if "register_agent" in s:
+            elif "register_agent" in s:
                 agent = s["register_agent"]
                 email = self.resolve(agent["email"])
                 resp = self._raw("POST", "/v1/agents", {"email": email})
                 if resp.status_code >= 400 and resp.status_code != 409:
                     resp.raise_for_status()
                 self.vars["agent_email"] = email
+            else:
+                raise ValueError(f"unknown setup step: {s!r}")
 
         return False
 
@@ -625,6 +626,50 @@ def test_domain_crud_is_runnable_without_store_access():
     scenario = _scenario_by_name("domain_crud")
     assert scenario["setup"] == [{"register_domain": "domain-crud.test.dev"}]
     assert not scenario_needs_store(scenario)
+
+
+def test_execute_setup_registers_domain_then_agent(monkeypatch):
+    scenario = {
+        "name": "setup_domain_and_agent",
+        "description": "known setup keys still dispatch",
+        "setup": [
+            {"register_domain": "setup.test.dev"},
+            {"register_agent": {"email": "agent@setup.test.dev"}},
+        ],
+        "steps": [],
+    }
+    runner = Runner("https://contract.test", "key", scenario)
+    calls: list[tuple[str, str]] = []
+
+    def fake_raw(method: str, path: str, body: Any = None, **kwargs: Any) -> httpx.Response:
+        del body, kwargs
+        calls.append((method, path))
+        return httpx.Response(200, json={})
+
+    monkeypatch.setattr(runner, "_raw", fake_raw)
+    try:
+        skipped = runner.execute_setup()
+    finally:
+        runner.close()
+
+    assert skipped is False
+    assert calls == [("POST", "/v1/domains"), ("POST", "/v1/agents")]
+    assert runner.vars["agent_email"] == "agent@setup.test.dev"
+
+
+def test_execute_setup_rejects_unrecognized_key():
+    scenario = {
+        "name": "setup_typo",
+        "description": "a typo'd setup key must not silently no-op",
+        "setup": [{"regsiter_domain": "typo.test.dev"}],
+        "steps": [],
+    }
+    runner = Runner("https://contract.test", "key", scenario)
+    try:
+        with pytest.raises(ValueError, match="unknown setup step"):
+            runner.execute_setup()
+    finally:
+        runner.close()
 
 
 def test_runner_cleanup_preserves_primary_failure_and_runs_every_request(monkeypatch):

--- a/sdks/typescript/test/v1/contract.test.ts
+++ b/sdks/typescript/test/v1/contract.test.ts
@@ -925,6 +925,8 @@ class Runner {
         );
         continue;
       }
+
+      throw new Error(`unknown setup step: ${JSON.stringify(s)}`);
     }
     return false;
   }


### PR DESCRIPTION
## Summary

Issue #823 covers two gaps in the contract-test harness's permissive decoding: a strict-decode gap in the Go loader (fixed by #910) and this one, the TS/Python contract runners' setup-step dispatch.

`Runner.execute_setup` (Python, `sdks/python/tests/test_contract.py`) and `ScenarioRunner.executeSetup` (TypeScript, `sdks/typescript/test/v1/contract.test.ts`) each dispatch a setup step through a chain of checks for the four known primitives (`register_domain`, `register_agent`, `verify_domain`, `inject_message`) with no fallback branch. A step whose only key matches none of the four falls through the whole chain silently: no HTTP call, no exception, and the scenario still reports PASS with its precondition missing. `execute_steps`/`executeSteps` (the STEPS dispatch, a separate method) already raise/throw on an unrecognized `action`; this brings the setup dispatch to the same shape.

## Root cause

The setup dispatch chain never had an else/default branch, so an unrecognized key (a typo, or a new primitive added to `scenarios.yaml` before a runner implements it) degrades to "scenario runs without its precondition" instead of an error.

## Fix

Python's chain becomes `if/elif/else raise ValueError`. TypeScript keeps its existing `if (...) { ...; continue; }` branches and adds a `throw Error` after the last one. Checked every scenario in `tests/contract/scenarios.yaml`: `register_agent`, `register_domain`, `verify_domain`, `inject_message` are the only four setup keys used anywhere in the file, so no existing scenario reaches the new branch.

## Test plan

- Python: `pytest tests/ -v` (3.12, clean container): 613 passed, 48 skipped (need `E2A_TEST_BASE_URL`/`E2A_TEST_API_KEY`, a live contract server), coverage 94.12%. The new `test_execute_setup_rejects_unrecognized_key` fails on main (`DID NOT RAISE`) and passes on this branch; `test_execute_setup_registers_domain_then_agent` pins the known-key dispatch is unchanged.
- Python: `mypy` clean.
- TypeScript: `tsc --project tsconfig.test.json` clean (clean container).
- Not run: the live-server `python-contract`/`ts-contract` jobs (Postgres + a built Go contract server), so the TypeScript-side fix is verified by type-check and by mirroring the Python dispatch exactly, not executed against a live server.

Fixes #823
