### PR TITLE
fix(webhook): thread scheduled_at into the review-hold event payloads

### DIFF
--- a/internal/agent/webhooks_api.go
+++ b/internal/agent/webhooks_api.go
@@ -97,6 +97,9 @@ func (a *API) buildPendingApprovalEvent(
 		"conversation_id":     req.ConversationID,
 		"approval_expires_at": msg.ApprovalExpiresAt,
 	}
+	if msg.ScheduledAt != nil {
+		data["scheduled_at"] = msg.ScheduledAt
+	}
 	attachReviewLifecycle(data, msg.LifecycleTransitions)
 	return webhookpub.Event{
 		ID:             generateEventIDForAgent(),
@@ -130,6 +133,9 @@ func (a *API) buildApprovedEvent(
 	}
 	if sent.ProviderMessageID != "" && sent.Method != "loopback" {
 		data["provider_message_id"] = sent.ProviderMessageID
+	}
+	if sent.ScheduledAt != nil {
+		data["scheduled_at"] = sent.ScheduledAt
 	}
 	attachReviewLifecycle(data, sent.LifecycleTransitions)
 	return webhookpub.Event{

--- a/internal/agent/webhooks_events_test.go
+++ b/internal/agent/webhooks_events_test.go
@@ -219,6 +219,31 @@ func TestBuildPendingApprovalEvent(t *testing.T) {
 	}
 }
 
+func TestBuildPendingApprovalEvent_CarriesScheduledAt(t *testing.T) {
+	a := &API{}
+	agent := &identity.AgentIdentity{ID: "bot@x.example.com", UserID: "u_1"}
+	future := time.Now().Add(2 * time.Hour)
+	msg := &identity.Message{ID: "pend_1", ScheduledAt: &future}
+	req := outbound.SendRequest{To: []string{"alice@example.com"}, Subject: "review me"}
+	ev := a.buildPendingApprovalEvent(agent, msg, req, "send")
+	pdata := ev.Data.(map[string]interface{})
+	if pdata["scheduled_at"] != &future {
+		t.Errorf("scheduled_at = %v, want %v", pdata["scheduled_at"], &future)
+	}
+}
+
+func TestBuildPendingApprovalEvent_OmitsScheduledAtForImmediateSend(t *testing.T) {
+	a := &API{}
+	agent := &identity.AgentIdentity{ID: "bot@x.example.com", UserID: "u_1"}
+	msg := &identity.Message{ID: "pend_1"}
+	req := outbound.SendRequest{To: []string{"alice@example.com"}, Subject: "review me"}
+	ev := a.buildPendingApprovalEvent(agent, msg, req, "send")
+	pdata := ev.Data.(map[string]interface{})
+	if _, ok := pdata["scheduled_at"]; ok {
+		t.Errorf("scheduled_at should be omitted for an immediate send, got %v", pdata["scheduled_at"])
+	}
+}
+
 func TestBuildPendingApprovalEventUsesProvidedExactHoldTransition(t *testing.T) {
 	transition := messagelifecycle.MessageLifecycleTransition{ID: "mlt_exact", MessageID: "msg_pending", ReasonCode: messagelifecycle.ReasonReviewHoldCreated}
 	agent := &identity.AgentIdentity{ID: "bot@example.test", UserID: "user_owner"}
@@ -273,6 +298,27 @@ func TestBuildApprovedEvent(t *testing.T) {
 	localData := a.buildApprovedEvent(agent, sent, "u_reviewer").Data.(map[string]interface{})
 	if _, ok := localData["provider_message_id"]; ok {
 		t.Errorf("providerless loopback review event leaked provider_message_id: %v", localData)
+	}
+}
+
+func TestBuildApprovedEvent_CarriesScheduledAt(t *testing.T) {
+	a := &API{}
+	agent := &identity.AgentIdentity{ID: "bot@x.example.com", UserID: "u_1"}
+	future := time.Now().Add(2 * time.Hour)
+	sent := &identity.Message{ID: "msg_a", Type: "send", ScheduledAt: &future}
+	data := a.buildApprovedEvent(agent, sent, "u_reviewer").Data.(map[string]interface{})
+	if data["scheduled_at"] != &future {
+		t.Errorf("scheduled_at = %v, want %v", data["scheduled_at"], &future)
+	}
+}
+
+func TestBuildApprovedEvent_OmitsScheduledAtForImmediateSend(t *testing.T) {
+	a := &API{}
+	agent := &identity.AgentIdentity{ID: "bot@x.example.com", UserID: "u_1"}
+	sent := &identity.Message{ID: "msg_a", Type: "send"}
+	data := a.buildApprovedEvent(agent, sent, "u_reviewer").Data.(map[string]interface{})
+	if _, ok := data["scheduled_at"]; ok {
+		t.Errorf("scheduled_at should be omitted for an immediate send, got %v", data["scheduled_at"])
 	}
 }
 


### PR DESCRIPTION
## Summary

`buildPendingApprovalEvent` and `buildApprovedEvent` (`internal/agent/webhooks_api.go`) never read `msg.ScheduledAt` / `sent.ScheduledAt`, so a webhook-only subscriber of `email.review_requested` / `email.review_approved` cannot tell a deferred send from an immediate one without a follow-up `GET` on the message. Adds `scheduled_at` to both payloads when the row carries a schedule, the same optional-field pattern the same builders already use for `provider_message_id` and `lifecycle_transitions`.

On the issue's third fix step (regenerate the OpenAPI + generated SDK event models): `email.review_requested` and `email.review_approved` are deliberately kept as `map[string]any` at their trigger sites and are not registered as OpenAPI component schemas (`internal/eventpayload/payloads.go`'s package doc: these two stay untyped "until their shape settles"). There is no generated model or golden fixture for either event, so there is nothing to regenerate; `make generate-sdk-check` and the OpenAPI contract gates don't cover this payload.

## Client surface checklist

Not applicable: this is an additive field on an already-untyped, beta webhook payload, not a typed API or client-SDK surface (see note above).

## Test plan

- `TestBuildPendingApprovalEvent_CarriesScheduledAt` / `TestBuildApprovedEvent_CarriesScheduledAt`: fail on `main`, pass on this branch.
- `TestBuildPendingApprovalEvent_OmitsScheduledAtForImmediateSend` / `TestBuildApprovedEvent_OmitsScheduledAtForImmediateSend`: cover the unset case.
- `go test ./...` (full suite, go1.26 per CI) and `make fmt-check` both pass.
- Did not check: the coverage-gate job (`make cover`) needs Postgres and doesn't gate `internal/agent`, so I didn't run it.

Fixes #836
