### PR TITLE
fix(sdk-monitor): stop the hygiene sweep eating its own in-flight probes

### DIFF
--- a/tests/sdk-monitor/README.md
+++ b/tests/sdk-monitor/README.md
@@ -173,6 +173,8 @@ labeled by `iface`:
 | `monitor_replied` | Inbound leg received and replied to, via `iface`. |
 | `monitor_deleted` | Cleanup done for `iface`: the leg's message was trashed via `iface` (carries `inbox` + `message_id`). |
 | `monitor_stale` | A probe arrived past `MAX_AGE_MS` on `leg` (`outbound` or `reply`) for `iface`; not a success. |
+| `monitor_sweep` | The per-tick hygiene sweep moved rows in `inbox`: `trashed` live messages, `purged` from the trash. Housekeeping, never a verdict on the stack. |
+| `monitor_dropped` | A leg was abandoned rather than retried, because the failure is terminal — currently only `stage=hydrate` on a `not_found` (the message is gone, so redelivery can only 404 again). The iface falls silent and the absent-metric alert is the signal. |
 | `monitor_skip` | `iface` was skipped this tick because its config is absent (`stage=send`, currently only `mcp` without `E2A_MONITOR_MCP_URL`), or its cleanup was skipped because the interface's published client has no delete verb (`stage=cleanup`, currently always `cli`). |
 | `monitor_error` | Failure, with `stage` = `config` \| `send` \| `signature` \| `hydrate` \| `reply` \| `cleanup` \| `unknown_iface` \| `nonce_auth`, and (where applicable) `iface`. A `send`/`reply` failure includes a held (`pending_review`), terminal-`failed`, or unrecognized send-response `status` — see "Uniform send-status handling" below. A `cleanup` failure means the round trip succeeded (its `monitor_replied`/`monitor_ok` was already logged) but the trash step failed — hygiene, not an outage. |
 | `monitor_start` | Process start; lists the configured `ifaces` and whether `mcp` is configured. |
