### PR TITLE
feat(prober): add trusted delegated auth scenario

### DIFF
--- a/cmd/e2a-prober/config.go
+++ b/cmd/e2a-prober/config.go
@@ -9,36 +9,42 @@ import (
 // config is the prober's runtime configuration, sourced entirely from env so
 // the same binary runs in compose, CI, and locally with no flags.
 type config struct {
-	DatabaseURL   string // seed, validate
-	BaseURL       string // run-once, serve
-	SMTPAddr      string // run-once, serve
-	AgentEmail    string
-	APIKey        string
-	WebhookSecret string
-	MCPBaseURL    string        // deployed streamable-HTTP MCP endpoint; empty ⇒ mcp scenario skips
-	RequireMCP    bool          // E2A_PROBE_REQUIRE_MCP: empty MCPBaseURL fails the mcp scenario instead of skipping
-	SinkURL       string        // what the probe webhook targets (== Listen's public addr + /sink)
-	Listen        string        // serve/run-once bind addr for the sink + status server
-	Interval      time.Duration // serve loop period
-	Timeout       time.Duration // round-trip await timeout
-	MetricsBuild  string        // release/image identifier attached to every metric
+	DatabaseURL          string // seed, validate
+	BaseURL              string // run-once, serve
+	SMTPAddr             string // run-once, serve
+	AgentEmail           string
+	APIKey               string
+	WebhookSecret        string
+	MCPBaseURL           string        // deployed streamable-HTTP MCP endpoint; empty ⇒ mcp scenario skips
+	RequireMCP           bool          // E2A_PROBE_REQUIRE_MCP: empty MCPBaseURL fails the mcp scenario instead of skipping
+	DelegatedTokenURL    string        // E2A_PROBE_DELEGATED_TOKEN_URL: trusted fixed-principal token endpoint
+	DelegatedTokenSecret string        // E2A_PROBE_DELEGATED_TOKEN_SECRET: dedicated endpoint credential
+	RequireDelegatedAuth bool          // E2A_PROBE_REQUIRE_DELEGATED_AUTH: incomplete config fails instead of skipping
+	SinkURL              string        // what the probe webhook targets (== Listen's public addr + /sink)
+	Listen               string        // serve/run-once bind addr for the sink + status server
+	Interval             time.Duration // serve loop period
+	Timeout              time.Duration // round-trip await timeout
+	MetricsBuild         string        // release/image identifier attached to every metric
 }
 
 func configFromEnv() config {
 	return config{
-		DatabaseURL:   os.Getenv("E2A_DATABASE_URL"),
-		BaseURL:       os.Getenv("E2A_PROBE_BASE_URL"),
-		SMTPAddr:      os.Getenv("E2A_PROBE_SMTP_ADDR"),
-		AgentEmail:    os.Getenv("E2A_PROBE_AGENT_EMAIL"),
-		APIKey:        os.Getenv("E2A_PROBE_API_KEY"),
-		WebhookSecret: os.Getenv("E2A_PROBE_WEBHOOK_SECRET"),
-		MCPBaseURL:    os.Getenv("E2A_PROBE_MCP_URL"),
-		RequireMCP:    envBool("E2A_PROBE_REQUIRE_MCP"),
-		SinkURL:       os.Getenv("E2A_PROBE_SINK_URL"),
-		Listen:        envOr("E2A_PROBE_LISTEN", ":8090"),
-		Interval:      envDuration("E2A_PROBE_INTERVAL", 30*time.Second),
-		Timeout:       envDuration("E2A_PROBE_TIMEOUT", 30*time.Second),
-		MetricsBuild:  os.Getenv("E2A_METRICS_BUILD"),
+		DatabaseURL:          os.Getenv("E2A_DATABASE_URL"),
+		BaseURL:              os.Getenv("E2A_PROBE_BASE_URL"),
+		SMTPAddr:             os.Getenv("E2A_PROBE_SMTP_ADDR"),
+		AgentEmail:           os.Getenv("E2A_PROBE_AGENT_EMAIL"),
+		APIKey:               os.Getenv("E2A_PROBE_API_KEY"),
+		WebhookSecret:        os.Getenv("E2A_PROBE_WEBHOOK_SECRET"),
+		MCPBaseURL:           os.Getenv("E2A_PROBE_MCP_URL"),
+		RequireMCP:           envBool("E2A_PROBE_REQUIRE_MCP"),
+		DelegatedTokenURL:    os.Getenv("E2A_PROBE_DELEGATED_TOKEN_URL"),
+		DelegatedTokenSecret: os.Getenv("E2A_PROBE_DELEGATED_TOKEN_SECRET"),
+		RequireDelegatedAuth: envBool("E2A_PROBE_REQUIRE_DELEGATED_AUTH"),
+		SinkURL:              os.Getenv("E2A_PROBE_SINK_URL"),
+		Listen:               envOr("E2A_PROBE_LISTEN", ":8090"),
+		Interval:             envDuration("E2A_PROBE_INTERVAL", 30*time.Second),
+		Timeout:              envDuration("E2A_PROBE_TIMEOUT", 30*time.Second),
+		MetricsBuild:         os.Getenv("E2A_METRICS_BUILD"),
 	}
 }
 

--- a/cmd/e2a-prober/main.go
+++ b/cmd/e2a-prober/main.go
@@ -65,16 +65,19 @@ usage: e2a-prober <seed|seed-conformance|validate|run-once|serve>
 env:
   E2A_DATABASE_URL              Postgres URL (seed, seed-conformance, validate)
   E2A_CONFORMANCE_AGENT_EMAIL   primary agent for the conformance account (seed-conformance)
-  E2A_PROBE_BASE_URL        e2a HTTP base, e.g. http://e2a:8080 (run-once, serve)
-  E2A_PROBE_SMTP_ADDR       e2a SMTP listener host:port (run-once, serve)
-  E2A_PROBE_AGENT_EMAIL     synthetic probe agent address
-  E2A_PROBE_API_KEY         probe agent API key (Bearer)
-  E2A_PROBE_WEBHOOK_SECRET  probe webhook signing secret (HMAC verify)
-  E2A_PROBE_SINK_URL        URL the probe webhook posts to (== this prober's /sink)
-  E2A_PROBE_LISTEN          serve/run-once sink bind addr (default :8090)
-  E2A_PROBE_INTERVAL        serve probe interval (default 30s)
-  E2A_PROBE_TIMEOUT         round-trip await timeout (default 30s)
-  E2A_METRICS_BUILD         release/image identifier attached to every metric
+  E2A_PROBE_BASE_URL               e2a HTTP base, e.g. http://e2a:8080 (run-once, serve)
+  E2A_PROBE_SMTP_ADDR              e2a SMTP listener host:port (run-once, serve)
+  E2A_PROBE_AGENT_EMAIL            synthetic probe agent address
+  E2A_PROBE_API_KEY                probe agent API key (Bearer)
+  E2A_PROBE_WEBHOOK_SECRET         probe webhook signing secret (HMAC verify)
+  E2A_PROBE_DELEGATED_TOKEN_URL    trusted fixed-principal token endpoint
+  E2A_PROBE_DELEGATED_TOKEN_SECRET dedicated Bearer credential for that endpoint
+  E2A_PROBE_REQUIRE_DELEGATED_AUTH fail rather than skip when delegated config is absent
+  E2A_PROBE_SINK_URL               URL the probe webhook posts to (== this prober's /sink)
+  E2A_PROBE_LISTEN                 serve/run-once sink bind addr (default :8090)
+  E2A_PROBE_INTERVAL               serve probe interval (default 30s)
+  E2A_PROBE_TIMEOUT                round-trip await timeout (default 30s)
+  E2A_METRICS_BUILD                release/image identifier attached to every metric
 `)
 }
 

--- a/cmd/e2a-prober/prober_test.go
+++ b/cmd/e2a-prober/prober_test.go
@@ -247,6 +247,22 @@ func TestConfigRequireMCP(t *testing.T) {
 	}
 }
 
+func TestConfigDelegatedAuth(t *testing.T) {
+	t.Setenv("E2A_PROBE_DELEGATED_TOKEN_URL", "https://issuer.example.test/internal/probe")
+	t.Setenv("E2A_PROBE_DELEGATED_TOKEN_SECRET", "synthetic-secret")
+	t.Setenv("E2A_PROBE_REQUIRE_DELEGATED_AUTH", "true")
+	cfg := configFromEnv()
+	if cfg.DelegatedTokenURL != "https://issuer.example.test/internal/probe" ||
+		cfg.DelegatedTokenSecret != "synthetic-secret" || !cfg.RequireDelegatedAuth {
+		t.Fatalf("delegated config not loaded: %+v", cfg)
+	}
+	probe := newProber(cfg).probe()
+	if probe.DelegatedTokenURL != cfg.DelegatedTokenURL ||
+		probe.DelegatedTokenSecret != cfg.DelegatedTokenSecret || !probe.RequireDelegatedAuth {
+		t.Fatalf("delegated config not threaded to probe: %+v", probe)
+	}
+}
+
 func TestConfigMetricsBuild(t *testing.T) {
 	t.Setenv("E2A_METRICS_BUILD", "v1.3.0")
 	if got := configFromEnv().MetricsBuild; got != "v1.3.0" {

--- a/cmd/e2a-prober/serve.go
+++ b/cmd/e2a-prober/serve.go
@@ -44,15 +44,18 @@ func newProber(cfg config) *prober {
 
 func (p *prober) probe() *selftest.Probe {
 	return &selftest.Probe{
-		HTTPBaseURL:   p.cfg.BaseURL,
-		APIKey:        p.cfg.APIKey,
-		AgentEmail:    p.cfg.AgentEmail,
-		SMTPAddr:      p.cfg.SMTPAddr,
-		WebhookSecret: p.cfg.WebhookSecret,
-		MCPBaseURL:    p.cfg.MCPBaseURL,
-		RequireMCP:    p.cfg.RequireMCP,
-		Sink:          p.sink,
-		Timeout:       p.cfg.Timeout,
+		HTTPBaseURL:          p.cfg.BaseURL,
+		APIKey:               p.cfg.APIKey,
+		AgentEmail:           p.cfg.AgentEmail,
+		SMTPAddr:             p.cfg.SMTPAddr,
+		WebhookSecret:        p.cfg.WebhookSecret,
+		MCPBaseURL:           p.cfg.MCPBaseURL,
+		RequireMCP:           p.cfg.RequireMCP,
+		DelegatedTokenURL:    p.cfg.DelegatedTokenURL,
+		DelegatedTokenSecret: p.cfg.DelegatedTokenSecret,
+		RequireDelegatedAuth: p.cfg.RequireDelegatedAuth,
+		Sink:                 p.sink,
+		Timeout:              p.cfg.Timeout,
 	}
 }
 

--- a/docs/design/prober-selftest.md
+++ b/docs/design/prober-selftest.md
@@ -199,7 +199,14 @@ self-cleaning via a deferred best-effort delete, no email/owner-notify/metering)
 and **mcp_http_round_trip** (the deployed streamable-HTTP MCP surface: a stateless
 Bearer-authed `tools/list` then a `whoami` `tools/call` over the real SSE
 transport — both read-only; skips-as-pass when `E2A_PROBE_MCP_URL` is unset, so a
-stack without an MCP endpoint stays green).
+stack without an MCP endpoint stays green); and **delegated_auth**, which asks a
+trusted fixed-principal issuer endpoint for one fresh short-lived token and
+uses it for `GET /v1/agents?limit=1`. The endpoint accepts no identity,
+audience, scope, role, or TTL input. This covers issuer signing, JWKS discovery,
+the delegated claim policy, external-principal mapping, and account
+authorization without allowing arbitrary public traffic to manufacture the
+availability signal. It skips while unset and becomes fail-closed when
+`E2A_PROBE_REQUIRE_DELEGATED_AUTH=true`.
 *(fast-follow)* 5xx SLI from `e2a:/metrics`.
 
 ### SLI exposure on `e2a` (phase 2 / fast-follow)

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -198,13 +198,21 @@ endpoint (`E2A_PROBE_LISTEN`, default `:8090`) exposes:
 | `e2a_selftest_duration_seconds` | gauge | Total battery duration. |
 
 Scenarios (all non-destructive; see `internal/selftest/scenarios.go`):
-`liveness`, `auth_read`, `inbound_round_trip` (SMTP→webhook→HMAC),
+`liveness`, `auth_read`, `delegated_auth` (trusted issuer token vending →
+JWKS verification → external-principal mapping → account read),
+`inbound_round_trip` (SMTP→webhook→HMAC),
 `outbound_send` (real submit to the SES mailbox simulator),
 `self_send_loopback`, `websocket_round_trip` (WS handshake + live push),
 `agent_lifecycle` (self-cleaning ephemeral agent), `mcp_http_round_trip`
 (tools/list + whoami over the deployed MCP endpoint). Set
 `E2A_PROBE_REQUIRE_MCP=true` on stacks where MCP must be probed — it turns
 the skip-as-pass on an unset `E2A_PROBE_MCP_URL` into a failure.
+The delegated-auth scenario similarly skips when its token URL/secret are
+absent unless `E2A_PROBE_REQUIRE_DELEGATED_AUTH=true`. Its vending endpoint
+must own one fixed synthetic principal and accept no caller-selected identity,
+audience, scope, role, or lifetime. The prober fetches a fresh token for one
+read-only `GET /v1/agents?limit=1`, never emits the token or response body, and
+discards it after the request.
 
 `/status` (recent runs + `consecutive_green`) is the deploy bake-gate
 contract and also the natural feed for a hosted status page: scenario names
@@ -375,6 +383,18 @@ sum(rate(e2a_selftest_scenario_runs_total{
   scenario="mcp_http_round_trip",outcome="pass"}[6h]))
 / sum(rate(e2a_selftest_scenario_runs_total{
   scenario="mcp_http_round_trip"}[6h]))
+```
+
+**Delegated console authentication** — this is the page-safe signal for the
+trusted issuer/verifier/mapping path. Public invalid-token counters are useful
+diagnostics but are attacker-influenceable and therefore are not availability
+evidence by themselves:
+
+```promql
+sum(rate(e2a_selftest_scenario_runs_total{
+  scenario="delegated_auth",outcome="pass"}[6h]))
+/ sum(rate(e2a_selftest_scenario_runs_total{
+  scenario="delegated_auth"}[6h]))
 ```
 
 ## Initial SLO targets

--- a/internal/selftest/scenarios.go
+++ b/internal/selftest/scenarios.go
@@ -34,6 +34,12 @@ const defaultRoundTripTimeout = 30 * time.Second
 var All = []Scenario{
 	{Name: "liveness", SmokeSafe: true, Run: scenarioLiveness},
 	{Name: "auth_read", SmokeSafe: true, Run: scenarioAuthRead},
+	// delegated_auth obtains a fresh issuer-signed token from a trusted,
+	// fixed-principal vending endpoint and uses it for one read-only account
+	// request. It is the page-safe availability signal for delegated auth:
+	// unlike verifier failure counters, arbitrary public callers cannot choose
+	// the token or subject this scenario exercises.
+	{Name: "delegated_auth", SmokeSafe: true, Run: scenarioDelegatedAuth},
 	{Name: "inbound_round_trip", SmokeSafe: true, Run: scenarioInboundRoundTrip},
 	// outbound_send does a REAL SES submit, but only to the mailbox simulator
 	// (no real recipient, no cost, no owner notification, system-class = no
@@ -100,6 +106,80 @@ func scenarioAuthRead(ctx context.Context, p *Probe) Result {
 		return fail("GET agent: HTTP %d", resp.StatusCode)
 	}
 	return pass("authenticated read ok")
+}
+
+const maxDelegatedTokenResponseBytes = 20 * 1024
+
+// scenarioDelegatedAuth exercises the active issuer → JWKS → claim policy →
+// external-principal mapping → account authorization path. The vending
+// endpoint owns the synthetic principal and token shape; this client supplies
+// no identity, audience, scope, role, or lifetime input. Neither response body
+// is ever included in a result detail.
+func scenarioDelegatedAuth(ctx context.Context, p *Probe) Result {
+	configured := p.DelegatedTokenURL != "" && p.DelegatedTokenSecret != ""
+	if !configured {
+		if p.RequireDelegatedAuth {
+			return fail("delegated token vending is required but incomplete")
+		}
+		return pass("skipped: delegated token vending unset")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.DelegatedTokenURL, nil)
+	if err != nil {
+		return fail("delegated token request configuration invalid")
+	}
+	req.Header.Set("Authorization", "Bearer "+p.DelegatedTokenSecret)
+	resp, err := p.httpClient().Do(req)
+	if err != nil {
+		return fail("delegated token endpoint unavailable")
+	}
+	defer resp.Body.Close()
+	body, readErr := io.ReadAll(io.LimitReader(resp.Body, maxDelegatedTokenResponseBytes+1))
+	if readErr != nil {
+		return fail("delegated token response unreadable")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fail("delegated token endpoint: HTTP %d", resp.StatusCode)
+	}
+	if len(body) > maxDelegatedTokenResponseBytes {
+		return fail("delegated token response too large")
+	}
+	var exchanged struct {
+		AccessToken string `json:"access_token"`
+		TokenType   string `json:"token_type"`
+		ExpiresIn   int    `json:"expires_in"`
+		Scope       string `json:"scope"`
+	}
+	dec := json.NewDecoder(bytes.NewReader(body))
+	if err := dec.Decode(&exchanged); err != nil {
+		return fail("delegated token response malformed")
+	}
+	if err := dec.Decode(&struct{}{}); err != io.EOF {
+		return fail("delegated token response malformed")
+	}
+	if exchanged.AccessToken == "" || len(exchanged.AccessToken) > 16*1024 ||
+		strings.ContainsAny(exchanged.AccessToken, " \t\r\n") ||
+		exchanged.TokenType != "Bearer" || exchanged.Scope != "account" ||
+		exchanged.ExpiresIn < 1 || exchanged.ExpiresIn > 120 {
+		return fail("delegated token response malformed")
+	}
+
+	readURL := p.HTTPBaseURL + "/v1/agents?limit=1"
+	readReq, err := http.NewRequestWithContext(ctx, http.MethodGet, readURL, nil)
+	if err != nil {
+		return fail("delegated auth read configuration invalid")
+	}
+	readReq.Header.Set("Authorization", "Bearer "+exchanged.AccessToken)
+	readResp, err := p.httpClient().Do(readReq)
+	if err != nil {
+		return fail("delegated auth read unavailable")
+	}
+	defer readResp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(readResp.Body, 1<<20))
+	if readResp.StatusCode != http.StatusOK {
+		return fail("delegated auth read: HTTP %d", readResp.StatusCode)
+	}
+	return pass("delegated issuer, verification, mapping, and account read ok")
 }
 
 // scenarioInboundRoundTrip is the core check: inject a unique inbound message

--- a/internal/selftest/scenarios_internal_test.go
+++ b/internal/selftest/scenarios_internal_test.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -60,6 +61,83 @@ func TestScenarioAuthRead_Fail(t *testing.T) {
 	}))
 	defer srv.Close()
 	mustFail(t, "auth 401", scenarioAuthRead(context.Background(), failProbe(srv.URL, "", nil)))
