### PR TITLE
fix(db): index the webhook_status failing-deliveries probe (migration 111)

### DIFF
--- a/migrations/111_wsd_failed_probe_index.sql
+++ b/migrations/111_wsd_failed_probe_index.sql
@@ -1,0 +1,27 @@
+-- 111_wsd_failed_probe_index.sql
+-- e2a:no-transaction
+--
+-- Partial index backing the webhook_status derivation's failing-deliveries
+-- probe (webhookStatusSQL in internal/identity/store.go):
+--
+--   EXISTS (SELECT 1 FROM webhook_subscriber_deliveries wsd
+--           JOIN webhooks w ON w.id = wsd.webhook_id
+--           WHERE ... wsd.status = 'failed'
+--             AND wsd.last_attempt_at > now() - interval '24 hours')
+--
+-- webhook_subscriber_deliveries previously had NO index on webhook_id, so
+-- this correlated probe walked the whole table — once per agent row — in
+-- every surface that derives webhook_status (ListAgentsByUser, the account
+-- export, MCP list_agents). Measured on staging 2026-08-28: 479,767 delivery
+-- rows made the probe ~600ms per agent; a 3,072-agent account's GDPR export
+-- exceeded the 60s proxy timeout, failing the release conformance gate. The
+-- partial predicate keeps the index tiny (failed rows only — typically a
+-- sliver of deliveries) while making the probe an index range scan.
+--
+-- CREATE INDEX CONCURRENTLY so the build doesn't block delivery writes on
+-- deployments with large tables; the runner's e2a:no-transaction directive
+-- (internal/identity/migrate.go) is required for CONCURRENTLY and the file
+-- must stay single-statement.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_wsd_failed_by_webhook
+    ON webhook_subscriber_deliveries (webhook_id, last_attempt_at)
+    WHERE status = 'failed';


### PR DESCRIPTION
Root-cause fix for today's staging conformance-gate 504s, sibling to #954 (test hygiene).

**Mechanism, measured on staging:** `webhook_subscriber_deliveries` (479,767 rows there) has no `webhook_id` index, so `webhookStatusSQL`'s failing-deliveries `EXISTS` walks the table once **per agent row** wherever `webhook_status` is derived — `ListAgentsByUser`, the GDPR export (`scanAgentsForUser`), MCP `list_agents`. At ~600ms/agent, a 3,072-agent account's export deterministically exceeded HAProxy's 60s (`pg_stat_activity` caught the agents query as the hang, twice); even at 20 agents the export still ran 19–24s. The probe's own answer set was **zero rows** — half a million rows scanned per probe to find nothing.

**Fix:** migration 111, `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_wsd_failed_by_webhook ON webhook_subscriber_deliveries (webhook_id, last_attempt_at) WHERE status='failed'` — partial, so it stays a sliver of the table; single-statement with the `e2a:no-transaction` directive per the 009/010 precedent.

**Prod relevance:** the same cliff exists in prod today for any account whose agent count × delivery-table size crosses the proxy timeout — this is a latent GDPR-export availability bug, not just a staging nuisance.

**Deliberately not done here:** batching the `webhook_status` derivation (one query per user instead of correlated per-row CASE) — a bigger refactor of `webhookStatusSQL`'s three call surfaces; the index removes the measured pain. Worth a follow-up issue if per-row derivation grows more branches.

Verified: full `internal/identity` suite green (migrations auto-applied incl. 111); readyz migration parity covered by existing checks. Rides the next release (1.8.2+); no ops-side coupling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScEpytuD7GvaXEssvJ2W32