### PR TITLE
fix(identity): close the check-then-act race on max_agents

### DIFF
--- a/internal/apiserver/apiserver.go
+++ b/internal/apiserver/apiserver.go
@@ -157,6 +157,7 @@ func BuildDeps(p Params) httpapi.Deps {
 		GetConversation:   p.Store.GetConversationByID,
 
 		CreateAgent:          p.Store.CreateAgent,
+		CreateAgentWithLimit: p.Store.CreateAgentWithLimit,
 		LookupDomain:         p.Store.LookupDomain,
 		LookupCoveringDomain: p.Store.LookupCoveringDomain,
 		// Exact-domain MX probe for the create-time two-way-inbox gate.

--- a/internal/e2e/agents_create_race_e2e_test.go
+++ b/internal/e2e/agents_create_race_e2e_test.go
@@ -1,0 +1,101 @@
+//go:build integration
+
+package e2e_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/tokencanopy/e2a/internal/limits"
+	"github.com/tokencanopy/e2a/internal/testutil"
+)
+
+// max_agents must be enforced under concurrency: N simultaneous POST
+// /v1/agents for distinct new addresses on one account, capped at 1, must
+// leave exactly one agent created (same class as #822/#901's max_domains
+// race). Before the fix, CheckAgentCreate's count read and CreateAgent's
+// insert were two independent DB calls with nothing serializing them, so
+// every concurrent request could read the same pre-insert count and all pass
+// the cap.
+func TestCreateAgentConcurrentRequestsRespectMaxAgentsE2E(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ts := testutil.TestServer(t, pool)
+	ctx := context.Background()
+
+	user, err := ts.Store.CreateOrGetUser(ctx, "agent-race-owner@example.com", "Agent Race Owner", "google-agent-race-owner")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	apiKey, err := ts.Store.CreateAPIKey(ctx, user.ID, "agent-race-key", nil)
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+	if err := limits.NewStore(pool).Upsert(ctx, user.ID, limits.Limits{
+		PlanCode: "test", MaxAgents: 1, MaxDomains: 100000,
+		MaxMessagesMonth: 100000, MaxStorageBytes: 1 << 40,
+	}); err != nil {
+		t.Fatalf("Upsert limits: %v", err)
+	}
+
+	const n = 8
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	codes := make([]int, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			// A shared-domain address (testutil's default SharedDomain,
+			// agents.e2a.dev) needs no domain ownership/verification, so the
+			// only thing under test is the max_agents race.
+			body := []byte(fmt.Sprintf(`{"email":"race-agent-%d@agents.e2a.dev","name":"race agent"}`, i))
+			req, err := http.NewRequest("POST", ts.HTTPServer.URL+"/v1/agents", bytes.NewReader(body))
+			if err != nil {
+				t.Errorf("build request %d: %v", i, err)
+				return
+			}
+			req.Header.Set("Authorization", "Bearer "+apiKey.PlaintextKey)
+			req.Header.Set("Content-Type", "application/json")
+			<-start
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Errorf("POST %d: %v", i, err)
+				return
+			}
+			codes[i] = resp.StatusCode
+			resp.Body.Close()
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	var created, rejected int
+	for _, code := range codes {
+		switch code {
+		case http.StatusCreated:
+			created++
+		case http.StatusPaymentRequired:
+			rejected++
+		default:
+			t.Errorf("unexpected status code %d", code)
+		}
+	}
+	if created != 1 || rejected != n-1 {
+		t.Fatalf("want 1 created and %d rejected (max_agents=1), got created=%d rejected=%d (codes=%v)",
+			n-1, created, rejected, codes)
+	}
+
+	var agentCount int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM agent_identities WHERE user_id = $1 AND deleted_at IS NULL`, user.ID,
+	).Scan(&agentCount); err != nil {
+		t.Fatalf("count agents: %v", err)
+	}
+	if agentCount != 1 {
+		t.Fatalf("agent_identities row count = %d, want 1 (max_agents cap was bypassed)", agentCount)
+	}
+}

--- a/internal/httpapi/agents_write.go
+++ b/internal/httpapi/agents_write.go
@@ -371,22 +371,38 @@ func (s *Server) handleCreateAgent(ctx context.Context, in *createAgentInput) (*
 
 	// Per-user agent cap (after auth + domain checks, so a 402 means
 	// "valid request, out of capacity" — never masks a 400/401).
-	if s.deps.EnforceAgentCreate != nil {
-		if err := s.deps.EnforceAgentCreate(ctx, user.ID); err != nil {
-			if env, ok := limitEnvelope(err); ok {
-				return nil, env
-			}
+	// maxAgents left at its zero value on a GetLimits failure would read as
+	// unlimited to CreateAgentWithLimit, so a lookup error must fail the
+	// request rather than fall through with the cap silently open.
+	maxAgents := 0
+	if s.deps.GetLimits != nil {
+		lim, err := s.deps.GetLimits(ctx, user.ID)
+		if err != nil {
 			return nil, NewError(http.StatusInternalServerError, "internal_error", "limits check failed")
 		}
+		maxAgents = lim.MaxAgents
 	}
 
-	if s.deps.CreateAgent == nil {
+	if s.deps.CreateAgentWithLimit == nil {
 		return nil, NewError(http.StatusInternalServerError, "internal_error", "agent create unavailable")
 	}
-	// webhookURL/agentMode params are ignored by the store (migration 029);
-	// pass "" to satisfy the retained signature.
-	ag, err := s.deps.CreateAgent(ctx, email, domain, req.Name, "", "", user.ID)
+	ag, err := s.deps.CreateAgentWithLimit(ctx, email, domain, req.Name, user.ID, maxAgents)
 	if err != nil {
+		var limErr *identity.AgentLimitExceededError
+		if errors.As(err, &limErr) {
+			// CreateAgentWithLimit is the race-proof source of truth for the
+			// cap; ask EnforceAgentCreate only for the plan/upgrade-URL
+			// details a bare AgentLimitExceededError doesn't carry.
+			if s.deps.EnforceAgentCreate != nil {
+				if enfErr := s.deps.EnforceAgentCreate(ctx, user.ID); enfErr != nil {
+					if env, ok := limitEnvelope(enfErr); ok {
+						return nil, env
+					}
+				}
+			}
+			return nil, NewError(http.StatusPaymentRequired, "limit_exceeded", limErr.Error()).
+				WithDetails(LimitExceededDetails{Resource: "agents", Limit: int64(limErr.Limit), Current: int64(limErr.Current)})
+		}
 		if isUniqueViolation(err) {
 			// Soft-delete (migration 063) keeps the trashed row's PK, so the
 			// address stays reserved: a user who trashed an inbox and tries to

--- a/internal/httpapi/agents_write_test.go
+++ b/internal/httpapi/agents_write_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/tokencanopy/e2a/internal/identity"
+	"github.com/tokencanopy/e2a/internal/limits"
 )
 
 // coveringParentDep wires the covering-parent lookup used by the subdomain
@@ -459,6 +460,53 @@ func TestCreateAgentLimitExceeded(t *testing.T) {
 		if d, _ := e["details"].(map[string]any); d == nil || d["resource"] != "agents" {
 			t.Fatalf("missing limit details: %v", body)
 		}
+	}
+}
+
+// CreateAgentWithLimit must still 402 an over-cap caller when
+// EnforceAgentCreate is unwired (nil), riding the bare AgentLimitExceededError
+// rather than EnforceAgentCreate's richer envelope.
+func TestCreateAgentLimitExceededWithoutEnforcer(t *testing.T) {
+	srv := testServer(t, func(d *Deps) { d.EnforceAgentCreate = nil })
+	code, body := postJSON(t, srv.URL+"/v1/agents", "overcap", map[string]any{
+		"email": "bot@acme.com",
+	})
+	if code != 402 || errCode(body) != "limit_exceeded" {
+		t.Fatalf("want 402 limit_exceeded, got %d %v", code, body)
+	}
+	e, _ := body["error"].(map[string]any)
+	if e == nil {
+		t.Fatalf("missing error envelope: %v", body)
+	}
+	d, _ := e["details"].(map[string]any)
+	if d == nil || d["resource"] != "agents" {
+		t.Fatalf("missing limit details: %v", body)
+	}
+	// 10 is testServer's default GetLimits MaxAgents.
+	if d["limit"] != float64(10) || d["current"] != float64(10) {
+		t.Fatalf("want limit=current=10 from AgentLimitExceededError, got %v", d)
+	}
+}
+
+// A GetLimits failure must not fall through with maxAgents left at its zero
+// value, which CreateAgentWithLimit reads as unlimited.
+func TestCreateAgentEnforcesWhenGetLimitsErrors(t *testing.T) {
+	calledWith := -1
+	srv := testServer(t, func(d *Deps) {
+		d.GetLimits = func(ctx context.Context, userID string) (limits.Limits, error) {
+			return limits.Limits{}, errors.New("connection refused")
+		}
+		d.CreateAgentWithLimit = func(ctx context.Context, email, domain, name, userID string, maxAgents int) (*identity.AgentIdentity, error) {
+			calledWith = maxAgents
+			return &identity.AgentIdentity{ID: email, RegisteredDomain: domain, Email: email, Name: name, UserID: userID}, nil
+		}
+	})
+	code, body := postJSON(t, srv.URL+"/v1/agents", "good", map[string]any{"email": "new-agent@acme.com"})
+	if code != 500 || errCode(body) != "internal_error" {
+		t.Fatalf("want 500 internal_error when GetLimits fails, got %d %v", code, body)
+	}
+	if calledWith != -1 {
+		t.Fatalf("CreateAgentWithLimit must not be called after GetLimits fails, but it was called with maxAgents=%d", calledWith)
 	}
 }
 

--- a/internal/httpapi/httpapi.go
+++ b/internal/httpapi/httpapi.go
@@ -78,6 +78,10 @@ type ConversationGetter func(ctx context.Context, agentID, conversationID string
 // legacy columns were dropped (migration 029). Handlers pass "".
 type AgentCreator func(ctx context.Context, email, domain, name, webhookURL, agentMode, userID string) (*identity.AgentIdentity, error)
 
+// AgentCreatorWithLimit mirrors store.CreateAgentWithLimit, the race-proof
+// source of truth for max_agents. maxAgents <= 0 means unlimited.
+type AgentCreatorWithLimit func(ctx context.Context, email, domain, name, userID string, maxAgents int) (*identity.AgentIdentity, error)
+
 // DomainDeleteIdemCompleter commits the keyed operation record in the same
 // transaction as the domain deletion and its incarnation-bound teardown
 // receipt. A post-commit process crash therefore cannot leave the key stale
@@ -166,7 +170,10 @@ type Deps struct {
 	ListConversations ConversationLister
 	GetConversation   ConversationGetter
 
-	CreateAgent          AgentCreator
+	CreateAgent AgentCreator
+	// CreateAgentWithLimit is the create path handleCreateAgent actually
+	// uses; CreateAgent stays for the other callers of store.CreateAgent.
+	CreateAgentWithLimit AgentCreatorWithLimit
 	LookupDomain         DomainLookup
 	LookupCoveringDomain CoveringDomainLookup
 	// ResolveMX backs the required create-time subdomain MX gate.

--- a/internal/httpapi/operations_test.go
+++ b/internal/httpapi/operations_test.go
@@ -663,6 +663,17 @@ func testServer(t *testing.T, opts ...func(*Deps)) *httptest.Server {
 			}
 			return &identity.AgentIdentity{ID: email, RegisteredDomain: domain, Email: email, Name: name, UserID: userID}, nil
 		},
+		// CreateAgentWithLimit is what handleCreateAgent actually calls; mirror
+		// ClaimDomain's u_overcap/maxAgents branch (#822's shape on agents).
+		CreateAgentWithLimit: func(ctx context.Context, email, domain, name, userID string, maxAgents int) (*identity.AgentIdentity, error) {
+			if email == "dupe@acme.com" {
+				return nil, &pgconn.PgError{Code: "23505", Message: "duplicate key value"}
+			}
+			if maxAgents > 0 && userID == "u_overcap" {
+				return nil, &identity.AgentLimitExceededError{Limit: maxAgents, Current: maxAgents}
+			}
+			return &identity.AgentIdentity{ID: email, RegisteredDomain: domain, Email: email, Name: name, UserID: userID}, nil
+		},
 		EnforceAgentCreate: func(ctx context.Context, userID string) error {
 			if userID == "u_overcap" {
 				return &limits.LimitExceededError{Resource: "agents", Limit: 1, Current: 1, Limits: limits.Limits{PlanCode: "free", UpgradeURL: "https://e2a.dev/upgrade"}}

--- a/internal/httpapi/trash_endpoints_test.go
+++ b/internal/httpapi/trash_endpoints_test.go
@@ -675,7 +675,7 @@ func TestAgentScopedCannotManageAgentTrash(t *testing.T) {
 func TestCreateAgentTrashedAddressConflict(t *testing.T) {
 	var createCalled string
 	srv := testServer(t, func(d *Deps) {
-		d.CreateAgent = func(ctx context.Context, email, domain, name, webhookURL, agentMode, userID string) (*identity.AgentIdentity, error) {
+		d.CreateAgentWithLimit = func(ctx context.Context, email, domain, name, userID string, maxAgents int) (*identity.AgentIdentity, error) {
 			createCalled = email
 			return nil, &pgconn.PgError{Code: "23505", Message: "duplicate key value"}
 		}
@@ -691,7 +691,7 @@ func TestCreateAgentTrashedAddressConflict(t *testing.T) {
 		t.Fatalf("want 409 address_in_trash, got %d %v", code, body)
 	}
 	if createCalled != "support@acme.com" {
-		t.Fatalf("CreateAgent not invoked with the trashed address; got %q", createCalled)
+		t.Fatalf("CreateAgentWithLimit not invoked with the trashed address; got %q", createCalled)
 	}
 }
 
@@ -701,7 +701,7 @@ func TestCreateAgentTrashedAddressConflict(t *testing.T) {
 // reveal another account's trashed inbox.
 func TestCreateAgentTrashedByOtherUserIsAgentTaken(t *testing.T) {
 	srv := testServer(t, func(d *Deps) {
-		d.CreateAgent = func(ctx context.Context, email, domain, name, webhookURL, agentMode, userID string) (*identity.AgentIdentity, error) {
+		d.CreateAgentWithLimit = func(ctx context.Context, email, domain, name, userID string, maxAgents int) (*identity.AgentIdentity, error) {
 			return nil, &pgconn.PgError{Code: "23505", Message: "duplicate key value"}
 		}
 		other := trashedSampleAgent()

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -2225,6 +2225,61 @@ func (s *Store) CreateAgentTx(ctx context.Context, tx pgx.Tx, agentEmail, domain
 	return createAgent(ctx, tx, agentEmail, domain, name, userID)
 }
 
+// AgentLimitExceededError is returned by CreateAgentWithLimit when userID is
+// already at maxAgents. Mirrors DomainLimitExceededError.
+type AgentLimitExceededError struct {
+	Limit, Current int
+}
+
+func (e *AgentLimitExceededError) Error() string {
+	return fmt.Sprintf("agent limit exceeded: %d/%d agents", e.Current, e.Limit)
+}
+
+// CreateAgentWithLimit is CreateAgent plus an atomic max_agents check
+// (keyspace-2 advisory lock) inside the INSERT's transaction, closing the
+// pre-insert-count race (#822's class). maxAgents <= 0 means unlimited.
+func (s *Store) CreateAgentWithLimit(ctx context.Context, agentEmail, domain, name, userID string, maxAgents int) (*AgentIdentity, error) {
+	if maxAgents <= 0 {
+		return createAgent(ctx, s.pool, agentEmail, domain, name, userID)
+	}
+
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback(ctx)
+
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1, 2))`, userID); err != nil {
+		return nil, err
+	}
+
+	// Read under the per-user lock, so this reflects every insert already
+	// committed by a concurrent request, not a stale count. Mirrors
+	// usage.Store.CountAgentsByUser's predicate; keep the two in sync.
+	var count int
+	if err := tx.QueryRow(ctx,
+		`SELECT count(*)
+		   FROM agent_identities a
+		   JOIN domains d ON a.registered_domain = d.domain
+		  WHERE a.user_id = $1 AND a.deleted_at IS NULL`,
+		userID,
+	).Scan(&count); err != nil {
+		return nil, err
+	}
+	if count >= maxAgents {
+		return nil, &AgentLimitExceededError{Limit: maxAgents, Current: count}
+	}
+
+	a, err := createAgent(ctx, tx, agentEmail, domain, name, userID)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	return a, nil
+}
+
 // agentExecutor is the subset of pgxpool.Pool + pgx.Tx that
 // createAgent needs. Lets the same body serve both stand-alone and
 // in-transaction callers without duplicating the SQL.


