### PR TITLE
fix(web): add-on card states the asymmetric refund policy

### DIFF
--- a/web/src/app/(app)/billing/page.addon.test.tsx
+++ b/web/src/app/(app)/billing/page.addon.test.tsx
@@ -183,6 +183,11 @@ describe("BillingPage — inbox add-on", () => {
     // Price and per-unit adds come from the payload, never hardcoded.
     expect(screen.getByText(/\$2\/mo each/)).toBeInTheDocument();
     expect(screen.getByText(/adds 1 inbox and 3,000 sends/)).toBeInTheDocument();
+    // The refund policy is asymmetric (ops#348): increases prorate,
+    // decreases carry no partial-month refund — the card must say so
+    // and must not claim blanket proration.
+    expect(screen.getByText(/no partial-month refund/)).toBeInTheDocument();
+    expect(screen.queryByText(/charges are prorated/)).not.toBeInTheDocument();
     // Free plan + lifts_free_daily_cap → the daily-cap hint shows.
     expect(screen.getByText(/daily send cap/)).toBeInTheDocument();
   });

--- a/web/src/app/(app)/billing/page.tsx
+++ b/web/src/app/(app)/billing/page.tsx
@@ -854,8 +854,9 @@ export default function BillingPage() {
                   Each one adds {formatNumber(planData.addon.per_unit.max_agents)}{" "}
                   inbox{planData.addon.per_unit.max_agents === 1 ? "" : "es"} and{" "}
                   {formatNumber(planData.addon.per_unit.max_messages_month)} sends
-                  / mo to your account&apos;s shared pool. Adjust anytime; charges
-                  are prorated.
+                  / mo to your account&apos;s shared pool. Add anytime (charged
+                  prorated); reduce anytime — reductions apply immediately with
+                  no partial-month refund.
                 </div>
                 {/* The free tier is identified structurally (price 0),
                     like ctaFor does — never by a hardcoded plan code. */}


### PR DESCRIPTION
Companion to tokencanopy/e2a-ops#348, which turns off prorated credits on add-on **decreases** (increases still prorate charges). The card's "Adjust anytime; charges are prorated" is now a false claim for reductions — on a purchase surface that's a policy misstatement.

New copy: *"Add anytime (charged prorated); reduce anytime — reductions apply immediately with no partial-month refund."* A test pins the policy wording and forbids the blanket claim from returning. Addon suite 17/17, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScEpytuD7GvaXEssvJ2W32