### PR TITLE
chore(plugins): publish support@agents.e2a.dev as the contact address

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "e2a plugins for Claude Code — open-source email API for applications and AI agents",
-    "version": "0.9.4"
+    "version": "0.9.5"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "e2a",
   "owner": {
     "name": "TokenCanopy",
-    "email": "support@e2a.dev",
+    "email": "support@agents.e2a.dev",
     "url": "https://e2a.dev"
   },
   "metadata": {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "e2a — open-source email API for applications and AI agents (MCP configuration and canonical docs).",
-    "version": "0.9.4"
+    "version": "0.9.5"
   },
   "plugins": [
     {

--- a/plugins/e2a-labs/.claude-plugin/plugin.json
+++ b/plugins/e2a-labs/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "e2a-labs",
   "displayName": "e2a Labs",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Experimental autonomous workflows for the e2a agent email gateway. Requires the core e2a plugin for MCP tools and authentication.",
   "author": {
     "name": "TokenCanopy",

--- a/plugins/e2a-labs/.codex-plugin/plugin.json
+++ b/plugins/e2a-labs/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "e2a-labs",
   "displayName": "e2a Labs",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Experimental autonomous workflows for e2a. Install the core e2a plugin first; it supplies the MCP connection and authentication.",
   "author": {
     "name": "TokenCanopy"

--- a/plugins/e2a-labs/plugin.json
+++ b/plugins/e2a-labs/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "e2a-labs",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Experimental autonomous workflows for the e2a agent email gateway. Requires the core e2a plugin for MCP tools and authentication.",
   "author": {
     "name": "TokenCanopy",

--- a/plugins/e2a-labs/plugin.meta.json
+++ b/plugins/e2a-labs/plugin.meta.json
@@ -3,7 +3,7 @@
 
   "name": "e2a-labs",
   "displayName": "e2a Labs",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "Apache-2.0",
   "homepage": "https://e2a.dev",
   "repository": "https://github.com/tokencanopy/e2a",

--- a/plugins/e2a-labs/plugin.meta.json
+++ b/plugins/e2a-labs/plugin.meta.json
@@ -12,7 +12,7 @@
   "author": {
     "name": "TokenCanopy",
     "url": "https://e2a.dev",
-    "email": "support@e2a.dev"
+    "email": "support@agents.e2a.dev"
   },
 
   "keywords": ["email", "agents", "automation", "experimental"],

--- a/plugins/e2a/.claude-plugin/plugin.json
+++ b/plugins/e2a/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "e2a",
   "displayName": "e2a",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Open-source email API for applications and AI agents — transactional sending from any product, per-agent two-way inboxes, structured SPF/DKIM/DMARC evidence, and a queryable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "TokenCanopy",

--- a/plugins/e2a/.codex-plugin/plugin.json
+++ b/plugins/e2a/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "e2a",
   "displayName": "e2a",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Open-source email API for applications and AI agents — transactional sending from any product, per-agent two-way inboxes, structured SPF/DKIM/DMARC evidence, and a queryable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "TokenCanopy"

--- a/plugins/e2a/.cursor-plugin/plugin.json
+++ b/plugins/e2a/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "e2a",
   "displayName": "e2a",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Open-source email API for applications and AI agents — transactional sending from any product, per-agent two-way inboxes, structured SPF/DKIM/DMARC evidence, and a queryable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "TokenCanopy",

--- a/plugins/e2a/plugin.json
+++ b/plugins/e2a/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "e2a",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Open-source email API for applications and AI agents — transactional sending from any product, per-agent two-way inboxes, structured SPF/DKIM/DMARC evidence, and a queryable event log. 78 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "TokenCanopy",

--- a/plugins/e2a/plugin.meta.json
+++ b/plugins/e2a/plugin.meta.json
@@ -3,7 +3,7 @@
 
   "name": "e2a",
   "displayName": "e2a",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "license": "Apache-2.0",
   "homepage": "https://e2a.dev",
   "repository": "https://github.com/tokencanopy/e2a",

--- a/plugins/e2a/plugin.meta.json
+++ b/plugins/e2a/plugin.meta.json
@@ -12,7 +12,7 @@
   "author": {
     "name": "TokenCanopy",
     "url": "https://e2a.dev",
-    "email": "support@e2a.dev"
+    "email": "support@agents.e2a.dev"
   },
 
   "keywords": ["email", "smtp", "agents", "spf", "dkim", "inbox", "mcp", "oauth"],

--- a/scripts/plugin-email-evals.test.mjs
+++ b/scripts/plugin-email-evals.test.mjs
@@ -603,7 +603,7 @@ test("templates and skill contain only synthetic email identities", async () => 
 test("all plugin manifests release email-evals together without changing discovery conventions", async () => {
   for (const file of manifestFiles) {
     const manifest = JSON.parse(await readFile(file, "utf8"));
-    assert.equal(manifest.version ?? manifest.metadata?.version, "0.9.4", file);
+    assert.equal(manifest.version ?? manifest.metadata?.version, "0.9.5", file);
   }
 
   const claude = JSON.parse(await readFile(manifestFiles[0], "utf8"));

--- a/scripts/plugin-packaging.test.mjs
+++ b/scripts/plugin-packaging.test.mjs
@@ -55,16 +55,16 @@ test("marketplaces expose the supported plugin set and release versions", async 
   assert.deepEqual(claudeMarket.plugins.map((plugin) => plugin.name).sort(), ["e2a", "e2a-labs"]);
   assert.deepEqual(codexMarket.plugins.map((plugin) => plugin.name).sort(), ["e2a", "e2a-labs"]);
   assert.deepEqual(cursorMarket.plugins.map((plugin) => plugin.name), ["e2a"]);
-  assert.equal(claudeMarket.metadata.version, "0.9.4");
-  assert.equal(cursorMarket.metadata.version, "0.9.4");
+  assert.equal(claudeMarket.metadata.version, "0.9.5");
+  assert.equal(cursorMarket.metadata.version, "0.9.5");
 
   for (const client of [".claude-plugin", ".codex-plugin", ".cursor-plugin"]) {
     const core = JSON.parse(await readFile(`plugins/e2a/${client}/plugin.json`, "utf8"));
-    assert.equal(core.version, "0.9.4");
+    assert.equal(core.version, "0.9.5");
   }
   for (const client of [".claude-plugin", ".codex-plugin"]) {
     const labs = JSON.parse(await readFile(`plugins/e2a-labs/${client}/plugin.json`, "utf8"));
-    assert.equal(labs.version, "0.3.0");
+    assert.equal(labs.version, "0.3.1");
   }
 });
 


### PR DESCRIPTION
## What

The published contact address on the plugin author block and the marketplace owner block moves from `support@e2a.dev` to **`support@agents.e2a.dev`**.

Edited in `plugins/e2a/plugin.meta.json` and `plugins/e2a-labs/plugin.meta.json` — the single source of truth — then regenerated. `.claude-plugin/marketplace.json` is the only downstream manifest that emits the address.

Two consequential changes ride along, both required by gates rather than chosen:

- **Version bumps.** `check-plugin-version-bump.mjs` requires every changed plugin to bump. Metadata-only, so patch: e2a `0.9.4 → 0.9.5`, e2a-labs `0.3.0 → 0.3.1`. Regenerating propagates them through the per-client manifests.
- **Test pins.** `plugin-packaging.test.mjs` and `plugin-email-evals.test.mjs` assert the released version as a literal across every generated manifest, so a bump is only half-applied until they move with it.

## Why

`support@e2a.dev` was the one public support address matching nothing else we publish. Everywhere else the hosted deployment already uses `support@agents.e2a.dev` — `notifications.reply_to` in `config.prod.yaml`, `FEEDBACK_NOTIFY_TO` in the feedback fan-out, and `NEXT_PUBLIC_FEEDBACK_EMAIL` on the dashboard. That address is a real e2a agent on a domain with a live MX, which is also what the fan-out's "target must be an existing agent" constraint requires.

`support@e2a.dev` depended instead on a Cloudflare Email Routing forward on the apex, with nothing in either repo pinning that rule — so a directory listing was sending people to an address whose delivery path wasn't owned anywhere. It also dogfoods the product: the support inbox for an agent-email company is an agent inbox.

This does not revisit the 2026-08-08 decision (e2a-ops#295) that kept `support@agents.e2a.dev` over `support@team.tokencanopy.com` — it brings the last stray reference into line with it.

## Worth knowing

The labs version pin at `plugin-packaging.test.mjs:67` was **masked by assertion order**: `assert.equal` on the core version throws first, so the `0.3.0` pin two blocks below never ran. The first CI failure reported only the core mismatch; the labs one would have surfaced on the next push. Both are fixed here.

## Not touched

- `scripts/validate-plugin.test.mjs` — `support@e2a.dev` there is a minimal valid-shaped fixture in synthetic base metadata, not a published address. Those tests assert schema and freshness, never the value.
- `plugins/e2a-labs/skills/agentify/examples/e2a/autonomous-repo.config.yml` — an example config whose `support_address` carries an explicit `TODO(open-q #6): confirm verified domain`, alongside a second open TODO on `approver`. Resolving one and leaving the other reads worse than leaving the pair for the open question that owns them.
- `design-system/src/Avatar/Avatar.stories.tsx` — a Storybook avatar fixture demonstrating initials-from-email, not a contact.

## Verification

- `node scripts/generate-plugin-manifests.mjs` → 9/12 manifests updated; every generated file regenerated, never hand-edited.
- `node scripts/validate-plugin.mjs` → green, freshness gate included (a hand-edited generated manifest is exactly what it fails on).
- `node --test` over the workflow's exact six-file list → **67/67 pass**.
- `grep -rn 'support@e2a.dev' --include='*.json'` on the branch → no matches.
- Full PR CI: **24/24 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JS3LokLt1bMyMwi8Aa1Td7