### PR TITLE
test(e2e-prod): permanently delete agent churn in the conformance suites

### DIFF
--- a/tests/e2e-prod/suites/01-basic.test.ts
+++ b/tests/e2e-prod/suites/01-basic.test.ts
@@ -87,7 +87,7 @@ test("agents: create + read + delete (slug on shared domain)", async () => {
   assert.equal(got.body?.domain_verified, true, "slug-domain agent should be auto-verified");
 
   const del = await client.delete<{ deleted: boolean; email: string; messages_deleted: number }>(
-    `/v1/agents/${encodeURIComponent(email)}?confirm=DELETE`,
+    `/v1/agents/${encodeURIComponent(email)}?confirm=DELETE&permanent=true`,
   );
   assert.equal(del.status, 200, `delete expected 200 + deletion receipt, got ${del.status}`);
   assert.equal(del.body?.deleted, true, "deletion receipt has deleted:true");

--- a/tests/e2e-prod/suites/03-concurrency.test.ts
+++ b/tests/e2e-prod/suites/03-concurrency.test.ts
@@ -177,7 +177,7 @@ test("concurrency: parallel DELETE of the same agent is idempotent under content
   assert.equal(c.status, 201);
 
   const results = await Promise.all(
-    Array.from({ length: 4 }, () => burst.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE`)),
+    Array.from({ length: 4 }, () => burst.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE&permanent=true`)),
   );
   const ok = results.filter((r) => r.status === 200 || r.status === 204);
   const fivexx = results.filter((r) => r.status >= 500);

--- a/tests/e2e-prod/suites/09-postfix.test.ts
+++ b/tests/e2e-prod/suites/09-postfix.test.ts
@@ -18,7 +18,7 @@ after(async () => {
 const MAX_CLEANUP_RETRY_MS = 2_000;
 
 async function deleteStressProbeAgent(email: string): Promise<void> {
-  const path = `/v1/agents/${encodeURIComponent(email)}?confirm=DELETE`;
+  const path = `/v1/agents/${encodeURIComponent(email)}?confirm=DELETE&permanent=true`;
   let result = await client.delete(path);
   if (result.status === 429) {
     const retryAfterSeconds = Number(result.headers["retry-after"]);

--- a/tests/e2e-prod/suites/15-quota-enforcement.test.ts
+++ b/tests/e2e-prod/suites/15-quota-enforcement.test.ts
@@ -53,7 +53,7 @@ test("quota: agent-count cap is enforced (402 limit_exceeded)", { skip }, async 
     assert.ok(created.length >= 1, "at least one create succeeded before the cap");
   } finally {
     for (const email of created) {
-      await q!.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE`);
+      await q!.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE&permanent=true`);
     }
   }
 });

--- a/tests/e2e-prod/suites/18-reviews.test.ts
+++ b/tests/e2e-prod/suites/18-reviews.test.ts
@@ -40,7 +40,7 @@ interface Page {
 }
 
 async function del(email: string): Promise<void> {
-  await client.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE`);
+  await client.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE&permanent=true`);
 }
 
 // createHeldReview: throwaway agent -> hold-all-outbound -> send. Returns the

--- a/tests/e2e-prod/suites/20-attachments.test.ts
+++ b/tests/e2e-prod/suites/20-attachments.test.ts
@@ -331,7 +331,7 @@ function pathAndQuery(absoluteUrl: string): string {
 
 after(async () => {
   for (const email of createdAgents) {
-    const del = await client.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE`);
+    const del = await client.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE&permanent=true`);
     if (!(del.status === 204 || del.status === 200)) {
       fail(SUITE, "cleanup", `failed to delete throwaway agent ${email} (got ${del.status})`, del.raw.slice(0, 200));
     }

--- a/tests/e2e-prod/suites/21-webhook-events.test.ts
+++ b/tests/e2e-prod/suites/21-webhook-events.test.ts
@@ -231,7 +231,7 @@ async function createHook(events: string[]): Promise<CreateWebhookResponse> {
 }
 
 async function delAgent(email: string): Promise<void> {
-  await client.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE`);
+  await client.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE&permanent=true`);
 }
 async function delHook(id: string): Promise<void> {
   await client.delete(`/v1/webhooks/${encodeURIComponent(id)}?confirm=DELETE`);

--- a/tests/e2e-prod/suites/24-trash-lifecycle.test.ts
+++ b/tests/e2e-prod/suites/24-trash-lifecycle.test.ts
@@ -232,6 +232,8 @@ test("agent trash lifecycle: message-held delete guard, then delete/restore the 
   const getAfterRestore = await client.get(`/v1/agents/${encodeURIComponent(email)}`);
   assert.equal(getAfterRestore.status, 200, `expected 200 after restore, got ${getAfterRestore.status}`);
 
-  // `after()` cleanup() re-trashes this tracked throwaway agent (soft
-  // delete), matching every other suite's teardown-into-trash convention.
+  // `after()` cleanup() PERMANENTLY deletes this tracked throwaway agent
+  // (harness/cleanup.ts uses ?permanent=true), so the trash rows this suite
+  // deliberately created don't outlive the run. The soft delete above stays
+  // soft on purpose — it IS the behavior under test.
 });

--- a/tests/e2e-prod/suites/28-mcp-domains-reviews.test.ts
+++ b/tests/e2e-prod/suites/28-mcp-domains-reviews.test.ts
@@ -194,7 +194,7 @@ test("mcp-domains-reviews: list_pending_messages + get_pending_message + approve
   } finally {
     // Agent delete cascades to its held/sent messages; explicit and tracked
     // regardless so a mid-test throw still gets cleaned up.
-    await apiClient.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE`);
+    await apiClient.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE&permanent=true`);
     untrack("agent", email);
   }
 });
@@ -212,7 +212,7 @@ test("mcp-domains-reviews: reject_message discards the held draft", async () => 
     const rereject = await callTool(mcp, "reject_message", { message_id: id, reason: "should fail" });
     assert.equal(rereject.isError, true, "re-reject of an already-resolved message must isError");
   } finally {
-    await apiClient.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE`);
+    await apiClient.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE&permanent=true`);
     untrack("agent", email);
   }
 });

