### PR TITLE
feat(senderidentity): let the reaper reclaim expired fixture orphans

### DIFF
--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -384,7 +384,19 @@ func main() {
 			}),
 			provider,
 			senderIdentityEventFirer(outboxPublisher),
-			senderidentity.Config{LegacyJobCompat: cfg.SenderIdentity.LegacyJobCompat},
+			senderidentity.Config{
+				LegacyJobCompat: cfg.SenderIdentity.LegacyJobCompat,
+				// Orphan reclaim reads the SAME deployment name the tags were
+				// written with, so an identity can only ever be reclaimed by
+				// the deployment that created it.
+				Reclaim: senderidentity.ReclaimConfig{
+					Enabled:     cfg.SenderIdentity.ReapOrphans,
+					Deployment:  cfg.DeploymentName,
+					Zones:       cfg.SenderIdentity.ReclaimZones,
+					MinAge:      cfg.SenderIdentity.ReclaimMinAge,
+					MaxPerSweep: cfg.SenderIdentity.ReclaimMaxPerSweep,
+				},
+			},
 		)
 		registrars = append(registrars, senderMgr)
 	}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -253,6 +253,37 @@ sender_identity:
   # a Go duration string; "0s" disables the tag. Override with
   # E2A_SENDER_IDENTITY_FIXTURE_TTL.
   fixture_ttl: "24h"