+}
+
+func TestScenarioDelegatedAuth_ReadsWithFreshVendedToken(t *testing.T) {
+	const token = "synthetic.jwt.value"
+	var tokenCalls, apiCalls int
+	var api *httptest.Server
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tokenCalls++
+		if r.Method != http.MethodPost || r.URL.RawQuery != "" {
+			t.Fatalf("token request = %s %s, want POST without query", r.Method, r.URL.String())
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer probe-secret" {
+			t.Fatalf("token authorization = %q", got)
+		}
+		if r.ContentLength > 0 {
+			t.Fatalf("token request body length = %d, want empty", r.ContentLength)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"access_token":%q,"token_type":"Bearer","expires_in":60,"scope":"account"}`, token)
+	}))
+	defer tokenServer.Close()
+	api = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiCalls++
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/agents" || r.URL.Query().Get("limit") != "1" {
+			t.Fatalf("API request = %s %s", r.Method, r.URL.String())
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer "+token {
+			t.Fatalf("API authorization = %q", got)
+		}
+		fmt.Fprint(w, `{"agents":[{"email":"must-not-be-reported@example.test"}]}`)
+	}))
+	defer api.Close()
+
+	p := failProbe(api.URL, "", nil)
+	p.DelegatedTokenURL = tokenServer.URL
+	p.DelegatedTokenSecret = "probe-secret"
+	p.RequireDelegatedAuth = true
+	result := scenarioDelegatedAuth(context.Background(), p)
+	if result.Status != StatusPass {
+		t.Fatalf("status = %s detail=%q, want pass", result.Status, result.Detail)
+	}
+	if tokenCalls != 1 || apiCalls != 1 {
+		t.Fatalf("calls token=%d api=%d, want 1/1", tokenCalls, apiCalls)
+	}
+	if strings.Contains(result.Detail, token) || strings.Contains(result.Detail, "must-not-be-reported") {
+		t.Fatalf("result leaked token or response body: %q", result.Detail)
+	}
+}
+
+func TestScenarioDelegatedAuth_ConfigurationAndOpaqueFailures(t *testing.T) {
+	p := failProbe("http://127.0.0.1:1", "", nil)
+	if result := scenarioDelegatedAuth(context.Background(), p); result.Status != StatusPass || !strings.Contains(result.Detail, "skipped") {
+		t.Fatalf("optional unconfigured result = %+v, want skipped pass", result)
+	}
+	p.RequireDelegatedAuth = true
+	mustFail(t, "required config missing", scenarioDelegatedAuth(context.Background(), p))
+
+	const sensitive = "sensitive-upstream-body"
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		fmt.Fprint(w, sensitive)
+	}))
+	defer tokenServer.Close()
+	p.DelegatedTokenURL = tokenServer.URL
+	p.DelegatedTokenSecret = "probe-secret"
+	result := scenarioDelegatedAuth(context.Background(), p)
+	mustFail(t, "token endpoint unavailable", result)
+	if strings.Contains(result.Detail, sensitive) || strings.Contains(result.Detail, "probe-secret") {
+		t.Fatalf("failure leaked body or secret: %q", result.Detail)
+	}
+
+	malformed := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"access_token":"","token_type":"Bearer","expires_in":60,"scope":"account"}`)
+	}))
+	defer malformed.Close()
+	p.DelegatedTokenURL = malformed.URL
+	mustFail(t, "malformed token response", scenarioDelegatedAuth(context.Background(), p))
 }
 
 func TestScenarioSelfSendLoopback_Fail(t *testing.T) {

--- a/internal/selftest/selftest.go
+++ b/internal/selftest/selftest.go
@@ -52,16 +52,19 @@ type Scenario struct {
 // is transport-only config plus collaborators; it holds no test scaffolding so
 // both the shipped prober and the in-process tests construct it directly.
 type Probe struct {
-	HTTPBaseURL   string        // e.g. http://e2a:8080 — API + /api/health
-	APIKey        string        // probe agent's API key (Bearer)
-	AgentEmail    string        // the synthetic probe agent address
-	SMTPAddr      string        // host:port of the inbound SMTP listener
-	WebhookSecret string        // signing secret of the probe webhook (HMAC verify)
-	MCPBaseURL    string        // deployed streamable-HTTP MCP endpoint, e.g. http://mcp-server:3000/mcp; empty ⇒ mcp scenario skips
-	RequireMCP    bool          // when true, an empty MCPBaseURL FAILS the mcp scenario instead of skipping — set on stacks where MCP must be probed (prod)
-	Sink          *HTTPSink     // receives the webhook callback for the round-trip
-	HTTP          *http.Client  // nil → defaultHTTPClient
-	Timeout       time.Duration // round-trip await timeout; 0 → defaultRoundTripTimeout
+	HTTPBaseURL          string        // e.g. http://e2a:8080 — API + /api/health
+	APIKey               string        // probe agent's API key (Bearer)
+	AgentEmail           string        // the synthetic probe agent address
+	SMTPAddr             string        // host:port of the inbound SMTP listener
+	WebhookSecret        string        // signing secret of the probe webhook (HMAC verify)
+	MCPBaseURL           string        // deployed streamable-HTTP MCP endpoint, e.g. http://mcp-server:3000/mcp; empty ⇒ mcp scenario skips
+	RequireMCP           bool          // when true, an empty MCPBaseURL FAILS the mcp scenario instead of skipping — set on stacks where MCP must be probed (prod)
+	DelegatedTokenURL    string        // trusted endpoint that vends one short-lived delegated token; empty ⇒ delegated scenario skips
+	DelegatedTokenSecret string        // dedicated Bearer credential for DelegatedTokenURL; never logged
+	RequireDelegatedAuth bool          // when true, incomplete delegated config FAILS instead of skipping
+	Sink                 *HTTPSink     // receives the webhook callback for the round-trip
+	HTTP                 *http.Client  // nil → defaultHTTPClient
+	Timeout              time.Duration // round-trip await timeout; 0 → defaultRoundTripTimeout
 }
 
 func (p *Probe) httpClient() *http.Client {


### PR DESCRIPTION
## Summary

- add an optional delegated_auth self-test scenario that requests a short-lived fixed-principal token from TokenCanopy Hub
- exercise a read-only account-scoped GET /v1/agents?limit=1 through the normal e2a API path
- bound and discard token endpoint and API response bodies, and keep errors opaque
- preserve self-host behavior with skip-as-pass unless E2A_PROBE_REQUIRE_DELEGATED_AUTH is explicitly true

## Verification

- GOCACHE=/tmp/e2a-delegated-auth-go-cache go test ./internal/selftest ./cmd/e2a-prober
- all required GitHub checks passed
- independent correctness and adversarial reviews passed

The broader local go test ./... gate hit existing database-sensitive internal/agent failures that reproduce unchanged on origin/main; the touched packages and GitHub Go gate pass.

Coordinated Hub PR: https://github.com/tokencanopy/tokencanopy/pull/425
Coordinated hosted wiring PR: https://github.com/tokencanopy/e2a-ops/pull/355