### PR TITLE
docs(brand): position e2a for applications and AI agents

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -15,7 +15,7 @@
         "authentication": "ON_USE"
       },
       "category": "Productivity",
-      "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log."
+      "description": "Open-source email API for AI agents — transactional sending, per-agent two-way inboxes, HITL approval, structured SPF/DKIM/DMARC evidence, and a queryable event log."
     },
     {
       "name": "e2a-labs",

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -15,7 +15,7 @@
         "authentication": "ON_USE"
       },
       "category": "Productivity",
-      "description": "Open-source email API for AI agents — transactional sending, per-agent two-way inboxes, HITL approval, structured SPF/DKIM/DMARC evidence, and a queryable event log."
+      "description": "Open-source email API for applications and AI agents — transactional sending from any product, per-agent two-way inboxes, HITL approval, structured SPF/DKIM/DMARC evidence, and a queryable event log."
     },
     {
       "name": "e2a-labs",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
     "url": "https://e2a.dev"
   },
   "metadata": {
-    "description": "e2a plugins for Claude Code — authenticated email for AI agents",
-    "version": "0.9.2"
+    "description": "e2a plugins for Claude Code — open-source email API for AI agents",
+    "version": "0.9.3"
   },
   "plugins": [
     {
       "name": "e2a",
-      "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
+      "description": "Open-source email API for AI agents — transactional sending, per-agent two-way inboxes, HITL approval, structured SPF/DKIM/DMARC evidence, and a queryable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
       "category": "productivity",
       "source": "./plugins/e2a",
       "homepage": "https://e2a.dev"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,13 +6,13 @@
     "url": "https://e2a.dev"
   },
   "metadata": {
-    "description": "e2a plugins for Claude Code — open-source email API for AI agents",
-    "version": "0.9.3"
+    "description": "e2a plugins for Claude Code — open-source email API for applications and AI agents",
+    "version": "0.9.4"
   },
   "plugins": [
     {
       "name": "e2a",
-      "description": "Open-source email API for AI agents — transactional sending, per-agent two-way inboxes, HITL approval, structured SPF/DKIM/DMARC evidence, and a queryable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
+      "description": "Open-source email API for applications and AI agents — transactional sending from any product, per-agent two-way inboxes, HITL approval, structured SPF/DKIM/DMARC evidence, and a queryable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
       "category": "productivity",
       "source": "./plugins/e2a",
       "homepage": "https://e2a.dev"

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,14 +5,14 @@
     "url": "https://e2a.dev"
   },
   "metadata": {
-    "description": "e2a — open-source email API for AI agents (MCP configuration and canonical docs).",
-    "version": "0.9.3"
+    "description": "e2a — open-source email API for applications and AI agents (MCP configuration and canonical docs).",
+    "version": "0.9.4"
   },
   "plugins": [
     {
       "name": "e2a",
       "source": "./plugins/e2a",
-      "description": "Open-source email API for AI agents — transactional sending, per-agent two-way inboxes, HITL approval, structured SPF/DKIM/DMARC evidence, and a queryable event log."
+      "description": "Open-source email API for applications and AI agents — transactional sending from any product, per-agent two-way inboxes, HITL approval, structured SPF/DKIM/DMARC evidence, and a queryable event log."
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -5,14 +5,14 @@
     "url": "https://e2a.dev"
   },
   "metadata": {
-    "description": "e2a — authenticated email gateway for AI agents (MCP configuration and canonical docs).",
-    "version": "0.9.2"
+    "description": "e2a — open-source email API for AI agents (MCP configuration and canonical docs).",
+    "version": "0.9.3"
   },
   "plugins": [
     {
       "name": "e2a",
       "source": "./plugins/e2a",
-      "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log."
+      "description": "Open-source email API for AI agents — transactional sending, per-agent two-way inboxes, HITL approval, structured SPF/DKIM/DMARC evidence, and a queryable event log."
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Receive inbound over **webhook · WebSocket · REST · MCP**. Send through an **
 
 **`/v1` is now generally available** — shipped in [**v1.5.0**](https://github.com/tokencanopy/e2a/releases/tag/v1.5.0).
 
-[Hosted (e2a.dev)](https://e2a.dev) · [Quickstart](#quickstart) · [Examples](#working-examples) · [Concepts](#concepts) · [API](#api) · [SDKs](#sdks) · [MCP](#mcp-server) · [Deploy](#deployment) · [FAQ](#faq)
+[Hosted (e2a.dev)](https://e2a.dev) · [Transactional email API](https://e2a.dev/transactional-email-api) · [Agent quickstart](#quickstart) · [Examples](#working-examples) · [Concepts](#concepts) · [API](#api) · [SDKs](#sdks) · [MCP](#mcp-server) · [Deploy](#deployment) · [FAQ](#faq)
 
 <a href="https://www.producthunt.com/products/e2a-open-source-email-api-for-agents?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-e2a-open-source-email-api-for-agents" target="_blank" rel="noopener noreferrer"><img alt="e2a, the open-source email API for AI agents | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1145559&theme=light&t=1778615217650"></a>
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@
   <img src="assets/e2a-wordmark-light.svg" width="320" alt="e2a">
 </picture>
 
-### The first open-source email service built for AI agents.
+### The open-source email API for AI agents.
 
-### Give your AI agents a real, authenticated email address.
+### Send transactional email, give agents real two-way inboxes, and keep people in control.
 
-Receive inbound over **webhook · WebSocket · REST · MCP**. Send through an **HTTP API**. Every sender — human or agent — **identity-verified**.
+Use e2a as a hosted service or run the Apache-2.0 stack yourself. Built for developers, agent-native teams, and businesses adding email to products and workflows.
+
+Receive inbound over **webhook · WebSocket · REST · MCP**. Send through an **HTTP API**. Inbound mail includes structured **SPF · DKIM · DMARC** evidence.
 
 <sub>A [Token Canopy](https://tokencanopy.com) product</sub>
 
@@ -25,7 +27,7 @@ Receive inbound over **webhook · WebSocket · REST · MCP**. Send through an **
 
 [Hosted (e2a.dev)](https://e2a.dev) · [Quickstart](#quickstart) · [Examples](#working-examples) · [Concepts](#concepts) · [API](#api) · [SDKs](#sdks) · [MCP](#mcp-server) · [Deploy](#deployment) · [FAQ](#faq)
 
-<a href="https://www.producthunt.com/products/e2a-open-source-email-api-for-agents?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-e2a-open-source-email-api-for-agents" target="_blank" rel="noopener noreferrer"><img alt="e2a – open-source email API for agents - Give your AI agents a real, authenticated email address. | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1145559&theme=light&t=1778615217650"></a>
+<a href="https://www.producthunt.com/products/e2a-open-source-email-api-for-agents?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-e2a-open-source-email-api-for-agents" target="_blank" rel="noopener noreferrer"><img alt="e2a, the open-source email API for AI agents | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1145559&theme=light&t=1778615217650"></a>
 
 </div>
 
@@ -34,7 +36,7 @@ Receive inbound over **webhook · WebSocket · REST · MCP**. Send through an **
 > [!IMPORTANT]
 > **The core `/v1` API and SDKs are stable and generally available (GA) as of [v1.5.0](https://github.com/tokencanopy/e2a/releases/tag/v1.5.0): no breaking changes within `/v1`.** That tag is the compatibility baseline — every later release is audited against it. A small, explicitly enumerated surface is still **beta** and may change before it is declared stable — contacts & outreach, scheduled sending (`send_at`), email templates & starter templates, the reviews (HITL) queue, agent protection config, agent-scoped suppressions, managed unsubscribe, message lifecycle diagnostics, delivery metrics, and the `thread_id` message-read field. Beta surface is marked `x-stability-level: beta` in the OpenAPI spec and `(beta)` in the docs; where only specific *values* of a stable field are beta (the `scheduled` send status, the screening/review-hold event types, the `blocked_by_policy` error code), the field carries `x-experimental-values` naming exactly those values. Everything else is covered by the GA freeze. See the full matrix in [docs/api.md → Stability: GA and beta surface](docs/api.md#stability-ga-and-beta-surface). Existing `v1.0.x` application/cherry-pick tags predate the API freeze and are not `/v1` compatibility baselines.
 
-e2a is an **authenticated email gateway for AI agents**. It receives inbound mail, evaluates SPF, every DKIM signature, and DMARC, and delivers structured authentication evidence over whichever channel fits your runtime. Outbound goes back out through an HTTP API, with an optional human-in-the-loop approval gate.
+e2a is the **open-source email API for AI agents**. Send transactional email, give agents real two-way inboxes, and keep people in control. Inbound mail arrives with structured SPF, DKIM, and DMARC evidence; outbound mail goes through an HTTP API with an optional human-in-the-loop approval gate. Use the hosted service or run the Apache-2.0 stack yourself.
 
 **Four ways to plug an agent in:**
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
   <img src="assets/e2a-wordmark-light.svg" width="320" alt="e2a">
 </picture>
 
-### The open-source email API for AI agents.
+### The open-source email API for applications and AI agents.
 
-### Send transactional email, give agents real two-way inboxes, and keep people in control.
+### Send transactional email from any product, give agents real two-way inboxes, and keep people in control.
 
 Use e2a as a hosted service or run the Apache-2.0 stack yourself. Built for developers, agent-native teams, and businesses adding email to products and workflows.
 
@@ -36,7 +36,7 @@ Receive inbound over **webhook · WebSocket · REST · MCP**. Send through an **
 > [!IMPORTANT]
 > **The core `/v1` API and SDKs are stable and generally available (GA) as of [v1.5.0](https://github.com/tokencanopy/e2a/releases/tag/v1.5.0): no breaking changes within `/v1`.** That tag is the compatibility baseline — every later release is audited against it. A small, explicitly enumerated surface is still **beta** and may change before it is declared stable — contacts & outreach, scheduled sending (`send_at`), email templates & starter templates, the reviews (HITL) queue, agent protection config, agent-scoped suppressions, managed unsubscribe, message lifecycle diagnostics, delivery metrics, and the `thread_id` message-read field. Beta surface is marked `x-stability-level: beta` in the OpenAPI spec and `(beta)` in the docs; where only specific *values* of a stable field are beta (the `scheduled` send status, the screening/review-hold event types, the `blocked_by_policy` error code), the field carries `x-experimental-values` naming exactly those values. Everything else is covered by the GA freeze. See the full matrix in [docs/api.md → Stability: GA and beta surface](docs/api.md#stability-ga-and-beta-surface). Existing `v1.0.x` application/cherry-pick tags predate the API freeze and are not `/v1` compatibility baselines.
 
-e2a is the **open-source email API for AI agents**. Send transactional email, give agents real two-way inboxes, and keep people in control. Inbound mail arrives with structured SPF, DKIM, and DMARC evidence; outbound mail goes through an HTTP API with an optional human-in-the-loop approval gate. Use the hosted service or run the Apache-2.0 stack yourself.
+e2a is the **open-source email API for applications and AI agents**. Any product can send transactional email over HTTP, TypeScript, or Python; agent-native systems can also use real two-way inboxes. Inbound mail arrives with structured SPF, DKIM, and DMARC evidence, and outbound mail can use an optional human-in-the-loop approval gate. Use the hosted service or run the Apache-2.0 stack yourself. No AI agent or agent framework is required for application-triggered sending.
 
 **Four ways to plug an agent in:**
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -268,8 +268,8 @@ func writeCLIHandoffPage(store *identity.Store, w http.ResponseWriter, r *http.R
 // CLI login params (cli_callback, cli_state) are encoded into the OAuth state
 // parameter so they survive the redirect through Google without relying on cookies.
 // return_to (optional) is a same-origin server path the user resumes on after
-// callback success. MCP OAuth paths plus the dashboard's consolidated review
-// and threaded inbox routes are permitted.
+// callback success. MCP OAuth paths plus the dashboard's sender setup,
+// consolidated review, and threaded inbox routes are permitted.
 func (ua *UserAuth) HandleLogin(w http.ResponseWriter, r *http.Request) {
 	cliCallback := r.URL.Query().Get("cli_callback")
 	cliState := r.URL.Query().Get("cli_state")
@@ -307,8 +307,8 @@ func (ua *UserAuth) HandleLogin(w http.ResponseWriter, r *http.Request) {
 // validateReturnToPath enforces the same-origin / known-route allow-list
 // for return_to values. Accepting an arbitrary URL would turn /api/auth/login
 // into an open redirector that an attacker could chain with phishing-class
-// social engineering. The OAuth flow owns /oauth2/*; the two exact dashboard
-// routes preserve review-email and post-approval thread deep links.
+// social engineering. The OAuth flow owns /oauth2/*; exact application routes
+// preserve sender setup, review-email, and post-approval thread deep links.
 func validateReturnToPath(raw string) error {
 	if strings.ContainsAny(raw, "\\\n\r\x00") {
 		return errors.New("return_to contains forbidden characters")
@@ -322,6 +322,7 @@ func validateReturnToPath(raw string) error {
 		return errors.New("return_to must be a path with no scheme or authority")
 	}
 	allowed := strings.HasPrefix(u.Path, "/oauth2/") ||
+		u.Path == "/get-started" ||
 		u.Path == "/reviews" ||
 		u.Path == "/inboxes/messages"
 	if !allowed {
@@ -336,6 +337,7 @@ func validateReturnToPath(raw string) error {
 	cleaned := path.Clean(u.Path)
 	cleanedAllowed := strings.HasPrefix(cleaned, "/oauth2/") ||
 		cleaned == "/oauth2" ||
+		cleaned == "/get-started" ||
 		cleaned == "/reviews" ||
 		cleaned == "/inboxes/messages"
 	if !cleanedAllowed {

--- a/internal/auth/cli_login_test.go
+++ b/internal/auth/cli_login_test.go
@@ -190,6 +190,36 @@ func TestHandleLogin_EncodesInboxThreadReturnToInOAuthState(t *testing.T) {
 	}
 }
 
+func TestHandleLogin_EncodesGetStartedReturnToInOAuthState(t *testing.T) {
+	ua, _, _ := setupUserAuth(t)
+
+	returnTo := "/get-started?step=address"
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"/api/auth/login?return_to="+url.QueryEscape(returnTo),
+		nil,
+	)
+	w := httptest.NewRecorder()
+
+	ua.HandleLogin(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusFound, w.Body.String())
+	}
+	loc, _ := url.Parse(w.Result().Header.Get("Location"))
+	stateParam := loc.Query().Get("state")
+	stateJSON, _ := base64.URLEncoding.DecodeString(stateParam)
+	var state struct {
+		ReturnTo string `json:"rt"`
+	}
+	if err := json.Unmarshal(stateJSON, &state); err != nil {
+		t.Fatalf("unmarshal state: %v", err)
+	}
+	if state.ReturnTo != returnTo {
+		t.Errorf("return_to = %q, want %q", state.ReturnTo, returnTo)
+	}
+}
+
 // TestHandleLogin_RejectsReturnToOutsideAllowList: every value the
 // allow-list refuses must produce 400 rather than silently strip — a
 // silent strip would land the user on /dashboard, leaving the original
@@ -199,6 +229,8 @@ func TestHandleLogin_RejectsReturnToOutsideAllowList(t *testing.T) {
 
 	bad := []string{
 		"/dashboard",                         // unrelated dashboard route
+		"/get-started/other",                 // sender setup allow-list is exact
+		"/get-started/../dashboard",          // sender setup path traversal
 		"/reviews/other",                     // review allow-list is exact
 		"/reviews/../dashboard",              // review path traversal
 		"/inboxes/messages/view",             // inbox allow-list is exact

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -880,6 +880,22 @@ func TestOIDCLoginCarriesInboxThreadReturnToInResumeCookie(t *testing.T) {
 	}
 }
 
+func TestOIDCLoginCarriesGetStartedReturnToInResumeCookie(t *testing.T) {
+	fx := setupOIDC(t)
+
+	returnTo := "/get-started?step=address"
+	tx := beginOIDCLoginRaw(t, fx, "/api/auth/oidc/login?return_to="+url.QueryEscape(returnTo))
+
+	cookie := findCookie(tx.cookies, "e2a_oidc_resume")
+	if cookie == nil {
+		t.Fatal("resume cookie not set for sender setup return_to login")
+	}
+	resume := decodeResumeCookieValue(t, cookie)
+	if resume.ReturnTo != returnTo {
+		t.Errorf("resume return_to = %q, want %q", resume.ReturnTo, returnTo)
+	}
+}
+
 // TestOIDCLoginRejectsReturnToOutsideAllowList applies the legacy door's
 // exact reject list (TestHandleLogin_RejectsReturnToOutsideAllowList):
 // every value the allow-list refuses must 400 the login, before any
@@ -889,6 +905,8 @@ func TestOIDCLoginRejectsReturnToOutsideAllowList(t *testing.T) {
 
 	bad := []string{
 		"/dashboard",                         // unrelated dashboard route
+		"/get-started/other",                 // sender setup allow-list is exact
+		"/get-started/../dashboard",          // sender setup path traversal
 		"/reviews/other",                     // review allow-list is exact
 		"/reviews/../dashboard",              // review path traversal
 		"/inboxes/messages/view",             // inbox allow-list is exact

--- a/internal/auth/return_to_test.go
+++ b/internal/auth/return_to_test.go
@@ -1,0 +1,28 @@
+package auth
+
+import "testing"
+
+func TestValidateReturnToPathAllowsGetStartedStep(t *testing.T) {
+	t.Parallel()
+
+	if err := validateReturnToPath("/get-started?step=address"); err != nil {
+		t.Fatalf("validateReturnToPath() error = %v, want nil", err)
+	}
+}
+
+func TestValidateReturnToPathKeepsGetStartedExact(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{
+		"/get-started/other",
+		"/get-started/../dashboard",
+	} {
+		raw := raw
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+			if err := validateReturnToPath(raw); err == nil {
+				t.Fatal("validateReturnToPath() error = nil, want rejection")
+			}
+		})
+	}
+}

--- a/plugins/e2a/.claude-plugin/plugin.json
+++ b/plugins/e2a/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "e2a",
   "displayName": "e2a",
-  "version": "0.9.2",
-  "description": "Authenticated email gateway for AI agents — per-agent inboxes, SPF/DKIM verification, and a queryable, replayable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
+  "version": "0.9.3",
+  "description": "Open-source email API for AI agents — transactional sending, per-agent two-way inboxes, structured SPF/DKIM/DMARC evidence, and a queryable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "TokenCanopy",
     "url": "https://e2a.dev"

--- a/plugins/e2a/.claude-plugin/plugin.json
+++ b/plugins/e2a/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "e2a",
   "displayName": "e2a",
-  "version": "0.9.3",
-  "description": "Open-source email API for AI agents — transactional sending, per-agent two-way inboxes, structured SPF/DKIM/DMARC evidence, and a queryable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
+  "version": "0.9.4",
+  "description": "Open-source email API for applications and AI agents — transactional sending from any product, per-agent two-way inboxes, structured SPF/DKIM/DMARC evidence, and a queryable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "TokenCanopy",
     "url": "https://e2a.dev"

--- a/plugins/e2a/.codex-plugin/plugin.json
+++ b/plugins/e2a/.codex-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "e2a",
   "displayName": "e2a",
-  "version": "0.9.2",
-  "description": "Authenticated email gateway for AI agents — per-agent inboxes, SPF/DKIM verification, and a queryable, replayable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
+  "version": "0.9.3",
+  "description": "Open-source email API for AI agents — transactional sending, per-agent two-way inboxes, structured SPF/DKIM/DMARC evidence, and a queryable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "TokenCanopy"
   },
@@ -23,8 +23,8 @@
   "mcpServers": "./.mcp.json",
   "interface": {
     "displayName": "e2a",
-    "shortDescription": "Authenticated email for AI agents",
-    "longDescription": "Bundles the hosted e2a MCP server and five stable skills for setup, application integration, inbox operation, diagnosis, and evaluation — with SPF/DKIM verification, custom domains, attachments, and a replayable event log.",
+    "shortDescription": "Open-source email API for AI agents",
+    "longDescription": "Bundles the hosted e2a MCP server and five stable skills for setup, application integration, inbox operation, diagnosis, and evaluation — with structured inbound domain evidence, custom domains, attachments, and a replayable event log.",
     "developerName": "TokenCanopy",
     "category": "Productivity",
     "websiteURL": "https://e2a.dev",

--- a/plugins/e2a/.codex-plugin/plugin.json
+++ b/plugins/e2a/.codex-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "e2a",
   "displayName": "e2a",
-  "version": "0.9.3",
-  "description": "Open-source email API for AI agents — transactional sending, per-agent two-way inboxes, structured SPF/DKIM/DMARC evidence, and a queryable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
+  "version": "0.9.4",
+  "description": "Open-source email API for applications and AI agents — transactional sending from any product, per-agent two-way inboxes, structured SPF/DKIM/DMARC evidence, and a queryable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "TokenCanopy"
   },
@@ -23,7 +23,7 @@
   "mcpServers": "./.mcp.json",
   "interface": {
     "displayName": "e2a",
-    "shortDescription": "Open-source email API for AI agents",
+    "shortDescription": "Open-source email API for applications and AI agents",
     "longDescription": "Bundles the hosted e2a MCP server and five stable skills for setup, application integration, inbox operation, diagnosis, and evaluation — with structured inbound domain evidence, custom domains, attachments, and a replayable event log.",
     "developerName": "TokenCanopy",
     "category": "Productivity",

--- a/plugins/e2a/.cursor-plugin/plugin.json
+++ b/plugins/e2a/.cursor-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "e2a",
   "displayName": "e2a",
-  "version": "0.9.2",
-  "description": "Authenticated email gateway for AI agents — per-agent inboxes, SPF/DKIM verification, and a queryable, replayable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
+  "version": "0.9.3",
+  "description": "Open-source email API for AI agents — transactional sending, per-agent two-way inboxes, structured SPF/DKIM/DMARC evidence, and a queryable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "TokenCanopy",
     "url": "https://e2a.dev"

--- a/plugins/e2a/.cursor-plugin/plugin.json
+++ b/plugins/e2a/.cursor-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "name": "e2a",
   "displayName": "e2a",
-  "version": "0.9.3",
-  "description": "Open-source email API for AI agents — transactional sending, per-agent two-way inboxes, structured SPF/DKIM/DMARC evidence, and a queryable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
+  "version": "0.9.4",
+  "description": "Open-source email API for applications and AI agents — transactional sending from any product, per-agent two-way inboxes, structured SPF/DKIM/DMARC evidence, and a queryable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "TokenCanopy",
     "url": "https://e2a.dev"

--- a/plugins/e2a/README.md
+++ b/plugins/e2a/README.md
@@ -1,7 +1,8 @@
 # e2a plugin
 
-Gives an AI coding agent a real, authenticated email inbox. Installing this
-plugin registers the hosted **e2a MCP server** (`https://api.e2a.dev/mcp`,
+The open-source email API for AI agents. Send transactional email, give agents
+real two-way inboxes, and keep people in control. Installing this plugin
+registers the hosted **e2a MCP server** (`https://api.e2a.dev/mcp`,
 Streamable HTTP + OAuth 2.1) and five stable skills for setup, application
 integration, diagnosis, evaluation, and everyday inbox operation. Installing core supplies
 the MCP connection used by both core and the optional Labs workflows.

--- a/plugins/e2a/README.md
+++ b/plugins/e2a/README.md
@@ -1,7 +1,8 @@
 # e2a plugin
 
-The open-source email API for AI agents. Send transactional email, give agents
-real two-way inboxes, and keep people in control. Installing this plugin
+The open-source email API for applications and AI agents. Send transactional
+email from any product, give agents real two-way inboxes, and keep people in
+control. Installing this plugin
 registers the hosted **e2a MCP server** (`https://api.e2a.dev/mcp`,
 Streamable HTTP + OAuth 2.1) and five stable skills for setup, application
 integration, diagnosis, evaluation, and everyday inbox operation. Installing core supplies

--- a/plugins/e2a/docs/auth.md
+++ b/plugins/e2a/docs/auth.md
@@ -11,7 +11,7 @@ Two hosts are relevant:
 
 e2a already implements the OAuth 2.1 surface that MCP clients depend on: RFC 8414 authorization-server metadata at [`/.well-known/oauth-authorization-server`](https://api.e2a.dev/.well-known/oauth-authorization-server), RFC 7591 Dynamic Client Registration at `/oauth2/register` (rate-limited per IP), `authorization_code` + `refresh_token` grants with PKCE S256, RFC 7009 revocation, and RFC 6750 Bearer challenges on 401s. MCP clients can register and onboard without any human-supplied secret — the user only sees a browser consent screen.
 
-e2a also implements the first pieces of the WorkOS [auth.md](https://github.com/workos/auth.md) autonomous-agent flow: a JSON Web Key Set at `/.well-known/jwks.json`, an `agent_auth` block in the AS metadata, and a bootstrap endpoint (`POST /agent/identity`) that exchanges an agent-scoped API key for a long-lived identity assertion, redeemable at `/oauth2/token` via `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer` for a short-lived access token. Still missing: an RFC 9728 protected-resource metadata document, ID-JAG assertion intake from third parties, and the email-OTP claim ceremony. See [Agent identity](#agent-identity) for where we're heading — because every e2a agent has an end-to-end-verified email address, e2a is positioned to act as an identity provider in this protocol, and that's the direction we're building.
+e2a also implements the first pieces of the WorkOS [auth.md](https://github.com/workos/auth.md) autonomous-agent flow: a JSON Web Key Set at `/.well-known/jwks.json`, an `agent_auth` block in the AS metadata, and a bootstrap endpoint (`POST /agent/identity`) that exchanges an agent-scoped API key for a long-lived identity assertion, redeemable at `/oauth2/token` via `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer` for a short-lived access token. Still missing: an RFC 9728 protected-resource metadata document, ID-JAG assertion intake from third parties, and the email-OTP claim ceremony. See [Agent identity](#agent-identity) for where we're heading. Each e2a agent has a stable, provisioned email address and can obtain an e2a-issued identity assertion; that issuer-backed assertion, rather than arbitrary inbound mail, is the basis for the identity-provider direction.
 
 ## Use the existing tooling first
 
@@ -133,7 +133,7 @@ The `WWW-Authenticate` header on 401 responses tells you whether the failing cre
 
 This section describes e2a's bet on where agent auth is heading. The bootstrap identity endpoint below is shipped (behind an opt-in signing-key config); third-party ID-JAG consumption and the email-loop claim ceremony are still direction, not shipped surface. If you are implementing today, use the credential paths above for anything beyond the identity bootstrap.
 
-Every e2a agent has a stable, verified email address. The owner proved control of the domain (via DNS records and a verification token), and e2a evaluates SPF, DKIM, and DMARC on every inbound message routed to that agent. Equivalently for agents on the shared `agents.e2a.dev` domain, e2a is the authoritative issuer. **The agent's email is not a label — it's an identity claim e2a stands behind.**
+Every e2a agent has a stable, provisioned email address. For a custom domain, the owner proves control through DNS records and a verification token. For the shared `agents.e2a.dev` domain, e2a provisions the address directly. e2a also evaluates SPF, DKIM, and DMARC on inbound messages and returns structured evidence about the From domain. That evidence does not prove a person, mailbox, or message content. When agent-identity signing is enabled, the separate OAuth identity assertion is the claim e2a issues and signs.
 
 We are building two pieces on top of this:
 
@@ -142,12 +142,12 @@ We are building two pieces on top of this:
 e2a already operates as an OAuth issuer at `https://api.e2a.dev` (see AS metadata above), publishes a JSON Web Key Set at `https://api.e2a.dev/.well-known/jwks.json`, and lets an agent bootstrap a long-lived identity assertion from its API key via `POST /agent/identity`, redeemable for a short-lived access token at `/oauth2/token`. The remaining work is issuing audience-bound [ID-JAG](https://datatracker.ietf.org/doc/draft-ietf-oauth-identity-assertion-authz-grant/) assertions (`urn:ietf:params:oauth:token-type:id-jag`) that a *third-party* service can verify, with:
 
 - `iss` = `https://api.e2a.dev`
-- `sub` = the agent's verified email
+- `sub` = the agent's provisioned email
 - `email` / `email_verified: true`
 - `aud` = the third-party service the agent is registering with
 - Short `exp` (≤5 minutes), fresh `jti`
 
-Any auth.md-implementing service that adds e2a to its trust list will be able to onboard an e2a agent without an OTP ceremony — the agent's e2a identity vouches for it. e2a's contribution is an identity rooted in a verifiable email address, stable across agent runtimes.
+Any auth.md-implementing service that adds e2a to its trust list will be able to onboard an e2a agent without an OTP ceremony. The e2a-issued assertion vouches for the agent identity, which is tied to a stable, provisioned email address across agent runtimes.
 
 If you operate an agent service and want to accept e2a-issued assertions, watch for `iss: https://api.e2a.dev` to land in the WorkOS reference trust list, or open an issue at `https://github.com/tokencanopy/e2a/issues` to pre-register.
 

--- a/plugins/e2a/docs/auth.md
+++ b/plugins/e2a/docs/auth.md
@@ -1,6 +1,6 @@
 # auth.md
 
-You are an agent that wants to use e2a — the authenticated email gateway for AI agents. This file describes how to obtain credentials today, how to handle them safely, and where the protocol is going.
+This guide explains how an agent connects to e2a, the open-source email API for AI agents. It covers how to obtain credentials today, handle them safely, and follow the protocol as it evolves.
 
 Two hosts are relevant:
 

--- a/plugins/e2a/docs/llms.txt
+++ b/plugins/e2a/docs/llms.txt
@@ -1,17 +1,17 @@
 # e2a
 
-> e2a is an authenticated email gateway for AI agents: it gives an agent its own
-> verified email inbox to send, receive, reply, and forward, with SPF/DKIM
-> verification. Connect
-> over a hosted MCP server (OAuth, no API key), the REST API, or the SDKs.
+> e2a is the open-source email API for AI agents. Send transactional email, give
+> agents real two-way inboxes, and keep people in control. Use e2a as a hosted
+> service or run the Apache-2.0 stack yourself. Connect over a hosted MCP server
+> (OAuth, no API key), the REST API, or the SDKs.
 
-**The problem e2a solves.** An AI agent that has to reach people, or other
-agents, has no identity of its own on the one channel every organization
-already runs on. Pointing an agent at a human's mailbox borrows that person's
-identity, mixes the agent's mail in with theirs, and leaves the agent no way to
-tell a real sender from a spoofed one. e2a gives the mailbox to the agent: its
-own verified address, on the shared `agents.e2a.dev` domain or on a domain you
-own, with two-way send and receive.
+**The problem e2a solves.** Developers and businesses need email infrastructure
+that works for product notifications and agent workflows. Pointing an agent at
+a human's mailbox borrows that person's identity and mixes the agent's mail in
+with theirs. e2a gives the agent its own address on the shared
+`agents.e2a.dev` domain or on a domain you verify, with two-way send and receive.
+It also gives applications a transactional sending API, plus optional human
+approval before an agent's message leaves.
 
 **What is distinctive about e2a:**
 
@@ -32,8 +32,8 @@ own, with two-way send and receive.
   tools all work from a laptop or from behind a firewall. Webhooks are an
   option, not a prerequisite, and every webhook delivery is HMAC-signed.
 - **Apache-2.0 and self-hostable.** The whole stack is open source and runs
-  against your own Postgres and outbound relay, with every feature intact. The
-  hosted service at e2a.dev runs that same server image.
+  against your own Postgres and outbound relay. The hosted service at e2a.dev
+  runs the same server image.
 
 ## Start here
 

--- a/plugins/e2a/docs/llms.txt
+++ b/plugins/e2a/docs/llms.txt
@@ -1,9 +1,12 @@
 # e2a
 
-> e2a is the open-source email API for AI agents. Send transactional email, give
-> agents real two-way inboxes, and keep people in control. Use e2a as a hosted
-> service or run the Apache-2.0 stack yourself. Connect over a hosted MCP server
-> (OAuth, no API key), the REST API, or the SDKs.
+> e2a is the open-source email API for applications and AI agents. Send
+> transactional email from any product, give agents real two-way inboxes, and
+> keep people in control. Use e2a as a hosted service or run the Apache-2.0
+> stack yourself. Connect over a hosted MCP server (OAuth, no API key), the
+> REST API, or the SDKs.
+
+e2a is an open-source email API for transactional application email and agent-owned inboxes. Using e2a for application-triggered sending does not require an AI agent or agent framework.
 
 **The problem e2a solves.** Developers and businesses need email infrastructure
 that works for product notifications and agent workflows. Pointing an agent at
@@ -46,6 +49,7 @@ approval before an agent's message leaves.
 
 ## API & SDKs
 
+- [Transactional email API](https://e2a.dev/transactional-email-api): Use e2a from any application for receipts, verification messages, product notifications, and alerts. No AI agent or agent framework is required.
 - [sdk.md](https://e2a.dev/sdk.md): TypeScript (`@e2a/sdk`) and Python (`e2a`) quick-start with code examples — send, receive (webhook → fetch → reply), and real-time streaming — plus a Raw-REST section (base URL, auth, conventions) for other languages.
 - [openapi.yaml](https://e2a.dev/v1/openapi.yaml): The full OpenAPI 3.1 contract — every endpoint, field, enum, and error, generated from the live handlers. Authoritative for exact signatures.
 - [templates.md](https://e2a.dev/templates.md): Email templates (beta) — server-rendered reusable emails with `{{variable}}` interpolation, a prebuilt starter catalog (`from_starter`), validation, and send-by-alias. Includes a copy-paste setup prompt for coding agents.

--- a/plugins/e2a/docs/llms.txt
+++ b/plugins/e2a/docs/llms.txt
@@ -15,10 +15,10 @@ approval before an agent's message leaves.
 
 **What is distinctive about e2a:**
 
-- **Sender verification on every inbound message.** e2a evaluates SPF, every
-  DKIM signature, and DMARC — including alignment — before the agent sees a
-  message, and hands the result over as structured evidence rather than raw
-  headers the agent has to parse and trust.
+- **Structured inbound domain evidence.** e2a evaluates SPF, every DKIM
+  signature, and DMARC, including alignment, before the agent sees a message.
+  It hands the results over as structured data rather than raw headers. The
+  evidence applies to the From domain, not a person, mailbox, or message content.
 - **An approval gate before anything is sent.** Opt-in, per agent: an outbound
   message is accepted but not dispatched (`status: pending_review`) until a
   person approves it from the dashboard, the API, the MCP tools, or a magic
@@ -75,7 +75,7 @@ the source of truth for business data and policy.
 
 ## Pricing
 
-- [Pricing](https://e2a.dev/pricing): Hosted plans. The free tier needs no credit card and includes the shared `agents.e2a.dev` domain, a custom domain, sender verification, and real-time WebSocket delivery; paid Pro and Scale tiers raise the agent, custom-domain, monthly-message, and storage limits. Self-hosting the Apache-2.0 server costs nothing. Current amounts and limits live on the page rather than in this file, so read it before quoting a number.
+- [Pricing](https://e2a.dev/pricing): Hosted plans. The free tier needs no credit card and includes the shared `agents.e2a.dev` domain, a custom domain, structured inbound domain evidence, and real-time WebSocket delivery; paid Pro and Scale tiers raise the agent, custom-domain, monthly-message, and storage limits. Self-hosting the Apache-2.0 server costs nothing. Current amounts and limits live on the page rather than in this file, so read it before quoting a number.
 
 ## Blog
 

--- a/plugins/e2a/docs/llms.txt
+++ b/plugins/e2a/docs/llms.txt
@@ -59,9 +59,9 @@ approval before an agent's message leaves.
 ## Use cases
 
 The use-case pages below describe concrete workflows developers can build with
-an agent-owned inbox. e2a provides the email identity, inbound authentication
-evidence, delivery, threading, and outbound controls; the application remains
-the source of truth for business data and policy.
+an agent-owned inbox. e2a provides the provisioned address, structured inbound
+domain evidence, delivery, threading, and outbound controls; the application
+remains the source of truth for business data and policy.
 
 - [What can you build with e2a?](https://e2a.dev/use-cases): The canonical use-case directory.
 - [Support agent](https://e2a.dev/use-cases/support-agent): Triage customer requests, retrieve context, reply in-thread, and hold sensitive replies for approval.
@@ -75,7 +75,7 @@ the source of truth for business data and policy.
 
 ## Pricing
 
-- [Pricing](https://e2a.dev/pricing): Hosted plans. The free tier needs no credit card and includes the shared `agents.e2a.dev` domain, a custom domain, structured inbound domain evidence, and real-time WebSocket delivery; paid Pro and Scale tiers raise the agent, custom-domain, monthly-message, and storage limits. Self-hosting the Apache-2.0 server costs nothing. Current amounts and limits live on the page rather than in this file, so read it before quoting a number.
+- [Pricing](https://e2a.dev/pricing): Hosted plans. The free tier needs no credit card and includes the shared `agents.e2a.dev` domain, a custom domain, structured inbound domain evidence, and real-time WebSocket delivery; paid tiers raise the agent, custom-domain, monthly-message, and storage limits. Self-hosting the Apache-2.0 server costs nothing. Current amounts and limits live on the page rather than in this file, so read it before quoting a number.
 
 ## Blog
 

--- a/plugins/e2a/docs/setup.md
+++ b/plugins/e2a/docs/setup.md
@@ -1,8 +1,8 @@
 # Set up e2a
 
-e2a gives an AI agent its own real email inbox: a verified address it can send
-from, receive to, and use for multi-turn conversations. The inbox belongs to
-the agent—not to a human whose mailbox the agent reads.
+e2a gives an AI agent its own real email inbox: a provisioned address it can
+send from, receive to, and use for multi-turn conversations. The inbox belongs
+to the agent—not to a human whose mailbox the agent reads.
 
 This guide connects e2a, selects or creates an inbox, and verifies that it is
 ready. Most setups use the shared `agents.e2a.dev` domain and require no DNS

--- a/plugins/e2a/plugin.json
+++ b/plugins/e2a/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "e2a",
-  "version": "0.9.2",
-  "description": "Authenticated email gateway for AI agents — per-agent inboxes, SPF/DKIM verification, and a queryable, replayable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
+  "version": "0.9.3",
+  "description": "Open-source email API for AI agents — transactional sending, per-agent two-way inboxes, structured SPF/DKIM/DMARC evidence, and a queryable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "TokenCanopy",
     "url": "https://e2a.dev"

--- a/plugins/e2a/plugin.json
+++ b/plugins/e2a/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "e2a",
-  "version": "0.9.3",
-  "description": "Open-source email API for AI agents — transactional sending, per-agent two-way inboxes, structured SPF/DKIM/DMARC evidence, and a queryable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
+  "version": "0.9.4",
+  "description": "Open-source email API for applications and AI agents — transactional sending from any product, per-agent two-way inboxes, structured SPF/DKIM/DMARC evidence, and a queryable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "TokenCanopy",
     "url": "https://e2a.dev"

--- a/plugins/e2a/plugin.meta.json
+++ b/plugins/e2a/plugin.meta.json
@@ -3,7 +3,7 @@
 
   "name": "e2a",
   "displayName": "e2a",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "license": "Apache-2.0",
   "homepage": "https://e2a.dev",
   "repository": "https://github.com/tokencanopy/e2a",
@@ -19,9 +19,9 @@
 
   "descriptions": {
     "$comment": "Three variants ship today. `manifest` omits HITL; both marketplace variants mention it. See docs/design/2026-08-09-agent-plugins-conformance.md — unifying them is a copy decision, deliberately not made by this migration. The MCP tool count must match mcp/tool-names.v1.json; the validator checks numeric claims.",
-    "manifest": "Open-source email API for AI agents — transactional sending, per-agent two-way inboxes, structured SPF/DKIM/DMARC evidence, and a queryable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
-    "marketplaceLong": "Open-source email API for AI agents — transactional sending, per-agent two-way inboxes, HITL approval, structured SPF/DKIM/DMARC evidence, and a queryable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
-    "marketplaceShort": "Open-source email API for AI agents — transactional sending, per-agent two-way inboxes, HITL approval, structured SPF/DKIM/DMARC evidence, and a queryable event log."
+    "manifest": "Open-source email API for applications and AI agents — transactional sending from any product, per-agent two-way inboxes, structured SPF/DKIM/DMARC evidence, and a queryable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
+    "marketplaceLong": "Open-source email API for applications and AI agents — transactional sending from any product, per-agent two-way inboxes, HITL approval, structured SPF/DKIM/DMARC evidence, and a queryable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
+    "marketplaceShort": "Open-source email API for applications and AI agents — transactional sending from any product, per-agent two-way inboxes, HITL approval, structured SPF/DKIM/DMARC evidence, and a queryable event log."
   },
 
   "mcp": {
@@ -30,7 +30,7 @@
   },
 
   "codexInterface": {
-    "shortDescription": "Open-source email API for AI agents",
+    "shortDescription": "Open-source email API for applications and AI agents",
     "longDescription": "Bundles the hosted e2a MCP server and five stable skills for setup, application integration, inbox operation, diagnosis, and evaluation — with structured inbound domain evidence, custom domains, attachments, and a replayable event log.",
     "developerName": "TokenCanopy",
     "category": "Productivity"
@@ -38,11 +38,11 @@
 
   "marketplaces": {
     "claude": {
-      "blurb": "e2a plugins for Claude Code — open-source email API for AI agents",
+      "blurb": "e2a plugins for Claude Code — open-source email API for applications and AI agents",
       "category": "productivity"
     },
     "cursor": {
-      "blurb": "e2a — open-source email API for AI agents (MCP configuration and canonical docs).",
+      "blurb": "e2a — open-source email API for applications and AI agents (MCP configuration and canonical docs).",
       "extraKeyword": "cursor"
     },
     "agents": {

--- a/plugins/e2a/plugin.meta.json
+++ b/plugins/e2a/plugin.meta.json
@@ -3,7 +3,7 @@
 
   "name": "e2a",
   "displayName": "e2a",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "license": "Apache-2.0",
   "homepage": "https://e2a.dev",
   "repository": "https://github.com/tokencanopy/e2a",
@@ -19,9 +19,9 @@
 
   "descriptions": {
     "$comment": "Three variants ship today. `manifest` omits HITL; both marketplace variants mention it. See docs/design/2026-08-09-agent-plugins-conformance.md — unifying them is a copy decision, deliberately not made by this migration. The MCP tool count must match mcp/tool-names.v1.json; the validator checks numeric claims.",
-    "manifest": "Authenticated email gateway for AI agents — per-agent inboxes, SPF/DKIM verification, and a queryable, replayable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
-    "marketplaceLong": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
-    "marketplaceShort": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log."
+    "manifest": "Open-source email API for AI agents — transactional sending, per-agent two-way inboxes, structured SPF/DKIM/DMARC evidence, and a queryable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
+    "marketplaceLong": "Open-source email API for AI agents — transactional sending, per-agent two-way inboxes, HITL approval, structured SPF/DKIM/DMARC evidence, and a queryable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
+    "marketplaceShort": "Open-source email API for AI agents — transactional sending, per-agent two-way inboxes, HITL approval, structured SPF/DKIM/DMARC evidence, and a queryable event log."
   },
 
   "mcp": {
@@ -30,19 +30,19 @@
   },
 
   "codexInterface": {
-    "shortDescription": "Authenticated email for AI agents",
-    "longDescription": "Bundles the hosted e2a MCP server and five stable skills for setup, application integration, inbox operation, diagnosis, and evaluation — with SPF/DKIM verification, custom domains, attachments, and a replayable event log.",
+    "shortDescription": "Open-source email API for AI agents",
+    "longDescription": "Bundles the hosted e2a MCP server and five stable skills for setup, application integration, inbox operation, diagnosis, and evaluation — with structured inbound domain evidence, custom domains, attachments, and a replayable event log.",
     "developerName": "TokenCanopy",
     "category": "Productivity"
   },
 
   "marketplaces": {
     "claude": {
-      "blurb": "e2a plugins for Claude Code — authenticated email for AI agents",
+      "blurb": "e2a plugins for Claude Code — open-source email API for AI agents",
       "category": "productivity"
     },
     "cursor": {
-      "blurb": "e2a — authenticated email gateway for AI agents (MCP configuration and canonical docs).",
+      "blurb": "e2a — open-source email API for AI agents (MCP configuration and canonical docs).",
       "extraKeyword": "cursor"
     },
     "agents": {

--- a/plugins/e2a/skills/e2a/SKILL.md
+++ b/plugins/e2a/skills/e2a/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: e2a
 description: "Use when operating an already-connected e2a inbox over MCP: reading, composing, sending, replying, forwarding, handling attachments, managing contacts/outreach, scheduling mail, or using templates. Teaches correct threading, conversation correlation, concise multipart composition, and accepted/pending-review no-retry behavior."
-version: 28
+version: 29
 ---
 
 # Using e2a
 
-<!-- version: 28 -->
+<!-- version: 29 -->
 
-e2a is the open-source email API for AI agents. It gives an agent a real two-way address (`agent@agents.localhost` or `agent@example.com`), evaluates SPF, DKIM, and DMARC as structured evidence about the From domain, and threads conversations. That evidence does not prove a person, mailbox, or message content.
+e2a is the open-source email API for applications and AI agents. This operate-well skill focuses on agent-owned inboxes: it gives an agent a real two-way address (`agent@agents.localhost` or `agent@example.com`), evaluates SPF, DKIM, and DMARC as structured evidence about the From domain, and threads conversations. That evidence does not prove a person, mailbox, or message content.
 
 ## How this fits
 

--- a/plugins/e2a/skills/e2a/SKILL.md
+++ b/plugins/e2a/skills/e2a/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: e2a
 description: "Use when operating an already-connected e2a inbox over MCP: reading, composing, sending, replying, forwarding, handling attachments, managing contacts/outreach, scheduling mail, or using templates. Teaches correct threading, conversation correlation, concise multipart composition, and accepted/pending-review no-retry behavior."
-version: 27
+version: 28
 ---
 
 # Using e2a
 
-<!-- version: 27 -->
+<!-- version: 28 -->
 
-e2a is an authenticated email gateway for AI agents. It gives an agent a real email address (`agent@agents.e2a.dev` or `agent@your-domain.com`), verifies sender identity (SPF/DKIM), and threads conversations.
+e2a is the open-source email API for AI agents. It gives an agent a real two-way address (`agent@agents.localhost` or `agent@example.com`), evaluates SPF, DKIM, and DMARC as structured evidence about the From domain, and threads conversations. That evidence does not prove a person, mailbox, or message content.
 
 ## How this fits
 
@@ -25,7 +25,7 @@ The mental model below holds regardless of surface. Tool descriptions teach the 
 
 Six load-bearing facts. Internalize these before you start calling tools.
 
-1. **An agent is an email address.** `support-bot@agents.e2a.dev` is an agent. When you send mail, the recipient sees a message FROM that address — not from "the user." When you list messages, you are reading the agent's own inbox, not the user's personal mail. You are not a secretary; you are the mailbox owner.
+1. **An agent is an email address.** `support-bot@agents.localhost` is an agent. When you send mail, the recipient sees a message FROM that address — not from "the user." When you list messages, you are reading the agent's own inbox, not the user's personal mail. You are not a secretary; you are the mailbox owner.
 
 2. **Replies preserve threads; new sends do not.** `reply_to_message` carries the `In-Reply-To` and `References` headers from the original message, so the response lands in the same email thread. A fresh `send_message` creates a new thread every time. If a user (or an inbound message) is asking you to respond to something specific, reply with the original `message_id` — even when you could synthesize an equivalent body as a new send. Thread fragmentation is the #1 visible symptom of getting this wrong.
 

--- a/scripts/plugin-agent-guidance.test.mjs
+++ b/scripts/plugin-agent-guidance.test.mjs
@@ -42,7 +42,7 @@ test("the e2a skill description is quoted YAML", async () => {
 });
 
 test("plugin discovery surfaces use the canonical email API category", async () => {
-  const canonical = /open-source email API for AI agents/i;
+  const canonical = /open-source email API for applications and AI agents/i;
   const stale = /authenticated email gateway|authenticated email for AI agents|real, authenticated email inbox|verifies sender identity/i;
 
   const meta = JSON.parse(await readFile("plugins/e2a/plugin.meta.json", "utf8"));

--- a/scripts/plugin-agent-guidance.test.mjs
+++ b/scripts/plugin-agent-guidance.test.mjs
@@ -41,6 +41,44 @@ test("the e2a skill description is quoted YAML", async () => {
   assert.match(source, /^description: "(?:[^"\\]|\\.)*"$/m);
 });
 
+test("plugin discovery surfaces use the canonical email API category", async () => {
+  const canonical = /open-source email API for AI agents/i;
+  const stale = /authenticated email gateway|authenticated email for AI agents|real, authenticated email inbox|verifies sender identity/i;
+
+  const meta = JSON.parse(await readFile("plugins/e2a/plugin.meta.json", "utf8"));
+  for (const [key, description] of Object.entries(meta.descriptions)) {
+    if (key === "$comment") continue;
+    if (typeof description === "string") assert.match(description, canonical);
+  }
+  assert.match(meta.codexInterface.shortDescription, canonical);
+  assert.match(meta.marketplaces.claude.blurb, canonical);
+  assert.match(meta.marketplaces.cursor.blurb, canonical);
+
+  for (const file of [
+    "plugins/e2a/README.md",
+    "plugins/e2a/skills/e2a/SKILL.md",
+    "plugins/e2a/plugin.json",
+    "plugins/e2a/.claude-plugin/plugin.json",
+    "plugins/e2a/.codex-plugin/plugin.json",
+    "plugins/e2a/.cursor-plugin/plugin.json",
+  ]) {
+    const source = await readFile(file, "utf8");
+    assert.match(source, canonical, file);
+    assert.doesNotMatch(source, stale, file);
+  }
+
+  for (const file of [
+    ".claude-plugin/marketplace.json",
+    ".agents/plugins/marketplace.json",
+    ".cursor-plugin/marketplace.json",
+  ]) {
+    const marketplace = JSON.parse(await readFile(file, "utf8"));
+    const plugin = marketplace.plugins.find((candidate) => candidate.name === "e2a");
+    assert.ok(plugin, `${file} is missing e2a`);
+    assert.match(plugin.description, canonical, file);
+  }
+});
+
 test("the e2a skill teaches concise multipart email composition", async () => {
   const source = await readFile("plugins/e2a/skills/e2a/SKILL.md", "utf8");
 

--- a/scripts/plugin-email-evals.test.mjs
+++ b/scripts/plugin-email-evals.test.mjs
@@ -603,7 +603,7 @@ test("templates and skill contain only synthetic email identities", async () => 
 test("all plugin manifests release email-evals together without changing discovery conventions", async () => {
   for (const file of manifestFiles) {
     const manifest = JSON.parse(await readFile(file, "utf8"));
-    assert.equal(manifest.version ?? manifest.metadata?.version, "0.9.3", file);
+    assert.equal(manifest.version ?? manifest.metadata?.version, "0.9.4", file);
   }
 
   const claude = JSON.parse(await readFile(manifestFiles[0], "utf8"));

--- a/scripts/plugin-email-evals.test.mjs
+++ b/scripts/plugin-email-evals.test.mjs
@@ -603,7 +603,7 @@ test("templates and skill contain only synthetic email identities", async () => 
 test("all plugin manifests release email-evals together without changing discovery conventions", async () => {
   for (const file of manifestFiles) {
     const manifest = JSON.parse(await readFile(file, "utf8"));
-    assert.equal(manifest.version ?? manifest.metadata?.version, "0.9.2", file);
+    assert.equal(manifest.version ?? manifest.metadata?.version, "0.9.3", file);
   }
 
   const claude = JSON.parse(await readFile(manifestFiles[0], "utf8"));

--- a/scripts/plugin-packaging.test.mjs
+++ b/scripts/plugin-packaging.test.mjs
@@ -55,12 +55,12 @@ test("marketplaces expose the supported plugin set and release versions", async 
   assert.deepEqual(claudeMarket.plugins.map((plugin) => plugin.name).sort(), ["e2a", "e2a-labs"]);
   assert.deepEqual(codexMarket.plugins.map((plugin) => plugin.name).sort(), ["e2a", "e2a-labs"]);
   assert.deepEqual(cursorMarket.plugins.map((plugin) => plugin.name), ["e2a"]);
-  assert.equal(claudeMarket.metadata.version, "0.9.3");
-  assert.equal(cursorMarket.metadata.version, "0.9.3");
+  assert.equal(claudeMarket.metadata.version, "0.9.4");
+  assert.equal(cursorMarket.metadata.version, "0.9.4");
 
   for (const client of [".claude-plugin", ".codex-plugin", ".cursor-plugin"]) {
     const core = JSON.parse(await readFile(`plugins/e2a/${client}/plugin.json`, "utf8"));
-    assert.equal(core.version, "0.9.3");
+    assert.equal(core.version, "0.9.4");
   }
   for (const client of [".claude-plugin", ".codex-plugin"]) {
     const labs = JSON.parse(await readFile(`plugins/e2a-labs/${client}/plugin.json`, "utf8"));

--- a/scripts/plugin-packaging.test.mjs
+++ b/scripts/plugin-packaging.test.mjs
@@ -55,12 +55,12 @@ test("marketplaces expose the supported plugin set and release versions", async 
   assert.deepEqual(claudeMarket.plugins.map((plugin) => plugin.name).sort(), ["e2a", "e2a-labs"]);
   assert.deepEqual(codexMarket.plugins.map((plugin) => plugin.name).sort(), ["e2a", "e2a-labs"]);
   assert.deepEqual(cursorMarket.plugins.map((plugin) => plugin.name), ["e2a"]);
-  assert.equal(claudeMarket.metadata.version, "0.9.2");
-  assert.equal(cursorMarket.metadata.version, "0.9.2");
+  assert.equal(claudeMarket.metadata.version, "0.9.3");
+  assert.equal(cursorMarket.metadata.version, "0.9.3");
 
   for (const client of [".claude-plugin", ".codex-plugin", ".cursor-plugin"]) {
     const core = JSON.parse(await readFile(`plugins/e2a/${client}/plugin.json`, "utf8"));
-    assert.equal(core.version, "0.9.2");
+    assert.equal(core.version, "0.9.3");
   }
   for (const client of [".claude-plugin", ".codex-plugin"]) {
     const labs = JSON.parse(await readFile(`plugins/e2a-labs/${client}/plugin.json`, "utf8"));

--- a/scripts/sync-agent-docs.mjs
+++ b/scripts/sync-agent-docs.mjs
@@ -30,10 +30,11 @@ export const LLMS_FULL_SOURCES = [
 
 const LLMS_FULL_HEADER = `# e2a — full documentation
 
-> e2a is the open-source email API for AI agents. Send transactional email, give
-> agents real two-way inboxes, and keep people in control. Use e2a as a hosted
-> service or run the Apache-2.0 stack yourself. Connect over a hosted MCP server
-> (OAuth 2.1, no API key), the REST API, or the TypeScript/Python SDKs.
+> e2a is the open-source email API for applications and AI agents. Send
+> transactional email from any product, give agents real two-way inboxes, and
+> keep people in control. Use e2a as a hosted service or run the Apache-2.0
+> stack yourself. Connect over a hosted MCP server (OAuth 2.1, no API key), the
+> REST API, or the TypeScript/Python SDKs.
 
 This file inlines the full e2a documentation set so it can be read in one
 fetch. The per-document originals are linked above each section, and the

--- a/scripts/sync-agent-docs.mjs
+++ b/scripts/sync-agent-docs.mjs
@@ -30,10 +30,10 @@ export const LLMS_FULL_SOURCES = [
 
 const LLMS_FULL_HEADER = `# e2a — full documentation
 
-> e2a is an authenticated email gateway for AI agents: it gives an agent its
-> own verified email inbox to send, receive, reply, and forward, with SPF/DKIM
-> verification on inbound. Connect over a hosted MCP server (OAuth 2.1, no API
-> key), the REST API, or the TypeScript/Python SDKs.
+> e2a is the open-source email API for AI agents. Send transactional email, give
+> agents real two-way inboxes, and keep people in control. Use e2a as a hosted
+> service or run the Apache-2.0 stack yourself. Connect over a hosted MCP server
+> (OAuth 2.1, no API key), the REST API, or the TypeScript/Python SDKs.
 
 This file inlines the full e2a documentation set so it can be read in one
 fetch. The per-document originals are linked above each section, and the

--- a/scripts/sync-agent-docs.test.mjs
+++ b/scripts/sync-agent-docs.test.mjs
@@ -109,6 +109,7 @@ test("agent answer surfaces describe domain evidence without identity overclaims
   for (const path of [
     "../plugins/e2a/docs/auth.md",
     "../plugins/e2a/docs/llms.txt",
+    "../plugins/e2a/docs/setup.md",
     "../web/public/auth.md",
     "../web/public/llms.txt",
     "../web/public/llms-full.txt",
@@ -116,7 +117,7 @@ test("agent answer surfaces describe domain evidence without identity overclaims
     const body = await readFile(new URL(path, import.meta.url), "utf8");
     assert.doesNotMatch(
       body,
-      /authenticated email address|verified email inbox|sender verification|end-to-end-verified email address|identity claim e2a stands behind/i,
+      /authenticated email address|verified email inbox|sender verification|end-to-end-verified email address|identity claim e2a stands behind|a verified address|provides the email identity|inbound authentication evidence/i,
       `${path} contains an identity overclaim`,
     );
   }
@@ -126,6 +127,7 @@ test("agent answer surfaces describe domain evidence without identity overclaims
   );
   assert.match(llms, /structured inbound domain evidence/i);
   assert.match(llms, /not a person, mailbox, or message content/i);
+  assert.doesNotMatch(llms, /paid Pro and Scale tiers/i);
 });
 
 test("check reports a stale llms-full.txt without rewriting it", async () => {

--- a/scripts/sync-agent-docs.test.mjs
+++ b/scripts/sync-agent-docs.test.mjs
@@ -100,6 +100,7 @@ test("sync inlines every corpus source into llms-full.txt", async () => {
     assert.ok(full.includes(`<!-- source: ${url} -->`), `missing marker for ${url}`);
     assert.ok(full.includes(body.trim()), `missing body of ${source}`);
   }
+  assert.match(full, /open-source email API for applications and AI agents/i);
   await assert.doesNotReject(
     syncAgentDocs({ repoRoot, check: true, log: () => {} }),
   );

--- a/scripts/sync-agent-docs.test.mjs
+++ b/scripts/sync-agent-docs.test.mjs
@@ -105,6 +105,29 @@ test("sync inlines every corpus source into llms-full.txt", async () => {
   );
 });
 
+test("agent answer surfaces describe domain evidence without identity overclaims", async () => {
+  for (const path of [
+    "../plugins/e2a/docs/auth.md",
+    "../plugins/e2a/docs/llms.txt",
+    "../web/public/auth.md",
+    "../web/public/llms.txt",
+    "../web/public/llms-full.txt",
+  ]) {
+    const body = await readFile(new URL(path, import.meta.url), "utf8");
+    assert.doesNotMatch(
+      body,
+      /authenticated email address|verified email inbox|sender verification|end-to-end-verified email address|identity claim e2a stands behind/i,
+      `${path} contains an identity overclaim`,
+    );
+  }
+  const llms = await readFile(
+    new URL("../plugins/e2a/docs/llms.txt", import.meta.url),
+    "utf8",
+  );
+  assert.match(llms, /structured inbound domain evidence/i);
+  assert.match(llms, /not a person, mailbox, or message content/i);
+});
+
 test("check reports a stale llms-full.txt without rewriting it", async () => {
   const repoRoot = await fixture();
   await syncAgentDocs({ repoRoot, check: false, log: () => {} });

--- a/scripts/sync-agent-docs.test.mjs
+++ b/scripts/sync-agent-docs.test.mjs
@@ -127,6 +127,8 @@ test("agent answer surfaces describe domain evidence without identity overclaims
   );
   assert.match(llms, /structured inbound domain evidence/i);
   assert.match(llms, /not a person, mailbox, or message content/i);
+  assert.match(llms, /transactional application email and agent-owned inboxes/i);
+  assert.match(llms, /does not require an AI agent or agent framework/i);
   assert.doesNotMatch(llms, /paid Pro and Scale tiers/i);
 });
 

--- a/web/public/auth.md
+++ b/web/public/auth.md
@@ -11,7 +11,7 @@ Two hosts are relevant:
 
 e2a already implements the OAuth 2.1 surface that MCP clients depend on: RFC 8414 authorization-server metadata at [`/.well-known/oauth-authorization-server`](https://api.e2a.dev/.well-known/oauth-authorization-server), RFC 7591 Dynamic Client Registration at `/oauth2/register` (rate-limited per IP), `authorization_code` + `refresh_token` grants with PKCE S256, RFC 7009 revocation, and RFC 6750 Bearer challenges on 401s. MCP clients can register and onboard without any human-supplied secret — the user only sees a browser consent screen.
 
-e2a also implements the first pieces of the WorkOS [auth.md](https://github.com/workos/auth.md) autonomous-agent flow: a JSON Web Key Set at `/.well-known/jwks.json`, an `agent_auth` block in the AS metadata, and a bootstrap endpoint (`POST /agent/identity`) that exchanges an agent-scoped API key for a long-lived identity assertion, redeemable at `/oauth2/token` via `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer` for a short-lived access token. Still missing: an RFC 9728 protected-resource metadata document, ID-JAG assertion intake from third parties, and the email-OTP claim ceremony. See [Agent identity](#agent-identity) for where we're heading — because every e2a agent has an end-to-end-verified email address, e2a is positioned to act as an identity provider in this protocol, and that's the direction we're building.
+e2a also implements the first pieces of the WorkOS [auth.md](https://github.com/workos/auth.md) autonomous-agent flow: a JSON Web Key Set at `/.well-known/jwks.json`, an `agent_auth` block in the AS metadata, and a bootstrap endpoint (`POST /agent/identity`) that exchanges an agent-scoped API key for a long-lived identity assertion, redeemable at `/oauth2/token` via `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer` for a short-lived access token. Still missing: an RFC 9728 protected-resource metadata document, ID-JAG assertion intake from third parties, and the email-OTP claim ceremony. See [Agent identity](#agent-identity) for where we're heading. Each e2a agent has a stable, provisioned email address and can obtain an e2a-issued identity assertion; that issuer-backed assertion, rather than arbitrary inbound mail, is the basis for the identity-provider direction.
 
 ## Use the existing tooling first
 
@@ -133,7 +133,7 @@ The `WWW-Authenticate` header on 401 responses tells you whether the failing cre
 
 This section describes e2a's bet on where agent auth is heading. The bootstrap identity endpoint below is shipped (behind an opt-in signing-key config); third-party ID-JAG consumption and the email-loop claim ceremony are still direction, not shipped surface. If you are implementing today, use the credential paths above for anything beyond the identity bootstrap.
 
-Every e2a agent has a stable, verified email address. The owner proved control of the domain (via DNS records and a verification token), and e2a evaluates SPF, DKIM, and DMARC on every inbound message routed to that agent. Equivalently for agents on the shared `agents.e2a.dev` domain, e2a is the authoritative issuer. **The agent's email is not a label — it's an identity claim e2a stands behind.**
+Every e2a agent has a stable, provisioned email address. For a custom domain, the owner proves control through DNS records and a verification token. For the shared `agents.e2a.dev` domain, e2a provisions the address directly. e2a also evaluates SPF, DKIM, and DMARC on inbound messages and returns structured evidence about the From domain. That evidence does not prove a person, mailbox, or message content. When agent-identity signing is enabled, the separate OAuth identity assertion is the claim e2a issues and signs.
 
 We are building two pieces on top of this:
 
@@ -142,12 +142,12 @@ We are building two pieces on top of this:
 e2a already operates as an OAuth issuer at `https://api.e2a.dev` (see AS metadata above), publishes a JSON Web Key Set at `https://api.e2a.dev/.well-known/jwks.json`, and lets an agent bootstrap a long-lived identity assertion from its API key via `POST /agent/identity`, redeemable for a short-lived access token at `/oauth2/token`. The remaining work is issuing audience-bound [ID-JAG](https://datatracker.ietf.org/doc/draft-ietf-oauth-identity-assertion-authz-grant/) assertions (`urn:ietf:params:oauth:token-type:id-jag`) that a *third-party* service can verify, with:
 
 - `iss` = `https://api.e2a.dev`
-- `sub` = the agent's verified email
+- `sub` = the agent's provisioned email
 - `email` / `email_verified: true`
 - `aud` = the third-party service the agent is registering with
 - Short `exp` (≤5 minutes), fresh `jti`
 
-Any auth.md-implementing service that adds e2a to its trust list will be able to onboard an e2a agent without an OTP ceremony — the agent's e2a identity vouches for it. e2a's contribution is an identity rooted in a verifiable email address, stable across agent runtimes.
+Any auth.md-implementing service that adds e2a to its trust list will be able to onboard an e2a agent without an OTP ceremony. The e2a-issued assertion vouches for the agent identity, which is tied to a stable, provisioned email address across agent runtimes.
 
 If you operate an agent service and want to accept e2a-issued assertions, watch for `iss: https://api.e2a.dev` to land in the WorkOS reference trust list, or open an issue at `https://github.com/tokencanopy/e2a/issues` to pre-register.
 

--- a/web/public/auth.md
+++ b/web/public/auth.md
@@ -1,6 +1,6 @@
 # auth.md
 
-You are an agent that wants to use e2a — the authenticated email gateway for AI agents. This file describes how to obtain credentials today, how to handle them safely, and where the protocol is going.
+This guide explains how an agent connects to e2a, the open-source email API for AI agents. It covers how to obtain credentials today, handle them safely, and follow the protocol as it evolves.
 
 Two hosts are relevant:
 

--- a/web/public/llms-full.txt
+++ b/web/public/llms-full.txt
@@ -1,9 +1,9 @@
 # e2a — full documentation
 
-> e2a is an authenticated email gateway for AI agents: it gives an agent its
-> own verified email inbox to send, receive, reply, and forward, with SPF/DKIM
-> verification on inbound. Connect over a hosted MCP server (OAuth 2.1, no API
-> key), the REST API, or the TypeScript/Python SDKs.
+> e2a is the open-source email API for AI agents. Send transactional email, give
+> agents real two-way inboxes, and keep people in control. Use e2a as a hosted
+> service or run the Apache-2.0 stack yourself. Connect over a hosted MCP server
+> (OAuth 2.1, no API key), the REST API, or the TypeScript/Python SDKs.
 
 This file inlines the full e2a documentation set so it can be read in one
 fetch. The per-document originals are linked above each section, and the
@@ -201,7 +201,7 @@ The hosted shared-domain path is free to start without a card. See
 
 # auth.md
 
-You are an agent that wants to use e2a — the authenticated email gateway for AI agents. This file describes how to obtain credentials today, how to handle them safely, and where the protocol is going.
+This guide explains how an agent connects to e2a, the open-source email API for AI agents. It covers how to obtain credentials today, handle them safely, and follow the protocol as it evolves.
 
 Two hosts are relevant:
 

--- a/web/public/llms-full.txt
+++ b/web/public/llms-full.txt
@@ -212,7 +212,7 @@ Two hosts are relevant:
 
 e2a already implements the OAuth 2.1 surface that MCP clients depend on: RFC 8414 authorization-server metadata at [`/.well-known/oauth-authorization-server`](https://api.e2a.dev/.well-known/oauth-authorization-server), RFC 7591 Dynamic Client Registration at `/oauth2/register` (rate-limited per IP), `authorization_code` + `refresh_token` grants with PKCE S256, RFC 7009 revocation, and RFC 6750 Bearer challenges on 401s. MCP clients can register and onboard without any human-supplied secret — the user only sees a browser consent screen.
 
-e2a also implements the first pieces of the WorkOS [auth.md](https://github.com/workos/auth.md) autonomous-agent flow: a JSON Web Key Set at `/.well-known/jwks.json`, an `agent_auth` block in the AS metadata, and a bootstrap endpoint (`POST /agent/identity`) that exchanges an agent-scoped API key for a long-lived identity assertion, redeemable at `/oauth2/token` via `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer` for a short-lived access token. Still missing: an RFC 9728 protected-resource metadata document, ID-JAG assertion intake from third parties, and the email-OTP claim ceremony. See [Agent identity](#agent-identity) for where we're heading — because every e2a agent has an end-to-end-verified email address, e2a is positioned to act as an identity provider in this protocol, and that's the direction we're building.
+e2a also implements the first pieces of the WorkOS [auth.md](https://github.com/workos/auth.md) autonomous-agent flow: a JSON Web Key Set at `/.well-known/jwks.json`, an `agent_auth` block in the AS metadata, and a bootstrap endpoint (`POST /agent/identity`) that exchanges an agent-scoped API key for a long-lived identity assertion, redeemable at `/oauth2/token` via `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer` for a short-lived access token. Still missing: an RFC 9728 protected-resource metadata document, ID-JAG assertion intake from third parties, and the email-OTP claim ceremony. See [Agent identity](#agent-identity) for where we're heading. Each e2a agent has a stable, provisioned email address and can obtain an e2a-issued identity assertion; that issuer-backed assertion, rather than arbitrary inbound mail, is the basis for the identity-provider direction.
 
 ## Use the existing tooling first
 
@@ -334,7 +334,7 @@ The `WWW-Authenticate` header on 401 responses tells you whether the failing cre
 
 This section describes e2a's bet on where agent auth is heading. The bootstrap identity endpoint below is shipped (behind an opt-in signing-key config); third-party ID-JAG consumption and the email-loop claim ceremony are still direction, not shipped surface. If you are implementing today, use the credential paths above for anything beyond the identity bootstrap.
 
-Every e2a agent has a stable, verified email address. The owner proved control of the domain (via DNS records and a verification token), and e2a evaluates SPF, DKIM, and DMARC on every inbound message routed to that agent. Equivalently for agents on the shared `agents.e2a.dev` domain, e2a is the authoritative issuer. **The agent's email is not a label — it's an identity claim e2a stands behind.**
+Every e2a agent has a stable, provisioned email address. For a custom domain, the owner proves control through DNS records and a verification token. For the shared `agents.e2a.dev` domain, e2a provisions the address directly. e2a also evaluates SPF, DKIM, and DMARC on inbound messages and returns structured evidence about the From domain. That evidence does not prove a person, mailbox, or message content. When agent-identity signing is enabled, the separate OAuth identity assertion is the claim e2a issues and signs.
 
 We are building two pieces on top of this:
 
@@ -343,12 +343,12 @@ We are building two pieces on top of this:
 e2a already operates as an OAuth issuer at `https://api.e2a.dev` (see AS metadata above), publishes a JSON Web Key Set at `https://api.e2a.dev/.well-known/jwks.json`, and lets an agent bootstrap a long-lived identity assertion from its API key via `POST /agent/identity`, redeemable for a short-lived access token at `/oauth2/token`. The remaining work is issuing audience-bound [ID-JAG](https://datatracker.ietf.org/doc/draft-ietf-oauth-identity-assertion-authz-grant/) assertions (`urn:ietf:params:oauth:token-type:id-jag`) that a *third-party* service can verify, with:
 
 - `iss` = `https://api.e2a.dev`
-- `sub` = the agent's verified email
+- `sub` = the agent's provisioned email
 - `email` / `email_verified: true`
 - `aud` = the third-party service the agent is registering with
 - Short `exp` (≤5 minutes), fresh `jti`
 
-Any auth.md-implementing service that adds e2a to its trust list will be able to onboard an e2a agent without an OTP ceremony — the agent's e2a identity vouches for it. e2a's contribution is an identity rooted in a verifiable email address, stable across agent runtimes.
+Any auth.md-implementing service that adds e2a to its trust list will be able to onboard an e2a agent without an OTP ceremony. The e2a-issued assertion vouches for the agent identity, which is tied to a stable, provisioned email address across agent runtimes.
 
 If you operate an agent service and want to accept e2a-issued assertions, watch for `iss: https://api.e2a.dev` to land in the WorkOS reference trust list, or open an issue at `https://github.com/tokencanopy/e2a/issues` to pre-register.
 

--- a/web/public/llms-full.txt
+++ b/web/public/llms-full.txt
@@ -16,9 +16,9 @@ https://github.com/tokencanopy/e2a (Apache-2.0).
 
 # Set up e2a
 
-e2a gives an AI agent its own real email inbox: a verified address it can send
-from, receive to, and use for multi-turn conversations. The inbox belongs to
-the agent—not to a human whose mailbox the agent reads.
+e2a gives an AI agent its own real email inbox: a provisioned address it can
+send from, receive to, and use for multi-turn conversations. The inbox belongs
+to the agent—not to a human whose mailbox the agent reads.
 
 This guide connects e2a, selects or creates an inbox, and verifies that it is
 ready. Most setups use the shared `agents.e2a.dev` domain and require no DNS

--- a/web/public/llms-full.txt
+++ b/web/public/llms-full.txt
@@ -1,9 +1,10 @@
 # e2a — full documentation
 
-> e2a is the open-source email API for AI agents. Send transactional email, give
-> agents real two-way inboxes, and keep people in control. Use e2a as a hosted
-> service or run the Apache-2.0 stack yourself. Connect over a hosted MCP server
-> (OAuth 2.1, no API key), the REST API, or the TypeScript/Python SDKs.
+> e2a is the open-source email API for applications and AI agents. Send
+> transactional email from any product, give agents real two-way inboxes, and
+> keep people in control. Use e2a as a hosted service or run the Apache-2.0
+> stack yourself. Connect over a hosted MCP server (OAuth 2.1, no API key), the
+> REST API, or the TypeScript/Python SDKs.
 
 This file inlines the full e2a documentation set so it can be read in one
 fetch. The per-document originals are linked above each section, and the

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -1,17 +1,17 @@
 # e2a
 
-> e2a is an authenticated email gateway for AI agents: it gives an agent its own
-> verified email inbox to send, receive, reply, and forward, with SPF/DKIM
-> verification. Connect
-> over a hosted MCP server (OAuth, no API key), the REST API, or the SDKs.
+> e2a is the open-source email API for AI agents. Send transactional email, give
+> agents real two-way inboxes, and keep people in control. Use e2a as a hosted
+> service or run the Apache-2.0 stack yourself. Connect over a hosted MCP server
+> (OAuth, no API key), the REST API, or the SDKs.
 
-**The problem e2a solves.** An AI agent that has to reach people, or other
-agents, has no identity of its own on the one channel every organization
-already runs on. Pointing an agent at a human's mailbox borrows that person's
-identity, mixes the agent's mail in with theirs, and leaves the agent no way to
-tell a real sender from a spoofed one. e2a gives the mailbox to the agent: its
-own verified address, on the shared `agents.e2a.dev` domain or on a domain you
-own, with two-way send and receive.
+**The problem e2a solves.** Developers and businesses need email infrastructure
+that works for product notifications and agent workflows. Pointing an agent at
+a human's mailbox borrows that person's identity and mixes the agent's mail in
+with theirs. e2a gives the agent its own address on the shared
+`agents.e2a.dev` domain or on a domain you verify, with two-way send and receive.
+It also gives applications a transactional sending API, plus optional human
+approval before an agent's message leaves.
 
 **What is distinctive about e2a:**
 
@@ -32,8 +32,8 @@ own, with two-way send and receive.
   tools all work from a laptop or from behind a firewall. Webhooks are an
   option, not a prerequisite, and every webhook delivery is HMAC-signed.
 - **Apache-2.0 and self-hostable.** The whole stack is open source and runs
-  against your own Postgres and outbound relay, with every feature intact. The
-  hosted service at e2a.dev runs that same server image.
+  against your own Postgres and outbound relay. The hosted service at e2a.dev
+  runs the same server image.
 
 ## Start here
 

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -1,9 +1,12 @@
 # e2a
 
-> e2a is the open-source email API for AI agents. Send transactional email, give
-> agents real two-way inboxes, and keep people in control. Use e2a as a hosted
-> service or run the Apache-2.0 stack yourself. Connect over a hosted MCP server
-> (OAuth, no API key), the REST API, or the SDKs.
+> e2a is the open-source email API for applications and AI agents. Send
+> transactional email from any product, give agents real two-way inboxes, and
+> keep people in control. Use e2a as a hosted service or run the Apache-2.0
+> stack yourself. Connect over a hosted MCP server (OAuth, no API key), the
+> REST API, or the SDKs.
+
+e2a is an open-source email API for transactional application email and agent-owned inboxes. Using e2a for application-triggered sending does not require an AI agent or agent framework.
 
 **The problem e2a solves.** Developers and businesses need email infrastructure
 that works for product notifications and agent workflows. Pointing an agent at
@@ -46,6 +49,7 @@ approval before an agent's message leaves.
 
 ## API & SDKs
 
+- [Transactional email API](https://e2a.dev/transactional-email-api): Use e2a from any application for receipts, verification messages, product notifications, and alerts. No AI agent or agent framework is required.
 - [sdk.md](https://e2a.dev/sdk.md): TypeScript (`@e2a/sdk`) and Python (`e2a`) quick-start with code examples — send, receive (webhook → fetch → reply), and real-time streaming — plus a Raw-REST section (base URL, auth, conventions) for other languages.
 - [openapi.yaml](https://e2a.dev/v1/openapi.yaml): The full OpenAPI 3.1 contract — every endpoint, field, enum, and error, generated from the live handlers. Authoritative for exact signatures.
 - [templates.md](https://e2a.dev/templates.md): Email templates (beta) — server-rendered reusable emails with `{{variable}}` interpolation, a prebuilt starter catalog (`from_starter`), validation, and send-by-alias. Includes a copy-paste setup prompt for coding agents.

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -15,10 +15,10 @@ approval before an agent's message leaves.
 
 **What is distinctive about e2a:**
 
-- **Sender verification on every inbound message.** e2a evaluates SPF, every
-  DKIM signature, and DMARC — including alignment — before the agent sees a
-  message, and hands the result over as structured evidence rather than raw
-  headers the agent has to parse and trust.
+- **Structured inbound domain evidence.** e2a evaluates SPF, every DKIM
+  signature, and DMARC, including alignment, before the agent sees a message.
+  It hands the results over as structured data rather than raw headers. The
+  evidence applies to the From domain, not a person, mailbox, or message content.
 - **An approval gate before anything is sent.** Opt-in, per agent: an outbound
   message is accepted but not dispatched (`status: pending_review`) until a
   person approves it from the dashboard, the API, the MCP tools, or a magic
@@ -75,7 +75,7 @@ the source of truth for business data and policy.
 
 ## Pricing
 
-- [Pricing](https://e2a.dev/pricing): Hosted plans. The free tier needs no credit card and includes the shared `agents.e2a.dev` domain, a custom domain, sender verification, and real-time WebSocket delivery; paid Pro and Scale tiers raise the agent, custom-domain, monthly-message, and storage limits. Self-hosting the Apache-2.0 server costs nothing. Current amounts and limits live on the page rather than in this file, so read it before quoting a number.
+- [Pricing](https://e2a.dev/pricing): Hosted plans. The free tier needs no credit card and includes the shared `agents.e2a.dev` domain, a custom domain, structured inbound domain evidence, and real-time WebSocket delivery; paid Pro and Scale tiers raise the agent, custom-domain, monthly-message, and storage limits. Self-hosting the Apache-2.0 server costs nothing. Current amounts and limits live on the page rather than in this file, so read it before quoting a number.
 
 ## Blog
 

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -59,9 +59,9 @@ approval before an agent's message leaves.
 ## Use cases
 
 The use-case pages below describe concrete workflows developers can build with
-an agent-owned inbox. e2a provides the email identity, inbound authentication
-evidence, delivery, threading, and outbound controls; the application remains
-the source of truth for business data and policy.
+an agent-owned inbox. e2a provides the provisioned address, structured inbound
+domain evidence, delivery, threading, and outbound controls; the application
+remains the source of truth for business data and policy.
 
 - [What can you build with e2a?](https://e2a.dev/use-cases): The canonical use-case directory.
 - [Support agent](https://e2a.dev/use-cases/support-agent): Triage customer requests, retrieve context, reply in-thread, and hold sensitive replies for approval.
@@ -75,7 +75,7 @@ the source of truth for business data and policy.
 
 ## Pricing
 
-- [Pricing](https://e2a.dev/pricing): Hosted plans. The free tier needs no credit card and includes the shared `agents.e2a.dev` domain, a custom domain, structured inbound domain evidence, and real-time WebSocket delivery; paid Pro and Scale tiers raise the agent, custom-domain, monthly-message, and storage limits. Self-hosting the Apache-2.0 server costs nothing. Current amounts and limits live on the page rather than in this file, so read it before quoting a number.
+- [Pricing](https://e2a.dev/pricing): Hosted plans. The free tier needs no credit card and includes the shared `agents.e2a.dev` domain, a custom domain, structured inbound domain evidence, and real-time WebSocket delivery; paid tiers raise the agent, custom-domain, monthly-message, and storage limits. Self-hosting the Apache-2.0 server costs nothing. Current amounts and limits live on the page rather than in this file, so read it before quoting a number.
 
 ## Blog
 

--- a/web/public/setup.md
+++ b/web/public/setup.md
@@ -1,8 +1,8 @@
 # Set up e2a
 
-e2a gives an AI agent its own real email inbox: a verified address it can send
-from, receive to, and use for multi-turn conversations. The inbox belongs to
-the agent—not to a human whose mailbox the agent reads.
+e2a gives an AI agent its own real email inbox: a provisioned address it can
+send from, receive to, and use for multi-turn conversations. The inbox belongs
+to the agent—not to a human whose mailbox the agent reads.
 
 This guide connects e2a, selects or creates an inbox, and verifies that it is
 ready. Most setups use the shared `agents.e2a.dev` domain and require no DNS

--- a/web/src/app/(app)/AppLayoutClient.tsx
+++ b/web/src/app/(app)/AppLayoutClient.tsx
@@ -11,7 +11,11 @@ import { SIGN_IN_LABEL } from "../../lib/site";
 
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
-const APP_LOGIN_RETURN_PATHS = ["/reviews", "/inboxes/messages"] as const;
+const APP_LOGIN_RETURN_PATHS = [
+  "/get-started",
+  "/reviews",
+  "/inboxes/messages",
+] as const;
 
 export default function AppLayout({
   children,

--- a/web/src/app/(app)/get-started/_components/SuccessPanel.test.tsx
+++ b/web/src/app/(app)/get-started/_components/SuccessPanel.test.tsx
@@ -28,6 +28,13 @@ describe("SuccessPanel", () => {
     render(<SuccessPanel agent={agent} />);
     expect(screen.getByText("Inbox created!")).toBeInTheDocument();
     expect(screen.getByText("my-agent@agents.e2a.dev")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Connect your application or agent" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "API Keys" })).toHaveAttribute(
+      "href",
+      "/api-keys",
+    );
   });
 
   it("sends a test email to the new inbox and shows the delivered state", async () => {
@@ -45,7 +52,7 @@ describe("SuccessPanel", () => {
       "/v1/agents/my-agent%40agents.e2a.dev/test",
       expect.objectContaining({ method: "POST", credentials: "include" }),
     );
-    expect(screen.getByText(/Connect your agent below to receive it/)).toBeInTheDocument();
+    expect(screen.getByText(/Connect your application or agent below to receive it/)).toBeInTheDocument();
   });
 
   it("surfaces the server error and returns to the idle state on failure", async () => {

--- a/web/src/app/(app)/get-started/_components/SuccessPanel.test.tsx
+++ b/web/src/app/(app)/get-started/_components/SuccessPanel.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { SuccessPanel } from "./SuccessPanel";
 import type { AgentData } from "../../../components/types";
 
-const agent: AgentData = { domain: "agents.e2a.dev", email: "my-agent@agents.e2a.dev" };
+const agent: AgentData = { domain: "agents.localhost", email: "my-agent@agents.localhost" };
 
 const mockFetch = jest.fn();
 global.fetch = mockFetch;
@@ -27,7 +27,7 @@ describe("SuccessPanel", () => {
   it("announces the created inbox with its email address", () => {
     render(<SuccessPanel agent={agent} />);
     expect(screen.getByText("Inbox created!")).toBeInTheDocument();
-    expect(screen.getByText("my-agent@agents.e2a.dev")).toBeInTheDocument();
+    expect(screen.getByText("my-agent@agents.localhost")).toBeInTheDocument();
     expect(
       screen.getByRole("heading", { name: "Connect your application or agent" }),
     ).toBeInTheDocument();
@@ -42,14 +42,14 @@ describe("SuccessPanel", () => {
     render(<SuccessPanel agent={agent} />);
 
     await userEvent.click(
-      screen.getByRole("button", { name: /Send a test email to my-agent@agents\.e2a\.dev/ }),
+      screen.getByRole("button", { name: /Send a test email to my-agent@agents\.localhost/ }),
     );
 
     expect(
-      await screen.findByText(/Test email is on its way to my-agent@agents\.e2a\.dev/),
+      await screen.findByText(/Test email is on its way to my-agent@agents\.localhost/),
     ).toBeInTheDocument();
     expect(mockFetch).toHaveBeenCalledWith(
-      "/v1/agents/my-agent%40agents.e2a.dev/test",
+      "/v1/agents/my-agent%40agents.localhost/test",
       expect.objectContaining({ method: "POST", credentials: "include" }),
     );
     expect(screen.getByText(/Connect your application or agent below to receive it/)).toBeInTheDocument();

--- a/web/src/app/(app)/get-started/_components/SuccessPanel.tsx
+++ b/web/src/app/(app)/get-started/_components/SuccessPanel.tsx
@@ -150,9 +150,9 @@ function ApiKeyNote() {
     <div className="mb-6 p-4 border border-border rounded-lg text-sm text-muted">
       <p>
         <span className="font-medium text-foreground">Application API.</span>{" "}
-        Create an{" "}
+        Create a key on the{" "}
         <a href="/api-keys" className="text-accent hover:underline">API Keys</a>{" "}
-        and use it with the HTTP API, TypeScript SDK, or Python SDK. The CLI can
+        page and use it with the HTTP API, TypeScript SDK, or Python SDK. The CLI can
         also create and save a key automatically via{" "}
         <code className="bg-surface px-1 py-0.5 rounded border border-border">e2a login</code>.
         {" "}Full docs:{" "}

--- a/web/src/app/(app)/get-started/_components/SuccessPanel.tsx
+++ b/web/src/app/(app)/get-started/_components/SuccessPanel.tsx
@@ -93,7 +93,7 @@ export function SuccessPanel({
               Test email is on its way to {agent.email}
             </button>
             <p className="mt-3 text-sm text-muted text-center">
-              Connect your agent below to receive it. It will be the first message that arrives.
+              Connect your application or agent below to receive it. It will be the first message that arrives.
             </p>
           </>
         )}
@@ -112,13 +112,18 @@ export function SuccessPanel({
           color: "var(--fg)",
         }}
       >
-        Connect your agent
+        Connect your application or agent
       </h2>
       <p className="mb-6 text-[14px]" style={{ color: "var(--fg-muted)" }}>
-        Give the following commands to your agent to learn the e2a skill. Works with OpenClaw, Claude Code, Gemini CLI, or any agent that supports skills.
+        Use this address from any backend over the HTTP API or an SDK. If you are building an agent, you can also install the e2a skill for inbox tools.
       </p>
 
+      <ApiKeyNote />
+
       <div className="space-y-4">
+        <h3 className="text-[15px] font-semibold" style={{ color: "var(--fg)" }}>
+          Agent tools <span className="font-normal" style={{ color: "var(--fg-muted)" }}>(optional)</span>
+        </h3>
         <CodeBlock
           title="Install the e2a skill"
           code={`mkdir -p .claude/skills/e2a\ncurl -o .claude/skills/e2a/SKILL.md \\\n  https://raw.githubusercontent.com/tokencanopy/e2a/main/plugins/e2a/skills/e2a/SKILL.md`}
@@ -129,8 +134,6 @@ export function SuccessPanel({
           in your agent to get started. The skill walks through login, agent registration, and listening for emails automatically.
         </p>
       </div>
-
-      <ApiKeyNote />
 
       <a
         href="/inboxes"
@@ -144,14 +147,15 @@ export function SuccessPanel({
 
 function ApiKeyNote() {
   return (
-    <div className="mt-6 p-4 border border-border rounded-lg text-sm text-muted">
+    <div className="mb-6 p-4 border border-border rounded-lg text-sm text-muted">
       <p>
-        <span className="font-medium text-foreground">API key required.</span>{" "}
-        The CLI can create and save one automatically via{" "}
-        <code className="bg-surface px-1 py-0.5 rounded border border-border">e2a login</code>.
-        {" "}For direct API or SDK usage, manage keys on the{" "}
+        <span className="font-medium text-foreground">Application API.</span>{" "}
+        Create an{" "}
         <a href="/api-keys" className="text-accent hover:underline">API Keys</a>{" "}
-        page. Full docs:{" "}
+        and use it with the HTTP API, TypeScript SDK, or Python SDK. The CLI can
+        also create and save a key automatically via{" "}
+        <code className="bg-surface px-1 py-0.5 rounded border border-border">e2a login</code>.
+        {" "}Full docs:{" "}
         <a href="https://www.npmjs.com/package/@e2a/cli" target="_blank" rel="noopener noreferrer" className="text-accent hover:underline">CLI</a>,{" "}
         <a href="/api-docs" className="text-accent hover:underline">API</a>,{" "}
         <a href="https://pypi.org/project/e2a/" target="_blank" rel="noopener noreferrer" className="text-accent hover:underline">Python SDK</a>.

--- a/web/src/app/(app)/get-started/page.test.tsx
+++ b/web/src/app/(app)/get-started/page.test.tsx
@@ -325,7 +325,7 @@ describe("Shared local flow", () => {
     await waitFor(() => {
       expect(screen.getByText("Inbox created!")).toBeInTheDocument();
     });
-    expect(screen.getByText("Connect your agent")).toBeInTheDocument();
+    expect(screen.getByText("Connect your application or agent")).toBeInTheDocument();
     expect(screen.getByText("Install the e2a skill")).toBeInTheDocument();
   });
 });
@@ -587,7 +587,7 @@ describe("Custom-domain flow: new domain -> DNS -> verify -> local agent", () =>
     await waitFor(() => {
       expect(screen.getByText("Inbox created!")).toBeInTheDocument();
     });
-    expect(screen.getByText("Connect your agent")).toBeInTheDocument();
+    expect(screen.getByText("Connect your application or agent")).toBeInTheDocument();
   });
 });
 

--- a/web/src/app/(app)/get-started/page.tsx
+++ b/web/src/app/(app)/get-started/page.tsx
@@ -40,9 +40,9 @@ const PAGE_HEADER = {
   eyebrow: "Onboarding · est. 3 minutes",
   // Plain Inter heading to match the rest of the (app) pages —
   // editorial italic stays on marketing/landing surfaces only.
-  title: "Set up your first inbox.",
+  title: "Set up your first sender or inbox.",
   subtitle:
-    "Claim an email address for your agent, then point e2a at where your code runs. You can change all of this later from the dashboard.",
+    "Create an email identity for application sends, agent inboxes, or both. You can change all of this later from the dashboard.",
 };
 
 export default function GetStartedPage() {

--- a/web/src/app/(app)/layout.test.tsx
+++ b/web/src/app/(app)/layout.test.tsx
@@ -111,6 +111,21 @@ describe("(app) layout — auth gates", () => {
     );
   });
 
+  it("preserves the application sender setup step through sign-in", async () => {
+    mockAuth = { user: null, loading: false };
+    window.history.replaceState(null, "", "/get-started?step=address");
+
+    render(<AppLayout><div>page content</div></AppLayout>);
+
+    await waitFor(() =>
+      expect(screen.getByRole("link", { name: "Sign in with Google" }))
+        .toHaveAttribute(
+          "href",
+          "/api/auth/login?return_to=%2Fget-started%3Fstep%3Daddress",
+        ),
+    );
+  });
+
   it("renders children on the authenticated app surface", () => {
     const { container } = render(<AppLayout><div>page content</div></AppLayout>);
     expect(screen.getByText("page content")).toBeInTheDocument();

--- a/web/src/app/docs/layout.tsx
+++ b/web/src/app/docs/layout.tsx
@@ -1,13 +1,13 @@
 import type { Metadata } from "next";
 import { SITE_URL } from "../../lib/site";
 
-const TITLE = "Docs — e2a email API for AI agents";
+const TITLE = "Docs — e2a email API for applications and AI agents";
 // Describes what this page actually answers — connecting over MCP/REST/SDK,
 // the credential model, webhook vs WebSocket delivery, threading, idempotency
 // — rather than the whole product. A description that overshoots its page is
 // the one search engines rewrite.
 const DESC =
-  "Developer docs for e2a, the open-source email API for AI agents: transactional sending, two-way inboxes, MCP, REST, TypeScript and Python SDKs, OAuth 2.1, webhooks, WebSockets, threading, and idempotency.";
+  "Developer docs for e2a, the open-source email API for applications and AI agents: transactional sending, two-way inboxes, REST, TypeScript and Python SDKs, MCP, OAuth 2.1, webhooks, WebSockets, threading, and idempotency.";
 
 export const metadata: Metadata = {
   title: { absolute: TITLE },

--- a/web/src/app/docs/layout.tsx
+++ b/web/src/app/docs/layout.tsx
@@ -7,7 +7,7 @@ const TITLE = "Docs — e2a email API for AI agents";
 // — rather than the whole product. A description that overshoots its page is
 // the one search engines rewrite.
 const DESC =
-  "Developer docs for e2a, the authenticated email API for AI agents: connect over MCP, REST, or the TypeScript and Python SDKs; API keys and OAuth 2.1; webhook vs WebSocket delivery; conversation threading and idempotent sends.";
+  "Developer docs for e2a, the open-source email API for AI agents: transactional sending, two-way inboxes, MCP, REST, TypeScript and Python SDKs, OAuth 2.1, webhooks, WebSockets, threading, and idempotency.";
 
 export const metadata: Metadata = {
   title: { absolute: TITLE },

--- a/web/src/app/docs/page.test.tsx
+++ b/web/src/app/docs/page.test.tsx
@@ -35,6 +35,12 @@ describe("Docs page", () => {
     expect(
       screen.getByRole("heading", { level: 1, name: /e2a developer docs/i }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(/e2a is the open-source email API for AI agents/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/authenticated email gateway|verified email address/i),
+    ).not.toBeInTheDocument();
   });
 
   it("routes onward to the full API reference", () => {

--- a/web/src/app/docs/page.test.tsx
+++ b/web/src/app/docs/page.test.tsx
@@ -36,7 +36,7 @@ describe("Docs page", () => {
       screen.getByRole("heading", { level: 1, name: /e2a developer docs/i }),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/e2a is the open-source email API for AI agents/i),
+      screen.getByText(/e2a is the open-source email API for applications and AI agents/i),
     ).toBeInTheDocument();
     expect(
       screen.queryByText(/authenticated email gateway|verified email address/i),

--- a/web/src/app/docs/page.tsx
+++ b/web/src/app/docs/page.tsx
@@ -163,13 +163,14 @@ export default function DocsPage() {
         {/* The lede is the extractable answer: what the docs cover and where
             the exhaustive reference lives. */}
         <p className="text-[17px] leading-[1.6]" style={{ color: "var(--fg-muted)" }}>
-          e2a is the open-source email API for AI agents. It sends transactional
-          email, gives agents real two-way inboxes, and delivers structured SPF,
-          DKIM, and DMARC evidence for inbound mail over MCP, a signed webhook, a
-          WebSocket stream, or REST. The evidence applies to the From domain,
-          not a person or mailbox. These pages cover how to connect, authenticate
-          API calls, and work with email threads; the exhaustive endpoint
-          reference is the{" "}
+          e2a is the open-source email API for applications and AI agents. Any
+          product can send transactional email over HTTP or an SDK; agent-native
+          systems can also receive through real two-way inboxes over MCP, a
+          signed webhook, a WebSocket stream, or REST. Inbound mail includes
+          structured SPF, DKIM, and DMARC evidence that applies to the From
+          domain, not a person or mailbox. These pages cover how to connect,
+          authenticate API calls, and work with email threads; the exhaustive
+          endpoint reference is the{" "}
           <Link href="/api-docs" style={{ color: "var(--fg)", textDecoration: "underline" }}>
             API reference
           </Link>

--- a/web/src/app/docs/page.tsx
+++ b/web/src/app/docs/page.tsx
@@ -163,11 +163,12 @@ export default function DocsPage() {
         {/* The lede is the extractable answer: what the docs cover and where
             the exhaustive reference lives. */}
         <p className="text-[17px] leading-[1.6]" style={{ color: "var(--fg-muted)" }}>
-          e2a is an authenticated email gateway for AI agents: it gives an agent
-          its own verified email address, evaluates SPF, DKIM, and DMARC on every
-          inbound message, and delivers that mail over MCP, a signed webhook, a
-          WebSocket stream, or REST. These pages cover how to connect, how to
-          authenticate, and how mail is threaded; the exhaustive endpoint
+          e2a is the open-source email API for AI agents. It sends transactional
+          email, gives agents real two-way inboxes, and delivers structured SPF,
+          DKIM, and DMARC evidence for inbound mail over MCP, a signed webhook, a
+          WebSocket stream, or REST. The evidence applies to the From domain,
+          not a person or mailbox. These pages cover how to connect, authenticate
+          API calls, and work with email threads; the exhaustive endpoint
           reference is the{" "}
           <Link href="/api-docs" style={{ color: "var(--fg)", textDecoration: "underline" }}>
             API reference

--- a/web/src/app/docs/python/layout.tsx
+++ b/web/src/app/docs/python/layout.tsx
@@ -1,9 +1,9 @@
 import type { Metadata } from "next";
 import { SITE_URL } from "../../../lib/site";
 
-const TITLE = "Python SDK docs — send email from your AI agent";
+const TITLE = "Python SDK docs — send transactional email with e2a";
 const DESC =
-  "Python SDK guide for e2a. Install the e2a package, send transactional email, receive mail with structured domain evidence, use WebSocket delivery, and thread conversations across agents and humans.";
+  "Python SDK guide for e2a. Send transactional email from any application without an agent framework, or receive mail with structured domain evidence, WebSocket delivery, and threaded conversations.";
 
 export const metadata: Metadata = {
   title: { absolute: TITLE },

--- a/web/src/app/docs/python/layout.tsx
+++ b/web/src/app/docs/python/layout.tsx
@@ -3,7 +3,7 @@ import { SITE_URL } from "../../../lib/site";
 
 const TITLE = "Python SDK docs — send email from your AI agent";
 const DESC =
-  "Python SDK guide for e2a. Install the e2a package, send and receive authenticated email from your AI agent, use WebSocket for real-time delivery, thread conversations across agents and humans.";
+  "Python SDK guide for e2a. Install the e2a package, send transactional email, receive mail with structured domain evidence, use WebSocket delivery, and thread conversations across agents and humans.";
 
 export const metadata: Metadata = {
   title: { absolute: TITLE },

--- a/web/src/app/email-api-for-ai-agents/page.test.tsx
+++ b/web/src/app/email-api-for-ai-agents/page.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import EmailApiForAgentsPage from "./page";
+import EmailApiForAgentsPage, { metadata } from "./page";
 
 jest.mock("next/link", () => {
   return function MockLink({
@@ -24,9 +24,10 @@ describe("email API category page", () => {
     render(<EmailApiForAgentsPage />);
 
     expect(
-      screen.getByRole("heading", { level: 1, name: "Build agents that work over email." }),
+      screen.getByRole("heading", { level: 1, name: "The open-source email API for AI agents." }),
     ).toBeInTheDocument();
-    expect(screen.getByText(/e2a gives every agent a real, authenticated inbox/i)).toBeInTheDocument();
+    expect(screen.getByText(/Send transactional email, give agents real two-way inboxes/i)).toBeInTheDocument();
+    expect(metadata.description).not.toMatch(/authenticated inbox/i);
     for (const slug of ["support-agent", "ai-receptionist", "scheduling-agent", "ecommerce-agent", "sales-agent", "procurement-agent"]) {
       expect(document.querySelector(`a[href="/use-cases/${slug}"]`)).toBeInTheDocument();
     }
@@ -37,7 +38,7 @@ describe("email API category page", () => {
     expect(screen.getByText("What is an email API for AI agents?")).toBeInTheDocument();
     expect(screen.getByText("What is the difference between e2a and a transactional email API?")).toBeInTheDocument();
     expect(screen.getByText("How does e2a authenticate inbound email?")).toBeInTheDocument();
-    expect(screen.getByText("What are the best ways to give an AI agent its own email address?")).toBeInTheDocument();
+    expect(screen.getByText("What are the main ways to give an AI agent its own email address?")).toBeInTheDocument();
   });
 
   it("enumerates the ways to give an agent an email address", () => {

--- a/web/src/app/email-api-for-ai-agents/page.tsx
+++ b/web/src/app/email-api-for-ai-agents/page.tsx
@@ -6,7 +6,7 @@ import { JsonLd } from "../components/JsonLd";
 
 const TITLE = "Email API for AI Agents | e2a";
 const DESC =
-  "e2a is open-source email infrastructure for AI agents. Give agents real, authenticated inboxes to send, receive, and reply to email through an API, SDK, webhook, WebSocket, or MCP.";
+  "e2a is the open-source email API for AI agents. Send transactional email, give agents real two-way inboxes, and keep people in control. Use e2a as a hosted service or run the Apache-2.0 stack yourself.";
 
 export const metadata: Metadata = {
   title: { absolute: TITLE },
@@ -39,19 +39,19 @@ const WAYS_ROWS = [
 
 const FAQ: FaqEntry[] = [
   {
-    question: "What are the best ways to give an AI agent its own email address?",
+    question: "What are the main ways to give an AI agent its own email address?",
     answer:
-      "The best way is a dedicated email gateway: the agent gets a real, authenticated inbox it can send from, receive into, and reply in-thread — e2a is one such gateway. The other main options are connecting an existing Gmail or Outlook account, direct IMAP access, and forwarding mail into an AI integration.",
+      "The main options are a dedicated email API, connecting an existing Gmail or Outlook account, direct IMAP access, and forwarding mail into an AI integration. A dedicated email API such as e2a gives the agent its own two-way address rather than access to a person's mailbox.",
   },
   {
     question: "What is an email API for AI agents?",
     answer:
-      "An email API for AI agents gives an agent its own email identity and the programmatic ability to receive, send, and reply to messages. e2a adds authenticated inbound delivery, in-thread replies, multiple integration surfaces, and an optional human approval gate for outbound actions.",
+      "An email API for AI agents lets software send transactional email and gives agents the programmatic ability to receive, send, and reply to messages. e2a adds structured inbound domain evidence, in-thread replies, multiple integration surfaces, and an optional human approval gate for outbound actions.",
   },
   {
     question: "What is the difference between e2a and a transactional email API?",
     answer:
-      "A transactional email API primarily sends application mail. e2a gives an AI agent a two-way inbox of its own: it can receive requests, preserve conversation threads, reply from its identity, and hand sensitive actions to a human for approval.",
+      "e2a includes transactional sending and adds a two-way inbox for each agent. An agent can receive requests, preserve conversation threads, reply from its own address, and hand sensitive actions to a human for approval through the same API.",
   },
   {
     question: "What can I build with an AI agent email API?",
@@ -61,7 +61,7 @@ const FAQ: FaqEntry[] = [
   {
     question: "How does e2a authenticate inbound email?",
     answer:
-      "e2a evaluates SPF, DKIM, and DMARC on inbound messages and delivers the authentication result as structured evidence. Webhook deliveries are signed so the receiving service can verify that the event came from e2a before invoking an agent.",
+      "e2a evaluates SPF, DKIM, and DMARC on inbound messages and delivers the results as structured domain evidence. That evidence applies to the From domain, not a person, mailbox, or message content. Webhook deliveries are signed so the receiving service can verify that the event came from e2a before invoking an agent.",
   },
 ];
 
@@ -101,20 +101,20 @@ export default function EmailApiForAgentsPage() {
             EMAIL INFRASTRUCTURE FOR AI AGENTS
           </p>
           <h1 className="text-[40px] md:text-[60px] font-semibold leading-[1.04] mb-6" style={{ letterSpacing: "-0.045em" }}>
-            Build agents that work over email.
+            The open-source email API for AI agents.
           </h1>
           <p className="text-[18px] md:text-[21px] leading-[1.55]" style={{ color: "var(--fg-muted)" }}>
-            e2a gives every agent a real, authenticated inbox. Receive requests,
-            take action, reply in-thread, and bring in a human when the action
-            matters.
+            Send transactional email, give agents real two-way inboxes, and keep
+            people in control. Use e2a as a hosted service or run the Apache-2.0
+            stack yourself.
           </p>
         </header>
 
         <section className="grid md:grid-cols-3 gap-3" aria-labelledby="primitives-heading">
           <h2 id="primitives-heading" className="sr-only">What e2a provides</h2>
           {[
-            ["01", "An agent identity", "A real address that belongs to the agent, not a human mailbox it happens to read."],
-            ["02", "A two-way channel", "Receive authenticated mail and send replies that stay in the same conversation."],
+            ["01", "An agent-owned address", "A real address that belongs to the agent, not a human mailbox it happens to read."],
+            ["02", "A two-way channel", "Receive mail with domain-authentication evidence and send replies that stay in the same conversation."],
             ["03", "A safer action boundary", "Hold outbound mail for human approval and pass sender evidence into the agent."],
           ].map(([number, title, text]) => (
             <div key={number} className="p-6" style={{ background: "var(--bg-panel)", border: "1px solid var(--border)", borderRadius: "var(--r-lg)" }}>

--- a/web/src/app/layout.test.ts
+++ b/web/src/app/layout.test.ts
@@ -10,15 +10,15 @@ import { metadata } from "./layout";
 describe("root metadata", () => {
   it("uses the canonical open-source email API positioning", () => {
     expect(metadata.title).toMatchObject({
-      default: "e2a | The open-source email API for AI agents",
+      default: "e2a | The open-source email API for applications and AI agents",
     });
     expect(metadata.description).toBe(
-      "Send transactional email, give agents real two-way inboxes, and keep people in control. Use e2a as a hosted service or run the Apache-2.0 stack yourself.",
+      "Send transactional email from any product, give agents real two-way inboxes, and keep people in control. Use e2a as a hosted service or run the Apache-2.0 stack yourself.",
     );
     expect(metadata.openGraph).toMatchObject({
-      title: "e2a | The open-source email API for AI agents",
+      title: "e2a | The open-source email API for applications and AI agents",
       description:
-        "Send transactional email, give agents real two-way inboxes, and keep people in control. Use e2a as a hosted service or run the Apache-2.0 stack yourself.",
+        "Send transactional email from any product, give agents real two-way inboxes, and keep people in control. Use e2a as a hosted service or run the Apache-2.0 stack yourself.",
     });
   });
 });

--- a/web/src/app/layout.test.ts
+++ b/web/src/app/layout.test.ts
@@ -1,0 +1,24 @@
+jest.mock("@e2a/ui/styles.css", () => ({}), { virtual: true });
+jest.mock("./globals.css", () => ({}), { virtual: true });
+jest.mock("next/font/local", () => ({
+  __esModule: true,
+  default: () => ({ variable: "mock-font" }),
+}));
+
+import { metadata } from "./layout";
+
+describe("root metadata", () => {
+  it("uses the canonical open-source email API positioning", () => {
+    expect(metadata.title).toMatchObject({
+      default: "e2a | The open-source email API for AI agents",
+    });
+    expect(metadata.description).toBe(
+      "Send transactional email, give agents real two-way inboxes, and keep people in control. Use e2a as a hosted service or run the Apache-2.0 stack yourself.",
+    );
+    expect(metadata.openGraph).toMatchObject({
+      title: "e2a | The open-source email API for AI agents",
+      description:
+        "Send transactional email, give agents real two-way inboxes, and keep people in control. Use e2a as a hosted service or run the Apache-2.0 stack yourself.",
+    });
+  });
+});

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -44,9 +44,9 @@ const fraunces = localFont({
   display: "swap",
 });
 
-const ROOT_TITLE = "e2a | The open-source email API for AI agents";
+const ROOT_TITLE = "e2a | The open-source email API for applications and AI agents";
 const ROOT_DESC =
-  "Send transactional email, give agents real two-way inboxes, and keep people in control. Use e2a as a hosted service or run the Apache-2.0 stack yourself.";
+  "Send transactional email from any product, give agents real two-way inboxes, and keep people in control. Use e2a as a hosted service or run the Apache-2.0 stack yourself.";
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -44,9 +44,9 @@ const fraunces = localFont({
   display: "swap",
 });
 
-const ROOT_TITLE = "e2a — Authenticated Email for AI Agents";
+const ROOT_TITLE = "e2a | The open-source email API for AI agents";
 const ROOT_DESC =
-  "Authenticated email gateway for AI agents: verified sender identity, SPF/DKIM, agent-to-agent routing, conversation threading. Send and receive real email from your agent with a signed webhook or WebSocket.";
+  "Send transactional email, give agents real two-way inboxes, and keep people in control. Use e2a as a hosted service or run the Apache-2.0 stack yourself.";
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
@@ -58,8 +58,10 @@ export const metadata: Metadata = {
   applicationName: SITE_NAME,
   keywords: [
     "email api for ai agents",
+    "open source email api",
+    "transactional email api",
+    "two way email api",
     "agent email gateway",
-    "authenticated email webhook",
     "SPF DKIM AI agents",
     "agent-to-agent email",
     "conversation id email threading",

--- a/web/src/app/page.test.tsx
+++ b/web/src/app/page.test.tsx
@@ -43,14 +43,27 @@ describe("Landing page", () => {
     expect(
       screen.getByRole("heading", {
         level: 1,
-        name: /Build the best email agents with e2a/i,
+        name: "The open-source email API for AI agents.",
       }),
     ).toBeInTheDocument();
-    // The hero leads with the product promise and makes the first use cases
-    // explicit rather than asking a visitor to infer what e2a is for.
     expect(
-      screen.getByText(/e2a gives every agent a real, authenticated inbox/i),
+      screen.getByText(
+        /Send transactional email, give agents real two-way inboxes, and keep people in control\./i,
+      ),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Use e2a as a hosted service or run the Apache-2\.0 stack yourself\./i,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /For developers, agent-native teams, and businesses building email into their products and workflows\./i,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /What is an email API for AI agents\?/i }),
+    ).toHaveAttribute("href", "/email-api-for-ai-agents");
   });
 
   it("renders the e2a wordmark", () => {
@@ -219,7 +232,7 @@ describe("Landing page", () => {
     // The hero explainer link the row collided with is still present above.
     expect(
       screen.getByRole("link", {
-        name: /What is email infrastructure for AI agents\?/,
+        name: /What is an email API for AI agents\?/,
       }),
     ).toBeInTheDocument();
   });

--- a/web/src/app/page.test.tsx
+++ b/web/src/app/page.test.tsx
@@ -43,12 +43,12 @@ describe("Landing page", () => {
     expect(
       screen.getByRole("heading", {
         level: 1,
-        name: "The open-source email API for AI agents.",
+        name: "The open-source email API for applications and AI agents.",
       }),
     ).toBeInTheDocument();
     expect(
       screen.getByText(
-        /Send transactional email, give agents real two-way inboxes, and keep people in control\./i,
+        /Send transactional email from any product, give agents real two-way inboxes, and keep people in control\./i,
       ),
     ).toBeInTheDocument();
     expect(
@@ -62,8 +62,11 @@ describe("Landing page", () => {
     expect(audience).toBeInTheDocument();
     expect(audience).toHaveStyle({ color: "var(--fg-muted)" });
     expect(
-      screen.getByRole("link", { name: /What is an email API for AI agents\?/i }),
-    ).toHaveAttribute("href", "/email-api-for-ai-agents");
+      screen.getByRole("link", { name: /^Send from your app$/i }),
+    ).toHaveAttribute("href", "/transactional-email-api");
+    expect(
+      screen.getByRole("link", { name: /^Give an agent an inbox$/i }),
+    ).toHaveAttribute("href", "/get-started");
   });
 
   it("renders the e2a wordmark", () => {
@@ -163,15 +166,19 @@ describe("Landing page", () => {
     }
   });
 
-  // Onboarding is agent-native: the first thing the page asks you to do is
-  // install the plugin into a coding agent, not install an SDK. The SDK/CLI
-  // exist, but as the "wiring e2a into your own service" escape hatch.
-  it("leads onboarding with the plugin, not the SDK", () => {
+  it("presents application and agent onboarding as equal starting points", () => {
     render(<Home />);
     expect(
       screen.getByRole("heading", {
-        name: /Install the plugin\. Your agent has an inbox\./i,
+        name: /Start with the email path you need\./i,
       }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Send from your application")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /Give an agent an inbox/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /Install the plugin\. Your agent has an inbox\./i }),
     ).toBeInTheDocument();
     expect(
       screen.getByText(/claude plugin install e2a@e2a/),
@@ -181,14 +188,25 @@ describe("Landing page", () => {
     ).toBeInTheDocument();
   });
 
-  // The SDK path exists, but as the step AFTER onboarding — for people
-  // already running an agent framework, not as the way in.
-  it("offers the SDK path for existing agent frameworks, after the quick start", () => {
+  it("offers the SDK path to ordinary applications without requiring an agent framework", () => {
     render(<Home />);
     expect(
-      screen.getByRole("heading", { name: /Already have an agent framework\?/i }),
+      screen.getByRole("heading", { name: /Send from any application\./i }),
     ).toBeInTheDocument();
-    expect(screen.getByText(/LangChain, Google ADK/)).toBeInTheDocument();
+    expect(screen.getByText(/No agent framework is required/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Transactional email guide/i }),
+    ).toHaveAttribute("href", "/transactional-email-api");
+  });
+
+  it("answers whether conventional software can use e2a", () => {
+    render(<Home />);
+    expect(
+      screen.getByText("Can e2a be used as a general transactional email API?"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Any application can use e2a's HTTP API and TypeScript or Python SDKs/i),
+    ).toBeInTheDocument();
   });
 
   it("shows the use cases section", () => {
@@ -214,28 +232,19 @@ describe("Landing page", () => {
     expect(getStartedLinks.length).toBeGreaterThan(0);
   });
 
-  // Regression: the CTA button rows were `inline-flex`, so in the hero the
-  // "What is email infrastructure…" explainer link (itself inline) flowed
-  // onto the SAME line and sat jammed against "Get started free" instead of
-  // stacking above it. jsdom doesn't compute layout, so the guard is
-  // structural: every CTA row must be a block-level flex container.
+  // CTA rows must be block-level flex containers so their buttons wrap
+  // together cleanly at narrow widths.
   it("renders the CTA button rows as block-level flex containers", () => {
     render(<Home />);
     const rows = screen
       .getAllByRole("link", { name: /Get started free/ })
       .map((link) => link.parentElement!);
-    expect(rows).toHaveLength(2); // hero + closing CTA
+    expect(rows).toHaveLength(1); // closing CTA
     for (const row of rows) {
       const classes = row.className.split(/\s+/);
       expect(classes).toContain("flex");
       expect(classes).not.toContain("inline-flex");
     }
-    // The hero explainer link the row collided with is still present above.
-    expect(
-      screen.getByRole("link", {
-        name: /What is an email API for AI agents\?/,
-      }),
-    ).toBeInTheDocument();
   });
 });
 

--- a/web/src/app/page.test.tsx
+++ b/web/src/app/page.test.tsx
@@ -56,11 +56,11 @@ describe("Landing page", () => {
         /Use e2a as a hosted service or run the Apache-2\.0 stack yourself\./i,
       ),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        /For developers, agent-native teams, and businesses building email into their products and workflows\./i,
-      ),
-    ).toBeInTheDocument();
+    const audience = screen.getByText(
+      /For developers, agent-native teams, and businesses building email into their products and workflows\./i,
+    );
+    expect(audience).toBeInTheDocument();
+    expect(audience).toHaveStyle({ color: "var(--fg-muted)" });
     expect(
       screen.getByRole("link", { name: /What is an email API for AI agents\?/i }),
     ).toHaveAttribute("href", "/email-api-for-ai-agents");
@@ -263,6 +263,9 @@ describe("FAQ and structured data", () => {
     expect(
       screen.getByText(/The inbox belongs to the agent rather than to a human/),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/real, authenticated email address/i),
+    ).not.toBeInTheDocument();
   });
 
   it("emits a valid FAQPage whose answers match the visible ones", () => {

--- a/web/src/app/page.test.tsx
+++ b/web/src/app/page.test.tsx
@@ -198,6 +198,7 @@ describe("Landing page", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Support and intake")).toBeInTheDocument();
     expect(screen.getAllByText("Procurement").length).toBeGreaterThan(0);
+    expect(screen.queryByText(/verified agent identity/i)).not.toBeInTheDocument();
   });
 
   it("shows the human-in-the-loop section", () => {

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -343,35 +343,42 @@ export default function Home() {
               color: "var(--fg)",
             }}
           >
-            Build the best{" "}
+            The open-source{" "}
             <em
               style={{
                 fontStyle: "italic",
                 color: "var(--accent-strong)",
               }}
             >
-              email agents
+              email API
             </em>
-            {" "}with e2a.
+            {" "}for AI agents.
           </h1>
           <p
-            className="mx-auto mb-9 leading-[1.55]"
+            className="mx-auto mb-3 leading-[1.55]"
             style={{
               fontSize: 17,
               color: "var(--fg-muted)",
-              maxWidth: 540,
+              maxWidth: 660,
             }}
           >
-            e2a gives every agent a real, authenticated inbox — so it can handle
-            support, scheduling, reception, and ecommerce work over email, with
-            human approval when it matters.
+            Send transactional email, give agents real two-way inboxes, and keep
+            people in control. Use e2a as a hosted service or run the Apache-2.0
+            stack yourself.
+          </p>
+          <p
+            className="mx-auto mb-7 text-[13px] leading-[1.55]"
+            style={{ color: "var(--fg-subtle)", maxWidth: 660 }}
+          >
+            For developers, agent-native teams, and businesses building email
+            into their products and workflows.
           </p>
           <Link
             href="/email-api-for-ai-agents"
             className="inline-flex mb-7 text-[13px]"
             style={{ color: "var(--accent-strong)" }}
           >
-            What is email infrastructure for AI agents? <span className="font-mono ml-1">→</span>
+            What is an email API for AI agents? <span className="font-mono ml-1">→</span>
           </Link>
           <div className="flex flex-wrap items-center justify-center gap-2.5">
             <Link
@@ -422,7 +429,7 @@ export default function Home() {
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1145559&theme=light&t=1778615217650"
-                alt="e2a – open-source email API for agents - Give your AI agents a real, authenticated email address. | Product Hunt"
+                alt="e2a, the open-source email API for AI agents | Product Hunt"
                 width={250}
                 height={54}
                 style={{ display: "block" }}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -146,7 +146,7 @@ const FAQ: FaqEntry[] = [
   {
     question: "Can an AI agent have its own email address?",
     answer:
-      "Yes. e2a gives an AI agent its own real, authenticated email address — on the shared agents.e2a.dev domain, or on a domain you verify yourself — that it can send from, receive to, and reply in-thread on. The inbox belongs to the agent rather than to a human whose mailbox the agent reads, so recipients can tell agent mail apart from yours and revoking the agent never touches anyone's personal mail. The agent reaches that inbox over MCP tools, a signed webhook, a WebSocket stream, REST polling, or the TypeScript and Python SDKs.",
+      "Yes. e2a gives an AI agent its own dedicated, two-way email address on the shared agents.e2a.dev domain or on a domain you verify yourself. The inbox belongs to the agent rather than to a human whose mailbox the agent reads, so recipients can tell agent mail apart from yours and revoking the agent never touches anyone's personal mail. The agent reaches that inbox over MCP tools, a signed webhook, a WebSocket stream, REST polling, or the TypeScript and Python SDKs.",
   },
   {
     question: "How do you verify an email actually came from an AI agent?",
@@ -162,7 +162,7 @@ const FAQ: FaqEntry[] = [
   {
     question: "Is there an open-source email API for AI agents?",
     answer:
-      "Yes — e2a is Apache-2.0, and the whole stack is public at github.com/tokencanopy/e2a: the Go server and SMTP relay, the TypeScript and Python SDKs, the CLI, the MCP server, and the dashboard. You can self-host it against your own Postgres and your own outbound SMTP relay, and every feature works the same way there. The hosted service at e2a.dev runs that same open-source server image, so choosing hosted is a deployment decision rather than a different product.",
+      "Yes. e2a is Apache-2.0, and the whole stack is public at github.com/tokencanopy/e2a: the Go server and SMTP relay, the TypeScript and Python SDKs, the CLI, the MCP server, and the dashboard. You can self-host it against your own Postgres and outbound SMTP relay. The hosted service at e2a.dev runs the same open-source server image and manages the operating infrastructure for you.",
   },
   {
     question: "How do you stop an AI agent from sending an email without approval?",
@@ -368,7 +368,7 @@ export default function Home() {
           </p>
           <p
             className="mx-auto mb-7 text-[13px] leading-[1.55]"
-            style={{ color: "var(--fg-subtle)", maxWidth: 660 }}
+            style={{ color: "var(--fg-muted)", maxWidth: 660 }}
           >
             For developers, agent-native teams, and businesses building email
             into their products and workflows.

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -9,18 +9,18 @@ import { TokenCanopyBadge } from "./components/loft/TokenCanopyBadge";
 import { faqPage, type FaqEntry } from "../lib/jsonld";
 import { SIGN_IN_URL } from "../lib/site";
 
-// Onboarding surfaces, in the order an agent-native user meets them: install
-// the plugin in your coding agent, or point any MCP runtime at the hosted
-// server. SDKs/CLI/webhooks are the escape hatch below, not a tab — they're
-// how you'd wire e2a into your own service, not how you give an agent an inbox.
+// Agent onboarding surfaces: install the plugin in a coding agent, or point
+// any MCP runtime at the hosted server. Application integrations use the SDK
+// examples below instead of choosing one of these tabs.
 type Tab = "claude" | "codex" | "cursor" | "mcp";
 
-// The two SDKs shown side by side in the "build agent systems" section.
+// The two SDKs shown side by side in the application API section.
 type SdkTab = "python" | "ts";
 
 // Nav is three grouped menus rather than a flat row: at seven top-level
 // items plus four social icons it wrapped onto two lines at common widths.
-// Quick start stays a direct link — it's the one thing a first visit is for.
+// Start stays a direct link so visitors can choose the application or agent
+// path without first understanding e2a's resource model.
 // `newTab` is for INTERNAL routes we still want opened in a new tab, so a
 // visitor reading the landing page keeps their place instead of navigating
 // away. External links always open in one.
@@ -32,7 +32,8 @@ type NavItem = {
 };
 
 const PRODUCT_LINKS: NavItem[] = [
-  { label: "Build agent systems", href: "#build" },
+  { label: "Transactional email", href: "/transactional-email-api" },
+  { label: "Agent inboxes", href: "/email-api-for-ai-agents" },
   { label: "Human-in-the-loop", href: "#hitl" },
   { label: "Use cases", href: "/use-cases" },
   { label: "FAQ", href: "#faq" },
@@ -124,6 +125,7 @@ const SOCIAL_LINKS: { label: string; href: string; aria: string; path: string }[
 
 const FOOTER_LINKS: { label: string; href: string; external?: boolean }[] = [
   { label: "GitHub", href: "https://github.com/tokencanopy/e2a", external: true },
+  { label: "Transactional Email", href: "/transactional-email-api" },
   { label: "API Docs", href: "/api-docs" },
   { label: "Blog", href: "/blog" },
   { label: "Python SDK", href: "https://pypi.org/project/e2a/", external: true },
@@ -143,6 +145,11 @@ const FOOTER_LINKS: { label: string; href: string; external?: boolean }[] = [
 // it states only what ships today. The questions are the ones people actually
 // type; deliberately distinct from /mcp's, which answer "how do I connect".
 const FAQ: FaqEntry[] = [
+  {
+    question: "Can e2a be used as a general transactional email API?",
+    answer:
+      "Yes. Any application can use e2a's HTTP API and TypeScript or Python SDKs to send transactional email. Agent inboxes, inbound email, threading, and human approval are additional capabilities—not requirements.",
+  },
   {
     question: "Can an AI agent have its own email address?",
     answer:
@@ -227,11 +234,11 @@ export default function Home() {
           <div className="flex items-center gap-1 text-[13px]">
             <div className="hidden md:flex items-center gap-1">
               <a
-                href="#quickstart"
+                href="#start"
                 className="px-3 py-1.5 rounded-md transition hover:bg-[var(--bg-elev)]"
                 style={{ color: "var(--fg-muted)" }}
               >
-                Quick start
+                Start
               </a>
               <NavMenu label="Product" items={PRODUCT_LINKS} />
               <NavMenu label="Resources" items={RESOURCE_LINKS} />
@@ -352,7 +359,7 @@ export default function Home() {
             >
               email API
             </em>
-            {" "}for AI agents.
+            {" "}for applications and AI agents.
           </h1>
           <p
             className="mx-auto mb-3 leading-[1.55]"
@@ -362,9 +369,9 @@ export default function Home() {
               maxWidth: 660,
             }}
           >
-            Send transactional email, give agents real two-way inboxes, and keep
-            people in control. Use e2a as a hosted service or run the Apache-2.0
-            stack yourself.
+            Send transactional email from any product, give agents real two-way
+            inboxes, and keep people in control. Use e2a as a hosted service or
+            run the Apache-2.0 stack yourself.
           </p>
           <p
             className="mx-auto mb-7 text-[13px] leading-[1.55]"
@@ -373,16 +380,9 @@ export default function Home() {
             For developers, agent-native teams, and businesses building email
             into their products and workflows.
           </p>
-          <Link
-            href="/email-api-for-ai-agents"
-            className="inline-flex mb-7 text-[13px]"
-            style={{ color: "var(--accent-strong)" }}
-          >
-            What is an email API for AI agents? <span className="font-mono ml-1">→</span>
-          </Link>
           <div className="flex flex-wrap items-center justify-center gap-2.5">
             <Link
-              href="/get-started"
+              href="/transactional-email-api"
               className="inline-flex items-center gap-2 px-4 py-2.5 text-[14px] font-medium transition"
               style={{
                 background: "var(--accent-fill)",
@@ -390,11 +390,11 @@ export default function Home() {
                 borderRadius: "var(--r-md)",
               }}
             >
-              Get started free
-              <span className="font-mono">→</span>
+              Send from your app
+              <span className="font-mono" aria-hidden="true">→</span>
             </Link>
             <Link
-              href="/api-docs"
+              href="/get-started"
               className="inline-flex items-center gap-2 px-4 py-2.5 text-[14px] font-medium transition"
               style={{
                 background: "var(--bg-panel)",
@@ -403,7 +403,7 @@ export default function Home() {
                 borderRadius: "var(--r-md)",
               }}
             >
-              Read the docs
+              Give an agent an inbox
             </Link>
           </div>
 
@@ -479,7 +479,69 @@ export default function Home() {
       {/* Divider */}
       <div style={{ height: 1, background: "var(--border)" }} />
 
-      {/* Quick start */}
+      {/* Start paths */}
+      <section id="start" className="px-6 md:px-8 py-12 md:py-16 scroll-mt-20">
+        <div className="max-w-[1080px] mx-auto">
+          <div className="text-center mb-8">
+            <Eyebrow>01 · Choose a path</Eyebrow>
+            <h2
+              className="mt-3 mb-2"
+              style={{
+                fontFamily: "var(--f-editorial)",
+                fontWeight: 400,
+                fontSize: "clamp(28px, 4vw, 38px)",
+                letterSpacing: "-0.01em",
+                color: "var(--fg)",
+              }}
+            >
+              Start with the email path you need.
+            </h2>
+            <p className="mx-auto max-w-[580px] text-[14px]" style={{ color: "var(--fg-muted)" }}>
+              Use the same open-source API for familiar application email,
+              agent-owned conversations, or approval-sensitive workflows.
+            </p>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+            {[
+              {
+                title: "Send from your application",
+                desc: "Deliver receipts, verification messages, alerts, and product notifications over HTTP or an SDK.",
+                href: "/transactional-email-api",
+              },
+              {
+                title: "Give an agent an inbox",
+                desc: "Add a real two-way address through a plugin, MCP, webhooks, WebSocket, REST, or an SDK.",
+                href: "#quickstart",
+              },
+              {
+                title: "Keep people in control",
+                desc: "Hold sensitive outbound messages for human approval before they leave the system.",
+                href: "#hitl",
+              },
+            ].map((path) => (
+              <Link
+                key={path.title}
+                href={path.href}
+                className="group p-6 transition hover:bg-[var(--bg-elev)]"
+                style={{
+                  background: "var(--bg-panel)",
+                  border: "1px solid var(--border)",
+                  borderRadius: "var(--r-lg)",
+                }}
+              >
+                <h3 className="text-[16px] font-semibold mb-2" style={{ color: "var(--fg)" }}>
+                  {path.title} <span className="font-mono group-hover:translate-x-0.5 inline-block transition-transform">→</span>
+                </h3>
+                <p className="text-[13px] leading-[1.6]" style={{ color: "var(--fg-muted)" }}>
+                  {path.desc}
+                </p>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Agent quick start */}
       <section
         id="quickstart"
         className="px-6 md:px-8 py-12 md:py-16"
@@ -491,7 +553,7 @@ export default function Home() {
       >
         <div className="max-w-[1080px] mx-auto">
           <div className="text-center mb-7">
-            <Eyebrow>01 · Quick start</Eyebrow>
+            <Eyebrow>02 · Agent quick start</Eyebrow>
             <h2
               className="mt-3 mb-2"
               style={{
@@ -623,14 +685,13 @@ export default function Home() {
         </div>
       </section>
 
-      {/* Build agent systems — the SDK path, for people running their own agent
-          framework rather than a coding agent. Deliberately AFTER the plugin
-          quick start: this is the "now make it production" step, not the way
-          in. */}
+      {/* Application API — the conventional integration path. Agent inboxes
+          remain available, but application-triggered sending does not require
+          an agent framework. */}
       <section id="build" className="px-6 md:px-8 py-14 md:py-[72px]">
         <div className="max-w-[1080px] mx-auto grid grid-cols-1 md:grid-cols-2 gap-10 md:gap-14 items-center">
           <div>
-            <Eyebrow>02 · Build agent systems</Eyebrow>
+            <Eyebrow>03 · Application API</Eyebrow>
             <h2
               className="mt-3.5 mb-4 leading-[1.1]"
               style={{
@@ -641,31 +702,29 @@ export default function Home() {
                 color: "var(--fg)",
               }}
             >
-              Already have an{" "}
-              <em style={{ color: "var(--accent-strong)" }}>agent framework?</em>
+              Send from any{" "}
+              <em style={{ color: "var(--accent-strong)" }}>application.</em>
             </h2>
             <p
               className="mb-3.5 leading-[1.6]"
               style={{ fontSize: 15, color: "var(--fg-muted)" }}
             >
-              The SDKs are plain async clients, so an inbox drops into whatever
-              you already run — LangChain, Google ADK, the OpenAI Agents SDK.
-              Same hosted MCP server, or go straight at the API.
+              Use e2a for receipts, verification messages, product
+              notifications, and alerts from the software you already run. No
+              agent framework is required.
             </p>
             <p
               className="mb-5 leading-[1.65]"
               style={{ fontSize: 13, color: "var(--fg-muted)" }}
             >
-              TypeScript and Python SDKs with one-call webhook verification and a
-              WebSocket <code className="font-mono">listen()</code> stream, a CLI
-              that bridges inbound mail to a local handler, and HMAC-signed
-              webhooks for cloud runtimes. Conversation threading survives the
-              email ↔ structured-data boundary, so multi-turn replies keep their
-              session.
+              Call the HTTP API directly or use the TypeScript and Python SDKs.
+              If the workflow later needs replies, e2a can turn the same sender
+              into a two-way inbox with threading, signed webhooks, WebSocket
+              delivery, and optional human approval.
             </p>
             <div className="flex flex-wrap items-center gap-2.5">
               <Link
-                href="/blog/email-agent-with-google-adk"
+                href="/transactional-email-api"
                 className="inline-flex items-center gap-2 px-4 py-2.5 text-[14px] font-medium"
                 style={{
                   background: "var(--accent-fill)",
@@ -673,13 +732,11 @@ export default function Home() {
                   borderRadius: "var(--r-md)",
                 }}
               >
-                Google ADK walkthrough
+                Transactional email guide
                 <span className="font-mono">→</span>
               </Link>
-              <a
-                href="https://github.com/tokencanopy/e2a/tree/main/examples/adk-cloud-webhook"
-                target="_blank"
-                rel="noopener noreferrer"
+              <Link
+                href="/api-docs"
                 className="inline-flex items-center px-4 py-2.5 text-[14px] font-medium"
                 style={{
                   background: "var(--bg-panel)",
@@ -688,14 +745,13 @@ export default function Home() {
                   borderRadius: "var(--r-md)",
                 }}
               >
-                Runnable example
-              </a>
+                API reference
+              </Link>
             </div>
           </div>
 
           <div>
-            {/* Both SDKs, same shape: listen → filter to email.received →
-                hand the thread key to your agent → reply in thread. */}
+            {/* Both SDKs, same ordinary application-triggered send. */}
             <div className="flex mb-3">
               <div
                 className="inline-flex gap-0.5 p-1"
@@ -732,25 +788,23 @@ export default function Home() {
               <Tok c="keyword">from</Tok> e2a.v1 <Tok c="keyword">import</Tok> AsyncE2AClient
             </Line>
             <Line>&nbsp;</Line>
-            <Line c="comment"># conversation_id threads multi-turn replies —</Line>
-            <Line c="comment"># bind it to your framework&apos;s session id</Line>
             <Line>
               <Tok c="keyword">async with</Tok> <Tok c="fn">AsyncE2AClient</Tok>(api_key=<Tok c="string">&quot;e2a_…&quot;</Tok>) <Tok c="keyword">as</Tok> client:
             </Line>
             <Line>
-              &nbsp;&nbsp;<Tok c="keyword">async for</Tok> event <Tok c="keyword">in</Tok> client.<Tok c="fn">listen</Tok>(<Tok c="string">&quot;support@acme.dev&quot;</Tok>):
+              &nbsp;&nbsp;<Tok c="keyword">await</Tok> client.messages.<Tok c="fn">send</Tok>(<Tok c="string">&quot;receipts@example.com&quot;</Tok>, {`{`}
             </Line>
             <Line>
-              &nbsp;&nbsp;&nbsp;&nbsp;<Tok c="keyword">if</Tok> event.type != <Tok c="string">&quot;email.received&quot;</Tok>: <Tok c="keyword">continue</Tok>
+              &nbsp;&nbsp;&nbsp;&nbsp;<Tok c="string">&quot;to&quot;</Tok>: [{`{`}<Tok c="string">&quot;email&quot;</Tok>: <Tok c="string">&quot;customer@example.net&quot;</Tok>{`}`}],
             </Line>
             <Line>
-              &nbsp;&nbsp;&nbsp;&nbsp;d = event.data
+              &nbsp;&nbsp;&nbsp;&nbsp;<Tok c="string">&quot;subject&quot;</Tok>: <Tok c="string">&quot;Your receipt&quot;</Tok>,
             </Line>
             <Line>
-              &nbsp;&nbsp;&nbsp;&nbsp;reply = <Tok c="keyword">await</Tok> agent.<Tok c="fn">run</Tok>(d[<Tok c="string">&quot;conversation_id&quot;</Tok>])
+              &nbsp;&nbsp;&nbsp;&nbsp;<Tok c="string">&quot;text&quot;</Tok>: <Tok c="string">&quot;Thanks for your order.&quot;</Tok>,
             </Line>
             <Line>
-              &nbsp;&nbsp;&nbsp;&nbsp;<Tok c="keyword">await</Tok> client.messages.<Tok c="fn">reply</Tok>(d[<Tok c="string">&quot;delivered_to&quot;</Tok>], d[<Tok c="string">&quot;message_id&quot;</Tok>], {`{`}<Tok c="string">&quot;text&quot;</Tok>: reply{`}`})
+              &nbsp;&nbsp;{`}`})
             </Line>
               </>
             )}
@@ -759,31 +813,26 @@ export default function Home() {
             <Line c="comment">{"// npm i @e2a/sdk"}</Line>
             <Line>&nbsp;</Line>
             <Line>
-              <Tok c="keyword">import</Tok> {`{`} E2AClient, isEmailReceived {`}`} <Tok c="keyword">from</Tok> <Tok c="string">&quot;@e2a/sdk&quot;</Tok>;
+              <Tok c="keyword">import</Tok> {`{`} E2AClient {`}`} <Tok c="keyword">from</Tok> <Tok c="string">&quot;@e2a/sdk&quot;</Tok>;
             </Line>
             <Line>&nbsp;</Line>
-            <Line c="comment">{"// conversation_id threads multi-turn replies —"}</Line>
-            <Line c="comment">{"// bind it to your framework's session id"}</Line>
             <Line>
               <Tok c="keyword">const</Tok> client = <Tok c="keyword">new</Tok> <Tok c="fn">E2AClient</Tok>({`{`} apiKey: <Tok c="string">&quot;e2a_…&quot;</Tok> {`}`});
             </Line>
             <Line>&nbsp;</Line>
             <Line>
-              <Tok c="keyword">for await</Tok> (<Tok c="keyword">const</Tok> event <Tok c="keyword">of</Tok> client.<Tok c="fn">listen</Tok>(<Tok c="string">&quot;support@acme.dev&quot;</Tok>)) {`{`}
+              <Tok c="keyword">await</Tok> client.messages.<Tok c="fn">send</Tok>(<Tok c="string">&quot;receipts@example.com&quot;</Tok>, {`{`}
             </Line>
             <Line>
-              &nbsp;&nbsp;<Tok c="keyword">if</Tok> (!<Tok c="fn">isEmailReceived</Tok>(event)) <Tok c="keyword">continue</Tok>;
+              &nbsp;&nbsp;to: [{`{`} email: <Tok c="string">&quot;customer@example.net&quot;</Tok> {`}`}],
             </Line>
             <Line>
-              &nbsp;&nbsp;<Tok c="keyword">const</Tok> d = event.data;
+              &nbsp;&nbsp;subject: <Tok c="string">&quot;Your receipt&quot;</Tok>,
             </Line>
             <Line>
-              &nbsp;&nbsp;<Tok c="keyword">const</Tok> reply = <Tok c="keyword">await</Tok> agent.<Tok c="fn">run</Tok>(d.conversation_id);
+              &nbsp;&nbsp;text: <Tok c="string">&quot;Thanks for your order.&quot;</Tok>,
             </Line>
-            <Line>
-              &nbsp;&nbsp;<Tok c="keyword">await</Tok> client.messages.<Tok c="fn">reply</Tok>(d.delivered_to, d.message_id, {`{`} text: reply {`}`});
-            </Line>
-            <Line>{`}`}</Line>
+            <Line>{`}`});</Line>
               </>
             )}
             </CodeBlock>

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -52,7 +52,7 @@ const USE_CASES: { eyebrow: string; title: string; desc: string; href?: string }
   { eyebrow: "Admin", title: "Scheduling and admin", desc: "Coordinate meetings, send reminders, and follow up where most people already live — their inbox.", href: "/use-cases/scheduling-agent" },
   { eyebrow: "Reception", title: "AI receptionist", desc: "Answer common inquiries, route messages, and forward conversations to the right person.", href: "/use-cases/ai-receptionist" },
   { eyebrow: "Commerce", title: "E-commerce agents", desc: "Answer order questions, handle returns, and coordinate with vendors through persistent email threads.", href: "/use-cases/ecommerce-agent" },
-  { eyebrow: "Sales", title: "Sales and follow-through", desc: "Qualify leads, reply to outreach, and keep conversations moving with a verified agent identity.", href: "/use-cases/sales-agent" },
+  { eyebrow: "Sales", title: "Sales and follow-through", desc: "Qualify leads, reply to outreach, and keep conversations moving from an agent-owned address.", href: "/use-cases/sales-agent" },
   { eyebrow: "Recruiting", title: "Recruiting agents", desc: "Coordinate candidates, schedule interviews, and keep hiring conversations organized.", href: "/use-cases/recruiting-agent" },
   { eyebrow: "Auth", title: "OTP and verification", desc: "Receive verification codes, confirmation emails, and magic links — then act on them automatically." },
   { eyebrow: "Voice", title: "Voice agents", desc: "After a call ends, your voice agent sends a follow-up, receives a reply, and keeps the thread going." },

--- a/web/src/app/sitemap.test.ts
+++ b/web/src/app/sitemap.test.ts
@@ -57,6 +57,11 @@ describe("sitemap", () => {
     }
   });
 
+  it("includes the transactional email API page", () => {
+    delete process.env[ENV_KEY];
+    expect(urls()).toContain("http://localhost:3000/transactional-email-api");
+  });
+
   it("includes the use-case hub and every published use-case page", () => {
     delete process.env[ENV_KEY];
     const found = urls();

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -14,6 +14,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: "/docs/python", changeFrequency: "weekly", priority: 0.8 },
     { path: "/python-sdk", changeFrequency: "weekly", priority: 0.7 },
     { path: "/api-docs", changeFrequency: "weekly", priority: 0.7 },
+    { path: "/transactional-email-api", changeFrequency: "weekly", priority: 0.9 },
     { path: "/use-cases", changeFrequency: "weekly", priority: 0.9 },
     { path: "/email-api-for-ai-agents", changeFrequency: "weekly", priority: 0.9 },
     { path: "/compare/e2a-vs-agentmail", changeFrequency: "monthly", priority: 0.8 },

--- a/web/src/app/sitemap.ts
+++ b/web/src/app/sitemap.ts
@@ -10,11 +10,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
   const staticRoutes: Array<{ path: string; changeFrequency: "daily" | "weekly" | "monthly"; priority: number }> = [
     { path: "/", changeFrequency: "weekly", priority: 1.0 },
     { path: "/mcp", changeFrequency: "weekly", priority: 0.9 },
+    { path: "/transactional-email-api", changeFrequency: "weekly", priority: 0.9 },
     { path: "/docs", changeFrequency: "weekly", priority: 0.8 },
     { path: "/docs/python", changeFrequency: "weekly", priority: 0.8 },
     { path: "/python-sdk", changeFrequency: "weekly", priority: 0.7 },
     { path: "/api-docs", changeFrequency: "weekly", priority: 0.7 },
-    { path: "/transactional-email-api", changeFrequency: "weekly", priority: 0.9 },
     { path: "/use-cases", changeFrequency: "weekly", priority: 0.9 },
     { path: "/email-api-for-ai-agents", changeFrequency: "weekly", priority: 0.9 },
     { path: "/compare/e2a-vs-agentmail", changeFrequency: "monthly", priority: 0.8 },

--- a/web/src/app/transactional-email-api/page.test.tsx
+++ b/web/src/app/transactional-email-api/page.test.tsx
@@ -1,5 +1,8 @@
 import { render, screen } from "@testing-library/react";
-import TransactionalEmailApiPage, { metadata } from "./page";
+import TransactionalEmailApiPage, {
+  metadata,
+  TransactionalEmailApiPageContent,
+} from "./page";
 
 jest.mock("next/link", () => {
   return function MockLink({
@@ -31,7 +34,33 @@ describe("transactional email API page", () => {
     expect(
       screen.getAllByRole("link", { name: /Create a sender/i })[0],
     ).toHaveAttribute("href", "/get-started?step=address");
+    expect(screen.queryByRole("link", { name: "View pricing" })).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "View source" })).toHaveAttribute(
+      "href",
+      "https://github.com/tokencanopy/e2a",
+    );
     expect(metadata.description).toMatch(/receipts, verification messages, product notifications, and alerts/i);
+  });
+
+  it("keeps secondary navigation out of the 320px mobile row", () => {
+    render(<TransactionalEmailApiPage />);
+    for (const name of ["Agent inboxes", "API docs"]) {
+      expect(screen.getByRole("link", { name })).toHaveClass("hidden", "sm:inline");
+    }
+    expect(screen.getByRole("link", { name: "Create sender" })).not.toHaveClass("hidden");
+  });
+
+  it("links pricing only when the deployment provides a pricing route", () => {
+    const { rerender } = render(
+      <TransactionalEmailApiPageContent pricingPath="" />,
+    );
+    expect(screen.queryByRole("link", { name: "View pricing" })).not.toBeInTheDocument();
+
+    rerender(<TransactionalEmailApiPageContent pricingPath="/pricing" />);
+    expect(screen.getByRole("link", { name: "View pricing" })).toHaveAttribute(
+      "href",
+      "/pricing",
+    );
   });
 
   it("explains the existing agent resource to application developers", () => {

--- a/web/src/app/transactional-email-api/page.test.tsx
+++ b/web/src/app/transactional-email-api/page.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import TransactionalEmailApiPage, { metadata } from "./page";
+
+jest.mock("next/link", () => {
+  return function MockLink({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) {
+    return <a href={href} {...props}>{children}</a>;
+  };
+});
+
+describe("transactional email API page", () => {
+  it("makes the conventional application path explicit", () => {
+    render(<TransactionalEmailApiPage />);
+
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: "The open-source transactional email API for applications.",
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/No AI agent or agent framework is required/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByRole("link", { name: /Create a sender/i })[0],
+    ).toHaveAttribute("href", "/get-started?step=address");
+    expect(metadata.description).toMatch(/receipts, verification messages, product notifications, and alerts/i);
+  });
+
+  it("explains the existing agent resource to application developers", () => {
+    render(<TransactionalEmailApiPage />);
+    expect(
+      screen.getByText(/each sending identity is represented by an agent resource/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/treat it as the sender and optional inbox/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a direct general transactional API answer", () => {
+    render(<TransactionalEmailApiPage />);
+    expect(
+      screen.getByText("Can e2a be used as a general transactional email API?"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Agent inboxes, inbound email, threading, and human approval are additional capabilities—not requirements/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/app/transactional-email-api/page.tsx
+++ b/web/src/app/transactional-email-api/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { JsonLd } from "../components/JsonLd";
-import { SITE_URL } from "../../lib/site";
+import { PRICING_PATH, SITE_URL } from "../../lib/site";
 import {
   breadcrumbs,
   faqPage,
@@ -61,6 +61,10 @@ const CAPABILITIES = [
 ] as const;
 
 export default function TransactionalEmailApiPage() {
+  return <TransactionalEmailApiPageContent pricingPath={PRICING_PATH} />;
+}
+
+export function TransactionalEmailApiPageContent({ pricingPath }: { pricingPath: string }) {
   return (
     <div
       className="min-h-screen"
@@ -89,10 +93,10 @@ export default function TransactionalEmailApiPage() {
             e2a
           </Link>
           <div className="flex items-center gap-4 text-[13px]">
-            <Link href="/email-api-for-ai-agents" style={{ color: "var(--fg-muted)" }}>
+            <Link href="/email-api-for-ai-agents" className="hidden sm:inline" style={{ color: "var(--fg-muted)" }}>
               Agent inboxes
             </Link>
-            <Link href="/api-docs" style={{ color: "var(--fg-muted)" }}>
+            <Link href="/api-docs" className="hidden sm:inline" style={{ color: "var(--fg-muted)" }}>
               API docs
             </Link>
             <Link
@@ -138,6 +142,22 @@ export default function TransactionalEmailApiPage() {
             >
               Read the API docs
             </Link>
+            {pricingPath && (
+              <Link
+                href={pricingPath}
+                className="inline-flex items-center px-4 py-2.5 text-[14px] font-medium"
+                style={{ color: "var(--fg-muted)" }}
+              >
+                View pricing
+              </Link>
+            )}
+            <a
+              href="https://github.com/tokencanopy/e2a"
+              className="inline-flex items-center px-4 py-2.5 text-[14px] font-medium"
+              style={{ color: "var(--fg-muted)" }}
+            >
+              View source
+            </a>
           </div>
         </section>
 

--- a/web/src/app/transactional-email-api/page.tsx
+++ b/web/src/app/transactional-email-api/page.tsx
@@ -1,0 +1,208 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { JsonLd } from "../components/JsonLd";
+import { SITE_URL } from "../../lib/site";
+import {
+  breadcrumbs,
+  faqPage,
+  softwareApplication,
+  type FaqEntry,
+} from "../../lib/jsonld";
+
+const TITLE = "Transactional Email API for Applications | e2a";
+const DESC =
+  "Use e2a's open-source transactional email API to send receipts, verification messages, product notifications, and alerts from any application. No AI agent or agent framework is required.";
+
+export const metadata: Metadata = {
+  title: { absolute: TITLE },
+  description: DESC,
+  keywords: [
+    "transactional email API",
+    "open source email API",
+    "email API for developers",
+    "send email with TypeScript",
+    "send email with Python",
+    "self-hosted email API",
+  ],
+  alternates: { canonical: "/transactional-email-api" },
+  openGraph: {
+    title: TITLE,
+    description: DESC,
+    url: `${SITE_URL}/transactional-email-api`,
+    type: "website",
+    images: [{ url: "/og-image.png", width: 1200, height: 630 }],
+  },
+  twitter: { card: "summary_large_image", title: TITLE, description: DESC },
+};
+
+const FAQ: FaqEntry[] = [
+  {
+    question: "Can e2a be used as a general transactional email API?",
+    answer:
+      "Yes. Any application can use e2a's HTTP API and TypeScript or Python SDKs to send transactional email. Agent inboxes, inbound email, threading, and human approval are additional capabilities—not requirements.",
+  },
+  {
+    question: "Do I need an AI agent or agent framework to use e2a?",
+    answer:
+      "No. A conventional backend, scheduled job, serverless function, command-line script, or internal service can call e2a directly. An AI runtime is optional and is only needed when your product actually contains an agent.",
+  },
+  {
+    question: "Can I self-host the transactional email API?",
+    answer:
+      "Yes. e2a is Apache-2.0 open source, including the Go server, SMTP relay, TypeScript and Python SDKs, CLI, MCP server, and dashboard. You can run it with your own Postgres database and outbound SMTP relay, or use the hosted service.",
+  },
+];
+
+const CAPABILITIES = [
+  ["Application email", "Send receipts, verification messages, alerts, and product notifications from your backend."],
+  ["Typed integrations", "Use the TypeScript or Python SDK, or call the documented HTTP API from any language."],
+  ["Two-way when needed", "Add inbound email, persistent threads, signed webhooks, and WebSocket delivery without changing providers."],
+  ["Human approval", "Optionally hold sensitive outbound messages for a person to approve, edit, or reject."],
+] as const;
+
+export default function TransactionalEmailApiPage() {
+  return (
+    <div
+      className="min-h-screen"
+      style={{ background: "var(--bg)", color: "var(--fg)", fontFamily: "var(--f-ui)" }}
+    >
+      <JsonLd
+        data={[
+          softwareApplication(DESC),
+          faqPage(FAQ),
+          breadcrumbs([
+            { name: "e2a", path: "/" },
+            { name: "Transactional email API", path: "/transactional-email-api" },
+          ]),
+        ]}
+      />
+
+      <nav
+        className="sticky top-0 z-50"
+        style={{
+          background: "color-mix(in srgb, var(--bg) 88%, transparent)",
+          borderBottom: "1px solid var(--border)",
+        }}
+      >
+        <div className="max-w-[960px] mx-auto flex items-center justify-between px-6 md:px-8 py-3.5">
+          <Link href="/" className="font-mono font-bold text-[15px]" style={{ color: "var(--fg)" }}>
+            e2a
+          </Link>
+          <div className="flex items-center gap-4 text-[13px]">
+            <Link href="/email-api-for-ai-agents" style={{ color: "var(--fg-muted)" }}>
+              Agent inboxes
+            </Link>
+            <Link href="/api-docs" style={{ color: "var(--fg-muted)" }}>
+              API docs
+            </Link>
+            <Link
+              href="/get-started?step=address"
+              className="px-3.5 py-1.5 font-medium"
+              style={{ background: "var(--fg)", color: "var(--bg)", borderRadius: "var(--r-md)" }}
+            >
+              Create sender
+            </Link>
+          </div>
+        </div>
+      </nav>
+
+      <main className="max-w-[960px] mx-auto px-6 md:px-8 py-16 md:py-24 pb-24">
+        <section className="max-w-[820px]">
+          <p className="font-mono text-[11px] mb-4" style={{ color: "var(--accent-strong)", letterSpacing: "0.08em" }}>
+            TRANSACTIONAL EMAIL API
+          </p>
+          <h1
+            className="text-[42px] md:text-[62px] leading-[1.04] mb-6"
+            style={{ fontFamily: "var(--f-editorial)", fontWeight: 400, letterSpacing: "-0.025em" }}
+          >
+            The open-source transactional email API for applications.
+          </h1>
+          <p className="text-[18px] leading-[1.65] max-w-[760px] mb-4" style={{ color: "var(--fg-muted)" }}>
+            Send receipts, verification messages, product notifications, and alerts from the software you already run. No AI agent or agent framework is required.
+          </p>
+          <p className="text-[14px] leading-[1.65] max-w-[720px] mb-8" style={{ color: "var(--fg-muted)" }}>
+            Start with outbound email over HTTP, TypeScript, or Python. Add replies, threading, approval, or an agent-owned inbox only when your product needs them.
+          </p>
+          <div className="flex flex-wrap gap-2.5">
+            <Link
+              href="/get-started?step=address"
+              className="inline-flex items-center gap-2 px-4 py-2.5 text-[14px] font-medium"
+              style={{ background: "var(--accent-fill)", color: "var(--accent-fg)", borderRadius: "var(--r-md)" }}
+            >
+              Create a sender <span className="font-mono">→</span>
+            </Link>
+            <Link
+              href="/api-docs"
+              className="inline-flex items-center px-4 py-2.5 text-[14px] font-medium"
+              style={{ background: "var(--bg-panel)", color: "var(--fg)", border: "1px solid var(--border)", borderRadius: "var(--r-md)" }}
+            >
+              Read the API docs
+            </Link>
+          </div>
+        </section>
+
+        <section className="mt-16 md:mt-24" aria-labelledby="capabilities-heading">
+          <h2 id="capabilities-heading" className="text-[30px] md:text-[38px] font-semibold mb-7" style={{ letterSpacing: "-0.035em" }}>
+            Start simple. Keep the richer email workflow available.
+          </h2>
+          <div className="grid sm:grid-cols-2 gap-3">
+            {CAPABILITIES.map(([title, description]) => (
+              <div key={title} className="p-6" style={{ background: "var(--bg-panel)", border: "1px solid var(--border)", borderRadius: "var(--r-lg)" }}>
+                <h3 className="text-[17px] font-semibold mb-2">{title}</h3>
+                <p className="text-[14px] leading-[1.65]" style={{ color: "var(--fg-muted)" }}>{description}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="mt-16 md:mt-24 grid md:grid-cols-[1fr_1fr] gap-8 md:gap-12 items-start" aria-labelledby="resource-heading">
+          <div>
+            <p className="font-mono text-[11px] mb-3" style={{ color: "var(--accent-strong)", letterSpacing: "0.08em" }}>
+              ONE RESOURCE MODEL
+            </p>
+            <h2 id="resource-heading" className="text-[28px] md:text-[36px] font-semibold mb-4" style={{ letterSpacing: "-0.03em" }}>
+              A sender now. An inbox when you need one.
+            </h2>
+            <p className="text-[15px] leading-[1.7]" style={{ color: "var(--fg-muted)" }}>
+              In the e2a API, each sending identity is represented by an agent resource. For a conventional application, treat it as the sender and optional inbox; the name describes the resource, not a requirement to run AI. That same identity can later receive replies or participate in an automated workflow without a second email system.
+            </p>
+          </div>
+          <pre
+            className="overflow-x-auto p-5 text-[12px] leading-[1.7]"
+            style={{ background: "var(--code-bg)", color: "var(--code-fg)", border: "1px solid var(--border)", borderRadius: "var(--r-lg)" }}
+          >
+            <code>{`await client.messages.send("receipts@example.com", {
+  to: [{ email: "customer@example.net" }],
+  subject: "Your receipt",
+  text: "Thanks for your order.",
+});`}</code>
+          </pre>
+        </section>
+
+        <section className="mt-16 md:mt-24" aria-labelledby="faq-heading">
+          <h2 id="faq-heading" className="text-[28px] md:text-[34px] font-semibold mb-6" style={{ letterSpacing: "-0.03em" }}>
+            Transactional email API: FAQ
+          </h2>
+          <div style={{ borderTop: "1px solid var(--border)" }}>
+            {FAQ.map((entry) => (
+              <div key={entry.question} className="py-5" style={{ borderBottom: "1px solid var(--border)" }}>
+                <h3 className="text-[16px] font-semibold mb-2">{entry.question}</h3>
+                <p className="text-[14px] leading-[1.7]" style={{ color: "var(--fg-muted)" }}>{entry.answer}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="mt-16 md:mt-24 p-8 md:p-12 text-center" style={{ background: "var(--bg-elev)", border: "1px solid var(--border)", borderRadius: "var(--r-lg)" }}>
+          <h2 className="text-[28px] font-semibold mb-3">Send your first application email.</h2>
+          <p className="text-[15px] mb-6" style={{ color: "var(--fg-muted)" }}>
+            Start free with the hosted service, or run the Apache-2.0 stack yourself.
+          </p>
+          <Link href="/get-started?step=address" className="inline-flex items-center gap-2 px-4 py-2.5 text-[14px] font-medium" style={{ background: "var(--fg)", color: "var(--bg)", borderRadius: "var(--r-md)" }}>
+            Create a sender <span className="font-mono">→</span>
+          </Link>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/web/src/lib/jsonld.test.ts
+++ b/web/src/lib/jsonld.test.ts
@@ -21,6 +21,14 @@ describe("structured data", () => {
     });
   });
 
+  it("describes domain evidence without claiming an authenticated mailbox", () => {
+    const description = String(organization().description);
+    expect(description).toMatch(/open-source email API for AI agents/i);
+    expect(description).toMatch(/structured SPF, DKIM, and DMARC evidence/i);
+    expect(description).toMatch(/From domain, not a person, mailbox, or content/i);
+    expect(description).not.toMatch(/authenticated email address|verified inbox/i);
+  });
+
   it("gives the product a stable @id the pricing page can attach Offers to", () => {
     // The pricing page ships from a different repo and hangs its paid-tier
     // Offer nodes off this @id. Drop it and that reference dangles, leaving

--- a/web/src/lib/jsonld.test.ts
+++ b/web/src/lib/jsonld.test.ts
@@ -24,7 +24,7 @@ describe("structured data", () => {
 
   it("describes domain evidence without claiming an authenticated mailbox", () => {
     const description = String(organization().description);
-    expect(description).toMatch(/open-source email API for AI agents/i);
+    expect(description).toMatch(/open-source email API for applications and AI agents/i);
     expect(description).toMatch(/structured SPF, DKIM, and DMARC evidence/i);
     expect(description).toMatch(/From domain, not a person, mailbox, or content/i);
     expect(description).not.toMatch(/authenticated email address|verified inbox/i);

--- a/web/src/lib/jsonld.test.ts
+++ b/web/src/lib/jsonld.test.ts
@@ -1,4 +1,5 @@
 import {
+  FREE_OFFER_ID,
   ORGANIZATION_ID,
   SOFTWARE_ID,
   blogPosting,
@@ -46,9 +47,11 @@ describe("structured data", () => {
     // page so structured data cannot drift away from billing.
     expect(softwareApplication("desc").offers).toEqual({
       "@type": "Offer",
+      "@id": FREE_OFFER_ID,
       price: "0",
       priceCurrency: "USD",
     });
+    expect(FREE_OFFER_ID).toMatch(/#offer-free$/);
   });
 
   it("builds a BlogPosting with absolute URLs and an ISO publish date", () => {

--- a/web/src/lib/jsonld.ts
+++ b/web/src/lib/jsonld.ts
@@ -36,7 +36,7 @@ export function organization(): JsonLdNode {
     url: SITE_URL,
     logo: abs("/logo-wordmark.svg"),
     description:
-      "e2a is the open-source email API for AI agents. It sends transactional email, gives agents real two-way inboxes, and returns structured SPF, DKIM, and DMARC evidence for inbound mail. That evidence applies to the From domain, not a person, mailbox, or content.",
+      "e2a is the open-source email API for applications and AI agents. It sends transactional email from any product, gives agents real two-way inboxes, and returns structured SPF, DKIM, and DMARC evidence for inbound mail. That evidence applies to the From domain, not a person, mailbox, or content.",
     sameAs: [
       "https://github.com/tokencanopy/e2a",
       "https://www.npmjs.com/package/@e2a/sdk",

--- a/web/src/lib/jsonld.ts
+++ b/web/src/lib/jsonld.ts
@@ -70,6 +70,7 @@ export function website(): JsonLdNode {
  * instead of one.
  */
 export const SOFTWARE_ID = `${SITE_URL}/#software`;
+export const FREE_OFFER_ID = `${SITE_URL}/#offer-free`;
 
 export function softwareApplication(description: string): JsonLdNode {
   return {
@@ -91,6 +92,7 @@ export function softwareApplication(description: string): JsonLdNode {
     // or not sell at all.
     offers: {
       "@type": "Offer",
+      "@id": FREE_OFFER_ID,
       price: "0",
       priceCurrency: "USD",
     },

--- a/web/src/lib/jsonld.ts
+++ b/web/src/lib/jsonld.ts
@@ -36,7 +36,7 @@ export function organization(): JsonLdNode {
     url: SITE_URL,
     logo: abs("/logo-wordmark.svg"),
     description:
-      "e2a gives AI agents a real, authenticated email address — SPF/DKIM-verified inbound, HMAC-signed webhook and WebSocket delivery, and an HTTP API for outbound.",
+      "e2a is the open-source email API for AI agents. It sends transactional email, gives agents real two-way inboxes, and returns structured SPF, DKIM, and DMARC evidence for inbound mail. That evidence applies to the From domain, not a person, mailbox, or content.",
     sameAs: [
       "https://github.com/tokencanopy/e2a",
       "https://www.npmjs.com/package/@e2a/sdk",


### PR DESCRIPTION
## Summary

- establishes the canonical open-source email API positioning for applications and AI agents across the website, README, documentation, structured metadata, and plugin discovery
- adds a dedicated transactional email path and application-first onboarding while retaining agent inbox workflows
- preserves sender setup across sign-in and keeps hosted pricing links deployment-aware

## Operational risk

Low. Most changes are static copy, metadata, documentation, and onboarding presentation. The auth change adds the exact same-origin /get-started return path; subpaths and traversal remain rejected. No API schema, pricing, quota, or delivery behavior changes.

## Test plan

- [x] Web test suite: 103 suites, 884 tests
- [x] Web production build and lint; zero errors, two pre-existing warnings
- [x] Auth package tests, including both sign-in paths and rejection cases
- [x] Plugin contracts, packaging, manifest freshness, and validation
- [x] Generated documentation and repository text-integrity checks
- [x] Full diff, branch name, and commit metadata audit for restricted strategic names and unsafe added identities