### PR DESCRIPTION
## Summary

`EnforceAgentCreate` (the `max_agents` pre-check) and `CreateAgent` (the insert) ran as two independent operations with nothing serializing them: concurrent `POST /v1/agents` requests could all read the same pre-insert count and all pass. Reported with a live reproduction against real Postgres: 8 concurrent requests against a cap of 1, all 8 succeeded.

`CreateAgentWithLimit` now takes a per-user advisory lock (keyspace 2, distinct from `claimOrCreateDomain`'s keyspace 1) and re-checks the count inside the same transaction as the `INSERT`, mirroring #901's fix for `max_domains`. `handleCreateAgent` calls it directly instead of `EnforceAgentCreate` + `CreateAgent`. `EnforceAgentCreate` stays wired, called only on the limit-exceeded path, to attach the plan/upgrade-URL details a bare `AgentLimitExceededError` doesn't carry; if it's unset or doesn't corroborate, the endpoint still answers 402 from the bare error.

## Operational risk

No schema change, no behavior change on the non-concurrent path or in the 402 response shape (still `limit_exceeded` / resource `agents`, same fields). A request that previously slipped past the cap under a race now gets `402 limit_exceeded`, the same response the endpoint already returns for a non-racy over-cap request.

`internal/agent/oauth_handlers.go`'s `issueOAuthCodeWithNewAgent` (the OAuth auto-provisioning path) also creates an agent, via `CreateAgentTx`, and does not check `max_agents` at all, before or after this change. Left alone here (different mechanism, and I don't have context on the intended cap behavior for auto-provisioning); flagged in the issue.

## Client surface checklist

Not applicable: internal concurrency fix, the request/response shape of `POST /v1/agents` is unchanged.

## Test plan

- New e2e test (`internal/e2e/agents_create_race_e2e_test.go`, `-tags integration`): 8 concurrent `POST /v1/agents` against `max_agents=1`. Fails on `main` (8/8 succeed, cap blown 8x), passes on this branch (1 created, 7 `402 limit_exceeded`), both against a real Postgres 16 container.
- `go test ./internal/identity/...` and `./internal/httpapi/...` green, including two new unit tests for the `GetLimits`-failure and enforcer-unwired error-mapping paths.
- `go test ./...` (the `Go tests` job's own command) green.
- `internal/httpapi` coverage 87.0%, above the package's 73% floor.
- Not verified: contention beyond 8 concurrent requests, or across more than one connection pool / process.

Fixes #940
