### PR TITLE
chore(sdk-monitor): pin the published 5.8.0 / 2.5.0 client releases

### DIFF
--- a/tests/sdk-monitor/README.md
+++ b/tests/sdk-monitor/README.md
@@ -30,8 +30,8 @@ of five interfaces:
 | `api` | raw HTTP against the server's `/v1/agents/{email}/messages` (and `.../reply`) endpoints — no SDK. Catches a server-contract break distinct from an SDK break. | python (stdlib `urllib`) |
 | `python_sdk` | the published `e2a` PyPI package | python |
 | `mcp` | the deployed MCP streamable-HTTP server's `send_message` / `reply_to_message` tools | python (hand-rolled JSON-RPC over `urllib`) |
-| `ts_sdk` | the published `@e2a/sdk` npm package (v5.4.0) | node, shelled out from python |
-| `cli` | the published `@e2a/cli` npm package (v2.1.0, bin `e2a`) | node, shelled out from python |
+| `ts_sdk` | the published `@e2a/sdk` npm package | node, shelled out from python |
+| `cli` | the published `@e2a/cli` npm package (bin `e2a`) | node, shelled out from python |
 
 Anything that breaks any of those — a bad publish, a wire-contract drift, a
 packaging regression, an MCP transport change — stops that interface's
@@ -300,8 +300,8 @@ signal, not something to work around.
 ## SDK / package version bump policy
 
 `requirements.txt` pins an exact published Python SDK version (currently
-**5.4.0**); `package.json` pins exact published `@e2a/sdk` (**5.4.0**) and
-`@e2a/cli` (**2.1.0**) versions. None of these is ever a path or workspace
+**5.8.0**); `package.json` pins exact published `@e2a/sdk` (**5.8.0**) and
+`@e2a/cli` (**2.5.0**) versions. None of these is ever a path or workspace
 dependency on the corresponding source directory — installing from local
 source would defeat the entire purpose by hiding a broken publish.
 

--- a/tests/sdk-monitor/package.json
+++ b/tests/sdk-monitor/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "description": "Node-runtime dependencies for tests/sdk-monitor's ts_sdk and cli interfaces — pinned to the exact PUBLISHED npm packages so a broken publish surfaces here, never workspace source. Never add a path/workspace dependency on ../../sdks/typescript or ../../cli.",
   "dependencies": {
-    "@e2a/sdk": "5.4.0",
-    "@e2a/cli": "2.1.0"
+    "@e2a/sdk": "5.8.0",
+    "@e2a/cli": "2.5.0"
   }
 }

--- a/tests/sdk-monitor/requirements.txt
+++ b/tests/sdk-monitor/requirements.txt
@@ -2,4 +2,4 @@
 # this MUST stay a pinned PyPI release — never a path/editable dep on
 # ../../sdks/python. A broken publish has to surface here, not be papered over
 # by local source. Bump this on every Python SDK release (see README.md).
-e2a==5.4.0
+e2a==5.8.0


### PR DESCRIPTION
## Summary

Pins the sdk-monitor at the client releases users actually install: `e2a` and `@e2a/sdk` **5.4.0 → 5.8.0**, `@e2a/cli` **2.1.0 → 2.5.0**. All three are live on PyPI/npm and are the current `latest`, so this follows the README's policy of bumping after the publish.

The monitor exists to catch one thing — a published client that's broken or behind — and it had drifted into being that thing. For four releases it was certifying packages nobody was installing. Its own docstring names the failure it was built to prevent: *"the SDKs sat at 4.0.1 on PyPI/npm while `main` was at 5.2.0 and nothing caught it."*

**Why CI never caught it:** `test.yml`'s harness job installs `./sdks/python` — repo source, already 5.8.0-equivalent — so the offline suite has been green against a 5.8.0 API surface the whole time while the deployed image ran 5.4.0. The tests were never evidence about the pin, and still aren't; the image build is.

## Client surface checklist

Not applicable — no API, schema, or client-surface change. This bumps the versions of the *published* clients that `tests/sdk-monitor` installs from PyPI/npm, and touches nothing under `sdks/`, `cli/`, or `mcp/`.

## Operational risk

**Low.** Nothing deploys from this change on its own — the sdk-monitor Cloud Run services (staging and prod) are pinned to explicit image tags in `terraform/{staging,prod}/sdk-monitor.tf`, so this takes effect only when a new image is built and deployed.

- **All three pins move together, deliberately.** `@e2a/cli@2.5.0` declares `@e2a/sdk: ^5.7.0`. Raising the CLI alone would leave the top-level `@e2a/sdk` at 5.4.0 and let npm satisfy the CLI from a *nested* second copy — the `cli` iface would then exercise an SDK version nothing pins and nobody reads from `package.json`, which is the same class of blindness this PR fixes. Verified the tree resolves flat at 5.8.0 / 2.5.0.
- **Interface-table versions removed, not just updated.** They were the second place every bump had to touch, and the reason the docs said 5.4.0 in two spots. The bump-policy section is now the single place a version is written, matching the `python_sdk` row that never carried one.
- **Rollback** is a revert; the running images are unaffected either way.

## Test plan

- [x] Confirmed all three are published and are `latest` — PyPI `e2a` 5.8.0, npm `@e2a/sdk` 5.8.0, npm `@e2a/cli` 2.5.0 — rather than trusting the repo's git tags, which are not proof of a publish
- [x] `pip install -r requirements.txt` from **PyPI** into a clean venv resolves 5.8.0, and the offline suite passes against the real published package (191 checks) — the README's documented local check
- [x] `npm install` resolves `@e2a/sdk@5.8.0` + `@e2a/cli@2.5.0` flat, with the CLI's `^5.7.0` satisfied by the top-level copy and no nested duplicate
- [x] `node --check js/monitor-helper.mjs` clean against the 5.8.0 tree
- [ ] CI: the "Build SDK monitor image" job is the real gate — it installs both pins from the live registries, so a bad or yanked publish fails the build
- [ ] After merge: the next sdk-monitor image build carries these pins; confirm all five ifaces still report `monitor_ok` once it's deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZPjA3xV9hRmwsQQ6hhvFy