@@ -192,6 +194,29 @@ node helper it shells out to), and `cli` (via its own `emitSendResult`,
 an immediate failure: `monitor_error(stage=send` or `reply)` at send/reply
 time, not a success logged now that only surfaces later as a
 `monitor_stale` timeout once the reply never arrives.
+
+### Hygiene sweep
+
+Each tick ends by trashing and then purging up to `E2A_MONITOR_SWEEP_BUDGET`
+messages per inbox — the two agents would otherwise keep every probe the
+monitor ever sent (47k outbound rows per inbox on staging). Purge only accepts
+a message already in the trash, so the order is a requirement, not a
+preference.
+
+**The sweep may never touch a message younger than `MAX_AGE_MS`.** The tick
+returns as soon as the sends are away, but a round trip finishes later, on
+`/webhook` — so the tick's own probes are still in flight when the sweep runs,
+and the listing is newest-first unless asked otherwise. An unscoped sweep
+therefore deletes the round trip it just started: the leg 404s on hydrate or
+reply, the iface goes silent, and the alert fires for an outage the monitor
+manufactured. `_sweep_ids` pins both `sort=asc` and an `until` cutoff for this
+reason; `sort=asc` alone only postpones the collision until the backlog drains
+below one page.
+
+`MAX_AGE_MS` is exactly the right floor. A message's `created_at` is at or
+after the `sent_ms` its nonce carries, and a leg only counts while
+`now - sent_ms <= MAX_AGE_MS`, so anything past the cutoff can no longer
+produce a `monitor_ok` — purging it cannot cost a success.
 
 ### Ops contract
 
@@ -215,7 +240,8 @@ All via environment.
 | `E2A_MONITOR_NONCE_SECRET` | no | falls back to `E2A_MONITOR_WEBHOOK_SECRET` | Dedicated key for the nonce HMAC tag (see "Nonce authentication" above). Optional so protection never depends on an unset var — set it only if you want to rotate the nonce key independently of the webhook secret. |
 | `E2A_BASE_URL` | no | `https://api.e2a.dev` | API host, shared by `api`, `python_sdk`, `ts_sdk` (as `E2A_API_URL`), and `cli` (as `E2A_URL`). |
 | `E2A_MONITOR_MCP_URL` | no | — | Full streamable-HTTP MCP endpoint (e.g. `https://api.e2a.dev/mcp`), matching the prober's `E2A_PROBE_MCP_URL` convention. **Optional**: when unset, the `mcp` interface is skipped every tick (`monitor_skip`) instead of failing the whole service — see "Design decisions to review" below. |
-| `E2A_MONITOR_MAX_AGE_MS` | no | `900000` | Stale-reply cutoff. |
+| `E2A_MONITOR_MAX_AGE_MS` | no | `900000` | Stale-reply cutoff. Also the floor on what the hygiene sweep may delete — see "Hygiene sweep" below. |
+| `E2A_MONITOR_SWEEP_BUDGET` | no | `50` | Messages the hygiene sweep may touch per inbox per phase, per tick. Must stay within the endpoint's `limit` bounds (1–100): outside them the listing is a 422, which the sweep swallows as `monitor_error(stage=sweep)` and does nothing — a usable kill switch, but a deliberate one. |
 | `PORT` | no | `8080` | Cloud Run injects this. |
 
 `api`, `python_sdk`, `ts_sdk`, and `cli` are **core** interfaces: they need no

--- a/tests/sdk-monitor/monitor.py
+++ b/tests/sdk-monitor/monitor.py
@@ -58,6 +58,7 @@ from typing import Optional, Protocol
 
 from e2a.v1 import (
     E2AClient,
+    E2ANotFoundError,
     E2AWebhookSignatureError,
     construct_event,
     is_email_received,
@@ -103,6 +104,19 @@ MAX_AGE_MS = int(os.environ.get("E2A_MONITOR_MAX_AGE_MS", "900000"))
 # creates a handful of messages, so the surplus also drains backlog from
 # earlier ticks without turning the monitor into a bulk-delete client.
 SWEEP_BUDGET = int(os.environ.get("E2A_MONITOR_SWEEP_BUDGET", "50"))
+# How old a message must be before the sweep may touch it. NOT a tuning knob:
+# the sweep runs at the end of /tick, but a round trip completes LATER, on
+# /webhook, so the tick's own probes are still in flight when it runs. Below
+# this age a purge destroys the monitor's own probe and manufactures the
+# outage it exists to detect.
+#
+# MAX_AGE_MS is exactly the right floor, and provably so: a message's
+# created_at is >= the sent_ms its nonce carries (the row is written at or
+# after the send), and a leg only counts when now - sent_ms <= MAX_AGE_MS. So
+# a row older than this cutoff can no longer produce anything but
+# monitor_stale, and purging it cannot cost a success. The extra minute is
+# margin for clock skew between this container and the server.
+SWEEP_MIN_AGE_MS = MAX_AGE_MS + 60_000
 PORT = int(os.environ.get("PORT", "8080"))
 
 # Every interface this service exercises, in the fixed order /tick fires them.
@@ -641,15 +655,29 @@ def _sweep_api(path: str, method: str = "GET") -> dict:
 
 
 def _sweep_ids(inbox: str, *, deleted: bool) -> list:
-    """Up to SWEEP_BUDGET message ids from one inbox.
+    """Up to SWEEP_BUDGET message ids from one inbox, oldest first and none
+    of them younger than SWEEP_MIN_AGE_MS.
 
     direction=all and read_status=all are both load-bearing: the endpoint
     defaults to inbound-only, and for inbound to unread-only, so the defaults
     would walk straight past every outbound copy — which is precisely the
     residue this sweep exists to clear (the per-leg _cleanup trashes the
-    RECEIVED copy; the sent copy in the opposite folder was never in scope)."""
+    RECEIVED copy; the sent copy in the opposite folder was never in scope).
+
+    So are the other two. `until` is the correctness boundary: the listing is
+    newest-first by default, so an unscoped page is the tick's own in-flight
+    probes — the sweep would eat the round trip it just started and the
+    interface would go silent (see SWEEP_MIN_AGE_MS). `sort=asc` then aims
+    the budget at the oldest residue, which is what the sweep is FOR; on its
+    own it would only postpone the collision until the backlog drained below
+    one page, so both are required, not alternatives."""
+    cutoff = time.strftime(
+        "%Y-%m-%dT%H:%M:%SZ",
+        time.gmtime((time.time() * 1000 - SWEEP_MIN_AGE_MS) / 1000),
+    )
     q = (
-        f"direction=all&read_status=all&limit={SWEEP_BUDGET}"
+        f"direction=all&read_status=all&sort=asc&limit={SWEEP_BUDGET}"
+        f"&until={cutoff}"
         f"{'&deleted=true' if deleted else ''}"
     )
     page = _sweep_api(f"/v1/agents/{urllib.parse.quote(inbox, safe='')}/messages?{q}")
@@ -783,6 +811,16 @@ def handle_webhook(raw_body: bytes, signature: str) -> tuple[int, dict]:
 
     try:
         email = client().inbound.from_event(event)
+    except E2ANotFoundError as exc:
+        # Terminal, not transient: the message the event names is gone, and no
+        # number of redeliveries brings it back. Answering 5xx here would ask
+        # e2a to retry a delivery that can only 404 again — one purged probe
+        # becomes an unbounded redelivery loop, which is how this was found.
+        # Drop the leg with a 200 and let the iface fall silent: the
+        # absent-metric alert is the honest signal for a lost round trip.
+        log("monitor_dropped", stage="hydrate", event_id=event.id,
+            error=type(exc).__name__, detail=str(exc))
+        return 200, {"ok": False, "stage": "hydrate", "dropped": True}
     except Exception as exc:  # noqa: BLE001
         log("monitor_error", stage="hydrate", event_id=event.id, error=type(exc).__name__, detail=str(exc))
         # 5xx so e2a retries: a transient hydration failure shouldn't silently

--- a/tests/sdk-monitor/test_monitor.py
+++ b/tests/sdk-monitor/test_monitor.py
@@ -28,6 +28,7 @@ subprocess.run monkeypatched to capture/replay a call — no real network
 call, no real subprocess to node/npm.
 """
 
+import calendar
 import hashlib
 import hmac
 import io
@@ -228,6 +229,44 @@ FakeEmail.subject = "hello from a real human"
 emitted.clear()
 status, payload = monitor.handle_webhook(inbound_body, sign(inbound_body))
 check("non-probe subject ignored", payload.get("ignored"), "not a probe")
+
+# Hydration is where a leg can die before it is even classified, and the two
+# failure kinds need opposite answers.
+_saved_inbound = FakeClient.inbound
+
+
+class RaisingInbound:
+    def __init__(self, exc):
+        self._exc = exc
+
+    def from_event(self, event):
+        raise self._exc
+
+
+# not_found is terminal — the message is gone (purged by a sweep, deleted by an
+# operator) and no redelivery brings it back. 5xx here asks e2a to retry a
+# delivery that can only 404 again, turning one lost probe into an unbounded
+# retry loop against the very server under test.
+FakeClient.inbound = RaisingInbound(
+    monitor.E2ANotFoundError(code="not_found", message="message not found", status=404, retryable=False)
+)
+emitted.clear()
+status, payload = monitor.handle_webhook(inbound_body, sign(inbound_body))
+check("hydrate not_found does not ask for a retry", status, 200)
+check("hydrate not_found reports the drop", payload.get("dropped"), True)
+check("hydrate not_found logs monitor_dropped", "monitor_dropped" in emitted_events(), True)
+check("hydrate not_found claims no success", "monitor_ok" in emitted_events(), False)
+
+# Everything else may genuinely be transient (timeout, upstream 5xx). Dropping
+# those would lose a leg that would have succeeded on redelivery and
+# manufacture a false silence alert, so they keep asking for the retry.
+FakeClient.inbound = RaisingInbound(RuntimeError("connection reset"))
+emitted.clear()
+status, _ = monitor.handle_webhook(inbound_body, sign(inbound_body))
+check("hydrate transient failure still retries", status, 500)
+check("hydrate transient failure logs monitor_error", "monitor_error" in emitted_events(), True)
+
+FakeClient.inbound = _saved_inbound
 
 
 # ---------------------------------------------------------------------------
@@ -1212,6 +1251,38 @@ check(
 check("sweep bounds each page by the budget", all(f"limit={monitor.SWEEP_BUDGET}" in u for u in _sweep_lists), True)
 check("sweep's first list is live messages", "deleted=true" not in _sweep_lists[0], True)
 check("sweep's second list is the trash", "deleted=true" in _sweep_lists[1], True)
+
+# The regression this pair exists for: the sweep runs at the end of /tick, but
+# a round trip finishes LATER, on /webhook. An unscoped page is newest-first,
+# so it is the tick's own in-flight probes — the monitor purges the round trip
+# it just started, the leg 404s on hydrate or reply, and the interface goes
+# silent. That is a manufactured outage, not a detected one.
+check(
+    "sweep asks for the oldest residue first, not the newest",
+    all("sort=asc" in u for u in _sweep_lists),
+    True,
+)
+
+
+def _excludes_live_traffic(url):
+    """Whether one sweep listing is scoped past everything a round trip in
+    flight could still legitimately use. An unscoped listing is reported as
+    False rather than raising, so a regression reads as a failed check."""
+    if "until=" not in url:
+        return False
+    value = url.split("until=")[1].split("&")[0]
+    until_ms = calendar.timegm(time.strptime(value, "%Y-%m-%dT%H:%M:%SZ")) * 1000
+    return time.time() * 1000 - until_ms >= monitor.MAX_AGE_MS
+
+
+check("sweep scopes every list by an until cutoff", all("until=" in u for u in _sweep_lists), True)
+# sort=asc alone only postpones the collision until the backlog drains below
+# one page; the cutoff is what makes an in-flight probe unreachable at all.
+check(
+    "sweep's cutoff excludes everything a live round trip could still use",
+    all(_excludes_live_traffic(u) for u in _sweep_lists),
+    True,
+)
 
 
 # A delete that fails (message held for review, or provider submission still in


### PR DESCRIPTION
## Summary

The hygiene sweep added in #933 deletes the sdk-monitor's own in-flight probes, so the monitor manufactures the outage it exists to detect. `_sweep_ids` lists with no `sort` and the messages endpoint defaults to `desc`, so its page is the fifty **newest** messages in the inbox — and while the sweep runs at the end of `/tick`, a round trip doesn't finish there: the legs land later, on `/webhook`. This scopes the sweep to messages older than `MAX_AGE_MS` and points it at the oldest residue instead of the newest.

Staging showed it 26 minutes after the first deploy carrying the sweep: `cli` (the slowest leg — it shells to node) stopped reporting entirely, the other four went intermittent, and the per-iface absent-metric alert fired four times in ninety minutes. Every failure was `message not found`, at `stage=reply` for the leg that lost the race and `stage=hydrate` for the webhook that arrived after the purge.

The delay before it broke is just the backlog draining — `desc` walks newest-first, so the sweep only collides with live traffic once it's no longer purely clearing residue. That's also why `sort=asc` alone isn't the fix, only a postponement until the backlog falls below one page.

## Client surface checklist

Not applicable — no API, schema, or client-surface change. This is entirely within `tests/sdk-monitor/`, which drives the *published* clients from outside; it adds no endpoint and changes no contract. The only server-side facts it leans on already exist: `until` (`created_at < until`) and `sort=asc` on `GET /v1/agents/{email}/messages`.

## Operational risk

**Low, and it removes risk rather than adding it.** The sweep keeps working — a tick creates ~10 rows per inbox against a 50-row budget, so backlog still drains at ~40/tick net; it just can't reach anything younger than ~16 minutes.

- **Why `MAX_AGE_MS` is exactly the right floor, provably:** a message's `created_at` is at or after the `sent_ms` its nonce carries (the row is written at or after the send), and a leg only counts while `now - sent_ms <= MAX_AGE_MS`. So a row past the cutoff can no longer produce anything but `monitor_stale` — purging it cannot cost a success. The cutoff is derived from `MAX_AGE_MS` rather than hardcoded, so tuning that env var keeps the invariant.
- **New `monitor_dropped` log event.** Ops' log-based metric keys only on `event="monitor_ok"` and the alert is absence-of-that, so no alert policy changes. Nothing keys on `monitor_error`.
- **A `not_found` on hydrate is now terminal.** It answered 5xx so e2a would retry, but a message that's gone can't come back, so each purged probe became an unbounded redelivery loop against the server under test — the same events were still being retried, and still 500ing, minutes later. Transient failures (timeout, upstream 5xx) still ask for the retry; only `not_found` drops, and the iface falls silent so the absent alert stays the honest signal. Hardening, not the fix: with the sweep scoped, nothing purges an in-flight probe to begin with.
- **The prober does not need this change.** `internal/selftest/cleanup.go` has the identical unscoped newest-first shape, but `runOnce` calls `selftest.Run` synchronously and only sweeps after it returns, and runs come from a single ticker goroutine with no HTTP trigger — no battery is ever in flight during a sweep. The monitor's legs are asynchronous; the prober's are not. That asymmetry is the whole difference, and it's now written down in the README next to the invariant.
- **Prod is unaffected, verified live rather than by version.** The prod sdk-monitor Cloud Run service still runs a pre-sweep image and is reporting `monitor_ok` for all five ifaces every tick. Prod *does* carry the prober's sweep (it runs 1.8.2, and that sweep landed in v1.7.12), and it is healthy there: `consecutive_green: 50`, all eight scenarios passing, and the sweep steady at `trashed=4 purged=6` per minute — it only ever sees the residue of a battery that has already returned, which is the asymmetry described above.
- **Rollback** is a revert — the sweep returns to its current behavior, nothing else moves.

## Test plan

- [x] `python3 tests/sdk-monitor/test_monitor.py` green (191 checks) in a clean venv with `pip install ./sdks/python`, the way `test.yml`'s `harness-tests` job runs it
- [x] Negative control: reverting **only** the `_sweep_ids` query fails all three new sweep checks (`sort=asc`, cutoff present, cutoff excludes live traffic) and passes with it — the checks are coupled to the fix, not vacuous
- [x] Negative control: the hydrate tests don't run at all against the unfixed module (no `E2ANotFoundError` import), so they can't pass by accident
- [x] Cutoff format verified against the server's own parser — `parseRFC3339Filter` is `time.Parse(time.RFC3339, …)`, whose error text names `2026-05-25T00:00:00Z`, exactly what `_sweep_ids` emits
- [x] `until` confirmed to compose with `deleted=true`: the store applies it as an independent `AND m.created_at < $n`, so one cutoff covers both the live and trash passes
- [ ] After merge: rebuild the sdk-monitor image and redeploy staging, then confirm all five ifaces report `monitor_ok` every tick for ~30 minutes and `monitor_sweep` still drains backlog
- [ ] After merge: confirm the `POST /webhook` 500s stop (they're currently the top error on the staging Cloud Run service)

---

Staging is still burning until this ships. Two mitigations that need no merge: set `E2A_MONITOR_SWEEP_BUDGET=0` (out of the endpoint's 1–100 `limit` bounds → 422 → swallowed as `monitor_error(stage=sweep)`, so the sweep no-ops), or roll the service back to the last pre-sweep revision — which also clears the Terraform drift, since the running image digest is untagged and not what `terraform/staging` pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZPjA3xV9hRmwsQQ6hhvFy

