### PR TITLE
feat(web): hosted-gated Pricing link in the landing nav

### DIFF
--- a/web/src/app/page.pricing-nav.hosted.test.tsx
+++ b/web/src/app/page.pricing-nav.hosted.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * Hosted-build branch of the nav Pricing link: NEXT_PUBLIC_PRICING_PATH is
+ * inlined at build time and read at module load (lib/site.PRICING_PATH), so
+ * this file sets the env BEFORE importing the page. The unset/self-host
+ * branch (no Pricing link at all) is asserted in page.test.tsx, where jest
+ * runs with the env var absent.
+ */
+process.env.NEXT_PUBLIC_PRICING_PATH = "/pricing";
+
+import { render, screen } from "@testing-library/react";
+import Home from "./page";
+
+jest.mock("next/link", () => {
+  return function MockLink({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) {
+    return (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    );
+  };
+});
+
+jest.mock("./components/AuthProvider", () => ({
+  useAuth: () => ({ user: null, loading: false, signOut: jest.fn() }),
+}));
+
+describe("nav Pricing link (hosted build)", () => {
+  it("renders and targets the configured path", () => {
+    render(<Home />);
+    const link = screen.getByRole("link", { name: "Pricing" });
+    expect(link).toHaveAttribute("href", "/pricing");
+    // Same-site navigation: unlike the Resources links, Pricing must NOT
+    // open a new tab.
+    expect(link).not.toHaveAttribute("target");
+  });
+});

--- a/web/src/app/page.test.tsx
+++ b/web/src/app/page.test.tsx
@@ -74,6 +74,15 @@ describe("Landing page", () => {
     expect(screen.getAllByText("e2a").length).toBeGreaterThan(0);
   });
 
+  // Self-host builds have no /pricing route (lib/site.PRICING_PATH is unset
+  // in jest, matching a build without NEXT_PUBLIC_PRICING_PATH), so the nav
+  // must render no Pricing link rather than a 404. The hosted branch is
+  // covered in page.pricing-nav.hosted.test.tsx.
+  it("renders no Pricing link when no pricing path is configured", () => {
+    render(<Home />);
+    expect(screen.queryByRole("link", { name: "Pricing" })).toBeNull();
+  });
+
   // The nav groups into Quick start / Product / Resources — a flat row of
   // every link wrapped onto two lines once the social icons joined it.
   it("shows resources dropdown items on hover", () => {

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -7,7 +7,7 @@ import { Eyebrow } from "@e2a/ui";
 import { JsonLd } from "./components/JsonLd";
 import { TokenCanopyBadge } from "./components/loft/TokenCanopyBadge";
 import { faqPage, type FaqEntry } from "../lib/jsonld";
-import { SIGN_IN_URL } from "../lib/site";
+import { PRICING_PATH, SIGN_IN_URL } from "../lib/site";
 
 // Agent onboarding surfaces: install the plugin in a coding agent, or point
 // any MCP runtime at the hosted server. Application integrations use the SDK
@@ -241,6 +241,18 @@ export default function Home() {
                 Start
               </a>
               <NavMenu label="Product" items={PRODUCT_LINKS} />
+              {/* Hosted-only: /pricing is served by the deployment's proxy from
+                  outside this app (see PRICING_PATH in lib/site). Unset means
+                  no pricing page exists — render nothing rather than a 404. */}
+              {PRICING_PATH && (
+                <a
+                  href={PRICING_PATH}
+                  className="px-3 py-1.5 rounded-md transition hover:bg-[var(--bg-elev)]"
+                  style={{ color: "var(--fg-muted)" }}
+                >
+                  Pricing
+                </a>
+              )}
               <NavMenu label="Resources" items={RESOURCE_LINKS} />
               {SOCIAL_LINKS.map((s) => (
                 <a


### PR DESCRIPTION
Adds a top-level **Pricing** link to the landing page nav, between Product and Resources.

- **Hosted-gated via the existing precedent**: renders iff `NEXT_PUBLIC_PRICING_PATH` is set at build time (`lib/site.PRICING_PATH` — the same mechanism the sitemap uses, documented there: `/pricing` is served by the hosted deployment's proxy from the private ops repo; a self-host build has no such route, so unset renders nothing rather than a 404). The prod build args already set `NEXT_PUBLIC_PRICING_PATH=/pricing`, so the hosted site gets the link with no ops change.
- Styled identically to the existing `Start` anchor link; plain same-tab navigation (unlike the Resources external links).
- Tests: hosted branch (env set pre-import → link renders with the configured href, no `target`) in `page.pricing-nav.hosted.test.tsx`; self-host absence asserted in `page.test.tsx`. Full web suite: 886/886 green; lint has 0 errors (2 pre-existing warnings elsewhere).

Motivation: the pricing page currently has no inbound link from the site nav at all, and the usage-based pricing v1 launch (e2a#949, ops #340) makes it a page we actively want visitors to find. Intended to ride the v1.8.1 cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScEpytuD7GvaXEssvJ2W32