--- a/tests/e2e-prod/suites/29-inbound-mx.test.ts
+++ b/tests/e2e-prod/suites/29-inbound-mx.test.ts
@@ -111,7 +111,7 @@ async function createAgent(label: string): Promise<string> {
   return c.body.email;
 }
 async function delAgent(email: string): Promise<void> {
-  await client.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE`);
+  await client.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE&permanent=true`);
 }
 async function createHook(events: string[]): Promise<CreateWebhookResponse> {
   const r = await client.post<CreateWebhookResponse>("/v1/webhooks", {

--- a/tests/e2e-prod/suites/prod/31-ses-feedback.test.ts
+++ b/tests/e2e-prod/suites/prod/31-ses-feedback.test.ts
@@ -134,7 +134,7 @@ async function createAgent(label: string): Promise<string> {
   return c.body.email;
 }
 async function delAgent(email: string): Promise<void> {
-  await client.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE`);
+  await client.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE&permanent=true`);
 }
 async function createHook(events: string[]): Promise<CreateWebhookResponse> {
   const r = await client.post<CreateWebhookResponse>("/v1/webhooks", {

--- a/tests/e2e-prod/suites/prod/32-loopback-inbound-protection.test.ts
+++ b/tests/e2e-prod/suites/prod/32-loopback-inbound-protection.test.ts
@@ -94,7 +94,7 @@ async function createAgent(label: string): Promise<string> {
 }
 
 async function delAgent(email: string): Promise<void> {
-  await client.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE`);
+  await client.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE&permanent=true`);
 }
 
 // pollEvent mirrors suites/21-webhook-events.test.ts's helper (kept local —

--- a/tests/e2e-prod/suites/prod/33-quota-enforcement.test.ts
+++ b/tests/e2e-prod/suites/prod/33-quota-enforcement.test.ts
@@ -103,7 +103,7 @@ test("prod quota: agent-count cap (5) is enforced with full LimitExceededDetails
     info(SUITE, "agent-cap-trip", `cap tripped after ${created.length} successful creates`);
   } finally {
     for (const email of created) {
-      const d = await q.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE`);
+      const d = await q.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE&permanent=true`);
       if (![200, 204, 404].includes(d.status)) {
         fail(SUITE, "agent-cleanup-failed", `delete agent ${email} returned ${d.status}: ${d.raw.slice(0, 200)} — MANUAL CLEANUP MAY BE NEEDED (would strand the account at cap on the next run)`);
       }


### PR DESCRIPTION
Root-cause follow-up to today's staging conformance-gate failures (three timeout-shaped failures at ~61s, twice reproduced).

**What happened:** the suites soft-delete their agent churn, and the harness's tracked cleanup only covers tracked entries — thirteen sites delete directly or `untrack` after a soft delete. Six weeks of runs left **3,052 trashed agents** on the staging conformance account. `GET /v1/account/export` includes trashed agents (correct for a data-rights export) and computes `webhook_status` per agent row via up to four correlated `EXISTS` subqueries — 3,072 rows × ~20ms crossed HAProxy's 60s timeout, deterministically 504ing the two export tests (and the DB pressure slowed the MCP keep-alive past its client timeout).

**Change:** every direct agent delete now uses `?confirm=DELETE&permanent=true`. Kept soft on purpose: `24-trash-lifecycle` (trash semantics are the test itself; its agent is permanent-deleted by `cleanup()`, stale comment fixed) and `02-authz` (nonexistent-agent 404 probe). Assertions at the two semantic sites (01-basic delete receipt, 03-concurrency parallel-delete idempotency) hold unchanged under permanent deletion.

**Not fixed here (follow-up worth an issue):** the export's per-row correlated `webhook_status` derivation is a latent prod cliff — any real account with thousands of trashed agents would 504 its own GDPR export. The batched-derivation fix belongs in `internal/identity`.

Typecheck green. Staging-side, the accumulated debris is being pruned separately so the current release gate can pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScEpytuD7GvaXEssvJ2W32