+  # Orphan reclaim: let the hourly reaper DELETE sending identities that exist
+  # at the provider with no ledger row and no domain row (crashed test runs
+  # leak these). Off by default, and arming it is not enough on its own — an
+  # identity is deleted only when ALL of these hold: it carries e2a's ownership
+  # tag, its e2a-env tag names THIS deployment (deployment_name must be set),
+  # its e2a-purpose tag says "fixture", its e2a-expires stamp is in the past,
+  # its e2a-created stamp clears reclaim_min_age, its name falls under a
+  # reclaim_zones entry, and the provider reports it as NOT verified for
+  # sending. Anything missing or unparseable refuses. Deletion runs through the
+  # same ownership-verifying teardown path the ledgered phase uses.
+  #
+  # With reap_orphans false the reaper still runs the whole decision and logs
+  # "WOULD DELETE <domain>" (or the refusal reason) without touching the
+  # provider — run there for a few days and read the logs before arming.
+  reap_orphans: false
+  # DNS zones that hold ONLY e2a's own test fixtures. This is the strongest
+  # guard: customer domains are never under the test zone. Matching is on a
+  # label boundary, so "example.test" covers "a.example.test" and
+  # "example.test" itself but never "evilexample.test". EMPTY (the default)
+  # reclaims NOTHING — it is never read as "any zone".
+  reclaim_zones: []
+  # Absolute age floor before an identity may be reclaimed, checked
+  # independently of its expiry tag so clock skew or a mis-set fixture_ttl
+  # cannot make a brand-new identity instantly reclaimable. Go duration string;
+  # "0s" reclaims nothing.
+  reclaim_min_age: "168h"
+  # Cap on deletions per reaper JOB (the orphan phase is paginated across
+  # jobs, so this is a per-page budget, not a global one). A systematic
+  # mistake then costs a handful of identities and a loud log, not the
+  # account. 0 reclaims nothing.
+  reclaim_max_per_sweep: 5
 
 # Operator-managed recipient-volume ramp for newly verified custom sender
 # domains. Disabled by default for self-hosts. When enabled, the schedule is

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,18 @@ import (
 // day has been abandoned by the run that made it.
 const defaultSenderIdentityFixtureTTL = 24 * time.Hour
 
+// defaultSenderIdentityReclaimMinAge is the age floor for reclaiming an
+// orphaned fixture identity. A week is far longer than any test run and far
+// longer than any plausible clock skew, so an identity that clears it is
+// abandoned rather than merely idle.
+const defaultSenderIdentityReclaimMinAge = 168 * time.Hour
+
+// defaultSenderIdentityReclaimMaxPerSweep bounds deletions per reaper job. Set
+// so a systematic mistake costs a handful of identities and a loud log rather
+// than an account's worth, while still draining a realistic leak backlog
+// (single digits, accumulated over weeks) within a couple of hourly sweeps.
+const defaultSenderIdentityReclaimMaxPerSweep = 5
+
 // splitAndTrim splits a comma-separated env value into a clean slice (trimmed,
 // no empties). Used for list-valued overrides like SNS topic ARNs.
 func splitAndTrim(s string) []string {
@@ -428,6 +440,44 @@ type SenderIdentityConfig struct {
 	// E2A_SENDER_IDENTITY_FIXTURE_TTL; a malformed value there is logged and
 	// ignored rather than fatal, for the same reason as DeploymentName.
 	FixtureTTL time.Duration `yaml:"fixture_ttl"`
+
+	// ReapOrphans ARMS the reaper's orphan-identity reclaim. An orphan is a
+	// provider identity with no ledger row and no domain row; today the reaper
+	// only alerts on them, and crashed test runs leak them until a human
+	// sweeps by hand. Default false: with the flag off the reaper runs the
+	// entire deletion decision and logs what it WOULD delete (or why it
+	// refused) without touching the provider — the observe-only mode an
+	// operator is expected to run for days before arming.
+	//
+	// Arming is NOT sufficient on its own: ReclaimZones must also be set, and
+	// every guard in senderidentity.orphanReclaimable must pass. Deletion goes
+	// through the same ownership-verifying Deprovision path the managed-ledger
+	// phase uses.
+	ReapOrphans bool `yaml:"reap_orphans"`
+	// ReclaimZones bounds reclaim to identity names at or under a DNS zone
+	// that holds only e2a's OWN test fixtures (e.g. the conformance/prober
+	// zone). This is the strongest of the reclaim guards — a customer domain
+	// is never under the test zone — and matching is on a label boundary, so
+	// zone "example.test" covers "a.example.test" and "example.test" itself
+	// but never "evilexample.test".
+	//
+	// EMPTY (the default) means reclaim NOTHING. An empty list is never read
+	// as "any zone".
+	ReclaimZones []string `yaml:"reclaim_zones"`
+	// ReclaimMinAge is the absolute age floor an identity must clear (by its
+	// e2a-created tag) before it can be reclaimed, checked INDEPENDENTLY of
+	// its expiry tag so that clock skew or a mis-set FixtureTTL cannot make a
+	// brand-new identity instantly reclaimable. Written as a Go duration
+	// string; yaml.v3 decodes a duration only from a string, so spell zero
+	// "0s". Defaults to 168h (7 days). Zero or negative reclaims nothing — an
+	// unset floor is treated as an unconfigured policy, not as a waiver.
+	ReclaimMinAge time.Duration `yaml:"reclaim_min_age"`
+	// ReclaimMaxPerSweep caps how many identities one reaper JOB may delete.
+	// The orphan phase is paginated across River jobs, so this is a per-page
+	// budget rather than a global one (see reapProviderOrphanPage): it exists
+	// so a systematic mistake costs a handful of identities and a loud log
+	// rather than the account. Defaults to 5; 0 reclaims nothing.
+	ReclaimMaxPerSweep int `yaml:"reclaim_max_per_sweep"`
 }
 
 // SendingRampConfig is an operator-owned safety policy for newly verified
@@ -547,7 +597,13 @@ func Load(path string) (*Config, error) {
 		Trash:      TrashConfig{RetentionDays: 30},
 		// An absent sender_identity block keeps the fixture expiry default;
 		// an explicit `fixture_ttl: 0` survives unmarshal and disables it.
-		SenderIdentity: SenderIdentityConfig{FixtureTTL: defaultSenderIdentityFixtureTTL},
+		// The reclaim defaults are the SAFE ones: disarmed, no zones (which
+		// alone reclaims nothing), a 7-day age floor, and a 5-per-job cap.
+		SenderIdentity: SenderIdentityConfig{
+			FixtureTTL:         defaultSenderIdentityFixtureTTL,
+			ReclaimMinAge:      defaultSenderIdentityReclaimMinAge,
+			ReclaimMaxPerSweep: defaultSenderIdentityReclaimMaxPerSweep,
+		},
 		// Delegated verification is off by default. Only protocol-level
 		// values are defaulted (algorithm allowlist, lifetime, skew); the
 		// required/forbidden CLAIM lists are deployment identity policy

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1013,3 +1013,71 @@ func TestSenderIdentityFixtureTTL(t *testing.T) {
 		t.Errorf("malformed env override changed FixtureTTL to %v, want the yaml 2h", cfg.SenderIdentity.FixtureTTL)
 	}
 }
+
+// TestSenderIdentityOrphanReclaim covers the orphan-reclaim knobs. The whole
+// point of these defaults is that an operator who says nothing gets a
+// deployment that deletes nothing, so the default assertions here are the
+// safety property, not a convenience.
+func TestSenderIdentityOrphanReclaim(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, body string) string {
+		t.Helper()
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(body), 0644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	cfg, err := Load(write("default.yaml", "env: \"development\"\n"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.SenderIdentity.ReapOrphans {
+		t.Error("orphan reclaim must default to OFF")
+	}
+	if len(cfg.SenderIdentity.ReclaimZones) != 0 {
+		t.Errorf("default ReclaimZones = %v, want empty (which reclaims nothing)", cfg.SenderIdentity.ReclaimZones)
+	}
+	if cfg.SenderIdentity.ReclaimMinAge != 168*time.Hour {
+		t.Errorf("default ReclaimMinAge = %v, want 168h", cfg.SenderIdentity.ReclaimMinAge)
+	}
+	if cfg.SenderIdentity.ReclaimMaxPerSweep != 5 {
+		t.Errorf("default ReclaimMaxPerSweep = %d, want 5", cfg.SenderIdentity.ReclaimMaxPerSweep)
+	}
+
+	// reclaim_min_age is a duration, so — like fixture_ttl — yaml.v3 decodes it
+	// from a STRING only.
+	cfg, err = Load(write("armed.yaml", "env: \"development\"\nsender_identity:\n"+
+		"  reap_orphans: true\n"+
+		"  reclaim_zones:\n    - fixtures.example.test\n    - probes.example.test\n"+
+		"  reclaim_min_age: 48h\n"+
+		"  reclaim_max_per_sweep: 3\n"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !cfg.SenderIdentity.ReapOrphans {
+		t.Error("reap_orphans: true was not read")
+	}
+	if len(cfg.SenderIdentity.ReclaimZones) != 2 || cfg.SenderIdentity.ReclaimZones[0] != "fixtures.example.test" {
+		t.Errorf("ReclaimZones = %v, want the two configured zones", cfg.SenderIdentity.ReclaimZones)
+	}
+	if cfg.SenderIdentity.ReclaimMinAge != 48*time.Hour {
+		t.Errorf("ReclaimMinAge = %v, want 48h", cfg.SenderIdentity.ReclaimMinAge)
+	}
+	if cfg.SenderIdentity.ReclaimMaxPerSweep != 3 {
+		t.Errorf("ReclaimMaxPerSweep = %d, want 3", cfg.SenderIdentity.ReclaimMaxPerSweep)
+	}
+
+	// An explicit zero on either bound must SURVIVE defaulting: both are read
+	// downstream as "reclaim nothing", which an operator must be able to state.
+	cfg, err = Load(write("zeroed.yaml", "env: \"development\"\nsender_identity:\n"+
+		"  reclaim_min_age: 0s\n  reclaim_max_per_sweep: 0\n"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.SenderIdentity.ReclaimMinAge != 0 || cfg.SenderIdentity.ReclaimMaxPerSweep != 0 {
+		t.Errorf("explicit zeros were re-defaulted: min_age=%v max_per_sweep=%d",
+			cfg.SenderIdentity.ReclaimMinAge, cfg.SenderIdentity.ReclaimMaxPerSweep)
+	}
+}

--- a/internal/senderidentity/fake.go
+++ b/internal/senderidentity/fake.go
@@ -35,6 +35,14 @@ type FakeProvider struct {
 	// identities is the set of domains the fake "has" at the provider,
 	// for List/reaper tests. Provision adds; Deprovision removes.
 	identities map[string]bool
+	// audits backs InspectIdentity. A seeded identity with no entry here
+	// reports as UNTAGGED and not-verified — the shape of a legacy identity
+	// created before tags.go shipped, which the reclaim decision must always
+	// refuse. That default is what makes every pre-existing reaper test an
+	// implicit "never deletes an untagged identity" regression.
+	audits map[string]IdentityAudit
+	// inspectErr forces InspectIdentity to fail for a domain.
+	inspectErr map[string]error
 
 	ProvisionCalls []string
 	// ProvisionMetas is index-parallel to ProvisionCalls: the classification
@@ -45,6 +53,7 @@ type FakeProvider struct {
 	DeprovisionCalls []string
 	ListCalls        int
 	ListPageCalls    int
+	InspectCalls     []string
 }
 
 // StatusCall records one Status invocation's full argument set. Provider.Status
@@ -69,7 +78,43 @@ func NewFakeProvider() *FakeProvider {
 		notFoundOnStatus: map[string]bool{},
 		statusErr:        map[string]error{},
 		identities:       map[string]bool{},
+		audits:           map[string]IdentityAudit{},
+		inspectErr:       map[string]error{},
 	}
+}
+
+// SetIdentityAudit fixes what InspectIdentity reports for domain (the
+// classification tags + the verified-for-sending bit the reclaim decision
+// reads). Domain is filled in from the key so a test cannot seed an audit
+// whose name disagrees with the identity it describes.
+func (f *FakeProvider) SetIdentityAudit(domain string, audit IdentityAudit) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	audit.Domain = domain
+	f.audits[domain] = audit
+}
+
+// SetInspectErr makes InspectIdentity return err for domain.
+func (f *FakeProvider) SetInspectErr(domain string, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.inspectErr[domain] = err
+}
+
+func (f *FakeProvider) InspectIdentity(ctx context.Context, domain string) (IdentityAudit, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.InspectCalls = append(f.InspectCalls, domain)
+	if err := f.inspectErr[domain]; err != nil {
+		return IdentityAudit{}, err
+	}
+	if !f.identities[domain] {
+		return IdentityAudit{}, ErrIdentityNotFound
+	}
+	if audit, ok := f.audits[domain]; ok {
+		return audit, nil
+	}
+	return IdentityAudit{Domain: domain}, nil
 }
 
 // SetStatusErr makes Status return err (a transient error, not NotFound) for

--- a/internal/senderidentity/manager.go
+++ b/internal/senderidentity/manager.go
@@ -36,6 +36,11 @@ type Config struct {
 	// Default false: single-instance/self-host deployments have no blue/green
 	// overlap and want the v2 semantics immediately.
 	LegacyJobCompat bool
+	// Reclaim is the orphan-identity reclaim policy (config
+	// sender_identity.reap_orphans and friends). Its zero value — what every
+	// self-host and every deployment that omits the block gets — reclaims
+	// nothing, so the reaper's orphan phase stays alert-only exactly as before.
+	Reclaim ReclaimConfig
 }
 
 // Manager owns the sender-identity job lifecycle on the SHARED River client
@@ -97,7 +102,7 @@ func (m *Manager) RegisterJobs(w *river.Workers) []*river.PeriodicJob {
 	river.AddWorker(w, &ReconcileV2Worker{store: m.store, provider: m.provider, fire: m.fire, maxReconcileAttempt: m.cfg.MaxReconcileAttempts, legacyJobs: m.cfg.LegacyJobCompat})
 	river.AddWorker(w, &PostDrainAuditWorker{store: m.store, provider: m.provider, fire: m.fire, maxReconcileAttempt: m.cfg.MaxReconcileAttempts, legacyJobs: m.cfg.LegacyJobCompat})
 	river.AddWorker(w, &LegacyReapWorker{store: m.store, provider: m.provider, fire: m.fire, maxReconcileAttempt: m.cfg.MaxReconcileAttempts, legacyJobs: m.cfg.LegacyJobCompat})
-	river.AddWorker(w, &ReapWorker{store: m.store, provider: m.provider, fire: m.fire, maxReconcileAttempt: m.cfg.MaxReconcileAttempts, legacyJobs: m.cfg.LegacyJobCompat, enqueueNext: enqueueReapPage})
+	river.AddWorker(w, &ReapWorker{store: m.store, provider: m.provider, fire: m.fire, maxReconcileAttempt: m.cfg.MaxReconcileAttempts, legacyJobs: m.cfg.LegacyJobCompat, reclaim: m.cfg.Reclaim, enqueueNext: enqueueReapPage})
 
 	reaperInterval := m.cfg.ReaperInterval
 	if reaperInterval <= 0 {

--- a/internal/senderidentity/provider.go
+++ b/internal/senderidentity/provider.go
@@ -157,4 +157,17 @@ type Provider interface {
 	// token. The v2 orphan audit uses this so one River job never inventories
 	// the whole provider account.
 	ListPage(ctx context.Context, nextToken string, limit int) (domains []string, followingToken string, err error)
+
+	// InspectIdentity returns the facts the orphan-reclaim decision needs for
+	// one identity: its classification tags (tags.go) and whether the provider
+	// currently considers it able to SEND. Both must come from a SINGLE
+	// provider round trip — a two-call version could observe the tags before
+	// and the sending state after a change, and the decision would then be
+	// made against a state that never existed at once. Returns
+	// ErrIdentityNotFound if no identity exists for domain.
+	//
+	// Only orphan candidates are inspected (see reapProviderOrphanPage), so
+	// the per-candidate cost is bounded by how many orphans exist, not by the
+	// size of the provider account.
+	InspectIdentity(ctx context.Context, domain string) (IdentityAudit, error)
 }

--- a/internal/senderidentity/reaper.go
+++ b/internal/senderidentity/reaper.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"sort"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/riverqueue/river"
@@ -60,6 +61,10 @@ type ReapWorker struct {
 	fire                EventFirer
 	maxReconcileAttempt int
 	legacyJobs          bool
+	// reclaim is the orphan-reclaim policy (see ReclaimConfig). Its ZERO VALUE
+	// — every unit test that builds a ReapWorker by struct literal, and every
+	// deployment that does not configure the block — reclaims nothing.
+	reclaim ReclaimConfig
 	// enqueueNext is injected with the River continuation in production and a
 	// recorder/no-op in unit tests.
 	enqueueNext func(context.Context, ReapV2Args) error
@@ -71,7 +76,7 @@ func (w *ReapWorker) Work(ctx context.Context, job *river.Job[ReapV2Args]) error
 		enqueueNext = func(context.Context, ReapV2Args) error { return nil }
 	}
 	if job.Args.Phase == reapPhaseOrphans {
-		return reapProviderOrphanPage(ctx, w.store, w.provider, job.Args, 25, enqueueNext)
+		return reapProviderOrphanPage(ctx, w.store, w.provider, w.reclaim, job.Args, 25, enqueueNext)
 	}
 	return reapManagedIdentityPage(ctx, w.store, w.provider, w.fire, w.maxReconcileAttempt, true, w.legacyJobs, job.Args, 25, enqueueNext)
 }
@@ -165,7 +170,7 @@ func reapManagedIdentityPage(ctx context.Context, store Store, provider Provider
 	return errors.Join(errs...)
 }
 
-func reapProviderOrphanPage(ctx context.Context, store Store, provider Provider, args ReapV2Args, pageSize int, enqueueNext func(context.Context, ReapV2Args) error) error {
+func reapProviderOrphanPage(ctx context.Context, store Store, provider Provider, reclaim ReclaimConfig, args ReapV2Args, pageSize int, enqueueNext func(context.Context, ReapV2Args) error) error {
 	providerDomains, nextToken, err := provider.ListPage(ctx, args.ProviderToken, pageSize)
 	if err != nil {
 		return err
@@ -176,6 +181,14 @@ func reapProviderOrphanPage(ctx context.Context, store Store, provider Provider,
 		}
 	}
 	orphans := 0
+	// reclaimed counts deletions in THIS JOB INVOCATION only. The orphan phase
+	// is paginated across River jobs (each page is its own job), so this is a
+	// per-page budget, not a global one: a sweep over N pages can delete up to
+	// N*MaxPerSweep. That is deliberate — a genuinely global cap would need
+	// cross-job state, and the cap's purpose is to bound the blast radius of a
+	// systematic mistake to something a human notices in the log, which a
+	// per-page bound already achieves.
+	reclaimed := 0
 	for _, domain := range providerDomains {
 		_, ledgered, err := store.LookupManagedSendingIdentityDomain(ctx, domain)
 		if err != nil {
@@ -192,14 +205,75 @@ func reapProviderOrphanPage(ctx context.Context, store Store, provider Provider,
 		}
 		if !exists {
 			orphans++
-			log.Printf("[senderidentity:reaper] ALERT orphan sending identity with no live domain: %s "+
-				"(provider identity exists but is neither ledgered nor backed by a domain row) — manual review required", domain)
+			reclaimed += reclaimProviderOrphan(ctx, provider, reclaim, domain, reclaimed)
 		}
 	}
 	if orphans > 0 {
-		log.Printf("[senderidentity:reaper] audited %d provider identities in this page, %d orphan(s) flagged", len(providerDomains), orphans)
+		log.Printf("[senderidentity:reaper] audited %d provider identities in this page, %d orphan(s) flagged, %d reclaimed", len(providerDomains), orphans, reclaimed)
 	}
 	return nil
+}
+
+// reapOrphanAlert is the standing operator signal for an identity the reaper
+// found at the provider with neither a ledger row nor a domain row. It always
+// carries WHY the identity was not reclaimed, so "8 orphans accumulated" is
+// diagnosable from the log alone instead of needing a manual AWS session.
+const reapOrphanAlert = "[senderidentity:reaper] ALERT orphan sending identity with no live domain: %s " +
+	"(provider identity exists but is neither ledgered nor backed by a domain row) — manual review required (not reclaimed: %s)"
+
+// reclaimProviderOrphan runs the reclaim decision for one confirmed orphan and
+// returns 1 if it deleted the identity. Every path is non-fatal: this is a
+// cleanup pass layered on a diagnostic audit, and neither a provider read
+// failure nor a refused deletion may red a sweep in which every LEDGERED
+// domain converged.
+//
+// Deletion goes through provider.Deprovision — never a direct delete — so the
+// provider independently re-reads the ownership tag and returns
+// ErrIdentityNotOwned if it disagrees. That is the defense in depth that keeps
+// a bug in the tag logic above from being sufficient on its own to destroy an
+// identity.
+func reclaimProviderOrphan(ctx context.Context, provider Provider, reclaim ReclaimConfig, domain string, alreadyReclaimed int) int {
+	// Answered without a provider call, so an unconfigured deployment — every
+	// self-host, and prod until an operator opts in — keeps paying exactly what
+	// the alert-only audit paid before reclaim existed.
+	if _, reason := reclaimPolicyUsable(reclaim); reason != "" {
+		log.Printf(reapOrphanAlert, domain, reason)
+		return 0
+	}
+	audit, err := provider.InspectIdentity(ctx, domain)
+	if err != nil {
+		// Includes ErrIdentityNotFound (the identity vanished between the list
+		// and this read). No facts means no deletion, by construction.
+		log.Printf(reapOrphanAlert, domain, fmt.Sprintf("provider inspect failed: %v", err))
+		return 0
+	}
+	ok, reason := orphanReclaimable(audit, reclaim, time.Now())
+	if !ok {
+		log.Printf(reapOrphanAlert, domain, reason)
+		return 0
+	}
+	if !reclaim.Enabled {
+		// Observe-only mode: the full decision ran and said yes, but nothing is
+		// mutated. The operator runs here for days and reads these lines before
+		// arming sender_identity.reap_orphans. The per-sweep cap is deliberately
+		// NOT applied on this path — the point of the dry run is to see EVERY
+		// candidate, not a truncated preview.
+		log.Printf("[senderidentity:reaper] WOULD DELETE orphan sending identity %s (%s) — sender_identity.reap_orphans is off, no provider call made", domain, reason)
+		return 0
+	}
+	if alreadyReclaimed >= reclaim.MaxPerSweep {
+		log.Printf(reapOrphanAlert, domain, fmt.Sprintf("per-sweep reclaim cap of %d already reached in this job; a later sweep will retry", reclaim.MaxPerSweep))
+		return 0
+	}
+	if err := provider.Deprovision(ctx, domain); err != nil {
+		// Deprovision's own ownership re-check refusing here means the tag
+		// reasoning above and the provider disagree — exactly the case this
+		// second gate exists for. Loud, and never fatal to the sweep.
+		log.Printf(reapOrphanAlert, domain, fmt.Sprintf("delete failed: %v", err))
+		return 0
+	}
+	log.Printf("[senderidentity:reaper] DELETED orphan sending identity %s (%s)", domain, reason)
+	return 1
 }
 
 func recordReaperError(domain string, err error, errs *[]error) {

--- a/internal/senderidentity/reclaim.go
+++ b/internal/senderidentity/reclaim.go
@@ -1,0 +1,221 @@
+package senderidentity
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// IdentityAudit is everything the reaper needs from the provider to judge ONE
+// orphan candidate: the classification tags stamped at creation (tags.go) and
+// whether the provider currently considers the identity able to SEND. Both
+// come from a single GetEmailIdentity call (Provider.InspectIdentity), so a
+// candidate costs one round trip and only orphans ever pay it.
+//
+// Tags is the raw key→value map exactly as the provider reports it: this type
+// deliberately does no interpretation of its own, so every judgement lives in
+// orphanReclaimable where it can be exhaustively table-tested.
+type IdentityAudit struct {
+	// Domain is the provider's identity NAME. It is the value matched against
+	// the reclaim zones, not a value derived from e2a's database — the whole
+	// point is to decide without trusting a join that may not exist.
+	Domain string
+	Tags   map[string]string
+	// VerifiedForSending mirrors SES's VerifiedForSendingStatus: true means
+	// this identity can send mail RIGHT NOW.
+	VerifiedForSending bool
+}
+
+// ReclaimConfig is the operator's orphan-reclaim policy (config
+// sender_identity.reap_orphans / reclaim_zones / reclaim_min_age /
+// reclaim_max_per_sweep, plus the deployment name). Its zero value reclaims
+// NOTHING: disarmed, no zones, no minimum age, no deletion budget. That is the
+// only safe default for a subsystem whose failure mode is deleting a paying
+// customer's ability to send mail.
+type ReclaimConfig struct {
+	// Enabled arms actual deletion. When false the reaper still runs the whole
+	// decision and logs what it WOULD delete, but makes no provider mutation —
+	// the observe-only mode an operator runs for days before arming.
+	Enabled bool
+	// Deployment is this deployment's configured name ("prod" | "staging"),
+	// matched against the identity's e2a-env tag. Empty (an unnamed
+	// deployment, the self-host default) reclaims nothing: without a name
+	// there is no way to tell this deployment's fixtures from another
+	// deployment's in a shared AWS account.
+	Deployment string
+	// Zones bounds reclaim to identity names at or under a DNS zone e2a's own
+	// test fixtures live in. This is the strongest guard — a customer domain
+	// is never under the test zone — and an EMPTY list means reclaim nothing,
+	// never "any zone".
+	Zones []string
+	// MinAge is how old an identity must be (by its e2a-created stamp) before
+	// it can be reclaimed, independent of its expiry tag. <= 0 reclaims
+	// nothing: an unset floor is treated as an unconfigured policy, not as a
+	// waiver.
+	MinAge time.Duration
+	// MaxPerSweep caps deletions per REAP JOB INVOCATION (see
+	// reapProviderOrphanPage — the orphan phase is paginated across River
+	// jobs, so this is deliberately a per-page budget and not a global one).
+	// 0 reclaims nothing.
+	MaxPerSweep int
+}
+
+// orphanReclaimable decides whether ONE provider identity that the reaper has
+// already established is an orphan — present at the provider, with no ledger
+// row AND no domain row (the caller's precondition, guard 1, which this
+// function cannot see and therefore cannot re-check) — may be deleted.
+//
+// It is pure and total: every path returns a human-readable reason, and the
+// reason is what the reaper logs whether it deletes or refuses. Nothing here
+// consults cfg.Enabled — arming is the caller's separate question, which is
+// what lets observe-only mode log the same decision it would have acted on.
+//
+// EVERY guard below must hold. Anything missing, unparseable, or unrecognized
+// is a REFUSAL, never a default-allow: a dropped tag is expected (tags.go
+// fails open on purpose) and the only thing that makes that asymmetry safe is
+// this function failing closed.
+func orphanReclaimable(audit IdentityAudit, cfg ReclaimConfig, now time.Time) (bool, string) {
+	// Policy-level guards first. These describe the DEPLOYMENT rather than the
+	// identity, so an unconfigured policy refuses every candidate with one
+	// clear reason instead of N per-identity ones.
+	zones, reason := reclaimPolicyUsable(cfg)
+	if reason != "" {
+		return false, reason
+	}
+
+	// Guard 8, checked before any tag reasoning: an identity the provider will
+	// currently accept mail through is never deleted, whatever its tags claim.
+	// A tag is metadata e2a wrote; this bit is the provider's own answer to
+	// "can this thing send today?", and it is the one fact that would make a
+	// mistaken deletion immediately customer-visible.
+	if audit.VerifiedForSending {
+		return false, "identity is verified for sending"
+	}
+
+	// Guard 2: the ownership anchor. Same key/value isManagedIdentity reads —
+	// an identity e2a did not create (or a foreign one in a shared AWS
+	// account) is never a reclaim candidate.
+	if audit.Tags[managedIdentityTagKey] != managedIdentityTagValue {
+		return false, "identity is not tagged as managed by e2a (" + managedIdentityTagKey + ")"
+	}
+	// Guard 3: a shared AWS account can hold prod's and staging's identities
+	// side by side. Only this deployment's own may be reclaimed by it.
+	if env := audit.Tags[envTagKey]; env != cfg.Deployment {
+		return false, fmt.Sprintf("identity belongs to deployment %q, not %q", env, cfg.Deployment)
+	}
+	// Guard 4: purpose classifies the OWNER (tags.go). Only fixtures — e2a's
+	// own internal/monitoring accounts — are ever automatically reclaimable;
+	// "customer", an unrecognized value, and a missing tag are all refusals.
+	if purpose := audit.Tags[purposeTagKey]; purpose != purposeFixture {
+		return false, fmt.Sprintf("identity purpose is %q, not a fixture", purpose)
+	}
+
+	// Guard 5: the operator-chosen TTL has actually run out.
+	expires, reason := parseTagTime(audit.Tags, expiresTagKey)
+	if reason != "" {
+		return false, reason
+	}
+	if !expires.Before(now) {
+		return false, fmt.Sprintf("identity has not expired yet (%s=%s)", expiresTagKey, expires.Format(time.RFC3339))
+	}
+
+	// Guard 6: an absolute age floor, deliberately INDEPENDENT of the expiry
+	// above. The expiry is derived from a configured TTL and the provisioning
+	// host's clock, so a mis-set TTL or clock skew can stamp an already-past
+	// expiry onto an identity created seconds ago. The floor means the worst
+	// such a mistake can do is nothing at all until the identity is genuinely
+	// old. A future-dated created stamp fails this the same way a fresh one
+	// does, since its age is negative.
+	created, reason := parseTagTime(audit.Tags, createdTagKey)
+	if reason != "" {
+		return false, reason
+	}
+	if age := now.Sub(created); age < cfg.MinAge {
+		return false, fmt.Sprintf("identity is younger than the %s minimum age (created %s, age %s)", cfg.MinAge, created.Format(time.RFC3339), age.Round(time.Second))
+	}
+
+	// Guard 7, last and strongest: the name must sit at or under a zone the
+	// operator has declared to be e2a's own test space. Customer domains are
+	// never under it, so even a total failure of every tag guard above cannot
+	// reach one.
+	zone, ok := matchingZone(audit.Domain, zones)
+	if !ok {
+		return false, "identity name is outside every configured reclaim zone"
+	}
+	return true, fmt.Sprintf("expired %s fixture under reclaim zone %s, created %s, not verified for sending",
+		cfg.Deployment, zone, created.Format(time.RFC3339))
+}
+
+// reclaimPolicyUsable reports whether the POLICY could reclaim anything at
+// all, independent of any particular identity, returning the normalized zone
+// list when it can and the refusal reason when it cannot. Split out of
+// orphanReclaimable so the reaper can answer it BEFORE spending a provider
+// round trip inspecting a candidate: the default (self-host, and every
+// deployment that omits the config block) can never reclaim, and must keep
+// costing exactly what the alert-only audit cost before this existed.
+func reclaimPolicyUsable(cfg ReclaimConfig) (zones []string, refusal string) {
+	zones = normalizedZones(cfg.Zones)
+	if len(zones) == 0 {
+		return nil, "no reclaim zone is configured (an empty reclaim_zones list reclaims nothing)"
+	}
+	if cfg.Deployment == "" {
+		return nil, "this deployment is unnamed, so an identity's " + envTagKey + " tag cannot be attributed to it"
+	}
+	if cfg.MinAge <= 0 {
+		return nil, "no minimum age is configured (reclaim_min_age must be positive)"
+	}
+	return zones, ""
+}
+
+// parseTagTime reads one RFC3339 tag, returning a refusal reason (rather than
+// an error) for both "absent" and "unparseable" — the two cases the caller
+// treats identically. The reason names the tag key so an operator reading the
+// reaper's log knows exactly which stamp to go look at.
+func parseTagTime(tags map[string]string, key string) (time.Time, string) {
+	raw, ok := tags[key]
+	if !ok || raw == "" {
+		return time.Time{}, "identity carries no " + key + " tag"
+	}
+	parsed, err := time.Parse(time.RFC3339, raw)
+	if err != nil {
+		return time.Time{}, fmt.Sprintf("identity's %s tag %q is not RFC3339", key, raw)
+	}
+	return parsed, ""
+}
+
+// normalizedZones lowercases the configured zones and drops the empty ones. An
+// empty entry is dropped rather than kept because the suffix rule below would
+// otherwise turn it into a wildcard ("." + "" == "."), quietly converting a
+// stray blank line in the config into authority over every identity whose name
+// contains a dot — i.e. all of them.
+func normalizedZones(zones []string) []string {
+	out := make([]string, 0, len(zones))
+	for _, zone := range zones {
+		zone = strings.ToLower(strings.Trim(strings.TrimSpace(zone), "."))
+		if zone == "" {
+			continue
+		}
+		out = append(out, zone)
+	}
+	return out
+}
+
+// matchingZone reports which configured zone name falls under, matching on a
+// LABEL BOUNDARY only: name == zone, or name ends in "." + zone. A plain
+// strings.HasSuffix would make "eviltrymnexa.com" match zone "trymnexa.com",
+// handing a domain anyone can register the reclaim authority of e2a's own test
+// zone — which is exactly the mistake this guard exists to prevent. DNS names
+// are case-insensitive and the provider echoes back whatever case the identity
+// was created with, so both sides are lowercased first.
+func matchingZone(name string, normalizedZones []string) (string, bool) {
+	name = strings.ToLower(strings.Trim(strings.TrimSpace(name), "."))
+	if name == "" {
+		return "", false
+	}
+	for _, zone := range normalizedZones {
+		if name == zone || strings.HasSuffix(name, "."+zone) {
+			return zone, true
+		}
+	}
+	return "", false
+}

--- a/internal/senderidentity/reclaim_test.go
+++ b/internal/senderidentity/reclaim_test.go
@@ -1,0 +1,554 @@
+package senderidentity
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log"
+	"strings"
+	"testing"
+	"time"
+)
+
+// reclaimNow is the fixed "current time" every table case is judged against,
+// so a case's created/expires stamps read as explicit offsets from it rather
+// than as wall-clock-relative values that drift as the suite runs.
+var reclaimNow = time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
+
+// baseReclaimConfig is an ARMED, fully-configured policy. Every refusal case
+// below mutates exactly one thing away from a qualifying candidate, so a test
+// that starts passing for the wrong reason (a guard being dropped) fails here
+// rather than silently widening what the reaper may delete.
+func baseReclaimConfig() ReclaimConfig {
+	return ReclaimConfig{
+		Enabled:     true,
+		Deployment:  DeploymentStaging,
+		Zones:       []string{"trymnexa.com", "agents-staging.e2a.dev"},
+		MinAge:      7 * 24 * time.Hour,
+		MaxPerSweep: 5,
+	}
+}
+
+// qualifyingAudit is an orphan that satisfies EVERY tag-side guard: managed by
+// e2a, stamped for this deployment, a fixture, expired, old enough, and not
+// verified for sending.
+func qualifyingAudit() IdentityAudit {
+	return IdentityAudit{
+		Domain: "fixture-abc.trymnexa.com",
+		Tags: map[string]string{
+			managedIdentityTagKey: managedIdentityTagValue,
+			envTagKey:             DeploymentStaging,
+			purposeTagKey:         purposeFixture,
+			createdTagKey:         reclaimNow.Add(-30 * 24 * time.Hour).Format(time.RFC3339),
+			expiresTagKey:         reclaimNow.Add(-29 * 24 * time.Hour).Format(time.RFC3339),
+		},
+		VerifiedForSending: false,
+	}
+}
+
+func withTag(a IdentityAudit, key, value string) IdentityAudit {
+	tags := make(map[string]string, len(a.Tags))
+	for k, v := range a.Tags {
+		tags[k] = v
+	}
+	if value == "" {
+		delete(tags, key)
+	} else {
+		tags[key] = value
+	}
+	a.Tags = tags
+	return a
+}
+
+func TestOrphanReclaimable(t *testing.T) {
+	cases := []struct {
+		name       string
+		audit      IdentityAudit
+		mutate     func(ReclaimConfig) ReclaimConfig
+		wantOK     bool
+		wantReason string // substring; empty means "any reason" for a refusal
+	}{
+		{
+			name:   "every guard satisfied",
+			audit:  qualifyingAudit(),
+			wantOK: true,
+		},
+		{
+			name:       "empty zone list reclaims nothing",
+			audit:      qualifyingAudit(),
+			mutate:     func(c ReclaimConfig) ReclaimConfig { c.Zones = nil; return c },
+			wantReason: "no reclaim zone",
+		},
+		{
+			name:       "unnamed deployment reclaims nothing",
+			audit:      qualifyingAudit(),
+			mutate:     func(c ReclaimConfig) ReclaimConfig { c.Deployment = ""; return c },
+			wantReason: "deployment is unnamed",
+		},
+		{
+			name:       "no minimum age configured",
+			audit:      qualifyingAudit(),
+			mutate:     func(c ReclaimConfig) ReclaimConfig { c.MinAge = 0; return c },
+			wantReason: "minimum age",
+		},
+		{
+			name:       "identity is verified for sending",
+			audit:      func() IdentityAudit { a := qualifyingAudit(); a.VerifiedForSending = true; return a }(),
+			wantReason: "verified for sending",
+		},
+		{
+			name:       "ownership tag missing (untagged legacy identity)",
+			audit:      withTag(qualifyingAudit(), managedIdentityTagKey, ""),
+			wantReason: "not tagged as managed by e2a",
+		},
+		{
+			name:       "ownership tag carries a foreign value",
+			audit:      withTag(qualifyingAudit(), managedIdentityTagKey, "someone-elses-v1"),
+			wantReason: "not tagged as managed by e2a",
+		},
+		{
+			name:       "env tag names a different deployment",
+			audit:      withTag(qualifyingAudit(), envTagKey, DeploymentProd),
+			wantReason: "belongs to deployment",
+		},
+		{
+			name:       "env tag missing",
+			audit:      withTag(qualifyingAudit(), envTagKey, ""),
+			wantReason: "belongs to deployment",
+		},
+		{
+			name:       "purpose is customer",
+			audit:      withTag(qualifyingAudit(), purposeTagKey, purposeCustomer),
+			wantReason: "not a fixture",
+		},
+		{
+			name:       "purpose tag missing",
+			audit:      withTag(qualifyingAudit(), purposeTagKey, ""),
+			wantReason: "not a fixture",
+		},
+		{
+			name:       "purpose tag carries an unrecognized value",
+			audit:      withTag(qualifyingAudit(), purposeTagKey, "probe"),
+			wantReason: "not a fixture",
+		},
+		{
+			name:       "expires tag missing",
+			audit:      withTag(qualifyingAudit(), expiresTagKey, ""),
+			wantReason: "no " + expiresTagKey,
+		},
+		{
+			name:       "expires tag unparseable",
+			audit:      withTag(qualifyingAudit(), expiresTagKey, "next tuesday"),
+			wantReason: "not RFC3339",
+		},
+		{
+			name:       "expiry is in the future",
+			audit:      withTag(qualifyingAudit(), expiresTagKey, reclaimNow.Add(time.Hour).Format(time.RFC3339)),
+			wantReason: "has not expired",
+		},
+		{
+			name:       "created tag missing",
+			audit:      withTag(qualifyingAudit(), createdTagKey, ""),
+			wantReason: "no " + createdTagKey,
+		},
+		{
+			name:       "created tag unparseable",
+			audit:      withTag(qualifyingAudit(), createdTagKey, "2026/08/01"),
+			wantReason: "not RFC3339",
+		},
+		{
+			name: "younger than the minimum age despite an expired TTL",
+			// Guards 5 and 6 are independent on purpose: a bad TTL (or clock
+			// skew at provision time) can stamp an already-past expiry onto a
+			// brand-new identity, and the age floor is what stops that from
+			// making it instantly reclaimable.
+			audit: withTag(
+				withTag(qualifyingAudit(), createdTagKey, reclaimNow.Add(-time.Hour).Format(time.RFC3339)),
+				expiresTagKey, reclaimNow.Add(-time.Minute).Format(time.RFC3339),
+			),
+			wantReason: "younger than the",
+		},
+		{
+			name:       "created stamp is in the future",
+			audit:      withTag(qualifyingAudit(), createdTagKey, reclaimNow.Add(24*time.Hour).Format(time.RFC3339)),
+			wantReason: "younger than the",
+		},
+		{
+			name:       "name outside every configured zone",
+			audit:      func() IdentityAudit { a := qualifyingAudit(); a.Domain = "customer.example"; return a }(),
+			wantReason: "outside every configured reclaim zone",
+		},
+		{
+			name: "suffix near-miss must not match a zone",
+			// The whole point of matching on a label boundary: an attacker (or
+			// a typo) registering eviltrymnexa.com must not inherit
+			// trymnexa.com's reclaim authority.
+			audit:      func() IdentityAudit { a := qualifyingAudit(); a.Domain = "eviltrymnexa.com"; return a }(),
+			wantReason: "outside every configured reclaim zone",
+		},
+		{
+			name:   "the zone apex itself matches",
+			audit:  func() IdentityAudit { a := qualifyingAudit(); a.Domain = "trymnexa.com"; return a }(),
+			wantOK: true,
+		},
+		{
+			name:   "a deeper subdomain of a zone matches",
+			audit:  func() IdentityAudit { a := qualifyingAudit(); a.Domain = "a.b.trymnexa.com"; return a }(),
+			wantOK: true,
+		},
+		{
+			name:       "empty identity name matches nothing",
+			audit:      func() IdentityAudit { a := qualifyingAudit(); a.Domain = ""; return a }(),
+			wantReason: "outside every configured reclaim zone",
+		},
+		{
+			name:       "an empty configured zone must not match everything",
+			audit:      func() IdentityAudit { a := qualifyingAudit(); a.Domain = "customer.example"; return a }(),
+			mutate:     func(c ReclaimConfig) ReclaimConfig { c.Zones = []string{""}; return c },
+			wantReason: "no reclaim zone",
+		},
+		{
+			name:       "no tags at all",
+			audit:      IdentityAudit{Domain: "fixture-abc.trymnexa.com"},
+			wantReason: "not tagged as managed by e2a",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := baseReclaimConfig()
+			if tc.mutate != nil {
+				cfg = tc.mutate(cfg)
+			}
+			ok, reason := orphanReclaimable(tc.audit, cfg, reclaimNow)
+			if ok != tc.wantOK {
+				t.Fatalf("orphanReclaimable = (%v, %q), want ok=%v", ok, reason, tc.wantOK)
+			}
+			if ok {
+				if reason == "" {
+					t.Fatal("an accepted candidate must still report WHY it qualified, for the deletion log")
+				}
+				return
+			}
+			if reason == "" {
+				t.Fatal("a refusal must always carry a reason")
+			}
+			if tc.wantReason != "" && !strings.Contains(reason, tc.wantReason) {
+				t.Fatalf("refusal reason = %q, want it to mention %q", reason, tc.wantReason)
+			}
+		})
+	}
+}
+
+// TestOrphanReclaimableIgnoresEnabled proves the decision function is purely
+// about whether the identity QUALIFIES. Arming is the reaper's separate
+// question, which is what lets observe-only mode log the real decision.
+func TestOrphanReclaimableIgnoresEnabled(t *testing.T) {
+	cfg := baseReclaimConfig()
+	cfg.Enabled = false
+	ok, reason := orphanReclaimable(qualifyingAudit(), cfg, reclaimNow)
+	if !ok {
+		t.Fatalf("disarming must not change the decision, got refusal %q", reason)
+	}
+}
+
+// TestOrphanReclaimableCaseInsensitiveZone covers DNS names being
+// case-insensitive: SES echoes back whatever case the identity was created
+// with, and a mixed-case fixture must not silently escape its zone.
+func TestOrphanReclaimableCaseInsensitiveZone(t *testing.T) {
+	audit := qualifyingAudit()
+	audit.Domain = "Fixture-ABC.TryMnexa.com"
+	if ok, reason := orphanReclaimable(audit, baseReclaimConfig(), reclaimNow); !ok {
+		t.Fatalf("mixed-case identity refused: %q", reason)
+	}
+}
+
+// reclaimZone is the fictional zone the reaper-level tests declare as e2a's
+// own fixture space.
+const reclaimZone = "fixtures.example.test"
+
+// armedReaperReclaim is the policy the reaper-level tests wire into a
+// ReapWorker. It is judged against time.Now() (the reaper's own clock), so the
+// fixture audits below are stamped relative to that rather than to reclaimNow.
+func armedReaperReclaim(maxPerSweep int) ReclaimConfig {
+	return ReclaimConfig{
+		Enabled:     true,
+		Deployment:  DeploymentStaging,
+		Zones:       []string{reclaimZone},
+		MinAge:      7 * 24 * time.Hour,
+		MaxPerSweep: maxPerSweep,
+	}
+}
+
+// liveFixtureAudit is a qualifying audit stamped against the wall clock, for
+// the reaper-level tests that cannot inject a time source.
+func liveFixtureAudit() IdentityAudit {
+	now := time.Now().UTC()
+	return IdentityAudit{
+		Tags: map[string]string{
+			managedIdentityTagKey: managedIdentityTagValue,
+			envTagKey:             DeploymentStaging,
+			purposeTagKey:         purposeFixture,
+			createdTagKey:         now.Add(-30 * 24 * time.Hour).Format(time.RFC3339),
+			expiresTagKey:         now.Add(-29 * 24 * time.Hour).Format(time.RFC3339),
+		},
+	}
+}
+
+// captureLog redirects the standard logger for the duration of a test.
+func captureLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() { log.SetOutput(prev) })
+	return &buf
+}
+
+func TestReapWorkerOrphanReclaim(t *testing.T) {
+	t.Run("armed policy deletes a qualifying orphan", func(t *testing.T) {
+		domain := "run-1." + reclaimZone
+		store := newFakeStore()
+		prov := NewFakeProvider()
+		prov.SeedIdentity(domain)
+		prov.SetIdentityAudit(domain, liveFixtureAudit())
+		logs := captureLog(t)
+		w := &ReapWorker{store: store, provider: prov, reclaim: armedReaperReclaim(5)}
+
+		if err := runReapWorkerChain(context.Background(), w, ReapV2Args{}); err != nil {
+			t.Fatalf("Work returned error: %v", err)
+		}
+		if len(prov.DeprovisionCalls) != 1 || prov.DeprovisionCalls[0] != domain {
+			t.Fatalf("qualifying orphan was not deleted via Deprovision: %v", prov.DeprovisionCalls)
+		}
+		identities, _ := prov.List(context.Background())
+		if len(identities) != 0 {
+			t.Fatalf("identity survived deletion: %v", identities)
+		}
+		if !strings.Contains(logs.String(), "DELETED orphan sending identity "+domain) {
+			t.Fatalf("deletion must be logged loudly with the domain and why it qualified, got %q", logs.String())
+		}
+	})
+
+	t.Run("disarmed policy logs the decision without deleting", func(t *testing.T) {
+		domain := "run-2." + reclaimZone
+		store := newFakeStore()
+		prov := NewFakeProvider()
+		prov.SeedIdentity(domain)
+		prov.SetIdentityAudit(domain, liveFixtureAudit())
+		logs := captureLog(t)
+		cfg := armedReaperReclaim(5)
+		cfg.Enabled = false
+		w := &ReapWorker{store: store, provider: prov, reclaim: cfg}
+
+		if err := runReapWorkerChain(context.Background(), w, ReapV2Args{}); err != nil {
+			t.Fatalf("Work returned error: %v", err)
+		}
+		if len(prov.DeprovisionCalls) != 0 {
+			t.Fatalf("observe-only mode made a provider mutation: %v", prov.DeprovisionCalls)
+		}
+		if !strings.Contains(logs.String(), "WOULD DELETE orphan sending identity "+domain) {
+			t.Fatalf("observe-only mode must log the decision it would have acted on, got %q", logs.String())
+		}
+	})
+
+	t.Run("the per-job cap skips later candidates", func(t *testing.T) {
+		store := newFakeStore()
+		prov := NewFakeProvider()
+		// The fake pages identities in sorted order, so the two lowest names
+		// consume the budget and the third must be refused by the cap.
+		for _, name := range []string{"a", "b", "c"} {
+			domain := name + "." + reclaimZone
+			prov.SeedIdentity(domain)
+			prov.SetIdentityAudit(domain, liveFixtureAudit())
+		}
+		logs := captureLog(t)
+		w := &ReapWorker{store: store, provider: prov, reclaim: armedReaperReclaim(2)}
+
+		if err := runReapWorkerChain(context.Background(), w, ReapV2Args{}); err != nil {
+			t.Fatalf("Work returned error: %v", err)
+		}
+		if len(prov.DeprovisionCalls) != 2 {
+			t.Fatalf("cap of 2 not honored, deleted: %v", prov.DeprovisionCalls)
+		}
+		identities, _ := prov.List(context.Background())
+		if len(identities) != 1 || identities[0] != "c."+reclaimZone {
+			t.Fatalf("wrong survivor after the cap: %v", identities)
+		}
+		if !strings.Contains(logs.String(), "per-sweep reclaim cap of 2 already reached") {
+			t.Fatalf("the capped candidate must say so, got %q", logs.String())
+		}
+	})
+
+	t.Run("an untagged legacy orphan is never deleted", func(t *testing.T) {
+		// The fake reports a seeded-but-unaudited identity as untagged, which
+		// is the shape of every identity created before tags.go shipped.
+		domain := "legacy." + reclaimZone
+		store := newFakeStore()
+		prov := NewFakeProvider()
+		prov.SeedIdentity(domain)
+		logs := captureLog(t)
+		w := &ReapWorker{store: store, provider: prov, reclaim: armedReaperReclaim(5)}
+
+		if err := runReapWorkerChain(context.Background(), w, ReapV2Args{}); err != nil {
+			t.Fatalf("Work returned error: %v", err)
+		}
+		if len(prov.DeprovisionCalls) != 0 {
+			t.Fatalf("untagged legacy identity was deleted: %v", prov.DeprovisionCalls)
+		}
+		logged := logs.String()
+		if !strings.Contains(logged, "ALERT orphan sending identity") || !strings.Contains(logged, "not tagged as managed by e2a") {
+			t.Fatalf("expected the standing ALERT extended with the refusal reason, got %q", logged)
+		}
+	})
+
+	t.Run("an identity still verified for sending is never deleted", func(t *testing.T) {
+		domain := "sending." + reclaimZone
+		store := newFakeStore()
+		prov := NewFakeProvider()
+		prov.SeedIdentity(domain)
+		audit := liveFixtureAudit()
+		audit.VerifiedForSending = true
+		prov.SetIdentityAudit(domain, audit)
+		logs := captureLog(t)
+		w := &ReapWorker{store: store, provider: prov, reclaim: armedReaperReclaim(5)}
+
+		if err := runReapWorkerChain(context.Background(), w, ReapV2Args{}); err != nil {
+			t.Fatalf("Work returned error: %v", err)
+		}
+		if len(prov.DeprovisionCalls) != 0 {
+			t.Fatalf("a sendable identity was deleted: %v", prov.DeprovisionCalls)
+		}
+		if !strings.Contains(logs.String(), "verified for sending") {
+			t.Fatalf("expected the verified-for-sending refusal, got %q", logs.String())
+		}
+	})
+
+	t.Run("a candidate outside the reclaim zone is never deleted", func(t *testing.T) {
+		// The near-miss the zone rule exists for, exercised end to end: this
+		// name would pass every tag guard.
+		domain := "evil" + reclaimZone
+		store := newFakeStore()
+		prov := NewFakeProvider()
+		prov.SeedIdentity(domain)
+		prov.SetIdentityAudit(domain, liveFixtureAudit())
+		w := &ReapWorker{store: store, provider: prov, reclaim: armedReaperReclaim(5)}
+
+		if err := runReapWorkerChain(context.Background(), w, ReapV2Args{}); err != nil {
+			t.Fatalf("Work returned error: %v", err)
+		}
+		if len(prov.DeprovisionCalls) != 0 {
+			t.Fatalf("a near-miss of the reclaim zone was deleted: %v", prov.DeprovisionCalls)
+		}
+	})
+
+	t.Run("the zero-value policy reclaims nothing", func(t *testing.T) {
+		// The self-host / unconfigured default, and what every ReapWorker
+		// built by struct literal in this package's other tests gets.
+		domain := "default." + reclaimZone
+		store := newFakeStore()
+		prov := NewFakeProvider()
+		prov.SeedIdentity(domain)
+		prov.SetIdentityAudit(domain, liveFixtureAudit())
+		w := &ReapWorker{store: store, provider: prov}
+
+		if err := runReapWorkerChain(context.Background(), w, ReapV2Args{}); err != nil {
+			t.Fatalf("Work returned error: %v", err)
+		}
+		if len(prov.DeprovisionCalls) != 0 {
+			t.Fatalf("an unconfigured deployment deleted an identity: %v", prov.DeprovisionCalls)
+		}
+		// And it costs no provider round trip: an unconfigured policy is
+		// refused before the candidate is ever inspected, so the alert-only
+		// audit stays as cheap as it was before reclaim existed.
+		if len(prov.InspectCalls) != 0 {
+			t.Fatalf("an unconfigured deployment still inspected the identity: %v", prov.InspectCalls)
+		}
+	})
+
+	t.Run("a provider inspect failure refuses rather than deletes", func(t *testing.T) {
+		domain := "unreadable." + reclaimZone
+		store := newFakeStore()
+		prov := NewFakeProvider()
+		prov.SeedIdentity(domain)
+		prov.SetInspectErr(domain, errors.New("throttled"))
+		logs := captureLog(t)
+		w := &ReapWorker{store: store, provider: prov, reclaim: armedReaperReclaim(5)}
+
+		if err := runReapWorkerChain(context.Background(), w, ReapV2Args{}); err != nil {
+			t.Fatalf("an unreadable orphan must not red the sweep: %v", err)
+		}
+		if len(prov.DeprovisionCalls) != 0 {
+			t.Fatalf("deleted an identity it could not read: %v", prov.DeprovisionCalls)
+		}
+		if !strings.Contains(logs.String(), "provider inspect failed") {
+			t.Fatalf("expected the inspect-failure refusal, got %q", logs.String())
+		}
+	})
+
+	t.Run("Deprovision refusing ownership keeps the sweep green and the identity alive", func(t *testing.T) {
+		// Defense in depth: even with every tag guard satisfied, the provider
+		// re-checks ownership and may still say no.
+		domain := "disputed." + reclaimZone
+		store := newFakeStore()
+		prov := NewFakeProvider()
+		prov.SeedIdentity(domain)
+		prov.SetIdentityAudit(domain, liveFixtureAudit())
+		prov.SetDeprovisionErr(ErrIdentityNotOwned)
+		logs := captureLog(t)
+		w := &ReapWorker{store: store, provider: prov, reclaim: armedReaperReclaim(5)}
+
+		if err := runReapWorkerChain(context.Background(), w, ReapV2Args{}); err != nil {
+			t.Fatalf("a refused reclaim must not red the sweep: %v", err)
+		}
+		identities, _ := prov.List(context.Background())
+		if len(identities) != 1 {
+			t.Fatalf("identity was removed despite the provider refusing: %v", identities)
+		}
+		if !strings.Contains(logs.String(), "delete failed") {
+			t.Fatalf("expected the delete-failure refusal, got %q", logs.String())
+		}
+	})
+
+	t.Run("a live domain outside the ledger is never inspected or deleted", func(t *testing.T) {
+		// Guard 1, the caller's precondition: a domain row exists, so this is
+		// not an orphan at all and the reclaim decision must never run.
+		domain := "live." + reclaimZone
+		store := newFakeStore()
+		store.setStatus(domain, StatusVerified)
+		prov := NewFakeProvider()
+		prov.SeedIdentity(domain)
+		prov.SetIdentityAudit(domain, liveFixtureAudit())
+		w := &ReapWorker{store: store, provider: prov, reclaim: armedReaperReclaim(5)}
+
+		if err := runReapWorkerChain(context.Background(), w, ReapV2Args{}); err != nil {
+			t.Fatalf("Work returned error: %v", err)
+		}
+		if len(prov.InspectCalls) != 0 || len(prov.DeprovisionCalls) != 0 {
+			t.Fatalf("a domain-backed identity was evaluated for reclaim: inspect=%v deprovision=%v", prov.InspectCalls, prov.DeprovisionCalls)
+		}
+	})
+
+	t.Run("the managed-ledger phase is unchanged by an armed reclaim policy", func(t *testing.T) {
+		// Regression: reclaim touches only the orphan phase. A LEDGERED
+		// tombstone still converges through the ordinary teardown path, which
+		// consults neither the reclaim zones nor the cap.
+		domain := "ledgered.customer.example"
+		store := newFakeStore()
+		store.managed[domain] = "old-incarnation"
+		prov := NewFakeProvider()
+		prov.SeedIdentity(domain)
+		w := &ReapWorker{store: store, provider: prov, reclaim: armedReaperReclaim(5)}
+
+		if err := runReapWorkerChain(context.Background(), w, ReapV2Args{}); err != nil {
+			t.Fatalf("Work returned error: %v", err)
+		}
+		identities, _ := prov.List(context.Background())
+		if len(identities) != 0 || len(store.managed) != 0 {
+			t.Fatalf("managed orphan did not converge: provider=%v ledger=%v", identities, store.managed)
+		}
+		if len(prov.InspectCalls) != 0 {
+			t.Fatalf("the ledger phase must not run the reclaim decision: %v", prov.InspectCalls)
+		}
+	})
+}

--- a/internal/senderidentity/ses.go
+++ b/internal/senderidentity/ses.go
@@ -401,6 +401,35 @@ func (p *SESProvider) Status(ctx context.Context, domain string, evidence Adopti
 	}, nil
 }
 
+// InspectIdentity reads the classification tags and the verified-for-sending
+// bit off ONE GetEmailIdentity response (see Provider.InspectIdentity for why
+// they must share a call). It deliberately makes no judgement — not even
+// isManagedIdentity's — so that every reclaim decision lives in the pure,
+// exhaustively tested orphanReclaimable rather than being split across a
+// provider that is only exercised against live AWS.
+func (p *SESProvider) InspectIdentity(ctx context.Context, domain string) (IdentityAudit, error) {
+	out, err := p.api.GetEmailIdentity(ctx, &sesv2.GetEmailIdentityInput{EmailIdentity: &domain})
+	if err != nil {
+		var notFound *sestypes.NotFoundException
+		if errors.As(err, &notFound) {
+			return IdentityAudit{}, ErrIdentityNotFound
+		}
+		return IdentityAudit{}, err
+	}
+	audit := IdentityAudit{
+		Domain:             domain,
+		Tags:               make(map[string]string, len(out.Tags)),
+		VerifiedForSending: out.VerifiedForSendingStatus,
+	}
+	for _, tag := range out.Tags {
+		if tag.Key == nil || tag.Value == nil {
+			continue
+		}
+		audit.Tags[*tag.Key] = *tag.Value
+	}
+	return audit, nil
+}
+
 func (p *SESProvider) Deprovision(ctx context.Context, domain string) error {
 	out, err := p.api.GetEmailIdentity(ctx, &sesv2.GetEmailIdentityInput{EmailIdentity: &domain})
 	if err != nil {


### PR DESCRIPTION
Follow-up to #972 (identity classification tags). Crashed e2e runs leak fixture domains and their SES identities, and nothing reclaims them — 8 accumulated over weeks and had to be swept by hand. The reaper already *detects* them every hour and can only log `manual review required`, because a missing ledger row is ambiguous: leaked fixture, or a stale/restored database hiding a live customer domain.

This resolves that ambiguity from the identity's own tags, so the orphan branch of `reapProviderOrphanPage` can delete. Nothing else in the reaper changes.

## Safety model

Deletion requires **every** one of these; any missing, unparseable, or unrecognized value refuses and logs the reason. There is no fail-open path.

| # | Guard |
|---|---|
| 1 | The pre-existing orphan precondition: not ledgered **and** no domain row (unchanged) |
| 2 | Provider reports **not verified for sending** — an identity that can send today is never deleted |
| 3 | `e2a-managed` is e2a's ownership anchor |
| 4 | `e2a-env` equals **this** deployment (prod and staging share one AWS account) |
| 5 | `e2a-purpose` is `fixture` — customer, unrecognized, and missing are all refusals |
| 6 | `e2a-expires` parses and is in the past |
| 7 | `e2a-created` parses and the identity clears an absolute **age floor**, independent of the TTL, so clock skew or a mis-set TTL can't make something instantly reclaimable |
| 8 | The name sits at or under a configured **reclaim zone**, matched on a label boundary — customer domains are never under the test zone, so even total failure of guards 3-7 cannot reach one. Empty zone list means reclaim **nothing** |
| 9 | Per-invocation **cap** (default 5) — a systematic mistake costs a handful and a loud log, not the account |
| 10 | `reap_orphans` config flag, **default off**: the full decision still runs and logs `WOULD DELETE` / the refusal reason, so the operator can observe for days before arming |

Deletion goes through the existing `provider.Deprovision`, which independently verifies ownership and returns `ErrIdentityNotOwned` — defense in depth if the tag logic is ever wrong. On staging, AWS IAM additionally denies `DeleteEmailIdentity` outside `*.staging.trymnexa.com`.

All policy lives in a pure `orphanReclaimable(audit, cfg, now) (bool, reason)`; the provider reports facts and never decides.

## Tests

`TestOrphanReclaimable` — 26 subtests, one per refusal path (wrong env, purpose customer/missing/unrecognized, expires missing/unparseable/future, created missing/unparseable/future-dated, under min age, outside zones, the `eviltrymnexa.com` near-miss, empty zone list, unnamed deployment, verified-for-sending, foreign ownership tag, no tags at all) plus the accept case. `TestReapWorkerOrphanReclaim` — 11 subtests including disarmed mode mutating nothing, cap enforcement, untagged legacy orphans never deleted, an unusable policy never even calling the provider, and the managed-ledger phase unchanged. 37 subtests green; `-race` clean; build, vet, gofmt clean.

Two judgement calls beyond the spec: `reclaim_min_age: 0s` is treated as an unconfigured policy (refuse) rather than "no floor", closing the one fail-open reading; and the cap deliberately does **not** apply in observe-only mode, so a dry run shows every candidate rather than a truncated preview.

Inert until ops config sets `deployment_name`, `reclaim_zones`, and flips `reap_orphans` — three separate deliberate acts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScEpytuD7GvaXEssvJ2W32