### PR TITLE
feat(senderidentity): classify provisioned SES identities with tags

### DIFF
--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -277,6 +277,12 @@ func main() {
 	var jobsClient *jobs.Client
 	var registrars []jobs.Registrar
 
+	// Read-side usage store. Built up here rather than beside the limits
+	// enforcer that also consumes it, because the sender-identity registrar
+	// below reads account classes through it to classify (tag) the SES
+	// identities it provisions.
+	usageStore := usage.NewStore(pool)
+
 	// Usage tracking is hosted-deployment infrastructure (counts every
 	// inbound/outbound message into usage_events + usage_summaries for downstream
 	// billing reconciliation). Self-hosters get the no-op tracker by default — the
@@ -367,8 +373,15 @@ func main() {
 		if perr != nil {
 			log.Fatalf("sender identity: build SES provider: %v", perr)
 		}
+		// Classification tags on every identity e2a provisions, so a cleanup
+		// pass can judge one from AWS alone. Reuses the metrics build label as
+		// the provisioner stamp — it is already the deployed release string.
+		provider = provider.WithIdentityTags(cfg.DeploymentName, cfg.Metrics.Build, cfg.SenderIdentity.FixtureTTL)
 		senderMgr = senderidentity.NewManager(
-			senderidentity.NewStoreAdapter(store),
+			senderidentity.NewStoreAdapter(store, func(ctx context.Context, userID string) (string, error) {
+				class, err := usageStore.GetAccountClass(ctx, userID)
+				return string(class), err
+			}),
 			provider,
 			senderIdentityEventFirer(outboxPublisher),
 			senderidentity.Config{LegacyJobCompat: cfg.SenderIdentity.LegacyJobCompat},
@@ -689,7 +702,6 @@ func main() {
 	// run a provisioner get the generous config defaults applied to
 	// every user — effectively unlimited unless they tighten the
 	// `limits:` config block.
-	usageStore := usage.NewStore(pool)
 	enforcer := limits.NewEnforcer(
 		limits.NewStore(pool),
 		usageStore,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -10,6 +10,17 @@
 # "production" fails startup.
 env: "development"
 
+# Optional. Names WHICH deployment this is ("prod" or "staging"), for
+# classification metadata e2a attaches to resources it creates in external
+# systems — today the e2a-env tag on provisioned SES sender identities, so a
+# shared AWS account can be audited without this server's database. NOT the
+# same as `env` above: that is a development/production mode switch, and a
+# hosted staging deployment runs env: "production" too. Self-hosters leave
+# this empty and simply get no environment tag. Any other value is logged
+# once at startup and treated as empty — never a startup failure.
+# Override with E2A_DEPLOYMENT_NAME.
+deployment_name: ""
+
 # Optional. When set, users can register agents by slug (no DNS setup required)
 # and the server provisions <slug>@<shared_domain>. Leave empty on a self-host
 # that doesn't operate a shared mail domain — every agent then needs a custom
@@ -234,6 +245,14 @@ sender_identity:
   # (config-only deploy) to switch producers to the versioned v2 lane.
   # Single-instance deployments have no overlap and can leave this false.
   legacy_job_compat: false
+  # How long a FIXTURE sending identity — one provisioned for a non-customer
+  # account class (internal dogfooding, synthetic monitoring) — is assumed to
+  # still be in use. Stamped onto the identity as the e2a-expires tag so an
+  # abandoned test fixture is distinguishable from a live customer domain in
+  # the provider account alone. Customer identities never carry it. Written as
+  # a Go duration string; "0s" disables the tag. Override with
+  # E2A_SENDER_IDENTITY_FIXTURE_TTL.
+  fixture_ttl: "24h"
 
 # Operator-managed recipient-volume ramp for newly verified custom sender
 # domains. Disabled by default for self-hosts. When enabled, the schedule is

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,15 +3,22 @@ package config
 import (
 	"errors"
 	"fmt"
+	"log"
 	"net/mail"
 	"net/netip"
 	"net/url"
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
+
+// defaultSenderIdentityFixtureTTL is how long a fixture sending identity is
+// assumed to still be in use. A conformance or prober fixture that outlives a
+// day has been abandoned by the run that made it.
+const defaultSenderIdentityFixtureTTL = 24 * time.Hour
 
 // splitAndTrim splits a comma-separated env value into a clean slice (trimmed,
 // no empties). Used for list-valued overrides like SNS topic ARNs.
@@ -64,6 +71,24 @@ type Config struct {
 	OutboundFooter   OutboundFooterConfig   `yaml:"outbound_footer"`
 	Notifications    NotificationsConfig    `yaml:"notifications"`
 	Env              string                 `yaml:"env"` // "development" or "production"
+	// DeploymentName names WHICH deployment of e2a this process is, for
+	// classification metadata e2a attaches to the resources it creates in
+	// external systems (today: the e2a-env tag on provisioned SES sender
+	// identities — internal/senderidentity/tags.go). It is deliberately NOT
+	// Env: Env is a development/production MODE switch that gates security
+	// behavior, and both the hosted prod and hosted staging deployments run
+	// env: "production", so Env provably cannot tell them apart.
+	//
+	// Recognized values are "prod" and "staging" — the closed vocabulary
+	// internal/senderidentity stamps, mirrored here only to normalize the
+	// operator's input (that package owns the tag values, and re-screens
+	// whatever it is given). Empty — the default, and what every self-host
+	// leaves it at — means unset: the metadata is simply omitted. An
+	// unrecognized value is logged once at load and treated as unset rather
+	// than rejected: nothing about serving mail depends on this, so a typo
+	// must never stop a server from booting.
+	// Override with E2A_DEPLOYMENT_NAME.
+	DeploymentName string `yaml:"deployment_name"`
 	// SharedDomain enables slug-based agent registration. When set
 	// (e.g. "agents.example.com"), users can register agents with just a
 	// slug and get `<slug>@<shared_domain>` provisioned without DNS
@@ -388,6 +413,21 @@ type SenderIdentityConfig struct {
 	// Default false — single-instance deployments have no blue/green overlap.
 	// Override via E2A_SENDER_IDENTITY_LEGACY_JOB_COMPAT.
 	LegacyJobCompat bool `yaml:"legacy_job_compat"`
+	// FixtureTTL is how long a FIXTURE sending identity — one provisioned for
+	// a non-customer account class (internal dogfooding, synthetic monitoring)
+	// — is expected to stay useful. It is stamped onto the identity as the
+	// e2a-expires tag so a later cleanup pass can tell an abandoned test
+	// fixture from a live customer domain without joining against this
+	// server's database. Customer identities never carry it.
+	//
+	// Written as a Go duration string ("24h", "90m"); yaml.v3 decodes a
+	// duration field from a string only, so a bare `0` is a type error —
+	// spell the disabled case "0s". Defaults to 24h (a conformance/prober
+	// fixture that outlives a day has been abandoned). Zero disables the tag
+	// without disabling the rest of the classification metadata. Override via
+	// E2A_SENDER_IDENTITY_FIXTURE_TTL; a malformed value there is logged and
+	// ignored rather than fatal, for the same reason as DeploymentName.
+	FixtureTTL time.Duration `yaml:"fixture_ttl"`
 }
 
 // SendingRampConfig is an operator-owned safety policy for newly verified
@@ -505,6 +545,9 @@ func Load(path string) (*Config, error) {
 		RateLimits: RateLimitsConfig{PollPerMinute: 240},
 		Metrics:    MetricsConfig{ListenAddr: "127.0.0.1:9091"},
 		Trash:      TrashConfig{RetentionDays: 30},
+		// An absent sender_identity block keeps the fixture expiry default;
+		// an explicit `fixture_ttl: 0` survives unmarshal and disables it.
+		SenderIdentity: SenderIdentityConfig{FixtureTTL: defaultSenderIdentityFixtureTTL},
 		// Delegated verification is off by default. Only protocol-level
 		// values are defaulted (algorithm allowlist, lifetime, skew); the
 		// required/forbidden CLAIM lists are deployment identity policy
@@ -677,6 +720,26 @@ func Load(path string) (*Config, error) {
 			return nil, fmt.Errorf("E2A_SENDER_IDENTITY_LEGACY_JOB_COMPAT: %w", err)
 		}
 		cfg.SenderIdentity.LegacyJobCompat = b
+	}
+	if v := os.Getenv("E2A_SENDER_IDENTITY_FIXTURE_TTL"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			cfg.SenderIdentity.FixtureTTL = d
+		} else {
+			log.Printf("[config] E2A_SENDER_IDENTITY_FIXTURE_TTL=%q is not a Go duration — ignoring it and keeping %s", v, cfg.SenderIdentity.FixtureTTL)
+		}
+	}
+	if v := os.Getenv("E2A_DEPLOYMENT_NAME"); v != "" {
+		cfg.DeploymentName = v
+	}
+	// Normalize AFTER the env override so a typo in either source degrades the
+	// same way. See DeploymentName's doc for why this is not a hard error.
+	if name := strings.TrimSpace(cfg.DeploymentName); name != "prod" && name != "staging" {
+		if name != "" {
+			log.Printf("[config] deployment_name (or E2A_DEPLOYMENT_NAME) = %q is not %q or %q — treating this deployment as unnamed; resources e2a provisions will carry no environment tag", name, "prod", "staging")
+		}
+		cfg.DeploymentName = ""
+	} else {
+		cfg.DeploymentName = name
 	}
 	if v := os.Getenv("E2A_TRASH_RETENTION_DAYS"); v != "" {
 		if d, err := strconv.Atoi(v); err == nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestOutboundModeConfigurationRemoved is a source-level contract guard. Outbound
@@ -885,4 +886,130 @@ func TestNotificationsFromAddress(t *testing.T) {
 			t.Errorf("Validate rejected a valid bare reply_to: %v", err)
 		}
 	})
+}
+
+// TestDeploymentNameDefaultOverridesAndFallback covers the deployment name that
+// feeds the e2a-env classification tag on provisioned SES sender identities.
+// The load-time behavior that matters is the LAST case: a typo must degrade to
+// unset, never abort startup — nothing about serving mail depends on this value,
+// so refusing to boot over it would trade a cosmetic tag for an outage.
+func TestDeploymentNameDefaultOverridesAndFallback(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, body string) string {
+		t.Helper()
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(body), 0644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	// Absent → unset (the self-host default: no env tag at all).
+	cfg, err := Load(write("default.yaml", "env: \"development\"\n"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.DeploymentName != "" {
+		t.Errorf("default DeploymentName = %q, want \"\"", cfg.DeploymentName)
+	}
+
+	// YAML override, both accepted names.
+	for _, name := range []string{"prod", "staging"} {
+		cfg, err = Load(write(name+".yaml", "env: \"development\"\ndeployment_name: \""+name+"\"\n"))
+		if err != nil {
+			t.Fatalf("Load(%s): %v", name, err)
+		}
+		if cfg.DeploymentName != name {
+			t.Errorf("DeploymentName = %q, want %q", cfg.DeploymentName, name)
+		}
+	}
+
+	// Env override wins over yaml.
+	t.Setenv("E2A_DEPLOYMENT_NAME", "staging")
+	cfg, err = Load(write("env.yaml", "env: \"development\"\ndeployment_name: \"prod\"\n"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.DeploymentName != "staging" {
+		t.Errorf("env DeploymentName = %q, want \"staging\"", cfg.DeploymentName)
+	}
+	t.Setenv("E2A_DEPLOYMENT_NAME", "")
+
+	// An unrecognized value loads clean and reads as unset. "production" is the
+	// realistic typo: it is the legal value of the adjacent `env` field.
+	cfg, err = Load(write("bogus.yaml", "env: \"development\"\ndeployment_name: \"production\"\n"))
+	if err != nil {
+		t.Fatalf("Load must not reject an unrecognized deployment_name: %v", err)
+	}
+	if cfg.DeploymentName != "" {
+		t.Errorf("unrecognized DeploymentName = %q, want \"\" (treated as unset)", cfg.DeploymentName)
+	}
+	t.Setenv("E2A_DEPLOYMENT_NAME", "PROD")
+	cfg, err = Load(write("bogus-env.yaml", "env: \"development\"\n"))
+	if err != nil {
+		t.Fatalf("Load must not reject an unrecognized E2A_DEPLOYMENT_NAME: %v", err)
+	}
+	if cfg.DeploymentName != "" {
+		t.Errorf("unrecognized E2A_DEPLOYMENT_NAME left %q, want \"\"", cfg.DeploymentName)
+	}
+}
+
+// TestSenderIdentityFixtureTTL covers the TTL behind the e2a-expires tag on
+// fixture (internal/system) identities. A malformed env override is ignored
+// rather than fatal, for the same reason as the deployment name above.
+func TestSenderIdentityFixtureTTL(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, body string) string {
+		t.Helper()
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(body), 0644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	cfg, err := Load(write("default.yaml", "env: \"development\"\n"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.SenderIdentity.FixtureTTL != 24*time.Hour {
+		t.Errorf("default FixtureTTL = %v, want 24h", cfg.SenderIdentity.FixtureTTL)
+	}
+
+	cfg, err = Load(write("yaml.yaml", "env: \"development\"\nsender_identity:\n  fixture_ttl: 2h\n"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.SenderIdentity.FixtureTTL != 2*time.Hour {
+		t.Errorf("yaml FixtureTTL = %v, want 2h", cfg.SenderIdentity.FixtureTTL)
+	}
+
+	// An explicit zero disables the expiry tag and must survive defaulting.
+	// It has to be spelled as a duration ("0s"): yaml.v3 decodes a duration
+	// field from a STRING only, so a bare `0` is a type error like any other.
+	cfg, err = Load(write("zero.yaml", "env: \"development\"\nsender_identity:\n  fixture_ttl: 0s\n"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.SenderIdentity.FixtureTTL != 0 {
+		t.Errorf("explicit zero FixtureTTL = %v, want 0", cfg.SenderIdentity.FixtureTTL)
+	}
+
+	t.Setenv("E2A_SENDER_IDENTITY_FIXTURE_TTL", "90m")
+	cfg, err = Load(write("env.yaml", "env: \"development\"\nsender_identity:\n  fixture_ttl: 2h\n"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.SenderIdentity.FixtureTTL != 90*time.Minute {
+		t.Errorf("env FixtureTTL = %v, want 90m", cfg.SenderIdentity.FixtureTTL)
+	}
+
+	t.Setenv("E2A_SENDER_IDENTITY_FIXTURE_TTL", "not-a-duration")
+	cfg, err = Load(write("bad-env.yaml", "env: \"development\"\nsender_identity:\n  fixture_ttl: 2h\n"))
+	if err != nil {
+		t.Fatalf("Load must not reject a malformed E2A_SENDER_IDENTITY_FIXTURE_TTL: %v", err)
+	}
+	if cfg.SenderIdentity.FixtureTTL != 2*time.Hour {
+		t.Errorf("malformed env override changed FixtureTTL to %v, want the yaml 2h", cfg.SenderIdentity.FixtureTTL)
+	}
 }

--- a/internal/senderidentity/adapter.go
+++ b/internal/senderidentity/adapter.go
@@ -32,11 +32,35 @@ type RawStore interface {
 	DomainExists(ctx context.Context, domain string) (bool, error)
 }
 
+// AccountClassFunc resolves a user's usage account class ("standard",
+// "internal", "system", "demo"). *usage.Store's GetAccountClass satisfies it
+// after a one-line string conversion at the wiring site — kept as a plain func
+// over plain strings for the same reason RawStore is, so this package does not
+// import internal/usage.
+type AccountClassFunc func(ctx context.Context, userID string) (string, error)
+
 // NewStoreAdapter bridges a RawStore (e.g. *identity.Store) to the typed
 // Store the workers use, converting Status ↔ string and DNSRecord ↔ JSON.
-func NewStoreAdapter(raw RawStore) Store { return &storeAdapter{raw: raw} }
+//
+// accountClass is OPTIONAL and may be nil: the account class exists only to
+// classify provisioned provider identities (see tags.go), so a deployment that
+// does not wire it reads as "class unknown" and loses one tag, rather than
+// erroring on a path that verifies customer domains.
+func NewStoreAdapter(raw RawStore, accountClass AccountClassFunc) Store {
+	return &storeAdapter{raw: raw, accountClass: accountClass}
+}
 
-type storeAdapter struct{ raw RawStore }
+type storeAdapter struct {
+	raw          RawStore
+	accountClass AccountClassFunc
+}
+
+func (a *storeAdapter) AccountClassForUser(ctx context.Context, userID string) (string, error) {
+	if a.accountClass == nil {
+		return "", nil
+	}
+	return a.accountClass(ctx, userID)
+}
 
 func (a *storeAdapter) WithSendingIdentityMutationLock(ctx context.Context, domain string, fn func(context.Context) error) error {
 	return a.raw.WithSendingIdentityMutationLock(ctx, domain, fn)

--- a/internal/senderidentity/adapter_test.go
+++ b/internal/senderidentity/adapter_test.go
@@ -73,7 +73,7 @@ func (f *fakeRawStore) SetDomainTeardownState(context.Context, string, domaintea
 
 func TestStoreAdapter_SetSendingStatus(t *testing.T) {
 	raw := &fakeRawStore{}
-	store := NewStoreAdapter(raw)
+	store := NewStoreAdapter(raw, nil)
 	records := []DNSRecord{{Type: "TXT", Name: "_dmarc", Value: "v=DMARC1"}}
 
 	if err := store.SetSendingStatus(context.Background(), "example.com", "inc-1", StatusVerified, StatusVerified, StatusFailed, "ok", records); err != nil {
@@ -99,7 +99,7 @@ func TestStoreAdapter_SetSendingStatus(t *testing.T) {
 
 func TestStoreAdapter_SetSendingStatus_NoRecords(t *testing.T) {
 	raw := &fakeRawStore{}
-	store := NewStoreAdapter(raw)
+	store := NewStoreAdapter(raw, nil)
 	if err := store.SetSendingStatus(context.Background(), "example.com", "inc-1", StatusPending, "", "", "", nil); err != nil {
 		t.Fatalf("SetSendingStatus: %v", err)
 	}
@@ -113,7 +113,7 @@ func TestStoreAdapter_SetSendingStatus_NoRecords(t *testing.T) {
 
 func TestStoreAdapter_LoadSendingIdentityState(t *testing.T) {
 	raw := &fakeRawStore{getStatusReturn: "pending"}
-	store := NewStoreAdapter(raw)
+	store := NewStoreAdapter(raw, nil)
 	got, err := store.LoadSendingIdentityState(context.Background(), "example.com")
 	if err != nil {
 		t.Fatalf("GetSendingStatus: %v", err)

--- a/internal/senderidentity/fake.go
+++ b/internal/senderidentity/fake.go
@@ -36,7 +36,11 @@ type FakeProvider struct {
 	// for List/reaper tests. Provision adds; Deprovision removes.
 	identities map[string]bool
 
-	ProvisionCalls   []string
+	ProvisionCalls []string
+	// ProvisionMetas is index-parallel to ProvisionCalls: the classification
+	// metadata each Provision call carried. Recorded separately so existing
+	// tests keep asserting on the plain domain list.
+	ProvisionMetas   []ProvisionMeta
 	StatusCalls      []StatusCall
 	DeprovisionCalls []string
 	ListCalls        int
@@ -128,10 +132,11 @@ func (f *FakeProvider) SetDeprovisionErr(err error) {
 	f.deprovisionErr = err
 }
 
-func (f *FakeProvider) Provision(ctx context.Context, domain, dkimSelector string, dkimPrivateKeyDER []byte) (Result, error) {
+func (f *FakeProvider) Provision(ctx context.Context, domain, dkimSelector string, dkimPrivateKeyDER []byte, meta ProvisionMeta) (Result, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.ProvisionCalls = append(f.ProvisionCalls, domain)
+	f.ProvisionMetas = append(f.ProvisionMetas, meta)
 	if f.provisionErr != nil {
 		return Result{}, f.provisionErr
 	}

--- a/internal/senderidentity/fakestore_test.go
+++ b/internal/senderidentity/fakestore_test.go
@@ -21,7 +21,11 @@ type fakeStore struct {
 	// status holds the current sending status per domain. Absence ⇒ row gone.
 	status map[string]Status
 	// owners maps domain → owning user_id ("" or absent ⇒ no owner).
-	owners       map[string]string
+	owners map[string]string
+	// accountClass maps user_id → usage account class (absent ⇒ unknown).
+	accountClass    map[string]string
+	accountClassErr error
+
 	incarnations map[string]string
 	verified     map[string]bool
 	managed      map[string]string
@@ -77,6 +81,7 @@ func newFakeStore() *fakeStore {
 	return &fakeStore{
 		status:               map[string]Status{},
 		owners:               map[string]string{},
+		accountClass:         map[string]string{},
 		incarnations:         map[string]string{},
 		verified:             map[string]bool{},
 		managed:              map[string]string{},
@@ -380,6 +385,17 @@ func (s *fakeStore) DomainExists(ctx context.Context, domain string) (bool, erro
 	}
 	_, ok := s.status[domain]
 	return ok, nil
+}
+
+// AccountClassForUser mirrors the real adapter: an unseeded user reads as ""
+// ("class unknown"), which is a valid answer rather than an error.
+func (s *fakeStore) AccountClassForUser(ctx context.Context, userID string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.accountClassErr != nil {
+		return "", s.accountClassErr
+	}
+	return s.accountClass[userID], nil
 }
 
 func (s *fakeStore) ListManagedSendingIdentityDomains(ctx context.Context) ([]string, map[string]bool, error) {

--- a/internal/senderidentity/integration_test.go
+++ b/internal/senderidentity/integration_test.go
@@ -126,7 +126,7 @@ func TestProvisionToVerified(t *testing.T) {
 	fake.SetStatus(domain, senderidentity.Result{Status: senderidentity.StatusVerified})
 
 	rec := &recordingFire{}
-	mgr := senderidentity.NewManager(senderidentity.NewStoreAdapter(store), fake, rec.firer(), senderidentity.Config{})
+	mgr := senderidentity.NewManager(senderidentity.NewStoreAdapter(store, nil), fake, rec.firer(), senderidentity.Config{})
 	startShared(t, pool, mgr)
 
 	if err := mgr.EnqueueProvision(ctx, domain); err != nil {
@@ -157,7 +157,7 @@ func TestProvisionFailsClosed(t *testing.T) {
 	fake := senderidentity.NewFakeProvider()
 	fake.SetStatus(domain, senderidentity.Result{Status: senderidentity.StatusFailed, Error: "dkim mismatch"})
 
-	mgr := senderidentity.NewManager(senderidentity.NewStoreAdapter(store), fake, nil, senderidentity.Config{})
+	mgr := senderidentity.NewManager(senderidentity.NewStoreAdapter(store, nil), fake, nil, senderidentity.Config{})
 	startShared(t, pool, mgr)
 
 	if err := mgr.EnqueueProvision(ctx, domain); err != nil {
@@ -177,7 +177,7 @@ func TestDeprovisionTeardown(t *testing.T) {
 
 	fake := senderidentity.NewFakeProvider()
 	fake.SeedIdentity("teardown.example.com")
-	mgr := senderidentity.NewManager(senderidentity.NewStoreAdapter(store), fake, nil, senderidentity.Config{})
+	mgr := senderidentity.NewManager(senderidentity.NewStoreAdapter(store, nil), fake, nil, senderidentity.Config{})
 	startShared(t, pool, mgr)
 
 	// EnqueueDeprovisionTx requires a tx; use the pool's own.
@@ -218,7 +218,7 @@ func TestReprovisionAfterFailed(t *testing.T) {
 
 	fake := senderidentity.NewFakeProvider()
 	fake.SetStatus(domain, senderidentity.Result{Status: senderidentity.StatusFailed, Error: "dns not ready"})
-	mgr := senderidentity.NewManager(senderidentity.NewStoreAdapter(store), fake, nil, senderidentity.Config{})
+	mgr := senderidentity.NewManager(senderidentity.NewStoreAdapter(store, nil), fake, nil, senderidentity.Config{})
 	startShared(t, pool, mgr)
 
 	if err := mgr.EnqueueProvision(ctx, domain); err != nil {

--- a/internal/senderidentity/provider.go
+++ b/internal/senderidentity/provider.go
@@ -123,7 +123,13 @@ type Provider interface {
 	// matches this selector (see Provider doc); otherwise returns
 	// ErrIdentityNotOwned. Returns the initial Result — typically
 	// StatusPending — or an error to retry.
-	Provision(ctx context.Context, domain, dkimSelector string, dkimPrivateKeyDER []byte) (Result, error)
+	//
+	// meta is best-effort classification metadata for the identity being
+	// created (see ProvisionMeta and tags.go). Implementations MUST treat
+	// every field as optional and MUST NOT fail a provision over it: a
+	// partial or wholly empty ProvisionMeta yields a less self-describing
+	// identity, never a failed verification.
+	Provision(ctx context.Context, domain, dkimSelector string, dkimPrivateKeyDER []byte, meta ProvisionMeta) (Result, error)
 
 	// Status polls the current verification state from the provider.
 	// evidence is what e2a has on file for domain (see AdoptionEvidence) —

--- a/internal/senderidentity/ses.go
+++ b/internal/senderidentity/ses.go
@@ -61,6 +61,15 @@ type SESProvider struct {
 	// opt-IN via NewSESProviderFromConfig's production parameter, not opt-out.
 	refuseAdoption bool
 
+	// Classification-tag configuration (see tags.go). All optional: each
+	// missing piece omits its one tag, so the zero value still produces a
+	// correctly OWNED identity — only a less self-describing one. now is the
+	// injectable clock behind the created/expires stamps.
+	deploymentName   string
+	provisionerBuild string
+	fixtureTTL       time.Duration
+	now              func() time.Time
+
 	// accountID/partition resolution feeds the identity ARN adoption's
 	// TagResource call needs (arn:<partition>:ses:<region>:<accountID>:
 	// identity/<domain>) — GetEmailIdentity/ListEmailIdentities never return
@@ -264,7 +273,7 @@ func (p *SESProvider) identityForAdoption(ctx context.Context) (accountID, parti
 	return accountID, partition, nil
 }
 
-func (p *SESProvider) Provision(ctx context.Context, domain, dkimSelector string, dkimPrivateKeyDER []byte) (Result, error) {
+func (p *SESProvider) Provision(ctx context.Context, domain, dkimSelector string, dkimPrivateKeyDER []byte, meta ProvisionMeta) (Result, error) {
 	privB64, err := pkcs8Base64(dkimPrivateKeyDER)
 	if err != nil {
 		// A malformed key is not retryable — fail closed with a reason.
@@ -278,10 +287,13 @@ func (p *SESProvider) Provision(ctx context.Context, domain, dkimSelector string
 	_, err = p.api.CreateEmailIdentity(ctx, &sesv2.CreateEmailIdentityInput{
 		EmailIdentity:         &domain,
 		DkimSigningAttributes: dkimAttributes,
-		Tags: []sestypes.Tag{{
-			Key:   awsString(managedIdentityTagKey),
-			Value: awsString(managedIdentityTagValue),
-		}},
+		// Ownership anchor + best-effort classification metadata (tags.go).
+		// Only reachable on CREATE: the AlreadyExists branch below cannot
+		// retag, and adoption deliberately writes the ownership tag alone —
+		// back-dating a creation stamp and an owner classification onto an
+		// identity e2a did not create would be inventing evidence the reaper
+		// is meant to trust.
+		Tags: p.identityTags(meta),
 	})
 	if err != nil {
 		// AlreadyExists means the domain may belong to an older registration.

--- a/internal/senderidentity/ses_test.go
+++ b/internal/senderidentity/ses_test.go
@@ -321,7 +321,7 @@ func TestSESProvider_AdoptionDegradesWhenAccountIDUnavailable(t *testing.T) {
 		},
 	}
 
-	if _, err := p.Provision(context.Background(), "legacy.example", "e2a202607", pkcs1); !errors.Is(err, ErrIdentityNotOwned) {
+	if _, err := p.Provision(context.Background(), "legacy.example", "e2a202607", pkcs1, ProvisionMeta{}); !errors.Is(err, ErrIdentityNotOwned) {
 		t.Fatalf("Provision error = %v, want degraded ErrIdentityNotOwned when the account id is unavailable", err)
 	}
 	if len(stub.tagInputs) != 0 {
@@ -598,16 +598,17 @@ func TestSESProvider_ProvisionConfiguresMailFrom(t *testing.T) {
 	stub := &stubSESAPI{}
 	p := NewSESProvider(stub, "eu-west-1", testAccountID)
 
-	res, err := p.Provision(context.Background(), "acme.com", "e2a202606", pkcs1)
+	res, err := p.Provision(context.Background(), "acme.com", "e2a202606", pkcs1, ProvisionMeta{})
 	if err != nil {
 		t.Fatalf("Provision error: %v", err)
 	}
 	if res.Status != StatusPending {
 		t.Fatalf("want pending after provision, got %q", res.Status)
 	}
-	if stub.createInput == nil || len(stub.createInput.Tags) != 1 ||
-		stub.createInput.Tags[0].Key == nil || *stub.createInput.Tags[0].Key != managedIdentityTagKey ||
-		stub.createInput.Tags[0].Value == nil || *stub.createInput.Tags[0].Value != managedIdentityTagValue {
+	// The ownership tag is the anchor isManagedIdentity reads; the identity
+	// now also carries best-effort classification tags alongside it, pinned
+	// exhaustively by TestSESProvider_ProvisionIdentityTags.
+	if stub.createInput == nil || tagMap(stub.createInput.Tags)[managedIdentityTagKey] != managedIdentityTagValue {
 		t.Fatalf("created identity is missing ownership tag: %+v", stub.createInput)
 	}
 	// Configured the custom MAIL FROM on the identity.
@@ -646,7 +647,7 @@ func TestSESProvider_ProvisionAlreadyExistsStillSetsMailFrom(t *testing.T) {
 	// FROM must still be (re)configured.
 	stub := &stubSESAPI{createErr: &sestypes.AlreadyExistsException{}}
 	p := NewSESProvider(stub, "us-east-1", testAccountID)
-	res, err := p.Provision(context.Background(), "acme.com", "sel", pkcs1)
+	res, err := p.Provision(context.Background(), "acme.com", "sel", pkcs1, ProvisionMeta{})
 	if err != nil {
 		t.Fatalf("Provision error: %v", err)
 	}
@@ -893,7 +894,7 @@ func TestSESProvider_ProvisionRefusesForeignConfiguration(t *testing.T) {
 			},
 		}
 		p := NewSESProvider(stub, "us-east-1", testAccountID)
-		if _, err := p.Provision(context.Background(), "shared-config.example", "e2a202607", pkcs1); !errors.Is(err, ErrIdentityNotOwned) {
+		if _, err := p.Provision(context.Background(), "shared-config.example", "e2a202607", pkcs1, ProvisionMeta{}); !errors.Is(err, ErrIdentityNotOwned) {
 			t.Fatalf("Provision error = %v, want ErrIdentityNotOwned", err)
 		}
 		if len(stub.tagInputs) != 0 {
@@ -918,7 +919,7 @@ func TestSESProvider_ProvisionRefusesForeignConfiguration(t *testing.T) {
 			},
 		}
 		p := NewSESProvider(stub, "us-east-1", testAccountID)
-		if _, err := p.Provision(context.Background(), "shared-policy.example", "e2a202607", pkcs1); !errors.Is(err, ErrIdentityNotOwned) {
+		if _, err := p.Provision(context.Background(), "shared-policy.example", "e2a202607", pkcs1, ProvisionMeta{}); !errors.Is(err, ErrIdentityNotOwned) {
 			t.Fatalf("Provision error = %v, want ErrIdentityNotOwned", err)
 		}
 		if len(stub.tagInputs) != 0 {
@@ -949,7 +950,7 @@ func TestSESProvider_ProvisionAdoptsProvablyOwnIdentity(t *testing.T) {
 	}
 	p := NewSESProvider(stub, "us-east-1", testAccountID)
 
-	res, err := p.Provision(context.Background(), "legacy.example", "e2a202607", pkcs1)
+	res, err := p.Provision(context.Background(), "legacy.example", "e2a202607", pkcs1, ProvisionMeta{})
 	if err != nil {
 		t.Fatalf("Provision error = %v, want adoption to succeed", err)
 	}
@@ -1009,7 +1010,7 @@ func TestSESProvider_RefuseAdoptionOutsideProduction(t *testing.T) {
 		}
 		p := &SESProvider{api: stub, region: "us-east-1", refuseAdoption: true}
 
-		if _, err := p.Provision(context.Background(), "legacy.example", "e2a202607", pkcs1); !errors.Is(err, ErrIdentityNotOwned) {
+		if _, err := p.Provision(context.Background(), "legacy.example", "e2a202607", pkcs1, ProvisionMeta{}); !errors.Is(err, ErrIdentityNotOwned) {
 			t.Fatalf("Provision error = %v, want ErrIdentityNotOwned when refuseAdoption is set", err)
 		}
 		if len(stub.tagInputs) != 0 {
@@ -1062,7 +1063,7 @@ func TestSESProvider_AdoptIdentityUsesResolvedPartitionInARN(t *testing.T) {
 		},
 	}
 
-	if _, err := p.Provision(context.Background(), "legacy.example", "e2a202607", pkcs1); err != nil {
+	if _, err := p.Provision(context.Background(), "legacy.example", "e2a202607", pkcs1, ProvisionMeta{}); err != nil {
 		t.Fatalf("Provision error = %v, want adoption to succeed", err)
 	}
 	if len(stub.tagInputs) != 1 {
@@ -1095,7 +1096,7 @@ func TestSESProvider_ProvisionRefusesMismatchedSelector(t *testing.T) {
 	}
 	p := NewSESProvider(stub, "us-east-1", testAccountID)
 
-	if _, err := p.Provision(context.Background(), "shared.example", "e2a202607", pkcs1); !errors.Is(err, ErrIdentityNotOwned) {
+	if _, err := p.Provision(context.Background(), "shared.example", "e2a202607", pkcs1, ProvisionMeta{}); !errors.Is(err, ErrIdentityNotOwned) {
 		t.Fatalf("Provision error = %v, want ErrIdentityNotOwned", err)
 	}
 	if len(stub.tagInputs) != 0 {
@@ -1127,7 +1128,7 @@ func TestSESProvider_ProvisionRefusesAWSManagedDkimOrigin(t *testing.T) {
 	}
 	p := NewSESProvider(stub, "us-east-1", testAccountID)
 
-	if _, err := p.Provision(context.Background(), "easy-dkim.example", "e2a202607", pkcs1); !errors.Is(err, ErrIdentityNotOwned) {
+	if _, err := p.Provision(context.Background(), "easy-dkim.example", "e2a202607", pkcs1, ProvisionMeta{}); !errors.Is(err, ErrIdentityNotOwned) {
 		t.Fatalf("Provision error = %v, want ErrIdentityNotOwned", err)
 	}
 	if len(stub.tagInputs) != 0 {
@@ -1146,7 +1147,7 @@ func TestSESProvider_ProvisionAlreadyTaggedDoesNotRetag(t *testing.T) {
 	stub := &stubSESAPI{createErr: &sestypes.AlreadyExistsException{}}
 	p := NewSESProvider(stub, "us-east-1", testAccountID)
 
-	if _, err := p.Provision(context.Background(), "already-owned.example", "e2a202607", pkcs1); err != nil {
+	if _, err := p.Provision(context.Background(), "already-owned.example", "e2a202607", pkcs1, ProvisionMeta{}); err != nil {
 		t.Fatalf("Provision error: %v", err)
 	}
 	if len(stub.tagInputs) != 0 {
@@ -1178,7 +1179,7 @@ func TestSESProvider_ProvisionAdoptionTagFailurePropagates(t *testing.T) {
 	}
 	p := NewSESProvider(stub, "us-east-1", testAccountID)
 
-	if _, err := p.Provision(context.Background(), "legacy.example", "e2a202607", pkcs1); !errors.Is(err, boom) {
+	if _, err := p.Provision(context.Background(), "legacy.example", "e2a202607", pkcs1, ProvisionMeta{}); !errors.Is(err, boom) {
 		t.Fatalf("Provision error = %v, want the TagResource error to propagate", err)
 	}
 	if stub.dkimInput != nil || stub.mailFromInput != nil {
@@ -1268,7 +1269,7 @@ func TestSESProvider_ProvisionAdoptionAccessDeniedRefusesNotRetries(t *testing.T
 	}
 	p := NewSESProvider(stub, "us-east-1", testAccountID)
 
-	if _, err := p.Provision(context.Background(), "denied.example", "e2a202607", pkcs1); !errors.Is(err, ErrIdentityNotOwned) {
+	if _, err := p.Provision(context.Background(), "denied.example", "e2a202607", pkcs1, ProvisionMeta{}); !errors.Is(err, ErrIdentityNotOwned) {
 		t.Fatalf("Provision error = %v, want ErrIdentityNotOwned for a permanently denied TagResource call", err)
 	}
 	if stub.dkimInput != nil || stub.mailFromInput != nil {
@@ -1391,7 +1392,7 @@ func TestSESProvider_RefusesUnmanagedExistingIdentity(t *testing.T) {
 	stub := &stubSESAPI{createErr: &sestypes.AlreadyExistsException{}, unmanaged: true}
 	p := NewSESProvider(stub, "us-east-1", testAccountID)
 
-	if _, err := p.Provision(context.Background(), "shared.example", "sel", pkcs1); !errors.Is(err, ErrIdentityNotOwned) {
+	if _, err := p.Provision(context.Background(), "shared.example", "sel", pkcs1, ProvisionMeta{}); !errors.Is(err, ErrIdentityNotOwned) {
 		t.Fatalf("Provision error = %v, want ErrIdentityNotOwned", err)
 	}
 	if stub.dkimInput != nil || stub.mailFromInput != nil {
@@ -1409,7 +1410,7 @@ func TestSESProvider_ProvisionPropagatesMailFromError(t *testing.T) {
 	// must surface the error so River retries (not silently return pending).
 	stub := &stubSESAPI{putErr: errors.New("throttled")}
 	p := NewSESProvider(stub, "us-east-1", testAccountID)
-	if _, err := p.Provision(context.Background(), "acme.com", "sel", pkcs1); err == nil {
+	if _, err := p.Provision(context.Background(), "acme.com", "sel", pkcs1, ProvisionMeta{}); err == nil {
 		t.Fatal("expected PutEmailIdentityMailFromAttributes error to propagate")
 	}
 }
@@ -1421,7 +1422,7 @@ func TestSESProvider_ProvisionPropagatesReplacementDkimError(t *testing.T) {
 	stub := &stubSESAPI{createErr: &sestypes.AlreadyExistsException{}, putDkimErr: boom}
 	p := NewSESProvider(stub, "us-east-1", testAccountID)
 
-	if _, err := p.Provision(context.Background(), "acme.com", "sel", pkcs1); !errors.Is(err, boom) {
+	if _, err := p.Provision(context.Background(), "acme.com", "sel", pkcs1, ProvisionMeta{}); !errors.Is(err, boom) {
 		t.Fatalf("expected DKIM update error to propagate, got %v", err)
 	}
 	if stub.mailFromInput != nil {

--- a/internal/senderidentity/tags.go
+++ b/internal/senderidentity/tags.go
@@ -27,7 +27,7 @@ import (
 // one that gets deleted by mistake.
 const (
 	// managedIdentityTagKey/Value live in ses.go: they are the pre-existing
-	// OWNERSHIP anchor isMangedIdentity reads, load-bearing for adoption and
+	// OWNERSHIP anchor isManagedIdentity reads, load-bearing for adoption and
 	// for the IAM resource-tag condition, and are deliberately untouched here.
 
 	// envTagKey names the deployment that created the identity ("prod" |

--- a/internal/senderidentity/tags.go
+++ b/internal/senderidentity/tags.go
@@ -1,0 +1,201 @@
+package senderidentity
+
+import (
+	"time"
+
+	sestypes "github.com/aws/aws-sdk-go-v2/service/sesv2/types"
+)
+
+// Classification tags stamped on every sending identity e2a CREATES. They
+// exist so "is this identity safe to delete?" is answerable from the provider
+// account alone, without a correct join against this server's Postgres ledger
+// — the join that a reaper cannot make when it is pointed at an AWS account
+// whose database is gone, restored from a stale backup, or simply not the one
+// that provisioned the identity.
+//
+// The keys here and the value vocabularies below are HARDCODED, not
+// configurable, precisely because the writer (this package's provisioner) and
+// the future reader (the reaper that will be given delete authority on the
+// strength of these tags) must be unable to drift apart. Every VALUE is
+// derived at runtime.
+//
+// Tagging is strictly best-effort and fails OPEN: a value that cannot be
+// derived omits its one tag and never fails the provision. That asymmetry is
+// deliberate and only safe because the eventual deletion decision fails
+// CLOSED — an identity missing a tag is one the reaper must leave alone, so
+// the worst case of a dropped tag is an identity a human has to classify, not
+// one that gets deleted by mistake.
+const (
+	// managedIdentityTagKey/Value live in ses.go: they are the pre-existing
+	// OWNERSHIP anchor isMangedIdentity reads, load-bearing for adoption and
+	// for the IAM resource-tag condition, and are deliberately untouched here.
+
+	// envTagKey names the deployment that created the identity ("prod" |
+	// "staging"), so a shared AWS account can tell one deployment's
+	// identities from another's. Omitted when the deployment is unnamed —
+	// the self-host default.
+	envTagKey = "e2a-env"
+	// purposeTagKey classifies the OWNER, not the domain: purposeCustomer for
+	// a real account, purposeFixture for e2a's own internal/monitoring
+	// accounts. Only fixtures are ever candidates for automatic cleanup.
+	purposeTagKey = "e2a-purpose"
+	// createdTagKey is the provider-side creation stamp (RFC3339, UTC). SES
+	// does not report a creation time for an identity, so without this tag
+	// age is unknowable from AWS alone.
+	createdTagKey = "e2a-created"
+	// expiresTagKey is created + the fixture TTL, written ONLY for
+	// purposeFixture. A customer identity carries no expiry at all: there is
+	// no time after which deleting a customer's sending identity is correct.
+	expiresTagKey = "e2a-expires"
+	// userTagKey is the owning user id, so an identity can be traced back to
+	// an account without the ledger.
+	userTagKey = "e2a-user"
+	// provisionerTagKey is the build/release that created the identity —
+	// which code wrote the rest of these tags.
+	provisionerTagKey = "e2a-provisioner"
+)
+
+// Deployment names recognized for the e2a-env tag. This is the closed
+// vocabulary; internal/config mirrors these two literals to normalize operator
+// input, but this package is the authority and re-screens whatever it is
+// given, so a name that reaches here unrecognized drops the tag rather than
+// writing an unknown value the reaper would then have to interpret.
+const (
+	DeploymentProd    = "prod"
+	DeploymentStaging = "staging"
+)
+
+// Purpose values for the e2a-purpose tag. Closed vocabulary, derived from the
+// owner's usage account class:
+//
+//   - "standard" / "demo"    → purposeCustomer. A demo account is user-facing
+//     and its domain is a real customer domain in every way that matters for
+//     deletion, so it is deliberately NOT a fixture.
+//   - "internal" / "system"  → purposeFixture. Internal dogfooding and
+//     synthetic-monitoring probes; these are the identities a cleanup pass
+//     exists for.
+//
+// Anything else — including the empty string a failed lookup yields — is left
+// UNCLASSIFIED rather than guessed. purposeCustomer is not a safe default to
+// assume (it would hide abandoned fixtures forever) and purposeFixture
+// certainly is not (it would eventually mark a customer's identity
+// deletable), so the honest answer is no tag.
+const (
+	purposeCustomer = "customer"
+	purposeFixture  = "fixture"
+)
+
+// maxTagValueLen is the SES tag-value length limit.
+const maxTagValueLen = 256
+
+// ProvisionMeta is the ledger-side context a Provider may stamp onto an
+// identity it creates. Every field is optional: an absent value drops the tag
+// it would have fed and nothing else. The caller resolves these best-effort
+// (see the worker's provisionMeta), so a store lookup that fails yields a
+// partial ProvisionMeta rather than an error.
+type ProvisionMeta struct {
+	// UserID is the domain owner's user id (SendingIdentityState.Owner).
+	UserID string
+	// AccountClass is the owner's usage account class ("standard",
+	// "internal", "system", "demo"). Empty means "not known" — not
+	// "standard": see the purpose vocabulary above for why the difference
+	// matters.
+	AccountClass string
+}
+
+// WithIdentityTags configures the runtime-derived classification tags this
+// provider stamps on identities it creates. Every argument is optional:
+// deploymentName "" (or an unrecognized name) omits the env tag,
+// provisionerBuild "" omits the provisioner tag, and fixtureTTL <= 0 omits the
+// expiry tag. An SESProvider that never gets this call still writes the
+// ownership anchor and the creation stamp, so the zero value is a working
+// provider, not a broken one.
+func (p *SESProvider) WithIdentityTags(deploymentName, provisionerBuild string, fixtureTTL time.Duration) *SESProvider {
+	p.deploymentName = deploymentName
+	p.provisionerBuild = provisionerBuild
+	p.fixtureTTL = fixtureTTL
+	return p
+}
+
+// clock is the provider's time source, injectable so the created/expires
+// stamps are assertable in tests.
+func (p *SESProvider) clock() time.Time {
+	if p.now != nil {
+		return p.now()
+	}
+	return time.Now()
+}
+
+// identityTags builds the tag list for a newly created identity. It never
+// returns an error and never returns an empty list: the ownership tag is
+// unconditional, and every classification tag is appended only when its value
+// is both derivable and something SES will accept.
+func (p *SESProvider) identityTags(meta ProvisionMeta) []sestypes.Tag {
+	tags := []sestypes.Tag{{
+		Key:   awsString(managedIdentityTagKey),
+		Value: awsString(managedIdentityTagValue),
+	}}
+	add := func(key, value string) {
+		if !tagValueAccepted(value) {
+			return
+		}
+		tags = append(tags, sestypes.Tag{Key: awsString(key), Value: awsString(value)})
+	}
+
+	switch p.deploymentName {
+	case DeploymentProd, DeploymentStaging:
+		add(envTagKey, p.deploymentName)
+	}
+
+	purpose := purposeForAccountClass(meta.AccountClass)
+	add(purposeTagKey, purpose)
+
+	created := p.clock().UTC()
+	add(createdTagKey, created.Format(time.RFC3339))
+	if purpose == purposeFixture && p.fixtureTTL > 0 {
+		add(expiresTagKey, created.Add(p.fixtureTTL).Format(time.RFC3339))
+	}
+
+	add(userTagKey, meta.UserID)
+	add(provisionerTagKey, p.provisionerBuild)
+	return tags
+}
+
+// purposeForAccountClass maps a usage account class onto the closed purpose
+// vocabulary, returning "" for anything it does not recognize (see the
+// vocabulary's doc comment). The class strings are usage.AccountClass values
+// spelled literally so this package does not import internal/usage — the
+// workers already speak plain strings for exactly this reason (see RawStore).
+func purposeForAccountClass(class string) string {
+	switch class {
+	case "standard", "demo":
+		return purposeCustomer
+	case "internal", "system":
+		return purposeFixture
+	default:
+		return ""
+	}
+}
+
+// tagValueAccepted screens a value against the SES tag-value rule (letters,
+// digits, spaces, and + - = . _ : / @, up to 256 characters). It exists
+// because SES rejects the WHOLE CreateEmailIdentity call on one bad tag: the
+// provisioner build string is operator-supplied config that e2a does not
+// control, and without this screen a stray character in it would turn
+// cosmetic metadata into a provisioning outage for every custom domain. An
+// empty value is also refused, which is what makes "omit the tag" the uniform
+// behavior for every underivable value.
+func tagValueAccepted(value string) bool {
+	if value == "" || len(value) > maxTagValueLen {
+		return false
+	}
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case r == ' ', r == '+', r == '-', r == '=', r == '.', r == '_', r == ':', r == '/', r == '@':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/senderidentity/tags_test.go
+++ b/internal/senderidentity/tags_test.go
@@ -1,0 +1,427 @@
+package senderidentity
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/sesv2"
+	sestypes "github.com/aws/aws-sdk-go-v2/service/sesv2/types"
+)
+
+// tagMap flattens the SES tag list a Provision call sent, so a test can assert
+// the EXACT set (an unexpected extra tag fails too — the reaper will read these
+// as authority, so a stray tag is as much a defect as a missing one).
+func tagMap(tags []sestypes.Tag) map[string]string {
+	out := map[string]string{}
+	for _, tg := range tags {
+		if tg.Key == nil || tg.Value == nil {
+			continue
+		}
+		out[*tg.Key] = *tg.Value
+	}
+	return out
+}
+
+func testDKIMKey(t *testing.T) []byte {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	return x509.MarshalPKCS1PrivateKey(key)
+}
+
+// TestSESProvider_ProvisionIdentityTags pins the full classification tag set a
+// freshly created identity carries, case by case. The point of the tags is that
+// "is this identity safe to delete?" becomes answerable from AWS alone, so each
+// case asserts the WHOLE map: a missing tag and a spurious one are both defects.
+//
+// Every value is derived at runtime and every derivation is best-effort — the
+// absent-input cases below (no deployment name, unknown account class, no owner,
+// no build) prove that a missing input drops exactly ONE tag and never fails the
+// provision.
+func TestSESProvider_ProvisionIdentityTags(t *testing.T) {
+	created := time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC)
+	const createdRFC3339 = "2026-03-04T05:06:07Z"
+	const ttl = 24 * time.Hour
+	const expiresRFC3339 = "2026-03-05T05:06:07Z"
+
+	tests := []struct {
+		name       string
+		deployment string
+		build      string
+		fixtureTTL time.Duration
+		meta       ProvisionMeta
+		want       map[string]string
+	}{
+		{
+			name:       "standard account on prod → customer, no expires",
+			deployment: "prod",
+			build:      "1.7.11",
+			fixtureTTL: ttl,
+			meta:       ProvisionMeta{UserID: "user_abc", AccountClass: "standard"},
+			want: map[string]string{
+				managedIdentityTagKey: managedIdentityTagValue,
+				envTagKey:             "prod",
+				purposeTagKey:         purposeCustomer,
+				createdTagKey:         createdRFC3339,
+				userTagKey:            "user_abc",
+				provisionerTagKey:     "1.7.11",
+			},
+		},
+		{
+			name:       "demo account is a customer too (never auto-deletable)",
+			deployment: "staging",
+			build:      "1.7.11",
+			fixtureTTL: ttl,
+			meta:       ProvisionMeta{UserID: "user_abc", AccountClass: "demo"},
+			want: map[string]string{
+				managedIdentityTagKey: managedIdentityTagValue,
+				envTagKey:             "staging",
+				purposeTagKey:         purposeCustomer,
+				createdTagKey:         createdRFC3339,
+				userTagKey:            "user_abc",
+				provisionerTagKey:     "1.7.11",
+			},
+		},
+		{
+			name:       "internal account → fixture with an expiry",
+			deployment: "staging",
+			build:      "1.7.11",
+			fixtureTTL: ttl,
+			meta:       ProvisionMeta{UserID: "user_int", AccountClass: "internal"},
+			want: map[string]string{
+				managedIdentityTagKey: managedIdentityTagValue,
+				envTagKey:             "staging",
+				purposeTagKey:         purposeFixture,
+				createdTagKey:         createdRFC3339,
+				expiresTagKey:         expiresRFC3339,
+				userTagKey:            "user_int",
+				provisionerTagKey:     "1.7.11",
+			},
+		},
+		{
+			name:       "system (prober) account → fixture with an expiry",
+			deployment: "prod",
+			build:      "1.7.11",
+			fixtureTTL: ttl,
+			meta:       ProvisionMeta{UserID: "user_sys", AccountClass: "system"},
+			want: map[string]string{
+				managedIdentityTagKey: managedIdentityTagValue,
+				envTagKey:             "prod",
+				purposeTagKey:         purposeFixture,
+				createdTagKey:         createdRFC3339,
+				expiresTagKey:         expiresRFC3339,
+				userTagKey:            "user_sys",
+				provisionerTagKey:     "1.7.11",
+			},
+		},
+		{
+			name:       "deployment name unset (self-host) → env omitted, everything else stands",
+			build:      "1.7.11",
+			fixtureTTL: ttl,
+			meta:       ProvisionMeta{UserID: "user_abc", AccountClass: "standard"},
+			want: map[string]string{
+				managedIdentityTagKey: managedIdentityTagValue,
+				purposeTagKey:         purposeCustomer,
+				createdTagKey:         createdRFC3339,
+				userTagKey:            "user_abc",
+				provisionerTagKey:     "1.7.11",
+			},
+		},
+		{
+			name:       "unrecognized deployment name behaves as unset, never as a literal tag",
+			deployment: "production",
+			build:      "1.7.11",
+			fixtureTTL: ttl,
+			meta:       ProvisionMeta{UserID: "user_abc", AccountClass: "standard"},
+			want: map[string]string{
+				managedIdentityTagKey: managedIdentityTagValue,
+				purposeTagKey:         purposeCustomer,
+				createdTagKey:         createdRFC3339,
+				userTagKey:            "user_abc",
+				provisionerTagKey:     "1.7.11",
+			},
+		},
+		{
+			name:       "account class unknown (lookup failed) → purpose AND expires omitted",
+			deployment: "prod",
+			build:      "1.7.11",
+			fixtureTTL: ttl,
+			meta:       ProvisionMeta{UserID: "user_abc"},
+			want: map[string]string{
+				managedIdentityTagKey: managedIdentityTagValue,
+				envTagKey:             "prod",
+				createdTagKey:         createdRFC3339,
+				userTagKey:            "user_abc",
+				provisionerTagKey:     "1.7.11",
+			},
+		},
+		{
+			name:       "unrecognized account class is not a purpose → omitted, never guessed",
+			deployment: "prod",
+			build:      "1.7.11",
+			fixtureTTL: ttl,
+			meta:       ProvisionMeta{UserID: "user_abc", AccountClass: "platinum"},
+			want: map[string]string{
+				managedIdentityTagKey: managedIdentityTagValue,
+				envTagKey:             "prod",
+				createdTagKey:         createdRFC3339,
+				userTagKey:            "user_abc",
+				provisionerTagKey:     "1.7.11",
+			},
+		},
+		{
+			name:       "empty owner → user tag omitted",
+			deployment: "prod",
+			build:      "1.7.11",
+			fixtureTTL: ttl,
+			meta:       ProvisionMeta{AccountClass: "standard"},
+			want: map[string]string{
+				managedIdentityTagKey: managedIdentityTagValue,
+				envTagKey:             "prod",
+				purposeTagKey:         purposeCustomer,
+				createdTagKey:         createdRFC3339,
+				provisionerTagKey:     "1.7.11",
+			},
+		},
+		{
+			name:       "no build string → provisioner tag omitted",
+			deployment: "prod",
+			fixtureTTL: ttl,
+			meta:       ProvisionMeta{UserID: "user_abc", AccountClass: "standard"},
+			want: map[string]string{
+				managedIdentityTagKey: managedIdentityTagValue,
+				envTagKey:             "prod",
+				purposeTagKey:         purposeCustomer,
+				createdTagKey:         createdRFC3339,
+				userTagKey:            "user_abc",
+			},
+		},
+		{
+			name:       "build string SES would reject is dropped, not sent",
+			deployment: "prod",
+			build:      "1.7.11 (dirty#7)",
+			fixtureTTL: ttl,
+			meta:       ProvisionMeta{UserID: "user_abc", AccountClass: "standard"},
+			want: map[string]string{
+				managedIdentityTagKey: managedIdentityTagValue,
+				envTagKey:             "prod",
+				purposeTagKey:         purposeCustomer,
+				createdTagKey:         createdRFC3339,
+				userTagKey:            "user_abc",
+			},
+		},
+		{
+			name:       "fixture TTL disabled → fixture purpose without an expiry",
+			deployment: "staging",
+			build:      "1.7.11",
+			fixtureTTL: 0,
+			meta:       ProvisionMeta{UserID: "user_int", AccountClass: "internal"},
+			want: map[string]string{
+				managedIdentityTagKey: managedIdentityTagValue,
+				envTagKey:             "staging",
+				purposeTagKey:         purposeFixture,
+				createdTagKey:         createdRFC3339,
+				userTagKey:            "user_int",
+				provisionerTagKey:     "1.7.11",
+			},
+		},
+	}
+
+	pkcs1 := testDKIMKey(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stub := &stubSESAPI{}
+			p := NewSESProvider(stub, "us-east-2", testAccountID).
+				WithIdentityTags(tt.deployment, tt.build, tt.fixtureTTL)
+			p.now = func() time.Time { return created }
+
+			res, err := p.Provision(context.Background(), "acme.example", "e2a202603", pkcs1, tt.meta)
+			if err != nil {
+				t.Fatalf("Provision error: %v — tag construction must never fail a provision", err)
+			}
+			if res.Status != StatusPending {
+				t.Fatalf("status = %q, want pending", res.Status)
+			}
+			if stub.createInput == nil {
+				t.Fatal("CreateEmailIdentity was never called")
+			}
+			if got := tagMap(stub.createInput.Tags); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("identity tags = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSESProvider_ProvisionTagsDefaultToOwnershipOnly proves an SESProvider that
+// was never given tag configuration (every test constructing one by hand, and
+// any self-host wiring that skips WithIdentityTags) still emits the ownership
+// anchor plus only the tags it can actually derive — the created stamp. This is
+// the regression guard for isManagedIdentity's input: the ownership tag's key
+// and value are unchanged by this feature.
+func TestSESProvider_ProvisionTagsDefaultToOwnershipOnly(t *testing.T) {
+	stub := &stubSESAPI{}
+	p := NewSESProvider(stub, "us-east-2", testAccountID)
+
+	if _, err := p.Provision(context.Background(), "acme.example", "sel", testDKIMKey(t), ProvisionMeta{}); err != nil {
+		t.Fatalf("Provision error: %v", err)
+	}
+	got := tagMap(stub.createInput.Tags)
+	if got[managedIdentityTagKey] != managedIdentityTagValue {
+		t.Fatalf("ownership tag = %q, want %q", got[managedIdentityTagKey], managedIdentityTagValue)
+	}
+	if _, ok := got[createdTagKey]; !ok {
+		t.Fatalf("created tag missing: %v", got)
+	}
+	if len(got) != 2 {
+		t.Fatalf("unconfigured provider emitted %v, want only ownership + created", got)
+	}
+	// The tag e2a's own ownership check reads must still be recognizable.
+	if !isManagedIdentity(&sesv2.GetEmailIdentityOutput{Tags: stub.createInput.Tags}) {
+		t.Fatal("isManagedIdentity no longer recognizes a freshly provisioned identity")
+	}
+}
+
+// TestSESProvider_AdoptionWritesOnlyTheOwnershipTag pins that adoption is
+// untouched by this feature: an untagged pre-existing identity is still tagged
+// with exactly the ownership anchor. Classification tags describe what e2a
+// CREATED; back-dating them onto an adopted identity would invent a creation
+// time and an owner classification that were never observed.
+func TestSESProvider_AdoptionWritesOnlyTheOwnershipTag(t *testing.T) {
+	pkcs1 := testDKIMKey(t)
+	stub := &stubSESAPI{
+		createErr: &sestypes.AlreadyExistsException{},
+		unmanaged: true,
+		getOut: &sesv2.GetEmailIdentityOutput{
+			DkimAttributes: &sestypes.DkimAttributes{
+				SigningAttributesOrigin: sestypes.DkimSigningAttributesOriginExternal,
+				Status:                  sestypes.DkimStatusSuccess,
+				Tokens:                  []string{"e2a202607"},
+			},
+		},
+	}
+	p := NewSESProvider(stub, "us-east-2", testAccountID).
+		WithIdentityTags("prod", "1.7.11", 24*time.Hour)
+
+	if _, err := p.Provision(context.Background(), "legacy.example", "e2a202607", pkcs1, ProvisionMeta{UserID: "user_abc", AccountClass: "standard"}); err != nil {
+		t.Fatalf("Provision error: %v", err)
+	}
+	if len(stub.tagInputs) != 1 {
+		t.Fatalf("want exactly one TagResource call, got %d", len(stub.tagInputs))
+	}
+	want := map[string]string{managedIdentityTagKey: managedIdentityTagValue}
+	if got := tagMap(stub.tagInputs[0].Tags); !reflect.DeepEqual(got, want) {
+		t.Fatalf("adoption tags = %v, want %v", got, want)
+	}
+}
+
+// TestProvisionWorker_StampsOwnerClassification proves the worker resolves the
+// domain owner's account class and hands it (plus the owner id) to the provider,
+// which is the only way the SES-side tags can be derived at all.
+func TestProvisionWorker_StampsOwnerClassification(t *testing.T) {
+	const domain = "classified.example"
+	const owner = "user_1"
+
+	store := newFakeStore()
+	store.setStatus(domain, StatusNone)
+	store.setOwner(domain, owner)
+	store.setProvisionInputs("sel1", []byte("der"), true)
+	store.accountClass[owner] = "internal"
+	prov := NewFakeProvider()
+	w := &ProvisionWorker{store: store, provider: prov}
+
+	if err := w.Work(context.Background(), provisionJob(domain)); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	want := []ProvisionMeta{{UserID: owner, AccountClass: "internal"}}
+	if !reflect.DeepEqual(prov.ProvisionMetas, want) {
+		t.Fatalf("provision meta = %+v, want %+v", prov.ProvisionMetas, want)
+	}
+}
+
+// TestProvisionWorker_AccountClassLookupFailureStillProvisions is the fail-OPEN
+// half of the contract. Tagging is metadata for a LATER, fail-CLOSED deletion
+// decision: an untagged identity is simply one the reaper must leave alone, so a
+// class lookup that errors must degrade to a partial tag set and never turn a
+// customer's domain verification into a failure.
+func TestProvisionWorker_AccountClassLookupFailureStillProvisions(t *testing.T) {
+	const domain = "lookup-broke.example"
+	const owner = "user_1"
+
+	store := newFakeStore()
+	store.setStatus(domain, StatusNone)
+	store.setOwner(domain, owner)
+	store.setProvisionInputs("sel1", []byte("der"), true)
+	store.accountClassErr = errors.New("db down")
+	prov := NewFakeProvider()
+	w := &ProvisionWorker{store: store, provider: prov}
+
+	if err := w.Work(context.Background(), provisionJob(domain)); err != nil {
+		t.Fatalf("Work: %v — a class lookup failure must never fail provisioning", err)
+	}
+	if len(prov.ProvisionCalls) != 1 {
+		t.Fatalf("Provision calls = %v, want exactly one", prov.ProvisionCalls)
+	}
+	want := []ProvisionMeta{{UserID: owner}}
+	if !reflect.DeepEqual(prov.ProvisionMetas, want) {
+		t.Fatalf("provision meta = %+v, want the owner with no class", prov.ProvisionMetas)
+	}
+	if got, _ := store.GetSendingStatus(context.Background(), domain); got != StatusPending {
+		t.Fatalf("status = %q, want pending", got)
+	}
+}
+
+// TestStoreAdapterAccountClassIsOptional covers the self-host / test wiring that
+// passes no account-class source: it must read as "unknown", not as an error the
+// worker would have to handle.
+func TestStoreAdapterAccountClassIsOptional(t *testing.T) {
+	a := NewStoreAdapter(&fakeRawStore{}, nil)
+	class, err := a.AccountClassForUser(context.Background(), "user_1")
+	if err != nil || class != "" {
+		t.Fatalf("AccountClassForUser = (%q, %v), want (\"\", nil)", class, err)
+	}
+
+	a = NewStoreAdapter(&fakeRawStore{}, func(ctx context.Context, userID string) (string, error) {
+		return "system", nil
+	})
+	class, err = a.AccountClassForUser(context.Background(), "user_1")
+	if err != nil || class != "system" {
+		t.Fatalf("AccountClassForUser = (%q, %v), want (\"system\", nil)", class, err)
+	}
+}
+
+// TestTagValueAccepted pins the SES tag-value character/length rule the builder
+// screens against. It exists because an unscreened operator-supplied build
+// string is the one tag value e2a does not control, and SES rejects the WHOLE
+// CreateEmailIdentity call on a bad tag — which would turn cosmetic metadata
+// into a provisioning outage.
+func TestTagValueAccepted(t *testing.T) {
+	tests := []struct {
+		value string
+		want  bool
+	}{
+		{"1.7.11", true},
+		{"sha-0a1b2c3", true},
+		{"2026-03-04T05:06:07Z", true},
+		{"user_01JABCDEF", true},
+		{"prod", true},
+		{"", false},
+		{"1.7.11 (dirty#7)", false},
+		{"build\nname", false},
+		{strings.Repeat("v", 256), true},
+		{strings.Repeat("v", 257), false},
+	}
+	for _, tt := range tests {
+		if got := tagValueAccepted(tt.value); got != tt.want {
+			t.Errorf("tagValueAccepted(%q) = %v, want %v", tt.value, got, tt.want)
+		}
+	}
+}

--- a/internal/senderidentity/worker.go
+++ b/internal/senderidentity/worker.go
@@ -97,6 +97,12 @@ type Store interface {
 	// it to ALERT on provider identities that are neither ledgered nor backed
 	// by a row (pre-upgrade orphans the migration backfill could not see).
 	DomainExists(ctx context.Context, domain string) (bool, error)
+	// AccountClassForUser returns the owner's usage account class
+	// ("standard" | "internal" | "system" | "demo") for the provider's
+	// classification tags. An empty string means "not known" and is NOT an
+	// error: a store with no account-class source wired (self-host, tests)
+	// answers that way, and the provider simply omits the purpose tag.
+	AccountClassForUser(ctx context.Context, userID string) (string, error)
 }
 
 // SendingIdentityState is the incarnation-consistent desired-state snapshot
@@ -125,6 +131,33 @@ type SendingIdentityState struct {
 // could each get it wrong differently (batch C finding 5).
 func adoptionEvidence(state SendingIdentityState) AdoptionEvidence {
 	return AdoptionEvidence{Selector: state.Selector, HasPrivateKey: len(state.PrivateKey) > 0}
+}
+
+// provisionMeta resolves the classification metadata the provider stamps onto
+// an identity it creates (see tags.go). Deliberately returns no error: this is
+// cosmetic-until-the-reaper-lands metadata, and the whole design fails OPEN
+// here — a class lookup that errors, or an owner the ledger never recorded,
+// costs the identity one tag, never a customer's domain verification. The
+// eventual deletion decision fails CLOSED on the same missing tag, so nothing
+// dangerous follows from a partial answer.
+//
+// An absent owner short-circuits the lookup rather than passing "" down to it:
+// the account-class read resolves an unknown user to "standard" (see
+// usage.Store.GetAccountClass, which fails toward metering on purpose), and
+// letting that default through here would stamp a confident purpose=customer
+// derived from nothing.
+func provisionMeta(ctx context.Context, store Store, state SendingIdentityState) ProvisionMeta {
+	meta := ProvisionMeta{UserID: state.Owner}
+	if state.Owner == "" {
+		return meta
+	}
+	class, err := store.AccountClassForUser(ctx, state.Owner)
+	if err != nil {
+		log.Printf("[senderidentity:worker] account class lookup failed for owner %s — provisioning without purpose/expires tags: %v", state.Owner, err)
+		return meta
+	}
+	meta.AccountClass = class
+	return meta
 }
 
 // EventFirer publishes a domain.sending_verified / domain.sending_failed
@@ -670,7 +703,7 @@ func syncProviderIdentityWithInspection(ctx context.Context, domain string, stor
 		if err := store.MarkSendingIdentityManaged(lockedCtx, domain, state.Incarnation); err != nil {
 			return err
 		}
-		res, err := provider.Provision(lockedCtx, domain, state.Selector, state.PrivateKey)
+		res, err := provider.Provision(lockedCtx, domain, state.Selector, state.PrivateKey, provisionMeta(lockedCtx, store, state))
 		if errors.Is(err, ErrIdentityNotOwned) {
 			const reason = "provider identity exists but is not managed by e2a"
 			// See the identical comment in reconcileProviderIdentity's

--- a/internal/senderidentity/worker_test.go
+++ b/internal/senderidentity/worker_test.go
@@ -46,19 +46,19 @@ func (p *blockingStatusProvider) Status(ctx context.Context, domain string, evid
 	return Result{Status: StatusVerified}, nil
 }
 
-func (p *blockingStatusProvider) Provision(ctx context.Context, domain, selector string, key []byte) (Result, error) {
+func (p *blockingStatusProvider) Provision(ctx context.Context, domain, selector string, key []byte, meta ProvisionMeta) (Result, error) {
 	p.provisionOnce.Do(func() { close(p.provisionStarted) })
-	return p.FakeProvider.Provision(ctx, domain, selector, key)
+	return p.FakeProvider.Provision(ctx, domain, selector, key, meta)
 }
 
-func (p *blockingProvisionProvider) Provision(ctx context.Context, domain, selector string, key []byte) (Result, error) {
+func (p *blockingProvisionProvider) Provision(ctx context.Context, domain, selector string, key []byte, meta ProvisionMeta) (Result, error) {
 	p.once.Do(func() { close(p.started) })
 	select {
 	case <-p.release:
 	case <-ctx.Done():
 		return Result{}, ctx.Err()
 	}
-	return p.FakeProvider.Provision(ctx, domain, selector, key)
+	return p.FakeProvider.Provision(ctx, domain, selector, key, meta)
 }
 
 // workCtxWithClient returns a context carrying a real (but DB-less) River


### PR DESCRIPTION
Groundwork for automatic cleanup of leaked sender identities. Today every e2a-provisioned SES identity carries exactly one tag, `e2a-managed: sender-identity-v1`, so "is this safe to delete?" can only be answered by joining against this server's Postgres ledger. Prod and staging **share one AWS account and region**, which means nothing in AWS distinguishes a staging test fixture from a customer's production sending domain.

Adds six classification tags at create time:

| Key | Value | Derived from |
|---|---|---|
| `e2a-managed` | `sender-identity-v1` | **unchanged** — still the ownership anchor `isManagedIdentity` reads |
| `e2a-env` | `prod` \| `staging` | new optional `deployment_name` config |
| `e2a-purpose` | `customer` \| `fixture` | owner's account class (`standard`/`demo` vs `internal`/`system`) |
| `e2a-created` | RFC3339 UTC | provider clock — SES reports no creation time, so age is otherwise unknowable from AWS |
| `e2a-expires` | RFC3339 UTC | fixtures only: created + TTL. A customer identity never gets one |
| `e2a-user` | user id | `SendingIdentityState.Owner` |
| `e2a-provisioner` | build string | which code wrote these tags |

**Keys and value vocabularies are hardcoded constants**, because the writer here and the future reaper that will be granted delete authority on the strength of these tags must be unable to drift apart. Every value is derived at runtime.

**Tagging fails open; deletion will fail closed.** An underivable value omits its one tag and never fails a provision — safe only because a missing tag must make the future reaper leave the identity alone. Worst case is an identity a human has to classify, never one deleted by mistake.

Notes:
- `cfg.Env` could **not** be reused for `e2a-env`: it is documented as `development`/`production`, the validator rejects anything else, and both prod and staging set `production`. Hence a separate `deployment_name` (env override `E2A_DEPLOYMENT_NAME`), unset by default so self-hosters simply get no env tag.
- `tagValueAccepted` screens every optional value against SES's charset and 256-char cap — without it an operator build string containing `#` would make SES reject the whole `CreateEmailIdentity` call, turning cosmetic metadata into a provisioning outage.
- No IAM change needed: both `e2a-server` and `e2a-staging-server` already hold `ses:TagResource`.
- Adoption/`AlreadyExists` paths and `isManagedIdentity` are untouched. No reaper/deprovision behavior changes — that is the follow-up PR.

Tests: `tags_test.go` (12-case table over the full tag map, plus adoption-path, worker-stamping, lookup-failure, and charset cases) and two config cases, written failing first. `go build ./...` clean, `go test ./...` green repo-wide, gofmt clean.

Companion ops change (one line per file, after this merges): `deployment_name: prod` / `staging` in the prod and staging configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScEpytuD7GvaXEssvJ2W32