### PR TITLE
feat(sending): add protection foundation schema

### DIFF
--- a/internal/identity/migrate_test.go
+++ b/internal/identity/migrate_test.go
@@ -2,15 +2,518 @@ package identity_test
 
 import (
 	"context"
+	"errors"
+	"io/fs"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
 	"testing/fstest"
+	"time"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/tokencanopy/e2a/internal/identity"
+	"github.com/tokencanopy/e2a/internal/jobs"
 	"github.com/tokencanopy/e2a/internal/testutil"
 	"github.com/tokencanopy/e2a/migrations"
 )
+
+func TestEmbeddedMigrationNumbersAreUniqueFrom108(t *testing.T) {
+	entries, err := fs.ReadDir(migrations.FS, ".")
+	if err != nil {
+		t.Fatalf("read embedded migrations: %v", err)
+	}
+
+	seen := make(map[int]string, len(entries))
+	lastNumber := 107
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".sql") {
+			continue
+		}
+		if len(name) < 5 || name[3] != '_' {
+			t.Fatalf("migration %q must start with a three-digit numeric slot", name)
+		}
+		number, err := strconv.Atoi(name[:3])
+		if err != nil {
+			t.Fatalf("migration %q has invalid numeric slot: %v", name, err)
+		}
+		// Historical migrations contain intentionally retained duplicate slots.
+		// Enforce uniqueness for the current train and every future migration.
+		if number < 108 {
+			continue
+		}
+		if previous, ok := seen[number]; ok {
+			t.Fatalf("migration slot %03d is used by both %q and %q", number, previous, name)
+		}
+		if number <= lastNumber {
+			t.Fatalf("migration %q slot %03d is not after slot %03d", name, number, lastNumber)
+		}
+		seen[number] = name
+		lastNumber = number
+	}
+}
+
+func TestMigrationsRewriteLegacySendingJobsWithImmutableAttribution(t *testing.T) {
+	ctx := context.Background()
+	pool := testutil.TestDB(t)
+	if err := jobs.Migrate(ctx, pool); err != nil {
+		t.Fatalf("migrate River schema: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `
+			DELETE FROM river_job WHERE kind IN ('outbound_send','hitl_notify','webhook_notify');
+			DELETE FROM sending_provider_operations WHERE source_account_ref='usr_legacy_jobs';
+			DELETE FROM messages WHERE agent_id='agent_legacy_jobs';
+			ALTER TABLE messages DROP CONSTRAINT IF EXISTS messages_sent_as_check;
+			ALTER TABLE messages ADD CONSTRAINT messages_sent_as_check
+			    CHECK (sent_as IS NULL OR sent_as IN ('own_address','relay'));
+		`)
+	})
+	if _, err := pool.Exec(ctx, `
+		DELETE FROM river_job WHERE kind IN ('outbound_send','hitl_notify','webhook_notify');
+		DELETE FROM sending_provider_operations WHERE source_account_ref='usr_legacy_jobs';
+		DELETE FROM messages WHERE agent_id='agent_legacy_jobs';
+		ALTER TABLE messages DROP CONSTRAINT IF EXISTS messages_sent_as_check;
+	`); err != nil {
+		t.Fatalf("clear River fixtures: %v", err)
+	}
+
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO users (id,email,name,google_subject) VALUES ('usr_legacy_jobs','owner@legacy-jobs.test','Owner','sub-legacy-jobs');
+		INSERT INTO domains (domain,user_id,verified) VALUES ('legacy-jobs.test','usr_legacy_jobs',true);
+		INSERT INTO agent_identities (id,registered_domain,user_id,name) VALUES ('agent_legacy_jobs','legacy-jobs.test','usr_legacy_jobs','Legacy');
+		INSERT INTO messages (id,agent_id,direction,sender,recipient,subject,delivery_status,sent_as,scheduled_at) VALUES
+		  ('msg_legacy_outbound','agent_legacy_jobs','outbound','sender@legacy-jobs.test','recipient@example.test','Outbound','accepted','relay',NULL),
+		  ('msg_legacy_outbound_own','agent_legacy_jobs','outbound','sender@legacy-jobs.test','recipient@example.test','Outbound own identity','accepted','own_address',NULL),
+		  ('msg_legacy_scheduled','agent_legacy_jobs','outbound','sender@legacy-jobs.test','recipient@example.test','Scheduled','accepted','relay',transaction_timestamp()+interval '90 days'),
+		  ('msg_legacy_hitl','agent_legacy_jobs','outbound','sender@legacy-jobs.test','recipient@example.test','HITL','accepted','own_address',NULL),
+		  ('msg_legacy_null_sent_as','agent_legacy_jobs','outbound','sender@legacy-jobs.test','recipient@example.test','NULL sent_as','accepted',NULL,NULL),
+		  ('msg_legacy_invalid_sent_as','agent_legacy_jobs','outbound','sender@legacy-jobs.test','recipient@example.test','Invalid sent_as','accepted','unexpected',NULL),
+		  ('msg_legacy_inbound','agent_legacy_jobs','inbound','sender@example.test','recipient@legacy-jobs.test','Inbound mismatch','accepted','relay',NULL);
+		INSERT INTO webhooks (id,user_id,url,description,events,filters,signing_secret) VALUES
+		  ('wh_legacy_jobs','usr_legacy_jobs','https://hooks.example.test/health','Legacy health',ARRAY['email.received'],'{}','synthetic-secret');
+	`); err != nil {
+		t.Fatalf("seed legacy sources: %v", err)
+	}
+	var scheduledAt time.Time
+	if err := pool.QueryRow(ctx, `SELECT scheduled_at FROM messages WHERE id='msg_legacy_scheduled'`).Scan(&scheduledAt); err != nil {
+		t.Fatalf("read scheduled fixture time: %v", err)
+	}
+
+	type fixture struct {
+		kind string
+		args string
+	}
+	fixtures := []fixture{
+		{"outbound_send", `{"message_id":"msg_legacy_outbound"}`},
+		{"outbound_send", `{"message_id":"msg_legacy_outbound_own"}`},
+		{"outbound_send", `{"message_id":"msg_legacy_scheduled"}`},
+		{"hitl_notify", `{"message_id":"msg_legacy_hitl"}`},
+		{"webhook_notify", `{"webhook_id":"wh_legacy_jobs","kind":"warning"}`},
+		{"outbound_send", `{"message_id":"msg_orphan_legacy"}`},
+		{"webhook_notify", `{}`},
+		{"outbound_send", `{"message_id":"msg_legacy_null_sent_as"}`},
+		{"outbound_send", `{"message_id":"msg_legacy_invalid_sent_as"}`},
+		{"outbound_send", `{"message_id":"msg_legacy_inbound"}`},
+	}
+	jobIDs := make([]int64, 0, len(fixtures))
+	for _, f := range fixtures {
+		var id int64
+		if err := pool.QueryRow(ctx, `INSERT INTO river_job (args,kind,max_attempts) VALUES ($1::jsonb,$2,3) RETURNING id`, f.args, f.kind).Scan(&id); err != nil {
+			t.Fatalf("insert %s legacy job: %v", f.kind, err)
+		}
+		jobIDs = append(jobIDs, id)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE river_job SET state='scheduled',scheduled_at=$2 WHERE id=$1`, jobIDs[2], scheduledAt); err != nil {
+		t.Fatalf("schedule legacy job: %v", err)
+	}
+
+	migration, err := migrations.FS.ReadFile("110_sending_budget_ledger.sql")
+	if err != nil {
+		t.Fatalf("read sending budget migration: %v", err)
+	}
+	if _, err := pool.Exec(ctx, string(migration)); err != nil {
+		t.Fatalf("apply sending budget migration to legacy fixtures: %v", err)
+	}
+	if _, err := pool.Exec(ctx, string(migration)); err != nil {
+		t.Fatalf("reapply sending budget migration: %v", err)
+	}
+
+	for i, want := range []struct {
+		purpose string
+		shared  bool
+		source  string
+	}{
+		{"customer_message", true, "message_id"},
+		{"customer_message", false, "message_id"},
+		{"customer_message", true, "message_id"},
+		{"customer_notification", true, "message_id"},
+		{"customer_notification", true, "webhook_id"},
+	} {
+		var operationID, purpose, sourceAccount, policySubject, sourceValue string
+		var shared bool
+		var expiresAt time.Time
+		if err := pool.QueryRow(ctx, `
+			SELECT j.args->'operation_ref'->>'id',o.purpose,o.shared_reputation,
+			       o.source_account_ref,o.policy_subject_ref,j.args->>$2,o.expires_at
+			FROM river_job j JOIN sending_provider_operations o ON o.operation_id=j.args->'operation_ref'->>'id'
+			WHERE j.id=$1`, jobIDs[i], want.source,
+		).Scan(&operationID, &purpose, &shared, &sourceAccount, &policySubject, &sourceValue, &expiresAt); err != nil {
+			t.Fatalf("read rewritten job %d: %v", i, err)
+		}
+		if operationID == "" || purpose != want.purpose || shared != want.shared || sourceAccount != "usr_legacy_jobs" || policySubject != "usr_legacy_jobs" || sourceValue == "" {
+			t.Fatalf("rewritten job %d = op=%q purpose=%q shared=%v source=%q subject=%q legacy=%q", i, operationID, purpose, shared, sourceAccount, policySubject, sourceValue)
+		}
+		if i < 3 && operationID != sourceValue {
+			t.Fatalf("outbound operation id=%q, want retained message id %q", operationID, sourceValue)
+		}
+		if i == 2 && expiresAt.Before(scheduledAt.Add(30*24*time.Hour)) {
+			t.Errorf("scheduled operation expires_at=%s, want at least scheduled_at+30d=%s", expiresAt, scheduledAt.Add(30*24*time.Hour))
+		}
+	}
+
+	for i, jobID := range jobIDs[5:] {
+		var unavailableState string
+		var unavailableFinalized bool
+		var unavailableHasRef bool
+		if err := pool.QueryRow(ctx, `SELECT state::text,finalized_at IS NOT NULL,args ? 'operation_ref' FROM river_job WHERE id=$1`, jobID).Scan(&unavailableState, &unavailableFinalized, &unavailableHasRef); err != nil {
+			t.Fatalf("read unavailable disposition %d: %v", i, err)
+		}
+		if unavailableState != "discarded" || !unavailableFinalized || unavailableHasRef {
+			t.Errorf("unavailable disposition %d state=%q finalized=%v operation_ref=%v", i, unavailableState, unavailableFinalized, unavailableHasRef)
+		}
+	}
+
+	var operations int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM sending_provider_operations WHERE source_account_ref='usr_legacy_jobs'`).Scan(&operations); err != nil || operations != 5 {
+		t.Fatalf("legacy operation count=%d err=%v", operations, err)
+	}
+	var controls int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM account_sending_controls WHERE user_id='usr_legacy_jobs' AND state='active' AND outcome_epoch=1`).Scan(&controls); err != nil || controls != 1 {
+		t.Fatalf("bootstrapped account controls=%d err=%v", controls, err)
+	}
+}
+
+func TestSendingBudgetMigrationDoesNotDeadlockSourceFirstJobCancellation(t *testing.T) {
+	ctx := context.Background()
+	pool := testutil.TestDB(t)
+	if err := jobs.Migrate(ctx, pool); err != nil {
+		t.Fatalf("migrate River schema: %v", err)
+	}
+	client, err := jobs.New(pool, jobs.Config{})
+	if err != nil {
+		t.Fatalf("build real River cancellation client: %v", err)
+	}
+	migration, err := migrations.FS.ReadFile("110_sending_budget_ledger.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cleanupData := func() {
+		_, _ = pool.Exec(context.Background(), `
+			DELETE FROM river_job
+			WHERE kind IN ('outbound_send','hitl_notify','webhook_notify');
+			DELETE FROM sending_provider_operations
+			WHERE source_account_ref='usr_source_first_race';
+			DELETE FROM users WHERE id='usr_source_first_race';
+		`)
+	}
+	cleanupData()
+	if _, err := pool.Exec(ctx, `DROP TABLE account_sending_controls`); err != nil {
+		t.Fatalf("remove controls/FK for true first-apply race: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupData()
+		if _, err := pool.Exec(context.Background(), string(migration)); err != nil {
+			t.Errorf("restore budget migration after source-first race: %v", err)
+		}
+	})
+
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO users (id,email,name,google_subject)
+		VALUES ('usr_source_first_race','owner@source-first-race.test','Owner','sub-source-first-race');
+		INSERT INTO domains (domain,user_id,verified)
+		VALUES ('source-first-race.test','usr_source_first_race',true);
+		INSERT INTO agent_identities (id,registered_domain,user_id,name)
+		VALUES ('agent_source_first_race','source-first-race.test','usr_source_first_race','Race');
+		INSERT INTO messages
+		    (id,agent_id,direction,sender,recipient,subject,delivery_status,sent_as)
+		VALUES ('msg_source_first_race','agent_source_first_race','outbound',
+		        'sender@source-first-race.test','recipient@example.test','Source first',
+		        'accepted','relay');
+	`); err != nil {
+		t.Fatalf("seed source-first race: %v", err)
+	}
+	var jobID int64
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO river_job (args,kind,max_attempts)
+		VALUES ('{"message_id":"msg_source_first_race"}'::jsonb,'outbound_send',3)
+		RETURNING id
+	`).Scan(&jobID); err != nil {
+		t.Fatalf("insert source-first River job: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		UPDATE messages SET send_job_id=$2 WHERE id=$1
+	`, "msg_source_first_race", jobID); err != nil {
+		t.Fatalf("link source-first River job: %v", err)
+	}
+
+	deletionConn, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer deletionConn.Release()
+	deletionTx, err := deletionConn.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	deletionOpen := true
+	defer func() {
+		if deletionOpen {
+			_ = deletionTx.Rollback(context.Background())
+		}
+	}()
+	if _, err := deletionTx.Exec(ctx, `
+		SELECT id FROM agent_identities
+		WHERE id='agent_source_first_race' FOR UPDATE;
+		SELECT send_job_id FROM messages
+		WHERE id='msg_source_first_race' FOR UPDATE;
+	`); err != nil {
+		t.Fatalf("hold production source-first locks: %v", err)
+	}
+
+	migrator, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer migrator.Release()
+	var migratorPID int
+	if err := migrator.QueryRow(ctx, `SELECT pg_backend_pid()`).Scan(&migratorPID); err != nil {
+		t.Fatal(err)
+	}
+	migrationCtx, cancelMigration := context.WithTimeout(ctx, 8*time.Second)
+	defer cancelMigration()
+	migrationErrCh := make(chan error, 1)
+	go func() {
+		_, execErr := migrator.Exec(migrationCtx, string(migration))
+		migrationErrCh <- execErr
+	}()
+
+	waitCtx, cancelWait := context.WithTimeout(ctx, 3*time.Second)
+	defer cancelWait()
+	waitingOnSource := false
+	for !waitingOnSource {
+		if err := pool.QueryRow(waitCtx, `
+			SELECT COALESCE(wait_event_type='Lock',false)
+			FROM pg_stat_activity WHERE pid=$1
+		`, migratorPID).Scan(&waitingOnSource); err != nil {
+			t.Fatalf("observe migration source wait: %v", err)
+		}
+		if !waitingOnSource {
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	jobProbe, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, jobProbeErr := jobProbe.Exec(ctx, `
+		SELECT id FROM river_job WHERE id=$1 FOR UPDATE NOWAIT
+	`, jobID)
+	_ = jobProbe.Rollback(ctx)
+
+	cancelErr := client.CancelTx(ctx, deletionTx, jobID)
+	if cancelErr == nil {
+		_, cancelErr = deletionTx.Exec(ctx, `DELETE FROM users WHERE id='usr_source_first_race'`)
+	}
+	if cancelErr == nil {
+		cancelErr = deletionTx.Commit(ctx)
+	} else {
+		_ = deletionTx.Rollback(ctx)
+	}
+	deletionOpen = false
+	migrationErr := <-migrationErrCh
+
+	for name, got := range map[string]error{"migration": migrationErr, "cancellation": cancelErr} {
+		var pgErr *pgconn.PgError
+		if errors.As(got, &pgErr) && pgErr.Code == "40P01" {
+			t.Errorf("%s hit source/job lock-order deadlock: %v", name, got)
+		} else if got != nil {
+			t.Errorf("%s failed: %v", name, got)
+		}
+	}
+	var probePgErr *pgconn.PgError
+	if errors.As(jobProbeErr, &probePgErr) && probePgErr.Code == "55P03" && migrationErr == nil && cancelErr == nil {
+		t.Error("migration held the River job while waiting on its source")
+	} else if jobProbeErr != nil && !(errors.As(jobProbeErr, &probePgErr) && probePgErr.Code == "55P03") {
+		t.Fatalf("probe migration River lock: %v", jobProbeErr)
+	}
+
+	releaseProbe, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := releaseProbe.Exec(ctx, `
+		SELECT id FROM river_job WHERE id=$1 FOR UPDATE NOWAIT
+	`, jobID); err != nil {
+		_ = releaseProbe.Rollback(ctx)
+		t.Fatalf("race left River job lock behind: %v", err)
+	}
+	if err := releaseProbe.Rollback(ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSendingBudgetMigrationLeavesPostSnapshotLegacyJobForResolver(t *testing.T) {
+	ctx := context.Background()
+	pool := testutil.TestDB(t)
+	if err := jobs.Migrate(ctx, pool); err != nil {
+		t.Fatalf("migrate River schema: %v", err)
+	}
+
+	const advisoryKey int64 = 6_104_112
+	cleanup := func() {
+		_, _ = pool.Exec(context.Background(), `
+			DROP TRIGGER IF EXISTS sending_snapshot_barrier ON river_job;
+			DROP FUNCTION IF EXISTS sending_snapshot_barrier();
+			DELETE FROM river_job WHERE args->>'message_id'='msg_snapshot_late' OR args->>'webhook_id'='wh_snapshot_barrier';
+			DELETE FROM sending_provider_operations WHERE source_account_ref='usr_snapshot_test';
+			DELETE FROM users WHERE id='usr_snapshot_test';
+		`)
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO users (id,email,name,google_subject)
+		VALUES ('usr_snapshot_test','owner@snapshot.test','Owner','sub-snapshot-test');
+		INSERT INTO domains (domain,user_id,verified)
+		VALUES ('snapshot.test','usr_snapshot_test',true);
+		INSERT INTO agent_identities (id,registered_domain,user_id,name)
+		VALUES ('agent_snapshot_test','snapshot.test','usr_snapshot_test','Snapshot');
+		INSERT INTO messages
+		    (id,agent_id,direction,sender,recipient,subject,delivery_status,sent_as)
+		VALUES
+		    ('msg_snapshot_late','agent_snapshot_test','outbound','sender@snapshot.test',
+		     'recipient@example.test','Late snapshot job','accepted','relay');
+		INSERT INTO webhooks (id,user_id,url,description,events,filters,signing_secret)
+		VALUES ('wh_snapshot_barrier','usr_snapshot_test','https://hooks.snapshot.test/health',
+		        'Snapshot barrier',ARRAY['email.received'],'{}','synthetic-secret');
+	`); err != nil {
+		t.Fatalf("seed snapshot sources: %v", err)
+	}
+
+	var barrierJobID int64
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO river_job (args,kind,max_attempts)
+		VALUES ('{"webhook_id":"wh_snapshot_barrier","kind":"warning"}'::jsonb,'webhook_notify',3)
+		RETURNING id
+	`).Scan(&barrierJobID); err != nil {
+		t.Fatalf("insert snapshot barrier job: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		CREATE FUNCTION sending_snapshot_barrier() RETURNS trigger LANGUAGE plpgsql AS $$
+		BEGIN
+			IF OLD.id = `+strconv.FormatInt(barrierJobID, 10)+` AND NEW.args ? 'operation_ref' THEN
+				PERFORM pg_advisory_xact_lock(`+strconv.FormatInt(advisoryKey, 10)+`);
+			END IF;
+			RETURN NEW;
+		END
+		$$;
+		CREATE TRIGGER sending_snapshot_barrier
+		BEFORE UPDATE OF args ON river_job
+		FOR EACH ROW EXECUTE FUNCTION sending_snapshot_barrier();
+	`); err != nil {
+		t.Fatalf("install snapshot barrier: %v", err)
+	}
+
+	blocker, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire advisory blocker: %v", err)
+	}
+	defer blocker.Release()
+	if _, err := blocker.Exec(ctx, `SELECT pg_advisory_lock($1)`, advisoryKey); err != nil {
+		t.Fatalf("hold snapshot barrier: %v", err)
+	}
+	barrierHeld := true
+	defer func() {
+		if barrierHeld {
+			_, _ = blocker.Exec(context.Background(), `SELECT pg_advisory_unlock($1)`, advisoryKey)
+		}
+	}()
+
+	migrationConn, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire migration connection: %v", err)
+	}
+	defer migrationConn.Release()
+	var migrationPID int
+	if err := migrationConn.QueryRow(ctx, `SELECT pg_backend_pid()`).Scan(&migrationPID); err != nil {
+		t.Fatalf("read migration backend pid: %v", err)
+	}
+	migration, err := migrations.FS.ReadFile("110_sending_budget_ledger.sql")
+	if err != nil {
+		t.Fatalf("read sending budget migration: %v", err)
+	}
+	migrationErr := make(chan error, 1)
+	go func() {
+		_, execErr := migrationConn.Exec(context.Background(), string(migration))
+		migrationErr <- execErr
+	}()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		var waiting bool
+		if err := pool.QueryRow(ctx, `
+			SELECT EXISTS (
+				SELECT 1 FROM pg_locks
+				WHERE pid=$1 AND locktype='advisory' AND NOT granted
+			)
+		`, migrationPID).Scan(&waiting); err != nil {
+			t.Fatalf("observe snapshot barrier: %v", err)
+		}
+		if waiting {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("migration did not reach the post-snapshot rewrite barrier")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	var lateJobID int64
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO river_job (args,kind,max_attempts)
+		VALUES ('{"message_id":"msg_snapshot_late"}'::jsonb,'outbound_send',3)
+		RETURNING id
+	`).Scan(&lateJobID); err != nil {
+		t.Fatalf("insert post-snapshot legacy job: %v", err)
+	}
+	if _, err := blocker.Exec(ctx, `SELECT pg_advisory_unlock($1)`, advisoryKey); err != nil {
+		t.Fatalf("release snapshot barrier: %v", err)
+	}
+	barrierHeld = false
+	if err := <-migrationErr; err != nil {
+		t.Fatalf("apply sending budget migration: %v", err)
+	}
+
+	var state string
+	var finalized, hasOperationRef bool
+	if err := pool.QueryRow(ctx, `
+		SELECT state::text,finalized_at IS NOT NULL,args ? 'operation_ref'
+		FROM river_job WHERE id=$1
+	`, lateJobID).Scan(&state, &finalized, &hasOperationRef); err != nil {
+		t.Fatalf("read post-snapshot job: %v", err)
+	}
+	if state != "available" || finalized || hasOperationRef {
+		t.Fatalf("post-snapshot job state=%q finalized=%v operation_ref=%v, want untouched old-format available job", state, finalized, hasOperationRef)
+	}
+	var lateOperations int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM sending_provider_operations WHERE operation_id='msg_snapshot_late'`).Scan(&lateOperations); err != nil || lateOperations != 0 {
+		t.Fatalf("post-snapshot operations=%d err=%v, want 0", lateOperations, err)
+	}
+}
 
 func TestMessagesFailureReasonCodeMigrationIsNullableAndIdempotent(t *testing.T) {
 	ctx := context.Background()

--- a/internal/messagelifecycle/store_integration_test.go
+++ b/internal/messagelifecycle/store_integration_test.go
@@ -51,7 +51,7 @@ func TestMessageLifecycleMigrationCatalogMatchesCanonicalCatalog(t *testing.T) {
 	if err := rows.Err(); err != nil {
 		t.Fatal(err)
 	}
-	if want := messagelifecycle.Catalog(); !reflect.DeepEqual(got, want) {
+	if want := migrationLifecycleCatalog(); !reflect.DeepEqual(got, want) {
 		t.Fatalf("database catalog mismatch\ngot:  %#v\nwant: %#v", got, want)
 	}
 }
@@ -79,9 +79,25 @@ func TestMessageLifecycleMigrationIsIdempotent(t *testing.T) {
 	if !reflect.DeepEqual(after, before) {
 		t.Fatalf("catalog changed after migration replay\nbefore: %#v\nafter:  %#v", before, after)
 	}
-	if len(after) != 30 {
-		t.Fatalf("catalog row count = %d, want 30", len(after))
+	if want := len(migrationLifecycleCatalog()); len(after) != want {
+		t.Fatalf("catalog row count = %d, want %d", len(after), want)
 	}
+}
+
+// migrationLifecycleCatalog includes the dormant reason codes reserved by the
+// sending-protection foundation migration. They stay outside Catalog until B10
+// adds their emitters and public lifecycle documentation.
+func migrationLifecycleCatalog() map[messagelifecycle.ReasonCode]messagelifecycle.Definition {
+	result := messagelifecycle.Catalog()
+	result[messagelifecycle.ReasonCode("submission.policy_budget_expired")] = messagelifecycle.Definition{
+		Stage:   messagelifecycle.StageSubmission,
+		Outcome: messagelifecycle.OutcomeFailed,
+	}
+	result[messagelifecycle.ReasonCode("submission.sending_setup_expired")] = messagelifecycle.Definition{
+		Stage:   messagelifecycle.StageSubmission,
+		Outcome: messagelifecycle.OutcomeFailed,
+	}
+	return result
 }
 
 func TestMessageLifecycleMigrationRejectsCatalogDrift(t *testing.T) {

--- a/internal/sendingpolicy/schema_integration_test.go
+++ b/internal/sendingpolicy/schema_integration_test.go
@@ -1,0 +1,996 @@
+package sendingpolicy_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/tokencanopy/e2a/internal/jobs"
+	"github.com/tokencanopy/e2a/internal/testutil"
+	"github.com/tokencanopy/e2a/migrations"
+)
+
+const generationZeroPolicy = `{"all_customer_global_daily_recipients":5000,"bounce_min_outcomes":50,"bounce_pause_basis_points":400,"budget_hold_max_days":7,"budget_mode":"disabled","complaint_pause_basis_points":8,"critical_operational_daily_recipients":100,"daily_unlimited_plan_codes":["starter","pro","scale"],"default_account_daily_recipients":100,"detector_interval_seconds":300,"detector_mode":"disabled","detector_window_days":7,"operator_notice_recipient_version":1,"probation_global_daily_recipients":150,"ramp_days":30,"ramp_enabled":false,"ramp_start_daily":150,"ramp_target_daily":2000,"sending_control_audit_retention_days":90,"sending_feedback_post_account_retention_days":30,"shared_domain_account_daily_recipients":50,"shared_reputation_bounce_min_outcomes":1,"tenant_header_canary_account_ids":[],"tenant_header_mode":"disabled","tenant_provisioning_mode":"disabled","tenant_suppression_sync_mode":"disabled","violation_operational_daily_recipients":100}`
+
+func TestSendingProtectionMigrationsAreIdempotent(t *testing.T) {
+	ctx := context.Background()
+	pool := testutil.TestDB(t)
+	for _, name := range []string{
+		"109_sending_protection_policy.sql",
+		"110_sending_budget_ledger.sql",
+		"111_sending_feedback_provenance.sql",
+		"112_sending_controls_foreign_key.sql",
+		"113_sending_message_holds.sql",
+		"114_sending_suppression_provenance.sql",
+		"115_sending_protection_validate_constraints.sql",
+	} {
+		migration, err := migrations.FS.ReadFile(name)
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		if _, err := pool.Exec(ctx, string(migration)); err != nil {
+			t.Fatalf("reapply %s: %v", name, err)
+		}
+	}
+}
+
+func TestOperatorRecipientRegistryRejectsTruncate(t *testing.T) {
+	ctx := context.Background()
+	pool := testutil.TestDB(t)
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback(ctx)
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO sending_operator_recipient_versions
+		    (logical_version,commitment_key_id,recipient_commitment,created_by)
+		VALUES (2147483646,repeat('c',64),repeat('d',64),'truncate-test')
+		ON CONFLICT DO NOTHING
+	`); err != nil {
+		t.Fatalf("insert operator commitment: %v", err)
+	}
+	if _, err := tx.Exec(ctx, `TRUNCATE sending_operator_recipient_versions`); err == nil || !strings.Contains(err.Error(), "append-only") {
+		t.Fatalf("operator commitment truncate err=%v, want append-only rejection", err)
+	}
+}
+
+func TestSendingProtectionHotTableDDLIsEndLoadedBoundedAndNotValid(t *testing.T) {
+	budgetBytes, err := migrations.FS.ReadFile("110_sending_budget_ledger.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	budget := string(budgetBytes)
+	discardPos := strings.LastIndex(budget, "SET state = 'discarded'")
+	if discardPos < 0 || strings.Contains(budget, "ALTER TABLE messages") ||
+		strings.Contains(budget, "LOCK TABLE users") ||
+		strings.Contains(budget, "ADD CONSTRAINT account_sending_controls_user_id_fkey") {
+		t.Fatal("migration 110 must end after its source/job rewrite without users, controls-FK, or messages locks")
+	}
+	snapshotPos := strings.Index(budget, "captured_kind TEXT NOT NULL")
+	messageLockPos := strings.Index(budget, "FOR UPDATE OF message")
+	webhookLockPos := strings.Index(budget, "FOR UPDATE OF webhook")
+	jobLockPos := strings.Index(budget, "FOR UPDATE OF job")
+	if snapshotPos < 0 || messageLockPos < snapshotPos || webhookLockPos < snapshotPos ||
+		jobLockPos < messageLockPos || jobLockPos < webhookLockPos ||
+		strings.Contains(budget[:max(jobLockPos, 0)], "FOR UPDATE OF job") {
+		t.Fatal("migration 110 must snapshot targets unlocked, then lock every source before any target job")
+	}
+	for _, fragment := range []string{
+		"job.current_kind = target.captured_kind",
+		"job.current_args IS NOT DISTINCT FROM target.captured_args",
+		"locked.current_args IS NOT DISTINCT FROM target.captured_args",
+	} {
+		if !strings.Contains(budget, fragment) {
+			t.Errorf("migration 110 missing fixed-snapshot recheck %q", fragment)
+		}
+	}
+
+	controlsBytes, err := migrations.FS.ReadFile("112_sending_controls_foreign_key.sql")
+	if err != nil {
+		t.Fatalf("read controls FK migration: %v", err)
+	}
+	controls := strings.Join(strings.Fields(string(controlsBytes)), " ")
+	for _, fragment := range []string{
+		"SET LOCAL lock_timeout = '2s'",
+		"LOCK TABLE users IN SHARE ROW EXCLUSIVE MODE",
+		"LOCK TABLE account_sending_controls IN SHARE ROW EXCLUSIVE MODE",
+		"DELETE FROM account_sending_controls AS controls WHERE NOT EXISTS",
+		"ADD CONSTRAINT account_sending_controls_user_id_fkey",
+		"FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE NOT VALID",
+	} {
+		if !strings.Contains(controls, fragment) {
+			t.Errorf("source-free controls FK migration missing %q", fragment)
+		}
+	}
+	for _, forbidden := range []string{
+		"FROM river_job", "FROM agent_identities", "ALTER TABLE messages",
+		"LOCK TABLE messages", "FROM webhooks",
+	} {
+		if strings.Contains(controls, forbidden) {
+			t.Errorf("source-free controls FK migration references %q", forbidden)
+		}
+	}
+
+	feedbackBytes, err := migrations.FS.ReadFile("111_sending_feedback_provenance.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	feedback := string(feedbackBytes)
+	outcomesFKPos := strings.Index(feedback, "ADD CONSTRAINT account_sending_outcomes_daily_user_id_fkey")
+	outcomesLockTimeoutPos := strings.LastIndex(feedback[:max(outcomesFKPos, 0)], "SET LOCAL lock_timeout = '2s'")
+	if strings.Contains(feedback, "ALTER TABLE suppressions") {
+		t.Fatal("migration 111 must finish account FK work without taking suppressions table locks")
+	}
+	if strings.Contains(feedback, "user_id TEXT NOT NULL REFERENCES users") ||
+		outcomesFKPos < outcomesLockTimeoutPos ||
+		!strings.Contains(feedback[outcomesFKPos:], "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE NOT VALID") {
+		t.Fatal("account outcomes FK must be named, NOT VALID, and installed in migration 111's bounded tail")
+	}
+
+	messagesBytes, err := migrations.FS.ReadFile("113_sending_message_holds.sql")
+	if err != nil {
+		t.Fatalf("read messages hot-DDL migration: %v", err)
+	}
+	messages := strings.Join(strings.Fields(string(messagesBytes)), " ")
+	for _, fragment := range []string{
+		"SET LOCAL lock_timeout = '2s'",
+		"ALTER TABLE messages ADD COLUMN IF NOT EXISTS local_hold_class TEXT",
+		"ALTER TABLE messages ADD COLUMN IF NOT EXISTS local_hold_anchor TIMESTAMPTZ",
+		"messages_local_hold_check",
+		"NOT VALID",
+	} {
+		if !strings.Contains(messages, fragment) {
+			t.Errorf("messages hot-DDL migration missing %q", fragment)
+		}
+	}
+	if strings.Contains(messages, "LOCK TABLE users") ||
+		strings.Contains(messages, "ALTER TABLE account_sending") ||
+		strings.Contains(messages, "ALTER TABLE suppressions") {
+		t.Fatal("messages hot-DDL migration must contain no other strong-table work")
+	}
+
+	suppressionsBytes, err := migrations.FS.ReadFile("114_sending_suppression_provenance.sql")
+	if err != nil {
+		t.Fatalf("read suppressions hot-DDL migration: %v", err)
+	}
+	suppressions := strings.Join(strings.Fields(string(suppressionsBytes)), " ")
+	for _, fragment := range []string{
+		"SET LOCAL lock_timeout = '2s'",
+		"ALTER TABLE suppressions ADD COLUMN IF NOT EXISTS sync_generation BIGINT NOT NULL DEFAULT 1",
+		"ALTER TABLE suppressions ADD COLUMN IF NOT EXISTS removal_pending BOOLEAN NOT NULL DEFAULT false",
+		"suppressions_sync_generation_check",
+		"NOT VALID",
+	} {
+		if !strings.Contains(suppressions, fragment) {
+			t.Errorf("suppressions hot-DDL migration missing %q", fragment)
+		}
+	}
+	if strings.Contains(suppressions, "LOCK TABLE users") ||
+		strings.Contains(suppressions, "ALTER TABLE account_sending") ||
+		strings.Contains(suppressions, "ALTER TABLE messages") {
+		t.Fatal("suppressions hot-DDL migration must contain no other strong-table work")
+	}
+
+	validationBytes, err := migrations.FS.ReadFile("115_sending_protection_validate_constraints.sql")
+	if err != nil {
+		t.Fatalf("read validation migration: %v", err)
+	}
+	validation := strings.Join(strings.Fields(string(validationBytes)), " ")
+	for _, fragment := range []string{
+		"SET LOCAL lock_timeout = '2s'",
+		"ALTER TABLE messages VALIDATE CONSTRAINT messages_local_hold_check",
+		"ALTER TABLE suppressions VALIDATE CONSTRAINT suppressions_sync_generation_check",
+		"ALTER TABLE account_sending_controls VALIDATE CONSTRAINT account_sending_controls_user_id_fkey",
+		"ALTER TABLE account_sending_outcomes_daily VALIDATE CONSTRAINT account_sending_outcomes_daily_user_id_fkey",
+	} {
+		if !strings.Contains(validation, fragment) {
+			t.Errorf("validation migration missing %q", fragment)
+		}
+	}
+}
+
+func TestSendingBudgetMigrationDoesNotDeadlockAccountDeletionOrder(t *testing.T) {
+	for _, sourceKind := range []string{"outbound", "webhook"} {
+		t.Run(sourceKind, func(t *testing.T) {
+			testSendingBudgetMigrationDoesNotDeadlockAccountDeletionOrder(t, sourceKind)
+		})
+	}
+}
+
+func testSendingBudgetMigrationDoesNotDeadlockAccountDeletionOrder(t *testing.T, sourceKind string) {
+	ctx := context.Background()
+	pool := testutil.TestDB(t)
+	if err := jobs.Migrate(ctx, pool); err != nil {
+		t.Fatalf("migrate River schema: %v", err)
+	}
+	migration, err := migrations.FS.ReadFile("110_sending_budget_ledger.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	controlsMigration, err := migrations.FS.ReadFile("112_sending_controls_foreign_key.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	const barrierKey int64 = 8364511027
+	cleanupData := func() {
+		_, _ = pool.Exec(context.Background(), `
+			DROP TRIGGER IF EXISTS sending_controls_tail_barrier ON river_job;
+			DROP FUNCTION IF EXISTS sending_controls_tail_barrier();
+			DELETE FROM river_job
+			WHERE args->>'message_id'='msg_tail_deadlock'
+			   OR args->>'webhook_id'='wh_tail_deadlock';
+			DELETE FROM sending_provider_operations
+			WHERE source_account_ref='usr_tail_deadlock';
+			DELETE FROM users WHERE id='usr_tail_deadlock';
+		`)
+	}
+	cleanupData()
+	if _, err := pool.Exec(ctx, `DROP TABLE account_sending_controls`); err != nil {
+		t.Fatalf("remove controls/FK for true first-apply race: %v", err)
+	}
+	t.Cleanup(func() {
+		cleanupData()
+		if _, err := pool.Exec(context.Background(), string(migration)); err != nil {
+			t.Errorf("restore budget migration after controls-tail race: %v", err)
+			return
+		}
+		if _, err := pool.Exec(context.Background(), string(controlsMigration)); err != nil {
+			t.Errorf("restore controls FK after controls-tail race: %v", err)
+		}
+	})
+	seedSQL := `
+		INSERT INTO users (id,email,name,google_subject)
+		VALUES ('usr_tail_deadlock','owner@tail-deadlock.test','Owner','sub-tail-deadlock')`
+	jobArgs := `{"message_id":"msg_tail_deadlock"}`
+	jobKind := "outbound_send"
+	if sourceKind == "outbound" {
+		seedSQL += `;
+			INSERT INTO domains (domain,user_id,verified)
+			VALUES ('tail-deadlock.test','usr_tail_deadlock',true);
+			INSERT INTO agent_identities (id,registered_domain,user_id,name)
+			VALUES ('agent_tail_deadlock','tail-deadlock.test','usr_tail_deadlock','Tail');
+			INSERT INTO messages
+			    (id,agent_id,direction,sender,recipient,subject,delivery_status,sent_as)
+			VALUES ('msg_tail_deadlock','agent_tail_deadlock','outbound',
+			        'sender@tail-deadlock.test','recipient@example.test','Tail lock',
+			        'accepted','relay')`
+	} else {
+		seedSQL += `;
+			INSERT INTO webhooks
+			    (id,user_id,url,description,events,filters,signing_secret)
+			VALUES ('wh_tail_deadlock','usr_tail_deadlock',
+			        'https://hooks.tail-deadlock.test/notify','Tail lock',
+			        ARRAY['email.received'],'{}','synthetic-secret')`
+		jobArgs = `{"webhook_id":"wh_tail_deadlock","kind":"warning"}`
+		jobKind = "webhook_notify"
+	}
+	if _, err := pool.Exec(ctx, seedSQL); err != nil {
+		t.Fatalf("seed tail deadlock fixture: %v", err)
+	}
+	var jobID int64
+	if err := pool.QueryRow(ctx, `
+		INSERT INTO river_job (args,kind,max_attempts)
+		VALUES ($1::jsonb,$2,3)
+		RETURNING id
+	`, jobArgs, jobKind).Scan(&jobID); err != nil {
+		t.Fatalf("insert tail-deadlock River job: %v", err)
+	}
+	if sourceKind == "outbound" {
+		if _, err := pool.Exec(ctx, `UPDATE messages SET send_job_id=$2 WHERE id=$1`, "msg_tail_deadlock", jobID); err != nil {
+			t.Fatalf("link tail-deadlock River job: %v", err)
+		}
+	}
+	if _, err := pool.Exec(ctx, `
+		CREATE FUNCTION sending_controls_tail_barrier() RETURNS trigger
+		LANGUAGE plpgsql AS $$
+		BEGIN
+			PERFORM pg_advisory_xact_lock(8364511027);
+			RETURN NEW;
+		END
+		$$;
+		CREATE TRIGGER sending_controls_tail_barrier
+		BEFORE UPDATE ON river_job
+		FOR EACH ROW EXECUTE FUNCTION sending_controls_tail_barrier();
+	`); err != nil {
+		t.Fatalf("install controls-tail barrier: %v", err)
+	}
+
+	barrier, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer barrier.Release()
+	barrierHeld := true
+	defer func() {
+		if barrierHeld {
+			_, _ = barrier.Exec(context.Background(), `SELECT pg_advisory_unlock($1)`, barrierKey)
+		}
+	}()
+	if _, err := barrier.Exec(ctx, `SELECT pg_advisory_lock($1)`, barrierKey); err != nil {
+		t.Fatalf("hold controls-tail barrier: %v", err)
+	}
+
+	migrator, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer migrator.Release()
+	var migratorPID int
+	if err := migrator.QueryRow(ctx, `SELECT pg_backend_pid()`).Scan(&migratorPID); err != nil {
+		t.Fatal(err)
+	}
+	migrationCtx, cancelMigration := context.WithTimeout(ctx, 8*time.Second)
+	defer cancelMigration()
+	migrationErrCh := make(chan error, 1)
+	go func() {
+		_, execErr := migrator.Exec(migrationCtx, string(migration))
+		migrationErrCh <- execErr
+	}()
+
+	waitCtx, cancelWait := context.WithTimeout(ctx, 3*time.Second)
+	defer cancelWait()
+	waitingAtBarrier := false
+	for !waitingAtBarrier {
+		if err := pool.QueryRow(waitCtx, `
+			SELECT COALESCE(wait_event_type='Lock',false)
+			FROM pg_stat_activity WHERE pid=$1
+		`, migratorPID).Scan(&waitingAtBarrier); err != nil {
+			t.Fatalf("observe migration after source locks: %v", err)
+		}
+		if !waitingAtBarrier {
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	deletion, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer deletion.Release()
+	var deletionPID int
+	if err := deletion.QueryRow(ctx, `SELECT pg_backend_pid()`).Scan(&deletionPID); err != nil {
+		t.Fatal(err)
+	}
+	deletionErrCh := make(chan error, 1)
+	go func() {
+		_, deleteErr := deletion.Exec(migrationCtx, `DELETE FROM users WHERE id='usr_tail_deadlock'`)
+		deletionErrCh <- deleteErr
+	}()
+	waitingOnSource := false
+	for !waitingOnSource {
+		if err := pool.QueryRow(waitCtx, `
+			SELECT COALESCE(wait_event_type='Lock',false)
+			FROM pg_stat_activity WHERE pid=$1
+		`, deletionPID).Scan(&waitingOnSource); err != nil {
+			t.Fatalf("observe account deletion waiting on locked source: %v", err)
+		}
+		if !waitingOnSource {
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	if _, err := barrier.Exec(ctx, `SELECT pg_advisory_unlock($1)`, barrierKey); err != nil {
+		t.Fatalf("release controls-tail barrier: %v", err)
+	}
+	barrierHeld = false
+	migrationErr := <-migrationErrCh
+	deletionErr := <-deletionErrCh
+
+	for name, got := range map[string]error{"migration": migrationErr, "deletion": deletionErr} {
+		var pgErr *pgconn.PgError
+		if errors.As(got, &pgErr) && pgErr.Code == "40P01" {
+			t.Errorf("%s hit lock-order deadlock: %v", name, got)
+		} else if got != nil {
+			t.Errorf("%s failed: %v", name, got)
+		}
+	}
+
+	probe, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := probe.Exec(ctx, `LOCK TABLE users IN SHARE ROW EXCLUSIVE MODE NOWAIT`); err != nil {
+		_ = probe.Rollback(ctx)
+		t.Fatalf("race left users lock behind: %v", err)
+	}
+	sourceProbeSQL := `SELECT id FROM agent_identities WHERE id='agent_tail_deadlock' FOR UPDATE NOWAIT`
+	if sourceKind == "webhook" {
+		sourceProbeSQL = `SELECT id FROM webhooks WHERE id='wh_tail_deadlock' FOR UPDATE NOWAIT`
+	}
+	if _, err := probe.Exec(ctx, sourceProbeSQL); err != nil {
+		_ = probe.Rollback(ctx)
+		t.Fatalf("race left source lock behind: %v", err)
+	}
+	if _, err := probe.Exec(ctx, `SELECT id FROM river_job WHERE id=$1 FOR UPDATE NOWAIT`, jobID); err != nil {
+		_ = probe.Rollback(ctx)
+		t.Fatalf("race left River job lock behind: %v", err)
+	}
+	if err := probe.Rollback(ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSendingProtectionAccountFKFirstApplyLockWaitIsBounded(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		migration  string
+		resetSQL   string
+		seedHotRow string
+		hotUpdate  string
+		hotRead    string
+	}{
+		{
+			"controls", "112_sending_controls_foreign_key.sql",
+			`ALTER TABLE account_sending_controls DROP CONSTRAINT IF EXISTS account_sending_controls_user_id_fkey`,
+			`INSERT INTO users (id,email,name,google_subject)
+			 VALUES ('usr_first_apply_hot','owner@first-apply-hot.test','Owner','sub-first-apply-hot');
+			 INSERT INTO domains (domain,user_id,verified)
+			 VALUES ('first-apply-hot.test','usr_first_apply_hot',true);
+			 INSERT INTO agent_identities (id,registered_domain,user_id,name)
+			 VALUES ('agent_first_apply_hot','first-apply-hot.test','usr_first_apply_hot','Hot');
+			 INSERT INTO messages (id,agent_id,direction,sender,recipient,subject)
+			 VALUES ('msg_first_apply_hot','agent_first_apply_hot','outbound',
+			         'sender@first-apply-hot.test','recipient@example.test','Hot row')`,
+			`UPDATE messages SET subject=subject WHERE id='msg_first_apply_hot'`,
+			`SELECT count(*) FROM messages WHERE id='msg_first_apply_hot'`,
+		},
+		{
+			"outcomes", "111_sending_feedback_provenance.sql",
+			`DROP TABLE account_sending_outcomes_daily`,
+			`INSERT INTO users (id,email,name,google_subject)
+			 VALUES ('usr_first_apply_hot','owner@first-apply-hot.test','Owner','sub-first-apply-hot');
+			 INSERT INTO suppressions (id,user_id,address,reason,source)
+			 VALUES ('sup_first_apply_hot','usr_first_apply_hot','recipient@example.test','synthetic','manual')`,
+			`UPDATE suppressions SET reason=reason WHERE id='sup_first_apply_hot'`,
+			`SELECT count(*) FROM suppressions WHERE id='sup_first_apply_hot'`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			pool := testutil.TestDB(t)
+			migration, err := migrations.FS.ReadFile(tc.migration)
+			if err != nil {
+				t.Fatal(err)
+			}
+			validation, err := migrations.FS.ReadFile("115_sending_protection_validate_constraints.sql")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := pool.Exec(ctx, tc.seedHotRow); err != nil {
+				t.Fatalf("seed %s hot-table row: %v", tc.name, err)
+			}
+			if _, err := pool.Exec(ctx, tc.resetSQL); err != nil {
+				t.Fatalf("reset %s FK migration for first-apply probe: %v", tc.name, err)
+			}
+
+			restored := false
+			t.Cleanup(func() {
+				if restored {
+					return
+				}
+				if _, err := pool.Exec(context.Background(), string(migration)); err != nil {
+					t.Errorf("restore %s migration: %v", tc.name, err)
+					return
+				}
+				if _, err := pool.Exec(context.Background(), string(validation)); err != nil {
+					t.Errorf("restore validation migration after %s: %v", tc.name, err)
+				}
+			})
+
+			writer, err := pool.Acquire(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer writer.Release()
+			writerTx, err := writer.Begin(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer writerTx.Rollback(ctx)
+			if _, err := writerTx.Exec(ctx, `
+				INSERT INTO users (id,email,name,google_subject)
+				VALUES ('usr_first_apply_writer','owner@first-apply.test','Owner','sub-first-apply')
+			`); err != nil {
+				t.Fatalf("hold users writer: %v", err)
+			}
+
+			migrator, err := pool.Acquire(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer migrator.Release()
+			var migratorPID int
+			if err := migrator.QueryRow(ctx, `SELECT pg_backend_pid()`).Scan(&migratorPID); err != nil {
+				t.Fatalf("read migrator backend PID: %v", err)
+			}
+			type migrationResult struct {
+				err     error
+				elapsed time.Duration
+			}
+			migrationResultCh := make(chan migrationResult, 1)
+			migrationCtx, cancelMigration := context.WithTimeout(ctx, 4*time.Second)
+			go func() {
+				started := time.Now()
+				_, migrationErr := migrator.Exec(migrationCtx, string(migration))
+				migrationResultCh <- migrationResult{migrationErr, time.Since(started)}
+			}()
+
+			waitCtx, cancelWait := context.WithTimeout(ctx, time.Second)
+			defer cancelWait()
+			waitingOnUsers := false
+			for !waitingOnUsers {
+				if err := pool.QueryRow(waitCtx, `
+					SELECT EXISTS (
+						SELECT 1 FROM pg_locks
+						WHERE pid=$1
+						  AND relation='users'::regclass
+						  AND mode='ShareRowExclusiveLock'
+						  AND NOT granted
+					)`, migratorPID).Scan(&waitingOnUsers); err != nil {
+					cancelMigration()
+					<-migrationResultCh
+					t.Fatalf("observe %s migration waiting on users: %v", tc.name, err)
+				}
+				if !waitingOnUsers {
+					time.Sleep(10 * time.Millisecond)
+				}
+			}
+
+			hotCtx, cancelHot := context.WithTimeout(ctx, 500*time.Millisecond)
+			hotStarted := time.Now()
+			_, hotUpdateErr := pool.Exec(hotCtx, tc.hotUpdate)
+			var hotRows int
+			hotReadErr := pool.QueryRow(hotCtx, tc.hotRead).Scan(&hotRows)
+			cancelHot()
+			hotElapsed := time.Since(hotStarted)
+
+			result := <-migrationResultCh
+			cancelMigration()
+			if hotUpdateErr != nil || hotReadErr != nil || hotRows != 1 {
+				t.Errorf("%s traffic blocked while migration waited on users after %s: update=%v read=%v rows=%d", tc.name, hotElapsed, hotUpdateErr, hotReadErr, hotRows)
+			}
+
+			err = result.err
+			elapsed := result.elapsed
+			var pgErr *pgconn.PgError
+			if !errors.As(err, &pgErr) || pgErr.Code != "55P03" {
+				t.Fatalf("first-apply %s under users writer err=%v after %s, want bounded PostgreSQL lock timeout", tc.name, err, elapsed)
+			}
+			if elapsed > 3*time.Second {
+				t.Fatalf("first-apply %s users lock wait took %s, want <=3s", tc.name, elapsed)
+			}
+
+			if err := writerTx.Rollback(ctx); err != nil {
+				t.Fatalf("release users writer: %v", err)
+			}
+			if _, err := pool.Exec(ctx, string(migration)); err != nil {
+				t.Fatalf("restore %s after bounded failure: %v", tc.name, err)
+			}
+			if _, err := pool.Exec(ctx, string(validation)); err != nil {
+				t.Fatalf("validate restored %s constraints: %v", tc.name, err)
+			}
+			restored = true
+		})
+	}
+}
+
+func TestSendingControlsFKTailRemovesOnlyOrphans(t *testing.T) {
+	ctx := context.Background()
+	pool := testutil.TestDB(t)
+	migration, err := migrations.FS.ReadFile("112_sending_controls_foreign_key.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	validation, err := migrations.FS.ReadFile("115_sending_protection_validate_constraints.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), string(migration))
+		_, _ = pool.Exec(context.Background(), string(validation))
+		_, _ = pool.Exec(context.Background(), `
+			DELETE FROM users
+			WHERE id IN ('usr_controls_live','usr_controls_orphan')
+		`)
+	})
+
+	if _, err := pool.Exec(ctx, `
+		ALTER TABLE account_sending_controls
+		    DROP CONSTRAINT IF EXISTS account_sending_controls_user_id_fkey;
+		INSERT INTO users (id,email,name,google_subject) VALUES
+		    ('usr_controls_live','owner@controls-live.test','Owner','sub-controls-live'),
+		    ('usr_controls_orphan','owner@controls-orphan.test','Owner','sub-controls-orphan');
+		INSERT INTO account_sending_controls (user_id,reason) VALUES
+		    ('usr_controls_live','live synthetic control'),
+		    ('usr_controls_orphan','orphan synthetic control');
+		DELETE FROM users WHERE id='usr_controls_orphan';
+	`); err != nil {
+		t.Fatalf("seed realistic controls orphan: %v", err)
+	}
+	var orphanBefore int
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*) FROM account_sending_controls
+		WHERE user_id='usr_controls_orphan'
+	`).Scan(&orphanBefore); err != nil || orphanBefore != 1 {
+		t.Fatalf("pre-migration orphan controls=%d err=%v, want 1", orphanBefore, err)
+	}
+
+	if _, err := pool.Exec(ctx, string(migration)); err != nil {
+		t.Fatalf("apply controls FK tail to realistic orphan: %v", err)
+	}
+	var liveRows, orphanRows int
+	if err := pool.QueryRow(ctx, `
+		SELECT
+		    count(*) FILTER (WHERE user_id='usr_controls_live'),
+		    count(*) FILTER (WHERE user_id='usr_controls_orphan')
+		FROM account_sending_controls
+	`).Scan(&liveRows, &orphanRows); err != nil {
+		t.Fatalf("read controls after orphan cleanup: %v", err)
+	}
+	if liveRows != 1 || orphanRows != 0 {
+		t.Fatalf("controls after FK tail live=%d orphan=%d, want 1 and 0", liveRows, orphanRows)
+	}
+	if _, err := pool.Exec(ctx, string(validation)); err != nil {
+		t.Fatalf("validate controls FK after orphan cleanup: %v", err)
+	}
+}
+
+func TestSendingProtectionHotTableAlterLockWaitIsBounded(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		table     string
+		migration string
+	}{
+		{"messages", "messages", "113_sending_message_holds.sql"},
+		{"suppressions", "suppressions", "114_sending_suppression_provenance.sql"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pool := testutil.TestDB(t)
+			ctx := context.Background()
+			migration, err := migrations.FS.ReadFile(tc.migration)
+			if err != nil {
+				t.Fatal(err)
+			}
+			blocker, err := pool.Acquire(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer blocker.Release()
+			tx, err := blocker.Begin(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer tx.Rollback(ctx)
+			if _, err := tx.Exec(ctx, `LOCK TABLE `+tc.table+` IN ACCESS SHARE MODE`); err != nil {
+				t.Fatalf("hold reader lock on %s: %v", tc.table, err)
+			}
+
+			migrationCtx, cancel := context.WithTimeout(ctx, 4*time.Second)
+			defer cancel()
+			started := time.Now()
+			_, err = pool.Exec(migrationCtx, string(migration))
+			elapsed := time.Since(started)
+			var pgErr *pgconn.PgError
+			if !errors.As(err, &pgErr) || pgErr.Code != "55P03" {
+				t.Fatalf("migration under %s reader lock err=%v after %s, want bounded PostgreSQL lock timeout", tc.table, err, elapsed)
+			}
+			if elapsed > 3*time.Second {
+				t.Fatalf("migration lock wait on %s took %s, want <=3s", tc.table, elapsed)
+			}
+		})
+	}
+}
+
+func TestSendingProtectionConstraintValidationAllowsNormalDML(t *testing.T) {
+	validation, err := migrations.FS.ReadFile("115_sending_protection_validate_constraints.sql")
+	if err != nil {
+		t.Fatalf("read validation migration: %v", err)
+	}
+	ctx := context.Background()
+	pool := testutil.TestDB(t)
+	if _, err := pool.Exec(ctx, `
+		DELETE FROM users WHERE id='usr_validation_dml';
+		INSERT INTO users (id,email,name,google_subject)
+		VALUES ('usr_validation_dml','owner@validation-dml.test','Owner','sub-validation-dml');
+		INSERT INTO domains (domain,user_id,verified)
+		VALUES ('validation-dml.test','usr_validation_dml',true);
+		INSERT INTO agent_identities (id,registered_domain,user_id,name)
+		VALUES ('agent_validation_dml','validation-dml.test','usr_validation_dml','Validation');
+		INSERT INTO messages (id,agent_id,direction,sender,recipient,subject)
+		VALUES ('msg_validation_dml','agent_validation_dml','outbound','sender@validation-dml.test','recipient@example.test','Validation');
+		INSERT INTO suppressions (id,user_id,address,reason,source)
+		VALUES ('sup_validation_dml','usr_validation_dml','recipient@example.test','synthetic','manual');
+		INSERT INTO account_sending_controls (user_id)
+		VALUES ('usr_validation_dml');
+		INSERT INTO account_sending_outcomes_daily
+		    (user_id,outcome_epoch,day,shared_reputation,delivered_count)
+		VALUES ('usr_validation_dml',1,CURRENT_DATE,true,1);
+		ALTER TABLE messages DROP CONSTRAINT IF EXISTS messages_local_hold_check;
+		ALTER TABLE messages ADD CONSTRAINT messages_local_hold_check CHECK (
+			(local_hold_class IS NULL AND local_hold_anchor IS NULL)
+			OR (local_hold_class IN ('rate_ramp_or_provider','tenant_setup','policy_budget')
+			    AND local_hold_anchor IS NOT NULL)
+		) NOT VALID;
+		ALTER TABLE suppressions DROP CONSTRAINT IF EXISTS suppressions_sync_generation_check;
+		ALTER TABLE suppressions ADD CONSTRAINT suppressions_sync_generation_check
+		    CHECK (sync_generation > 0) NOT VALID;
+		ALTER TABLE account_sending_controls
+		    DROP CONSTRAINT IF EXISTS account_sending_controls_user_id_fkey;
+		ALTER TABLE account_sending_controls
+		    ADD CONSTRAINT account_sending_controls_user_id_fkey
+		    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE NOT VALID;
+		ALTER TABLE account_sending_outcomes_daily
+		    DROP CONSTRAINT IF EXISTS account_sending_outcomes_daily_user_id_fkey;
+		ALTER TABLE account_sending_outcomes_daily
+		    ADD CONSTRAINT account_sending_outcomes_daily_user_id_fkey
+		    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE NOT VALID;
+	`); err != nil {
+		t.Fatalf("seed validation fixture: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), string(validation))
+		_, _ = pool.Exec(context.Background(), `DELETE FROM users WHERE id='usr_validation_dml'`)
+	})
+
+	writer, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer writer.Release()
+	tx, err := writer.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback(ctx)
+	if _, err := tx.Exec(ctx, `
+		UPDATE users SET name=name WHERE id='usr_validation_dml';
+		UPDATE messages SET subject=subject WHERE id='msg_validation_dml';
+		UPDATE suppressions SET reason=reason WHERE id='sup_validation_dml';
+		UPDATE account_sending_controls SET reason=reason WHERE user_id='usr_validation_dml';
+		UPDATE account_sending_outcomes_daily SET delivered_count=delivered_count
+		WHERE user_id='usr_validation_dml';
+	`); err != nil {
+		t.Fatalf("hold normal DML transaction: %v", err)
+	}
+
+	validationCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	if _, err := pool.Exec(validationCtx, string(validation)); err != nil {
+		t.Fatalf("constraint validation blocked behind normal DML: %v", err)
+	}
+}
+
+func TestSendingProtectionSchemaContracts(t *testing.T) {
+	ctx := context.Background()
+	pool := testutil.TestDB(t)
+
+	tables := []string{
+		"sending_protection_runtime_policy", "sending_protection_policy_events",
+		"sending_protection_runtime_attestation", "sending_operator_recipient_versions",
+		"sending_ramp_grandfathering", "sending_provider_operations",
+		"sending_budget_counters", "sending_budget_reservations",
+		"account_sending_controls", "account_sending_control_events",
+		"sending_protection_notice_events", "sending_protection_notice_deliveries",
+		"sending_feedback_correlations", "sending_feedback_recipients",
+		"sending_feedback_events", "account_sending_outcomes_daily",
+	}
+	for _, table := range tables {
+		var exists bool
+		if err := pool.QueryRow(ctx, `SELECT to_regclass('public.' || $1) IS NOT NULL`, table).Scan(&exists); err != nil {
+			t.Fatal(err)
+		}
+		if !exists {
+			t.Errorf("missing table %s", table)
+		}
+	}
+	if t.Failed() {
+		t.FailNow()
+	}
+
+	var generation int64
+	var schemaVersion int
+	var policyJSON []byte
+	var policyHash, budgetMode string
+	if err := pool.QueryRow(ctx, `
+		SELECT generation, schema_version, policy, policy_sha256, policy->>'budget_mode'
+		FROM sending_protection_runtime_policy WHERE singleton`).Scan(
+		&generation, &schemaVersion, &policyJSON, &policyHash, &budgetMode,
+	); err != nil {
+		t.Fatalf("read generation zero: %v", err)
+	}
+	var decoded any
+	if err := json.Unmarshal(policyJSON, &decoded); err != nil {
+		t.Fatalf("decode policy: %v", err)
+	}
+	canonical, err := json.Marshal(decoded)
+	if err != nil {
+		t.Fatalf("canonicalize policy fixture: %v", err)
+	}
+	sum := sha256.Sum256(canonical)
+	if generation != 0 || schemaVersion != 1 || budgetMode != "disabled" || string(canonical) != generationZeroPolicy || policyHash != hex.EncodeToString(sum[:]) || policyHash != "198d8cfb3220b6094a3b8dfe13cb0e2ff97c512ad87ae14609e580ae335c9ce6" {
+		t.Fatalf("generation zero mismatch: generation=%d schema=%d mode=%q hash=%q canonical=%s", generation, schemaVersion, budgetMode, policyHash, canonical)
+	}
+
+	var revision int64
+	var activeDigest, rollbackDigest string
+	var activeContract, rollbackContract int
+	if err := pool.QueryRow(ctx, `SELECT revision, active_billing_digest, active_billing_contract, rollback_billing_digest, rollback_billing_contract FROM sending_protection_runtime_attestation WHERE singleton`).Scan(&revision, &activeDigest, &activeContract, &rollbackDigest, &rollbackContract); err != nil {
+		t.Fatalf("read runtime attestation: %v", err)
+	}
+	if revision != 0 || activeDigest != "" || rollbackDigest != "" || activeContract != 0 || rollbackContract != 0 {
+		t.Fatalf("runtime attestation sentinel = (%d,%q,%d,%q,%d)", revision, activeDigest, activeContract, rollbackDigest, rollbackContract)
+	}
+
+	for _, table := range []string{"sending_provider_operations", "sending_budget_reservations", "account_sending_control_events", "sending_protection_notice_events", "sending_feedback_correlations", "sending_feedback_recipients", "sending_feedback_events"} {
+		var fkCount int
+		if err := pool.QueryRow(ctx, `SELECT count(*) FROM pg_constraint WHERE conrelid=$1::regclass AND contype='f'`, table).Scan(&fkCount); err != nil {
+			t.Fatal(err)
+		}
+		if fkCount != 0 {
+			t.Errorf("%s has %d foreign keys; security ledger rows must not reference customer trees", table, fkCount)
+		}
+	}
+	var deliveryFKs int
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*) FROM pg_constraint
+		WHERE conrelid='sending_protection_notice_deliveries'::regclass
+		  AND contype='f'
+		  AND confrelid='sending_protection_notice_events'::regclass
+		  AND confdeltype='c'`).Scan(&deliveryFKs); err != nil || deliveryFKs != 1 {
+		t.Fatalf("notice delivery cascade foreign keys=%d err=%v, want exactly one", deliveryFKs, err)
+	}
+
+	var addressColumns int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM information_schema.columns WHERE table_name IN ('sending_protection_notice_events','sending_protection_notice_deliveries') AND column_name ILIKE '%address%'`).Scan(&addressColumns); err != nil {
+		t.Fatal(err)
+	}
+	if addressColumns != 0 {
+		t.Fatalf("notice outbox exposes %d address column(s)", addressColumns)
+	}
+
+	for _, index := range []string{
+		"account_sending_controls_active_scan_idx", "sending_protection_notice_pending_idx",
+		"sending_protection_notice_deadline_idx",
+		"sending_budget_reservations_expiry_idx", "sending_feedback_correlations_provider_message_idx",
+		"sending_feedback_correlations_account_retention_idx", "account_sending_outcomes_daily_scan_idx",
+		"sending_protection_notice_account_budget_uniq", "sending_protection_notice_global_guardrail_uniq",
+	} {
+		var exists bool
+		if err := pool.QueryRow(ctx, `SELECT to_regclass('public.' || $1) IS NOT NULL`, index).Scan(&exists); err != nil || !exists {
+			t.Errorf("missing index %s (err=%v)", index, err)
+		}
+	}
+
+	for _, constraint := range []string{
+		"messages_local_hold_check",
+		"suppressions_sync_generation_check",
+		"account_sending_controls_user_id_fkey",
+		"account_sending_outcomes_daily_user_id_fkey",
+	} {
+		var validated bool
+		if err := pool.QueryRow(ctx, `SELECT convalidated FROM pg_constraint WHERE conname=$1`, constraint).Scan(&validated); err != nil {
+			t.Fatalf("read validation state for %s: %v", constraint, err)
+		}
+		if !validated {
+			t.Errorf("constraint %s remains NOT VALID after migration 115", constraint)
+		}
+	}
+
+	// Registry versions are an immutable, lowercase commitment ledger. Keep the
+	// probe transactional because a successful row must otherwise live forever.
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback(ctx)
+	if _, err := tx.Exec(ctx, `INSERT INTO sending_operator_recipient_versions (logical_version, commitment_key_id, recipient_commitment, created_by) VALUES (2147483647, repeat('a',64), repeat('b',64), 'schema-test') ON CONFLICT DO NOTHING`); err != nil {
+		t.Fatalf("insert operator commitment: %v", err)
+	}
+	if _, err := tx.Exec(ctx, `UPDATE sending_operator_recipient_versions SET created_by='changed' WHERE logical_version=2147483647`); err == nil || !strings.Contains(err.Error(), "append-only") {
+		t.Fatalf("operator commitment update err=%v, want append-only rejection", err)
+	}
+
+	for _, code := range []string{"submission.policy_budget_expired", "submission.sending_setup_expired"} {
+		var stage, outcome string
+		var retryable bool
+		if err := pool.QueryRow(ctx, `SELECT stage,outcome,retryable FROM message_lifecycle_reason_codes WHERE code=$1`, code).Scan(&stage, &outcome, &retryable); err != nil || stage != "submission" || outcome != "failed" || retryable {
+			t.Errorf("lifecycle tuple %s=(%q,%q,%v) err=%v", code, stage, outcome, retryable, err)
+		}
+	}
+}
+
+func TestDeletionLeavesLedgerAndFeedbackProvenance(t *testing.T) {
+	ctx := context.Background()
+	pool := testutil.TestDB(t)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `
+			DELETE FROM sending_protection_notice_deliveries WHERE event_id='notice_ledger_test';
+			DELETE FROM sending_protection_notice_events WHERE id='notice_ledger_test';
+			DELETE FROM account_sending_control_events WHERE id='control_event_ledger_test';
+			DELETE FROM sending_feedback_recipients WHERE correlation_id='corr_ledger_test';
+			DELETE FROM sending_feedback_events WHERE correlation_id='corr_ledger_test';
+			DELETE FROM sending_feedback_correlations WHERE operation_id='msg_ledger_test';
+			DELETE FROM sending_budget_reservations WHERE operation_id='msg_ledger_test';
+			DELETE FROM sending_provider_operations WHERE operation_id='msg_ledger_test';
+		`)
+	})
+	if _, err := pool.Exec(ctx, `
+		DELETE FROM sending_protection_notice_deliveries WHERE event_id='notice_ledger_test';
+		DELETE FROM sending_protection_notice_events WHERE id='notice_ledger_test';
+		DELETE FROM account_sending_control_events WHERE id='control_event_ledger_test';
+		DELETE FROM sending_feedback_recipients WHERE correlation_id='corr_ledger_test';
+		DELETE FROM sending_feedback_events WHERE correlation_id='corr_ledger_test';
+		DELETE FROM sending_feedback_correlations WHERE operation_id='msg_ledger_test';
+		DELETE FROM sending_budget_reservations WHERE operation_id='msg_ledger_test';
+		DELETE FROM sending_provider_operations WHERE operation_id='msg_ledger_test';
+	`); err != nil {
+		t.Fatalf("clear durable fixture rows: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO users (id,email,name,google_subject) VALUES ('usr_ledger_test','owner@ledger.test','Owner','sub-ledger-test');
+		INSERT INTO domains (domain,user_id,verified) VALUES ('ledger.test','usr_ledger_test',true);
+		INSERT INTO agent_identities (id,registered_domain,user_id,name) VALUES ('agent_ledger_test','ledger.test','usr_ledger_test','Ledger');
+		INSERT INTO messages (id,agent_id,direction,sender,recipient,subject) VALUES ('msg_ledger_test','agent_ledger_test','outbound','sender@ledger.test','recipient@example.test','Synthetic');
+		INSERT INTO suppressions (id,user_id,address,reason,source) VALUES ('sup_ledger_test','usr_ledger_test','recipient@example.test','synthetic','manual');
+		INSERT INTO account_sending_controls (user_id) VALUES ('usr_ledger_test');
+		INSERT INTO account_sending_outcomes_daily (user_id,outcome_epoch,day,shared_reputation,delivered_count) VALUES ('usr_ledger_test',1,CURRENT_DATE,true,1);
+		INSERT INTO account_sending_control_events (id,account_ref,old_state,new_state,reason,actor,expires_at) VALUES ('control_event_ledger_test','usr_ledger_test','active','paused','synthetic','schema-test',now()+interval '90 days');
+		INSERT INTO sending_protection_notice_events (id,account_ref,kind,reason_code,source_event_id,expires_at) VALUES ('notice_ledger_test','usr_ledger_test','pause','manual','control_event_ledger_test',now()+interval '30 days');
+		INSERT INTO sending_protection_notice_deliveries (event_id,audience) VALUES ('notice_ledger_test','owner'),('notice_ledger_test','operator');
+		INSERT INTO sending_provider_operations (operation_id,source_account_ref,policy_subject_ref,purpose,expires_at) VALUES ('msg_ledger_test','usr_ledger_test','usr_ledger_test','customer_message',now()+interval '30 days');
+		INSERT INTO sending_budget_reservations (operation_id,submission_attempt,source_account_ref,policy_subject_ref,purpose,day,units,probation,state) VALUES ('msg_ledger_test',1,'usr_ledger_test','usr_ledger_test','customer_message',CURRENT_DATE,1,false,'reserved');
+		INSERT INTO sending_feedback_correlations (correlation_id,operation_id,submission_attempt,source_account_ref,policy_subject_ref,purpose,tenant_mode) VALUES ('corr_ledger_test','msg_ledger_test',1,'usr_ledger_test','usr_ledger_test','customer_message','none');
+		INSERT INTO sending_feedback_recipients (correlation_id,recipient_hmac,hmac_key_version) VALUES ('corr_ledger_test',decode(repeat('ab',32),'hex'),1);
+		INSERT INTO sending_feedback_events (provider_event_id,correlation_id,provider_occurred_at) VALUES ('feedback_event_ledger_test','corr_ledger_test',now());
+		DELETE FROM messages WHERE id='msg_ledger_test';
+	`); err != nil {
+		t.Fatalf("seed and delete message: %v", err)
+	}
+	for table, column := range map[string]string{"sending_budget_reservations": "operation_id", "sending_feedback_correlations": "operation_id"} {
+		var count int
+		if err := pool.QueryRow(ctx, `SELECT count(*) FROM `+table+` WHERE `+column+`='msg_ledger_test'`).Scan(&count); err != nil || count != 1 {
+			t.Fatalf("%s rows after message deletion=%d err=%v", table, count, err)
+		}
+	}
+	var generation int64
+	var removalPending bool
+	if err := pool.QueryRow(ctx, `SELECT sync_generation,removal_pending FROM suppressions WHERE id='sup_ledger_test'`).Scan(&generation, &removalPending); err != nil || generation != 1 || removalPending {
+		t.Fatalf("suppression safe defaults=(%d,%v) err=%v", generation, removalPending, err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO sending_budget_counters(scope,scope_id,day,daily_limit) VALUES('invalid_scope','x',CURRENT_DATE,1)`); err == nil {
+		t.Fatal("invalid budget scope unexpectedly accepted")
+	}
+
+	if _, err := pool.Exec(ctx, `DELETE FROM users WHERE id='usr_ledger_test'`); err != nil {
+		t.Fatalf("delete synthetic account: %v", err)
+	}
+	for table, predicate := range map[string]string{
+		"sending_provider_operations":          "operation_id='msg_ledger_test'",
+		"sending_budget_reservations":          "operation_id='msg_ledger_test'",
+		"sending_feedback_correlations":        "operation_id='msg_ledger_test'",
+		"sending_feedback_recipients":          "correlation_id='corr_ledger_test'",
+		"sending_feedback_events":              "correlation_id='corr_ledger_test'",
+		"account_sending_control_events":       "id='control_event_ledger_test'",
+		"sending_protection_notice_events":     "id='notice_ledger_test'",
+		"sending_protection_notice_deliveries": "event_id='notice_ledger_test'",
+	} {
+		var count int
+		if err := pool.QueryRow(ctx, `SELECT count(*) FROM `+table+` WHERE `+predicate).Scan(&count); err != nil || count == 0 {
+			t.Errorf("deletion-resistant %s rows=%d err=%v", table, count, err)
+		}
+	}
+	for _, table := range []string{"account_sending_controls", "account_sending_outcomes_daily"} {
+		var count int
+		if err := pool.QueryRow(ctx, `SELECT count(*) FROM `+table+` WHERE user_id='usr_ledger_test'`).Scan(&count); err != nil || count != 0 {
+			t.Errorf("account-owned %s rows after account deletion=%d err=%v", table, count, err)
+		}
+	}
+}

--- a/internal/testutil/db.go
+++ b/internal/testutil/db.go
@@ -300,6 +300,12 @@ func runMigrations(ctx context.Context, pool *pgxpool.Pool) error {
 //     (the "insert must be new" assertions saw the previous run's rows).
 //   - sender_identity_managed_domains: deliberately survives domain deletion
 //     until asynchronous provider teardown is confirmed.
+//   - sending-protection security ledgers: provider operations, budget rows,
+//     control audit, notice outbox, and feedback provenance deliberately have no
+//     customer-tree FK so account/message deletion cannot erase them.
+//   - sending-protection policy state: the event/marker tables have no FK, while
+//     the runtime-policy and attestation singletons must be restored to their
+//     migration-owned generation-zero sentinels between tests.
 //
 // Use DELETE for FK-less tables instead of adding them to TRUNCATE. The test suite
 // calls this helper hundreds of times; repeatedly truncating inbound_intake also
@@ -325,6 +331,41 @@ func truncateAll(ctx context.Context, pool *pgxpool.Pool) error {
 
 		DELETE FROM inbound_intake;
 		DELETE FROM sender_identity_managed_domains;
+		DELETE FROM sending_protection_notice_deliveries;
+		DELETE FROM sending_protection_notice_events;
+		DELETE FROM sending_feedback_recipients;
+		DELETE FROM sending_feedback_events;
+		DELETE FROM sending_feedback_correlations;
+		DELETE FROM sending_budget_reservations;
+		DELETE FROM sending_budget_counters;
+		DELETE FROM sending_provider_operations;
+		DELETE FROM account_sending_control_events;
+		DELETE FROM sending_protection_policy_events;
+		DELETE FROM sending_ramp_grandfathering;
+
+		-- This registry is append-only in application/migration use; its
+		-- unconditional trigger intentionally rejects DELETE. The disposable
+		-- test database bypasses user triggers for this one row-lock-scoped
+		-- cleanup instead of using TRUNCATE's ACCESS EXCLUSIVE table lock.
+		SET LOCAL session_replication_role = replica;
+		DELETE FROM sending_operator_recipient_versions;
+		SET LOCAL session_replication_role = origin;
+
+		DELETE FROM sending_protection_runtime_policy;
+		INSERT INTO sending_protection_runtime_policy
+		    (singleton, generation, schema_version, policy, policy_sha256, activated_at, activated_by)
+		VALUES (
+		    true, 0, 1,
+		    '{"all_customer_global_daily_recipients":5000,"bounce_min_outcomes":50,"bounce_pause_basis_points":400,"budget_hold_max_days":7,"budget_mode":"disabled","complaint_pause_basis_points":8,"critical_operational_daily_recipients":100,"daily_unlimited_plan_codes":["starter","pro","scale"],"default_account_daily_recipients":100,"detector_interval_seconds":300,"detector_mode":"disabled","detector_window_days":7,"operator_notice_recipient_version":1,"probation_global_daily_recipients":150,"ramp_days":30,"ramp_enabled":false,"ramp_start_daily":150,"ramp_target_daily":2000,"sending_control_audit_retention_days":90,"sending_feedback_post_account_retention_days":30,"shared_domain_account_daily_recipients":50,"shared_reputation_bounce_min_outcomes":1,"tenant_header_canary_account_ids":[],"tenant_header_mode":"disabled","tenant_provisioning_mode":"disabled","tenant_suppression_sync_mode":"disabled","violation_operational_daily_recipients":100}'::jsonb,
+		    '198d8cfb3220b6094a3b8dfe13cb0e2ff97c512ad87ae14609e580ae335c9ce6',
+		    now(), 'migration'
+		);
+
+		DELETE FROM sending_protection_runtime_attestation;
+		INSERT INTO sending_protection_runtime_attestation
+		    (singleton, revision, active_billing_digest, active_billing_contract,
+		     rollback_billing_digest, rollback_billing_contract, updated_by)
+		VALUES (true, 0, '', 0, '', 0, 'migration');
 
 		TRUNCATE oauth_pkce_requests, oauth_refresh_tokens, oauth_access_tokens,
 		         oauth_auth_codes, oauth_clients,

--- a/internal/testutil/db_test.go
+++ b/internal/testutil/db_test.go
@@ -18,6 +18,109 @@ import (
 
 const testDBErrorChildEnv = "E2A_TEST_DB_ERROR_CHILD"
 
+func TestTruncateAll_CleansSendingProtectionNoFKState(t *testing.T) {
+	pool := TestDB(t)
+	ctx := context.Background()
+
+	if _, err := pool.Exec(ctx, `
+		UPDATE sending_protection_runtime_policy SET generation=9, activated_by='schema-test';
+		UPDATE sending_protection_runtime_attestation SET revision=9, active_billing_digest='sha256:synthetic', active_billing_contract=1, updated_by='schema-test';
+		INSERT INTO sending_protection_policy_events (generation,prior_generation,prior_policy_sha256,new_policy_sha256,actor,reason) VALUES (9,0,repeat('a',64),repeat('b',64),'schema-test','synthetic');
+		INSERT INTO sending_operator_recipient_versions (logical_version,commitment_key_id,recipient_commitment,created_by) VALUES (9,repeat('a',64),repeat('b',64),'schema-test');
+		INSERT INTO sending_ramp_grandfathering (singleton,policy_generation,completed_at,completed_by) VALUES (true,0,now(),'schema-test');
+		INSERT INTO account_sending_control_events (id,account_ref,old_state,new_state,reason,actor,expires_at) VALUES ('control_cleanup','usr_cleanup','active','paused','synthetic','schema-test',now()+interval '90 days');
+		INSERT INTO sending_provider_operations (operation_id,source_account_ref,policy_subject_ref,purpose,expires_at) VALUES ('op_cleanup','usr_cleanup','usr_cleanup','customer_message',now()+interval '30 days');
+		INSERT INTO sending_budget_counters (scope,scope_id,day,daily_limit) VALUES ('account_daily','usr_cleanup',CURRENT_DATE,1);
+		INSERT INTO sending_budget_reservations (operation_id,submission_attempt,source_account_ref,policy_subject_ref,purpose,day,units,probation,state) VALUES ('op_cleanup',1,'usr_cleanup','usr_cleanup','customer_message',CURRENT_DATE,1,false,'reserved');
+		INSERT INTO sending_protection_notice_events (id,kind,reason_code,budget_scope,ledger_day,expires_at) VALUES ('notice_cleanup','global_guardrail','global_budget_exhausted','global_all',CURRENT_DATE,now()+interval '30 days');
+		INSERT INTO sending_protection_notice_deliveries (event_id,audience) VALUES ('notice_cleanup','operator');
+		INSERT INTO sending_feedback_correlations (correlation_id,operation_id,submission_attempt,source_account_ref,policy_subject_ref,purpose,tenant_mode) VALUES ('corr_cleanup','op_cleanup',1,'usr_cleanup','usr_cleanup','customer_message','none');
+		INSERT INTO sending_feedback_recipients (correlation_id,recipient_hmac,hmac_key_version) VALUES ('corr_cleanup',decode(repeat('ab',32),'hex'),1);
+		INSERT INTO sending_feedback_events (provider_event_id,correlation_id,provider_occurred_at) VALUES ('feedback_cleanup','corr_cleanup',now());
+	`); err != nil {
+		t.Fatalf("seed sending-protection cleanup state: %v", err)
+	}
+
+	if err := truncateAll(ctx, pool); err != nil {
+		t.Fatalf("truncate sending-protection state: %v", err)
+	}
+
+	for _, table := range []string{
+		"sending_protection_policy_events",
+		"sending_operator_recipient_versions",
+		"sending_ramp_grandfathering",
+		"account_sending_control_events",
+		"sending_provider_operations",
+		"sending_budget_counters",
+		"sending_budget_reservations",
+		"sending_protection_notice_events",
+		"sending_protection_notice_deliveries",
+		"sending_feedback_correlations",
+		"sending_feedback_recipients",
+		"sending_feedback_events",
+	} {
+		var count int
+		if err := pool.QueryRow(ctx, `SELECT count(*) FROM `+table).Scan(&count); err != nil || count != 0 {
+			t.Errorf("%s rows after cleanup=%d err=%v", table, count, err)
+		}
+	}
+
+	var generation, revision int64
+	var policyHash, activeDigest, rollbackDigest string
+	var activeContract, rollbackContract int
+	if err := pool.QueryRow(ctx, `SELECT generation,policy_sha256 FROM sending_protection_runtime_policy WHERE singleton`).Scan(&generation, &policyHash); err != nil {
+		t.Fatalf("read reset runtime policy: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `SELECT revision,active_billing_digest,active_billing_contract,rollback_billing_digest,rollback_billing_contract FROM sending_protection_runtime_attestation WHERE singleton`).Scan(&revision, &activeDigest, &activeContract, &rollbackDigest, &rollbackContract); err != nil {
+		t.Fatalf("read reset attestation: %v", err)
+	}
+	if generation != 0 || policyHash != "198d8cfb3220b6094a3b8dfe13cb0e2ff97c512ad87ae14609e580ae335c9ce6" {
+		t.Errorf("runtime policy reset=(generation=%d hash=%q)", generation, policyHash)
+	}
+	if revision != 0 || activeDigest != "" || activeContract != 0 || rollbackDigest != "" || rollbackContract != 0 {
+		t.Errorf("runtime attestation reset=(%d,%q,%d,%q,%d)", revision, activeDigest, activeContract, rollbackDigest, rollbackContract)
+	}
+}
+
+func TestTruncateAll_CleansOperatorRegistryWithoutExclusiveTableLock(t *testing.T) {
+	pool := TestDB(t)
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO sending_operator_recipient_versions
+		    (logical_version,commitment_key_id,recipient_commitment,created_by)
+		VALUES (10,repeat('a',64),repeat('b',64),'schema-lock-test')
+	`); err != nil {
+		t.Fatalf("seed operator registry: %v", err)
+	}
+
+	reader, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin registry reader: %v", err)
+	}
+	defer reader.Rollback(ctx) //nolint:errcheck
+	var before int
+	if err := reader.QueryRow(ctx, `SELECT count(*) FROM sending_operator_recipient_versions`).Scan(&before); err != nil || before != 1 {
+		t.Fatalf("registry rows before cleanup=%d err=%v", before, err)
+	}
+
+	cleanupCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
+	defer cancel()
+	if err := truncateAll(cleanupCtx, pool); err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "55P03" {
+			t.Fatalf("operator registry cleanup requested an exclusive lock: %v", err)
+		}
+		t.Fatalf("operator registry cleanup failed: %v", err)
+	}
+	if err := reader.Rollback(ctx); err != nil {
+		t.Fatalf("rollback registry reader: %v", err)
+	}
+	var after int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM sending_operator_recipient_versions`).Scan(&after); err != nil || after != 0 {
+		t.Fatalf("registry rows after cleanup=%d err=%v", after, err)
+	}
+}
+
 func TestTruncateAll_CleansInboundIntakeWithoutExclusiveTableLock(t *testing.T) {
 	pool := TestDB(t)
 	ctx := context.Background()

--- a/migrations/109_sending_protection_policy.sql
+++ b/migrations/109_sending_protection_policy.sql
@@ -1,0 +1,84 @@
+-- 109_sending_protection_policy.sql
+-- Expand-only sending-protection policy authority. Runtime behavior remains disabled.
+
+CREATE TABLE IF NOT EXISTS sending_protection_runtime_policy (
+    singleton BOOLEAN PRIMARY KEY DEFAULT true CHECK (singleton),
+    generation BIGINT NOT NULL CHECK (generation >= 0),
+    schema_version INTEGER NOT NULL CHECK (schema_version > 0),
+    policy JSONB NOT NULL,
+    policy_sha256 TEXT NOT NULL CHECK (policy_sha256 ~ '^[0-9a-f]{64}$'),
+    activated_at TIMESTAMPTZ NOT NULL,
+    activated_by TEXT NOT NULL CHECK (btrim(activated_by) <> '')
+);
+
+CREATE TABLE IF NOT EXISTS sending_protection_policy_events (
+    generation BIGINT PRIMARY KEY CHECK (generation > 0),
+    prior_generation BIGINT NOT NULL CHECK (prior_generation >= 0 AND prior_generation < generation),
+    prior_policy_sha256 TEXT NOT NULL CHECK (prior_policy_sha256 ~ '^[0-9a-f]{64}$'),
+    new_policy_sha256 TEXT NOT NULL CHECK (new_policy_sha256 ~ '^[0-9a-f]{64}$'),
+    actor TEXT NOT NULL CHECK (btrim(actor) <> ''),
+    reason TEXT NOT NULL CHECK (btrim(reason) <> ''),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS sending_protection_runtime_attestation (
+    singleton BOOLEAN PRIMARY KEY DEFAULT true CHECK (singleton),
+    revision BIGINT NOT NULL CHECK (revision >= 0),
+    active_billing_digest TEXT NOT NULL,
+    active_billing_contract INTEGER NOT NULL CHECK (active_billing_contract >= 0),
+    rollback_billing_digest TEXT NOT NULL,
+    rollback_billing_contract INTEGER NOT NULL CHECK (rollback_billing_contract >= 0),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_by TEXT NOT NULL CHECK (btrim(updated_by) <> '')
+);
+
+CREATE TABLE IF NOT EXISTS sending_operator_recipient_versions (
+    logical_version INTEGER PRIMARY KEY CHECK (logical_version > 0),
+    commitment_key_id TEXT NOT NULL CHECK (commitment_key_id ~ '^[0-9a-f]{64}$'),
+    recipient_commitment TEXT NOT NULL CHECK (recipient_commitment ~ '^[0-9a-f]{64}$'),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    created_by TEXT NOT NULL CHECK (btrim(created_by) <> '')
+);
+
+CREATE OR REPLACE FUNCTION reject_sending_operator_recipient_version_mutation()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    RAISE EXCEPTION 'sending operator recipient versions are append-only';
+END
+$$;
+
+DROP TRIGGER IF EXISTS sending_operator_recipient_versions_append_only ON sending_operator_recipient_versions;
+CREATE TRIGGER sending_operator_recipient_versions_append_only
+BEFORE UPDATE OR DELETE ON sending_operator_recipient_versions
+FOR EACH ROW EXECUTE FUNCTION reject_sending_operator_recipient_version_mutation();
+
+DROP TRIGGER IF EXISTS sending_operator_recipient_versions_reject_truncate ON sending_operator_recipient_versions;
+CREATE TRIGGER sending_operator_recipient_versions_reject_truncate
+BEFORE TRUNCATE ON sending_operator_recipient_versions
+FOR EACH STATEMENT EXECUTE FUNCTION reject_sending_operator_recipient_version_mutation();
+
+CREATE TABLE IF NOT EXISTS sending_ramp_grandfathering (
+    singleton BOOLEAN PRIMARY KEY DEFAULT true CHECK (singleton),
+    policy_generation BIGINT NOT NULL CHECK (policy_generation >= 0),
+    completed_at TIMESTAMPTZ NOT NULL,
+    completed_by TEXT NOT NULL CHECK (btrim(completed_by) <> '')
+);
+
+INSERT INTO sending_protection_runtime_policy
+    (singleton, generation, schema_version, policy, policy_sha256, activated_at, activated_by)
+VALUES (
+    true,
+    0,
+    1,
+    '{"all_customer_global_daily_recipients":5000,"bounce_min_outcomes":50,"bounce_pause_basis_points":400,"budget_hold_max_days":7,"budget_mode":"disabled","complaint_pause_basis_points":8,"critical_operational_daily_recipients":100,"daily_unlimited_plan_codes":["starter","pro","scale"],"default_account_daily_recipients":100,"detector_interval_seconds":300,"detector_mode":"disabled","detector_window_days":7,"operator_notice_recipient_version":1,"probation_global_daily_recipients":150,"ramp_days":30,"ramp_enabled":false,"ramp_start_daily":150,"ramp_target_daily":2000,"sending_control_audit_retention_days":90,"sending_feedback_post_account_retention_days":30,"shared_domain_account_daily_recipients":50,"shared_reputation_bounce_min_outcomes":1,"tenant_header_canary_account_ids":[],"tenant_header_mode":"disabled","tenant_provisioning_mode":"disabled","tenant_suppression_sync_mode":"disabled","violation_operational_daily_recipients":100}'::jsonb,
+    '198d8cfb3220b6094a3b8dfe13cb0e2ff97c512ad87ae14609e580ae335c9ce6',
+    now(),
+    'migration'
+)
+ON CONFLICT (singleton) DO NOTHING;
+
+INSERT INTO sending_protection_runtime_attestation
+    (singleton, revision, active_billing_digest, active_billing_contract,
+     rollback_billing_digest, rollback_billing_contract, updated_by)
+VALUES (true, 0, '', 0, '', 0, 'migration')
+ON CONFLICT (singleton) DO NOTHING;

--- a/migrations/110_sending_budget_ledger.sql
+++ b/migrations/110_sending_budget_ledger.sql
@@ -1,0 +1,440 @@
+-- 110_sending_budget_ledger.sql
+-- Expand-only account controls, provider-operation/budget ledger, and notice outbox.
+
+-- Freeze the exact pre-migration legacy River inventory before any per-kind
+-- statement runs. This snapshot deliberately takes no River row locks: source
+-- deletion paths lock account-owned rows before cancelling jobs, so attribution
+-- must finish locking sources before it locks this fixed set of jobs. Jobs
+-- committed after this statement remain old-format for the B6/B7 resolver.
+DO $$
+BEGIN
+    IF to_regclass('public.river_job') IS NULL THEN
+        RETURN;
+    END IF;
+
+    CREATE TEMP TABLE sending_protection_legacy_job_targets (
+        job_id BIGINT PRIMARY KEY,
+        captured_kind TEXT NOT NULL,
+        captured_args JSONB
+    ) ON COMMIT DROP;
+
+    EXECUTE $sql$
+        INSERT INTO sending_protection_legacy_job_targets
+            (job_id, captured_kind, captured_args)
+        SELECT job.id, job.kind::text, job.args
+        FROM river_job AS job
+        WHERE job.kind IN ('outbound_send', 'hitl_notify', 'webhook_notify')
+          AND NOT COALESCE(job.args ? 'operation_ref', false)
+    $sql$;
+END
+$$;
+
+CREATE TABLE IF NOT EXISTS account_sending_controls (
+    user_id TEXT PRIMARY KEY,
+    state TEXT NOT NULL DEFAULT 'active' CHECK (state IN ('active', 'paused')),
+    reason TEXT NOT NULL DEFAULT '',
+    actor TEXT NOT NULL DEFAULT '',
+    outcome_epoch BIGINT NOT NULL DEFAULT 1 CHECK (outcome_epoch > 0),
+    ses_tenant_name TEXT NOT NULL DEFAULT '',
+    ses_tenant_ready BOOLEAN NOT NULL DEFAULT false,
+    ses_tenant_ready_at TIMESTAMPTZ,
+    last_resumed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (ses_tenant_ready OR ses_tenant_ready_at IS NULL)
+);
+
+INSERT INTO account_sending_controls (user_id)
+SELECT id FROM users
+ON CONFLICT (user_id) DO NOTHING;
+
+CREATE INDEX IF NOT EXISTS account_sending_controls_active_scan_idx
+    ON account_sending_controls (updated_at, user_id)
+    WHERE state = 'active';
+
+CREATE TABLE IF NOT EXISTS account_sending_control_events (
+    id TEXT PRIMARY KEY,
+    account_ref TEXT NOT NULL CHECK (btrim(account_ref) <> ''),
+    old_state TEXT NOT NULL CHECK (old_state IN ('active', 'paused')),
+    new_state TEXT NOT NULL CHECK (new_state IN ('active', 'paused')),
+    reason TEXT NOT NULL CHECK (btrim(reason) <> ''),
+    actor TEXT NOT NULL CHECK (btrim(actor) <> ''),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at TIMESTAMPTZ NOT NULL,
+    CHECK (expires_at > created_at)
+);
+
+CREATE TABLE IF NOT EXISTS sending_provider_operations (
+    operation_id TEXT PRIMARY KEY CHECK (btrim(operation_id) <> ''),
+    source_account_ref TEXT,
+    policy_subject_ref TEXT NOT NULL CHECK (btrim(policy_subject_ref) <> ''),
+    purpose TEXT NOT NULL CHECK (purpose IN (
+        'customer_message', 'customer_notification', 'critical_operational',
+        'violation_operational', 'public_feedback_notification', 'trusted_system'
+    )),
+    shared_reputation BOOLEAN NOT NULL DEFAULT false,
+    current_attempt INTEGER NOT NULL DEFAULT 1 CHECK (current_attempt > 0),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS sending_budget_counters (
+    scope TEXT NOT NULL CHECK (scope IN (
+        'account_daily', 'account_shared_daily', 'global_probation',
+        'global_all', 'global_critical', 'global_violation'
+    )),
+    scope_id TEXT NOT NULL CHECK (btrim(scope_id) <> ''),
+    day DATE NOT NULL,
+    reserved_count INTEGER NOT NULL DEFAULT 0 CHECK (reserved_count >= 0),
+    confirmed_count INTEGER NOT NULL DEFAULT 0
+        CHECK (confirmed_count >= 0 AND confirmed_count <= reserved_count),
+    daily_limit INTEGER NOT NULL CHECK (daily_limit > 0),
+    PRIMARY KEY (scope, scope_id, day)
+);
+
+CREATE TABLE IF NOT EXISTS sending_budget_reservations (
+    operation_id TEXT NOT NULL CHECK (btrim(operation_id) <> ''),
+    submission_attempt INTEGER NOT NULL CHECK (submission_attempt > 0),
+    source_account_ref TEXT,
+    policy_subject_ref TEXT NOT NULL CHECK (btrim(policy_subject_ref) <> ''),
+    purpose TEXT NOT NULL CHECK (purpose IN (
+        'customer_message', 'customer_notification', 'critical_operational',
+        'violation_operational', 'public_feedback_notification', 'trusted_system'
+    )),
+    day DATE NOT NULL,
+    units INTEGER NOT NULL CHECK (units > 0),
+    probation BOOLEAN NOT NULL,
+    state TEXT NOT NULL CHECK (state IN ('reserved', 'confirmed', 'released')),
+    call_state TEXT NOT NULL DEFAULT 'none'
+        CHECK (call_state IN ('none', 'authorized', 'started')),
+    authorization_nonce TEXT,
+    notice_recipient_version INTEGER
+        CHECK (notice_recipient_version IS NULL OR notice_recipient_version > 0),
+    notice_recipient_commitment BYTEA,
+    provider_call_started_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at TIMESTAMPTZ NOT NULL DEFAULT now() + interval '30 days',
+    CHECK ((state = 'confirmed') = (call_state IN ('authorized', 'started'))),
+    CHECK ((call_state = 'none') = (authorization_nonce IS NULL)),
+    CHECK ((notice_recipient_version IS NULL) = (notice_recipient_commitment IS NULL)),
+    CHECK ((call_state = 'started') = (provider_call_started_at IS NOT NULL)),
+    PRIMARY KEY (operation_id, submission_attempt)
+);
+
+CREATE INDEX IF NOT EXISTS sending_budget_reservations_expiry_idx
+    ON sending_budget_reservations (expires_at, operation_id, submission_attempt);
+
+CREATE TABLE IF NOT EXISTS sending_protection_notice_events (
+    id TEXT PRIMARY KEY,
+    account_ref TEXT,
+    kind TEXT NOT NULL CHECK (kind IN ('pause', 'budget_violation', 'global_guardrail')),
+    reason_code TEXT NOT NULL CHECK (reason_code IN (
+        'detector_bounce', 'detector_complaint', 'ses_reputation',
+        'manual', 'budget_limit', 'global_budget_exhausted'
+    )),
+    budget_scope TEXT,
+    ledger_day DATE,
+    source_event_id TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at TIMESTAMPTZ NOT NULL,
+    CHECK (expires_at > created_at),
+    CHECK (
+        (kind = 'pause'
+            AND source_event_id IS NOT NULL
+            AND budget_scope IS NULL
+            AND ledger_day IS NULL
+            AND account_ref IS NOT NULL
+            AND reason_code NOT IN ('budget_limit', 'global_budget_exhausted'))
+        OR
+        (kind = 'budget_violation'
+            AND source_event_id IS NULL
+            AND account_ref IS NOT NULL
+            AND budget_scope IN ('account_daily', 'account_shared_daily')
+            AND ledger_day IS NOT NULL
+            AND reason_code = 'budget_limit')
+        OR
+        (kind = 'global_guardrail'
+            AND source_event_id IS NULL
+            AND account_ref IS NULL
+            AND budget_scope IN ('global_probation', 'global_all')
+            AND ledger_day IS NOT NULL
+            AND reason_code = 'global_budget_exhausted')
+    ),
+    UNIQUE (kind, source_event_id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS sending_protection_notice_account_budget_uniq
+    ON sending_protection_notice_events (account_ref, budget_scope, ledger_day)
+    WHERE kind = 'budget_violation';
+
+CREATE UNIQUE INDEX IF NOT EXISTS sending_protection_notice_global_guardrail_uniq
+    ON sending_protection_notice_events (budget_scope, ledger_day)
+    WHERE kind = 'global_guardrail';
+
+CREATE INDEX IF NOT EXISTS sending_protection_notice_deadline_idx
+    ON sending_protection_notice_events (created_at, id);
+
+CREATE TABLE IF NOT EXISTS sending_protection_notice_deliveries (
+    event_id TEXT NOT NULL REFERENCES sending_protection_notice_events(id) ON DELETE CASCADE,
+    audience TEXT NOT NULL CHECK (audience IN ('owner', 'operator')),
+    delivery_attempt INTEGER NOT NULL DEFAULT 0 CHECK (delivery_attempt >= 0),
+    current_operation_id TEXT UNIQUE,
+    state TEXT NOT NULL DEFAULT 'pending'
+        CHECK (state IN ('pending', 'sent', 'failed', 'skipped_account_deleted')),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (event_id, audience)
+);
+
+CREATE INDEX IF NOT EXISTS sending_protection_notice_pending_idx
+    ON sending_protection_notice_deliveries (updated_at, event_id, audience)
+    WHERE state = 'pending';
+
+INSERT INTO message_lifecycle_reason_codes (code, stage, outcome, retryable)
+VALUES
+    ('submission.policy_budget_expired', 'submission', 'failed', false),
+    ('submission.sending_setup_expired', 'submission', 'failed', false)
+ON CONFLICT (code) DO NOTHING;
+
+DO $$
+DECLARE
+    drifted_code TEXT;
+BEGIN
+    SELECT expected.code
+    INTO drifted_code
+    FROM (VALUES
+        ('submission.policy_budget_expired', 'submission', 'failed', false),
+        ('submission.sending_setup_expired', 'submission', 'failed', false)
+    ) AS expected(code, stage, outcome, retryable)
+    LEFT JOIN message_lifecycle_reason_codes AS actual
+      ON actual.code = expected.code
+     AND actual.stage = expected.stage
+     AND actual.outcome = expected.outcome
+     AND actual.retryable = expected.retryable
+    WHERE actual.code IS NULL
+    ORDER BY expected.code
+    LIMIT 1;
+
+    IF drifted_code IS NOT NULL THEN
+        RAISE EXCEPTION 'message lifecycle catalog mismatch for code %', drifted_code;
+    END IF;
+END
+$$;
+
+-- Snapshot migration for the exact three legacy provider-bound River job shapes.
+-- Existing source fields remain in args so pre-floor rollback readers stay compatible.
+DO $$
+BEGIN
+    IF to_regclass('public.river_job') IS NULL THEN
+        RETURN;
+    END IF;
+
+    -- Resolve source identities from the fixed args snapshot without touching
+    -- River rows. Agent rows are locked before their messages, matching the
+    -- irreversible deletion path; message identity/direction is then rechecked
+    -- under lock before any attribution is retained.
+    CREATE TEMP TABLE sending_protection_message_candidates (
+        job_id BIGINT PRIMARY KEY,
+        captured_kind TEXT NOT NULL,
+        message_id TEXT NOT NULL,
+        agent_id TEXT NOT NULL
+    ) ON COMMIT DROP;
+
+    INSERT INTO sending_protection_message_candidates
+        (job_id, captured_kind, message_id, agent_id)
+    SELECT target.job_id, target.captured_kind,
+           target.captured_args->>'message_id', message.agent_id
+    FROM sending_protection_legacy_job_targets AS target
+    JOIN messages AS message
+      ON message.id = target.captured_args->>'message_id'
+    WHERE target.captured_kind IN ('outbound_send', 'hitl_notify')
+      AND COALESCE(target.captured_args->>'message_id', '') <> '';
+
+    CREATE TEMP TABLE sending_protection_locked_agents (
+        agent_id TEXT PRIMARY KEY,
+        user_id TEXT NOT NULL
+    ) ON COMMIT DROP;
+
+    WITH wanted_agents AS MATERIALIZED (
+        SELECT DISTINCT agent_id
+        FROM sending_protection_message_candidates
+    ), locked_agents AS MATERIALIZED (
+        SELECT agent.id, agent.user_id
+        FROM wanted_agents AS wanted
+        JOIN agent_identities AS agent ON agent.id = wanted.agent_id
+        ORDER BY agent.id
+        FOR UPDATE OF agent
+    )
+    INSERT INTO sending_protection_locked_agents (agent_id, user_id)
+    SELECT id, user_id FROM locked_agents;
+
+    CREATE TEMP TABLE sending_protection_valid_sources (
+        job_id BIGINT PRIMARY KEY,
+        operation_id TEXT NOT NULL,
+        source_account_ref TEXT NOT NULL,
+        policy_subject_ref TEXT NOT NULL,
+        purpose TEXT NOT NULL,
+        shared_reputation BOOLEAN NOT NULL,
+        source_scheduled_at TIMESTAMPTZ
+    ) ON COMMIT DROP;
+
+    WITH locked_messages AS MATERIALIZED (
+        SELECT candidate.job_id,
+               candidate.captured_kind,
+               message.id AS message_id,
+               agent.user_id,
+               message.sent_as,
+               message.scheduled_at
+        FROM sending_protection_message_candidates AS candidate
+        JOIN sending_protection_locked_agents AS agent
+          ON agent.agent_id = candidate.agent_id
+        JOIN messages AS message
+          ON message.id = candidate.message_id
+         AND message.agent_id = candidate.agent_id
+        WHERE message.direction = 'outbound'
+          AND (
+              (candidate.captured_kind = 'outbound_send'
+                  AND message.sent_as IN ('relay', 'own_address'))
+              OR candidate.captured_kind = 'hitl_notify'
+          )
+        ORDER BY message.id, candidate.job_id
+        FOR UPDATE OF message
+    )
+    INSERT INTO sending_protection_valid_sources
+        (job_id, operation_id, source_account_ref, policy_subject_ref,
+         purpose, shared_reputation, source_scheduled_at)
+    SELECT job_id,
+           CASE captured_kind
+               WHEN 'outbound_send' THEN message_id
+               ELSE 'op_' || md5('hitl_notify:' || job_id::text)
+           END,
+           user_id,
+           user_id,
+           CASE captured_kind
+               WHEN 'outbound_send' THEN 'customer_message'
+               ELSE 'customer_notification'
+           END,
+           CASE captured_kind
+               WHEN 'outbound_send' THEN sent_as = 'relay'
+               ELSE true
+           END,
+           scheduled_at
+    FROM locked_messages;
+
+    -- Webhook ownership is likewise retained under its source-row lock before
+    -- the corresponding River job is touched.
+    WITH locked_webhooks AS MATERIALIZED (
+        SELECT target.job_id, webhook.user_id
+        FROM sending_protection_legacy_job_targets AS target
+        JOIN webhooks AS webhook
+          ON webhook.id = target.captured_args->>'webhook_id'
+        WHERE target.captured_kind = 'webhook_notify'
+          AND COALESCE(target.captured_args->>'webhook_id', '') <> ''
+          AND target.captured_args->>'kind' IN ('warning', 'disabled')
+        ORDER BY webhook.id, target.job_id
+        FOR UPDATE OF webhook
+    )
+    INSERT INTO sending_protection_valid_sources
+        (job_id, operation_id, source_account_ref, policy_subject_ref,
+         purpose, shared_reputation, source_scheduled_at)
+    SELECT job_id,
+           'op_' || md5('webhook_notify:' || job_id::text),
+           user_id,
+           user_id,
+           'customer_notification',
+           true,
+           NULL
+    FROM locked_webhooks;
+
+    -- Only after all valid sources are locked do we lock the fixed inventory.
+    -- Capturing the current tuple under lock lets every later write prove that
+    -- kind and args are still exactly the migration-start tuple.
+    CREATE TEMP TABLE sending_protection_locked_jobs (
+        job_id BIGINT PRIMARY KEY,
+        current_kind TEXT NOT NULL,
+        current_args JSONB,
+        current_scheduled_at TIMESTAMPTZ,
+        current_state TEXT NOT NULL
+    ) ON COMMIT DROP;
+
+    EXECUTE $sql$
+        WITH locked_jobs AS MATERIALIZED (
+            SELECT job.id, job.kind::text AS kind, job.args,
+                   job.scheduled_at, job.state::text AS state
+            FROM sending_protection_legacy_job_targets AS target
+            JOIN river_job AS job ON job.id = target.job_id
+            ORDER BY job.id
+            FOR UPDATE OF job
+        )
+        INSERT INTO sending_protection_locked_jobs
+            (job_id, current_kind, current_args, current_scheduled_at, current_state)
+        SELECT id, kind, args, scheduled_at, state FROM locked_jobs
+    $sql$;
+
+    INSERT INTO sending_provider_operations
+        (operation_id, source_account_ref, policy_subject_ref,
+         purpose, shared_reputation, expires_at)
+    SELECT DISTINCT ON (source.operation_id)
+           source.operation_id,
+           source.source_account_ref,
+           source.policy_subject_ref,
+           source.purpose,
+           source.shared_reputation,
+           GREATEST(
+               transaction_timestamp(),
+               COALESCE(source.source_scheduled_at, '-infinity'::timestamptz),
+               COALESCE(job.current_scheduled_at, '-infinity'::timestamptz)
+           ) + interval '30 days'
+    FROM sending_protection_valid_sources AS source
+    JOIN sending_protection_locked_jobs AS job ON job.job_id = source.job_id
+    JOIN sending_protection_legacy_job_targets AS target ON target.job_id = job.job_id
+    WHERE job.current_kind = target.captured_kind
+      AND job.current_args IS NOT DISTINCT FROM target.captured_args
+      AND NOT COALESCE(job.current_args ? 'operation_ref', false)
+    ORDER BY source.operation_id,
+             GREATEST(
+                 transaction_timestamp(),
+                 COALESCE(source.source_scheduled_at, '-infinity'::timestamptz),
+                 COALESCE(job.current_scheduled_at, '-infinity'::timestamptz)
+             ) DESC,
+             source.job_id
+    ON CONFLICT (operation_id) DO NOTHING;
+
+    EXECUTE $sql$
+        UPDATE river_job AS job
+        SET args = job.args || jsonb_build_object(
+            'operation_ref', jsonb_build_object('v', 1, 'id', source.operation_id))
+        FROM sending_protection_legacy_job_targets AS target,
+             sending_protection_locked_jobs AS locked,
+             sending_protection_valid_sources AS source,
+             sending_provider_operations AS operation
+        WHERE job.id = target.job_id
+          AND locked.job_id = job.id
+          AND source.job_id = job.id
+          AND job.kind::text = locked.current_kind
+          AND job.args IS NOT DISTINCT FROM locked.current_args
+          AND locked.current_kind = target.captured_kind
+          AND locked.current_args IS NOT DISTINCT FROM target.captured_args
+          AND NOT COALESCE(job.args ? 'operation_ref', false)
+          AND operation.operation_id = source.operation_id
+          AND operation.source_account_ref IS NOT DISTINCT FROM source.source_account_ref
+          AND operation.policy_subject_ref = source.policy_subject_ref
+          AND operation.purpose = source.purpose
+          AND operation.shared_reputation = source.shared_reputation
+    $sql$;
+
+    -- A snapshot-time job without a valid immutable source cannot be authorized.
+    -- Running jobs are intentionally left for the B6/B7 compatibility resolver.
+    EXECUTE $sql$
+        UPDATE river_job AS job
+        SET state = 'discarded', finalized_at = now()
+        FROM sending_protection_legacy_job_targets AS target,
+             sending_protection_locked_jobs AS locked
+        WHERE job.id = target.job_id
+          AND locked.job_id = job.id
+          AND job.kind::text = locked.current_kind
+          AND job.args IS NOT DISTINCT FROM locked.current_args
+          AND job.kind IN ('outbound_send', 'hitl_notify', 'webhook_notify')
+          AND NOT COALESCE(job.args ? 'operation_ref', false)
+          AND job.state::text IN ('available', 'retryable', 'scheduled', 'pending')
+    $sql$;
+END
+$$;

--- a/migrations/111_sending_feedback_provenance.sql
+++ b/migrations/111_sending_feedback_provenance.sql
@@ -1,0 +1,87 @@
+-- 111_sending_feedback_provenance.sql
+-- Deletion-resistant provider-feedback attribution and detector aggregates.
+
+CREATE TABLE IF NOT EXISTS sending_feedback_correlations (
+    correlation_id TEXT PRIMARY KEY CHECK (btrim(correlation_id) <> ''),
+    operation_id TEXT NOT NULL CHECK (btrim(operation_id) <> ''),
+    submission_attempt INTEGER NOT NULL CHECK (submission_attempt > 0),
+    source_account_ref TEXT,
+    policy_subject_ref TEXT NOT NULL CHECK (btrim(policy_subject_ref) <> ''),
+    purpose TEXT NOT NULL CHECK (purpose IN (
+        'customer_message', 'customer_notification', 'critical_operational',
+        'violation_operational', 'public_feedback_notification', 'trusted_system'
+    )),
+    shared_reputation BOOLEAN NOT NULL DEFAULT false,
+    tenant_mode TEXT NOT NULL CHECK (tenant_mode IN ('none', 'required')),
+    provider_message_id TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at TIMESTAMPTZ,
+    UNIQUE (operation_id, submission_attempt)
+);
+
+CREATE INDEX IF NOT EXISTS sending_feedback_correlations_provider_message_idx
+    ON sending_feedback_correlations (provider_message_id)
+    WHERE provider_message_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS sending_feedback_correlations_account_retention_idx
+    ON sending_feedback_correlations (source_account_ref, expires_at, created_at)
+    WHERE source_account_ref IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS sending_feedback_recipients (
+    correlation_id TEXT NOT NULL CHECK (btrim(correlation_id) <> ''),
+    recipient_hmac BYTEA NOT NULL,
+    hmac_key_version INTEGER NOT NULL CHECK (hmac_key_version > 0),
+    detector_bucket TEXT NOT NULL DEFAULT 'none'
+        CHECK (detector_bucket IN (
+            'none', 'delivered', 'terminal_other', 'hard_bounce', 'complaint'
+        )),
+    evidence_rank INTEGER NOT NULL DEFAULT 0 CHECK (evidence_rank BETWEEN 0 AND 4),
+    provider_occurred_at TIMESTAMPTZ,
+    evidence_event_id TEXT,
+    bucket_epoch BIGINT CHECK (bucket_epoch IS NULL OR bucket_epoch > 0),
+    bucket_day DATE,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK ((bucket_epoch IS NULL) = (bucket_day IS NULL)),
+    PRIMARY KEY (correlation_id, recipient_hmac)
+);
+
+CREATE TABLE IF NOT EXISTS sending_feedback_events (
+    provider_event_id TEXT PRIMARY KEY CHECK (btrim(provider_event_id) <> ''),
+    correlation_id TEXT NOT NULL CHECK (btrim(correlation_id) <> ''),
+    provider_occurred_at TIMESTAMPTZ NOT NULL,
+    received_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS account_sending_outcomes_daily (
+    user_id TEXT NOT NULL,
+    outcome_epoch BIGINT NOT NULL CHECK (outcome_epoch > 0),
+    day DATE NOT NULL,
+    shared_reputation BOOLEAN NOT NULL,
+    delivered_count INTEGER NOT NULL DEFAULT 0 CHECK (delivered_count >= 0),
+    terminal_other_count INTEGER NOT NULL DEFAULT 0 CHECK (terminal_other_count >= 0),
+    hard_bounce_count INTEGER NOT NULL DEFAULT 0 CHECK (hard_bounce_count >= 0),
+    complaint_count INTEGER NOT NULL DEFAULT 0 CHECK (complaint_count >= 0),
+    PRIMARY KEY (user_id, outcome_epoch, day, shared_reputation)
+);
+
+CREATE INDEX IF NOT EXISTS account_sending_outcomes_daily_scan_idx
+    ON account_sending_outcomes_daily (user_id, outcome_epoch, day, shared_reputation);
+
+-- Bound the account-owned aggregate FK independently from all hot-table
+-- metadata changes.
+SET LOCAL lock_timeout = '2s';
+
+-- Keep the FK's SHARE ROW EXCLUSIVE parent/child locks within the bounded tail.
+LOCK TABLE users IN SHARE ROW EXCLUSIVE MODE;
+LOCK TABLE account_sending_outcomes_daily IN SHARE ROW EXCLUSIVE MODE;
+
+DO $$
+BEGIN
+    ALTER TABLE account_sending_outcomes_daily
+        ADD CONSTRAINT account_sending_outcomes_daily_user_id_fkey
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE NOT VALID;
+EXCEPTION WHEN duplicate_object THEN
+    NULL;
+END
+$$;

--- a/migrations/112_sending_controls_foreign_key.sql
+++ b/migrations/112_sending_controls_foreign_key.sql
@@ -1,0 +1,27 @@
+-- 112_sending_controls_foreign_key.sql
+--
+-- Install the controls ownership FK in a source-free transaction. Migration
+-- 110 may retain legacy agent/message/webhook rows while it rewrites River
+-- jobs, so requesting a users table lock there would invert account deletion's
+-- users-to-cascade-source order. The bootstrap already ran in 110; remove only
+-- users deleted before this transaction makes new writes enforce the FK.
+
+SET LOCAL lock_timeout = '2s';
+
+LOCK TABLE users IN SHARE ROW EXCLUSIVE MODE;
+LOCK TABLE account_sending_controls IN SHARE ROW EXCLUSIVE MODE;
+
+DELETE FROM account_sending_controls AS controls
+WHERE NOT EXISTS (
+    SELECT 1 FROM users WHERE users.id = controls.user_id
+);
+
+DO $$
+BEGIN
+    ALTER TABLE account_sending_controls
+        ADD CONSTRAINT account_sending_controls_user_id_fkey
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE NOT VALID;
+EXCEPTION WHEN duplicate_object THEN
+    NULL;
+END
+$$;

--- a/migrations/113_sending_message_holds.sql
+++ b/migrations/113_sending_message_holds.sql
@@ -1,0 +1,23 @@
+-- 113_sending_message_holds.sql
+--
+-- Keep this bounded transaction limited to the unavoidable messages metadata
+-- lock. It follows the account FK transactions so it cannot invert the
+-- messages-to-users order used by irreversible account deletion.
+
+SET LOCAL lock_timeout = '2s';
+
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS local_hold_class TEXT;
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS local_hold_anchor TIMESTAMPTZ;
+
+DO $$
+BEGIN
+    ALTER TABLE messages ADD CONSTRAINT messages_local_hold_check CHECK (
+        (local_hold_class IS NULL AND local_hold_anchor IS NULL)
+        OR
+        (local_hold_class IN ('rate_ramp_or_provider', 'tenant_setup', 'policy_budget')
+            AND local_hold_anchor IS NOT NULL)
+    ) NOT VALID;
+EXCEPTION WHEN duplicate_object THEN
+    NULL;
+END
+$$;

--- a/migrations/114_sending_suppression_provenance.sql
+++ b/migrations/114_sending_suppression_provenance.sql
@@ -1,0 +1,21 @@
+-- 114_sending_suppression_provenance.sql
+--
+-- Keep this bounded transaction limited to the unavoidable suppressions
+-- metadata lock. Safe defaults preserve the pre-sync local DELETE path; this
+-- migration never contacts SES or changes existing local suppression behavior.
+
+SET LOCAL lock_timeout = '2s';
+
+ALTER TABLE suppressions
+    ADD COLUMN IF NOT EXISTS sync_generation BIGINT NOT NULL DEFAULT 1;
+
+ALTER TABLE suppressions
+    ADD COLUMN IF NOT EXISTS removal_pending BOOLEAN NOT NULL DEFAULT false;
+
+DO $$
+BEGIN
+    ALTER TABLE suppressions ADD CONSTRAINT suppressions_sync_generation_check
+        CHECK (sync_generation > 0) NOT VALID;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END
+$$;

--- a/migrations/115_sending_protection_validate_constraints.sql
+++ b/migrations/115_sending_protection_validate_constraints.sql
@@ -1,0 +1,21 @@
+-- 115_sending_protection_validate_constraints.sql
+--
+-- Validate the hot-table CHECKs and account FKs only after the migrations that
+-- install them have committed. VALIDATE CONSTRAINT uses the weaker SHARE UPDATE
+-- EXCLUSIVE lock, which remains compatible with ordinary
+-- SELECT/INSERT/UPDATE/DELETE traffic. Bound acquisition in case another DDL or
+-- maintenance operation already holds an incompatible lock.
+
+SET LOCAL lock_timeout = '2s';
+
+ALTER TABLE messages
+    VALIDATE CONSTRAINT messages_local_hold_check;
+
+ALTER TABLE suppressions
+    VALIDATE CONSTRAINT suppressions_sync_generation_check;
+
+ALTER TABLE account_sending_controls
+    VALIDATE CONSTRAINT account_sending_controls_user_id_fkey;
+
+ALTER TABLE account_sending_outcomes_daily
+    VALIDATE CONSTRAINT account_sending_outcomes_daily_user_id_fkey;


### PR DESCRIPTION
## Summary

- Add the dormant database foundation for hosted sending-abuse protection: generation-zero policy and attestation state, account controls and audit history, provider-operation and budget ledgers, notice outbox, feedback provenance, and suppression metadata.
- Migrate eligible legacy River send/notification jobs to immutable operation references while retaining their legacy fields for old-worker compatibility. Malformed or orphaned claimable jobs fail closed; jobs created after the migration snapshot remain for the later compatibility resolver.
- Keep this slice schema-only. It adds no API, runtime enforcement, provider calls, customer-visible limits, or production activation.

## Operational risk

These migrations run during server startup and may inspect or rewrite queued legacy jobs. The data pass uses a fixed snapshot, locks source rows before River jobs, and isolates account foreign keys plus messages/suppressions metadata into separately tracked transactions. Strong metadata locks have a two-second acquisition bound; constraint validation is deferred to a DML-compatible transaction. The schema is expand-only and old binaries ignore the additive operation reference, so rollback remains compatible.

Migrations 109-115 are owned by this slice. The later tenant and provider-suppression migrations begin at 116/117.

## Test plan

- [x] Focused PostgreSQL schema, idempotence, deletion-retention, append-only, legacy-attribution, late-snapshot, and test-harness cleanup tests
- [x] Deterministic PostgreSQL regressions for source-first River cancellation and concurrent account deletion across outbound and webhook legacy jobs
- [x] Bounded-lock and ordinary-DML-compatible constraint validation tests
- [x] make test-unit
- [x] make test-integration
- [x] Independent task/design, consistency, and concurrency/data-integrity reviews
- [x] Public-data boundary and diff checks

No client surface changes apply to this schema-only slice.