### PR TITLE
feat(web): surface owned add-ons prominently on the billing page

### DIFF
--- a/web/src/app/(app)/billing/page.addon.test.tsx
+++ b/web/src/app/(app)/billing/page.addon.test.tsx
@@ -403,3 +403,45 @@ describe("BillingPage — add-on provisioning sync", () => {
     expect(screen.queryByText(/Updating your add-ons/)).not.toBeInTheDocument();
   });
 });
+
+describe("BillingPage — owned add-on visibility", () => {
+  it("shows a prominent owned-state strip and a plan-banner badge", async () => {
+    limitsPayload = PRO_LIMITS;
+    planPayload = proPlan(3);
+    renderPage();
+
+    await screen.findByText("Inbox add-on");
+    // The card leads with what the user owns, not just an editable number.
+    expect(screen.getByText("You have 3 add-ons")).toBeInTheDocument();
+    // The strip attributes what those add-ons grant, priced from the catalog.
+    expect(
+      screen.getByText(/\+3 inboxes, \+9,000 sends \/ mo · \$6\/mo/),
+    ).toBeInTheDocument();
+    // The current-plan banner carries the ownership badge too — visible
+    // without scrolling to the card.
+    expect(screen.getByText("+ 3 inbox add-ons · $6/mo")).toBeInTheDocument();
+  });
+
+  it("uses singular wording for one add-on", async () => {
+    limitsPayload = PRO_LIMITS;
+    planPayload = proPlan(1);
+    renderPage();
+
+    await screen.findByText("Inbox add-on");
+    expect(screen.getByText("You have 1 add-on")).toBeInTheDocument();
+    expect(
+      screen.getByText(/\+1 inbox, \+3,000 sends \/ mo · \$2\/mo/),
+    ).toBeInTheDocument();
+    expect(screen.getByText("+ 1 inbox add-on · $2/mo")).toBeInTheDocument();
+  });
+
+  it("shows neither strip nor badge when the account owns none", async () => {
+    limitsPayload = PRO_LIMITS;
+    planPayload = proPlan(0);
+    renderPage();
+
+    await screen.findByText("Inbox add-on");
+    expect(screen.queryByText(/You have/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/inbox add-on ·/)).not.toBeInTheDocument();
+  });
+});

--- a/web/src/app/(app)/billing/page.tsx
+++ b/web/src/app/(app)/billing/page.tsx
@@ -739,8 +739,23 @@ export default function BillingPage() {
                 <div className="text-xs uppercase tracking-wide text-muted">
                   Current plan
                 </div>
-                <div className="text-lg font-semibold text-foreground mt-1">
-                  {currentPlanLabel}
+                <div className="text-lg font-semibold text-foreground mt-1 flex items-baseline gap-2 flex-wrap">
+                  <span>{currentPlanLabel}</span>
+                  {/* Owned add-ons surface at the very top of the page,
+                      not only down in the purchase card — the count and
+                      its monthly cost are part of "what plan am I on". */}
+                  {BILLING_API && planData?.addon && addonServerQty > 0 && (
+                    <span
+                      className="text-xs font-medium rounded px-1.5 py-0.5 border"
+                      style={{ borderColor: "var(--accent)", color: "var(--fg)" }}
+                    >
+                      + {formatNumber(addonServerQty)} inbox add-on
+                      {addonServerQty === 1 ? "" : "s"} ·{" "}
+                      {formatPrice(
+                        addonServerQty * planData.addon.monthly_price_cents_per_unit,
+                      )}
+                    </span>
+                  )}
                 </div>
               </div>
               {BILLING_API && data.upgrade_url && (
@@ -852,6 +867,39 @@ export default function BillingPage() {
                     </div>
                   )}
               </div>
+
+              {/* What the account owns, stated as a sentence with the
+                  grants and cost attributed — the stepper below is only
+                  the editor, and its number can be a staged edit. */}
+              {addonServerQty > 0 && (
+                <div
+                  className="rounded-lg border px-4 py-3 flex items-baseline justify-between gap-3 flex-wrap"
+                  style={{
+                    borderColor: "var(--accent)",
+                    background: "var(--bg-elev)",
+                  }}
+                >
+                  <span className="text-sm font-semibold text-foreground">
+                    You have {formatNumber(addonServerQty)} add-on
+                    {addonServerQty === 1 ? "" : "s"}
+                  </span>
+                  <span className="text-sm text-muted">
+                    +{formatNumber(addonServerQty * planData.addon.per_unit.max_agents)}{" "}
+                    inbox
+                    {addonServerQty * planData.addon.per_unit.max_agents === 1
+                      ? ""
+                      : "es"}
+                    , +
+                    {formatNumber(
+                      addonServerQty * planData.addon.per_unit.max_messages_month,
+                    )}{" "}
+                    sends / mo ·{" "}
+                    {formatPrice(
+                      addonServerQty * planData.addon.monthly_price_cents_per_unit,
+                    )}
+                  </span>
+                </div>
+              )}
 
               {addonEditConflict && (
                 <div
@@ -993,14 +1041,6 @@ export default function BillingPage() {
                   </span>
                 )}
 
-                {addonServerQty > 0 && (
-                  <span className="text-xs text-muted">
-                    Currently {formatNumber(addonServerQty)} — {" "}
-                    {formatPrice(
-                      addonServerQty * planData.addon.monthly_price_cents_per_unit,
-                    )}
-                  </span>
-                )}
               </div>
             </section>
           )}


### PR DESCRIPTION
Follow-up to #960 from dogfooding on staging: after buying an add-on, the only evidence of ownership was the muted "Currently 1 — $2/mo" aside, and the stepper's number can't distinguish a staged edit from what's owned.

Two additions, both priced from the catalog payload (nothing hardcoded):

- **Current-plan banner badge** — `Free  [+ 1 inbox add-on · $2/mo]` — ownership reads at the top of the page.
- **Owned-state strip leading the add-on card** — `You have 1 add-on   +1 inbox, +3,000 sends / mo · $2/mo` — grants and cost attributed; the stepper below is purely the editor. The muted aside is removed.

Both render only when `current.addon_quantity > 0`.

Tests: 3 new cases (plural strip+badge, singular wording, hidden at qty 0); addon suite 15/15, full web 901/901, tsc clean, prod build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScEpytuD7GvaXEssvJ2W32