### PR TITLE
test(ts-sdk): explicit timeouts on environment-scaled live e2e reads

### DIFF
--- a/sdks/typescript/test/e2e-account.test.ts
+++ b/sdks/typescript/test/e2e-account.test.ts
@@ -43,6 +43,13 @@ describe.skipIf(!env)("ts sdk live e2e: account", () => {
     recordCovered("account.get");
   });
 
+  // Explicit timeout: the export walks every section of the account's data,
+  // so its cost scales with account population and with whatever load the
+  // environment is under — in the release pipeline this suite runs right
+  // after the conformance battery, against a still-draining staging DB, and
+  // vitest's 5s default proved marginal there (2026-08-28: two pipeline
+  // failures at exactly the default). Same rule as the grouped-metrics test
+  // below: do not "tidy" this back to the default.
   it("export() returns a UserExport with the required sections", async () => {
     const exported = await client.account.export();
     expect(exported.generatedAt).toBeTruthy();
@@ -52,7 +59,7 @@ describe.skipIf(!env)("ts sdk live e2e: account", () => {
     expect(Array.isArray(exported.agents)).toBe(true);
     expect(Array.isArray(exported.apiKeys)).toBe(true);
     recordCovered("account.export");
-  });
+  }, 30_000);
 
   it("suppressions.list returns the envelope shape (possibly empty)", async () => {
     const list = await client.account.suppressions.list().toArray({ limit: 100 });

--- a/sdks/typescript/test/e2e-metrics.test.ts
+++ b/sdks/typescript/test/e2e-metrics.test.ts
@@ -92,6 +92,10 @@ describe.skipIf(!env)("ts sdk live e2e: metrics (beta)", () => {
     recordCovered("messages.getMetrics");
   });
 
+  // Explicit timeout, same rationale as the grouped variant below: the
+  // aggregate's cost is environment-dependent, and the release pipeline runs
+  // this suite against a post-conformance staging DB where the 5s default
+  // failed (2026-08-28).
   it("account.metrics() aggregates across the account", async () => {
     const flat = await client.account.metrics();
 
@@ -105,7 +109,7 @@ describe.skipIf(!env)("ts sdk live e2e: metrics (beta)", () => {
     }
 
     recordCovered("account.metrics");
-  });
+  }, 30_000);
 
   // Split from the flat read, and the only test in this suite carrying an
   // explicit timeout. group_by=agent fans the aggregate out per agent, so its


### PR DESCRIPTION
Final piece of today's release-gate stabilization (with #954 test hygiene and #955 the wsd index).

The pipeline's client-surface gates run the TS SDK live suite immediately downstream of the conformance battery, against a staging DB still draining that suite's async churn. Two reads whose cost scales with account population — `export()` and the flat `account.metrics()` — sat right at vitest's 5s default there (both failed at exactly the default in two consecutive pipeline attempts, while answering in ~1s on idle staging). The grouped-metrics test in the same file already carries an explicit 30s timeout with a "do not tidy this back" comment for precisely this reason; this PR applies the same treatment (and comment) to the other two environment-scaled reads.

No behavior change; live tests still skip without env. Needed in the next tag (v1.8.2) for the pipeline to pass its client gates reliably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScEpytuD7GvaXEssvJ2W32