### PR TITLE
fix(cli): strip CR inside quoted CSV fields, not just outside them

### DIFF
--- a/cli/src/__tests__/contacts.test.ts
+++ b/cli/src/__tests__/contacts.test.ts
@@ -60,6 +60,14 @@ describe("contacts commands", () => {
       ]);
   });
 
+  it("normalizes CRLF to LF inside a quoted multi-line field instead of leaking a raw CR", async () => {
+    const { parseCSV } = await import("../commands/contacts.js");
+    expect(parseCSV('email,notes\r\na@x.com,"two\r\nlines"\r\n')).toEqual([
+      ["email", "notes"],
+      ["a@x.com", "two\nlines"],
+    ]);
+  });
+
   it("dry-run previews CSV without calling the API", async () => {
     const dir = await mkdtemp(join(tmpdir(), "e2a-contacts-"));
     const path = join(dir, "contacts.csv");

--- a/cli/src/commands/contacts.ts
+++ b/cli/src/commands/contacts.ts
@@ -167,7 +167,7 @@ export function parseCSV(input: string): string[][] {
         } else {
           quoted = false;
         }
-      } else {
+      } else if (char !== "\r") {
         field += char;
       }
       continue;


### PR DESCRIPTION
## Summary

`parseCSV` (`cli/src/commands/contacts.ts`) drops every `\r` unconditionally
outside a quoted field, but inside a quoted field it appends `\r` to the
field verbatim. The function's own docstring claims RFC 4180 conformance
specifically for CRLF exports from Sheets/Excel/CRMs, and a Windows- or
Excel-produced multi-line cell uses CRLF line breaks internally too, so
importing one via `e2a contacts import` bakes a stray carriage return into
stored contact metadata.

Fix mirrors the existing unquoted branch: drop `\r` inside a quoted field
the same unconditional way, instead of appending it.

## Test plan

- [x] New regression test (`normalizes CRLF to LF inside a quoted
      multi-line field instead of leaking a raw CR`) fails on unmodified
      `main` and passes on this branch, both runs in a clean `node:22-slim`
      container.
- [x] Full `npm run test:coverage --workspace @e2a/cli` (322 tests) green.
- [x] `npm run build --workspace @e2a/cli` and `npm run typecheck
      --workspace @e2a/cli` both clean.
- Not checked: the live `e2a contacts import` path end to end against a
  real API server; this is covered at the `parseCSV` unit level only.
