### PR TITLE
chore(ui): add npm publish workflow and package metadata

### DIFF
--- a/.github/workflows/publish-ui.yml
+++ b/.github/workflows/publish-ui.yml
@@ -1,0 +1,54 @@
+name: Publish UI
+
+# Dedicated tag (ui-v*), matching the CLI/SDK publish-tag convention: the
+# product "v*" tag must never drive a package publish. @e2a/ui has no
+# intra-repo published deps, so its tag is independent of ts-sdk-v* / cli-v*.
+on:
+  push:
+    tags: ["ui-v*"]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false # never cancel a running publish
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          cache: "npm"
+      - run: npm ci
+      - run: npm run build --workspace @e2a/ui
+      - run: npm run typecheck --workspace @e2a/ui
+
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v7
+
+      # Node 24 ships with npm >= 11, which is the floor npm's trusted-publisher
+      # OIDC flow requires (docs.npmjs.com/trusted-publishers: "npm CLI 11.5.1
+      # or later and Node 22.14.0 or higher"). Node 20 + npm 10.x silently
+      # skips the OIDC handshake and surfaces a misleading 404 PUT error
+      # (npm/cli#9088, #8730).
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
+
+      - run: npm ci
+      - run: npm run build --workspace @e2a/ui
+
+      - name: Publish to npm
+        run: npm publish --workspace @e2a/ui --access public --provenance

--- a/design-system/package.json
+++ b/design-system/package.json
@@ -3,6 +3,14 @@
   "version": "0.1.0",
   "description": "Loft — the e2a design system. Standalone, buildable React component library.",
   "license": "Apache-2.0",
+  "author": "TokenCanopy <josh@tokencanopy.com>",
+  "homepage": "https://github.com/tokencanopy/e2a/tree/main/design-system",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tokencanopy/e2a",
+    "directory": "design-system"
+  },
+  "bugs": "https://github.com/tokencanopy/e2a/issues",
   "type": "module",
   "sideEffects": [
     "*.css"


### PR DESCRIPTION
## Summary

Prepares `@e2a/ui` for its first npm release:

- Adds `.github/workflows/publish-ui.yml`, triggered by the `ui-v*` tag (and manual `workflow_dispatch`). It mirrors the existing `publish-cli.yml`: a `test` job that builds + typechecks the package, then a `publish` job using OIDC trusted publishing (`id-token: write`, Node 24) with `npm publish --workspace @e2a/ui --access public --provenance`.
- Adds the `repository` / `homepage` / `author` / `bugs` metadata to `design-system/package.json`, matching what `@e2a/sdk` and `@e2a/cli` already carry.

No package version bump — `0.1.0` is the intended first release.

## Post-merge manual step (required before the first publish)

The `@e2a` npm org must register a **trusted publisher** for this package before the workflow can publish (this is the same one-time OIDC setup the SDK/CLI already use; no token lives in repo secrets):

- npmjs.com → `@e2a/ui` → Settings → Access → add trusted publisher → owner `tokencanopy`, repo `e2a`, workflow `.github/workflows/publish-ui.yml`, environment (leave unset).

Then the first release is cut by pushing the tag:

```
git tag ui-v0.1.0 && git push origin ui-v0.1.0
```

(or run the workflow via `workflow_dispatch`).

## Operational risk

None. Adds a workflow file and package metadata only; no runtime code, data, or existing CI behavior changes.

## Test plan

- [x] `design-system/package.json` parses as valid JSON; new fields confirmed
- [x] `publish-ui.yml` parses as valid YAML and mirrors `publish-cli.yml` step-for-step
- [x] `npm run build` / `npm run typecheck` for `@e2a/ui` are already exercised by the existing `design-system dist freshness` CI job
